### PR TITLE
MMT-637: Prevent writing the return_to path to the session for ajax endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,8 +49,7 @@ gem 'faker'
 
 gem 'pundit'
 
-gem 'libxml-to-hash', :git => "https://github.com/johannesthoma/libxml-to-hash"
-
+gem 'libxml-to-hash', git: 'https://github.com/johannesthoma/libxml-to-hash'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -104,5 +103,3 @@ gem 'builder'
 # run this command to work from a local copy of the gem's repo
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
 gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', branch: 'master'
-
-gem 'libxml-to-hash', git: 'https://github.com/johannesthoma/libxml-to-hash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     carmen (1.0.2)
       activesupport (>= 3.0.0)
     cliver (0.3.2)
-    coderay (1.1.0)
+    coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)

--- a/app/concerns/chooser_endpoints.rb
+++ b/app/concerns/chooser_endpoints.rb
@@ -5,17 +5,19 @@ module ChooserEndpoints
 
   def render_collections_for_chooser(collections)
     # The chooser expects an array of arrays, so that's what we'll give it
+    items = collections.fetch('items', [])
+
     render json: {
-        'hits': collections.fetch('hits', 0),
-        'items': collections.fetch('items', []).map do |collection|
+      'hits': collections.fetch('hits', 0),
+      'items': items.map do |collection|
+        [
+          collection.fetch('meta', {}).fetch('concept-id'),
           [
-              collection.fetch('meta', {}).fetch('concept-id'),
-              [
-                  collection.fetch('umm', {}).fetch('entry-id'),
-                  collection.fetch('umm', {}).fetch('entry-title')
-              ].join(' | ')
-          ]
-        end
+            collection.fetch('umm', {}).fetch('short-name'),
+            collection.fetch('umm', {}).fetch('entry-title')
+          ].join(' | ')
+        ]
+      end
     }
   end
 

--- a/app/controllers/manage_cmr_controller.rb
+++ b/app/controllers/manage_cmr_controller.rb
@@ -7,6 +7,13 @@ class ManageCmrController < PagesController
   before_filter :check_if_system_acl_administrator, only: :show
   before_filter :check_if_current_provider_acl_administrator, only: :show
 
+  # These are json respones for ajax calls that user wouldnt get to without being logged in.
+  skip_before_filter :is_logged_in, only: [
+    :provider_collections,
+    :service_implementations_with_datasets,
+    :datasets_for_service_implementation
+  ]
+
   layout 'manage_cmr'
 
   def show; end


### PR DESCRIPTION
On certain endpoints the paths were pretty long, this was being written to the session for the purposes of redirecting after login, but a user will never visit these pages which means we can skip the filter that sets it. The filter also ensures that the user is logged in but the ajax request wont fire because the page itself WILL run through that before filter.

A user could hit the endpoint directly but will get nothing back because it requires a token that is retrieved and stored for logged in user, so there is no risk here.