### PR TITLE
MMT-745: remove initial management group from groups form and control…

### DIFF
--- a/app/assets/javascripts/group_validation.coffee
+++ b/app/assets/javascripts/group_validation.coffee
@@ -7,12 +7,8 @@ $(document).ready ->
           required: true
         'group[description]':
           required: true
-        'group[initial_management_group]':
-          required: true
       messages:
         'group[name]':
           required: 'Name is required.'
         'group[description]':
           required: 'Description is required.'
-        'group[initial_management_group]':
-          required: 'Initial Management Group is required.'

--- a/app/assets/javascripts/groups.coffee
+++ b/app/assets/javascripts/groups.coffee
@@ -26,7 +26,7 @@ $(document).ready ->
       lastName = $('#invite_last_name').val('')
       email = $('#invite_email').val('')
 
-    # We're using 'readonly' instead 'disabled' which still
+    # We're using 'readonly' instead of 'disabled' which still
     # allows the following actions so we're manually disabling them
     $('.system-group-checkbox[readonly]')
       .on 'click', ->
@@ -41,19 +41,9 @@ $(document).ready ->
       # Toggle the display of the SYS badge
       $('#badge-container').toggle()
 
-      $initialManagementGroup = $('#group_initial_management_group')
-
       # Toggle the provider based on whether or not the
       # System Level Group checkbox is checked
       if this.checked
         $('h2 .provider-context').text('CMR')
-
-        # show only system groups in initial management group select if creating a system group
-        system_group_options = $('#system_group_options').val()
-        $initialManagementGroup.empty().append(system_group_options)
       else
         $('h2 .provider-context').text(provider)
-
-        # show provider and system groups in initial management group select if creating a provider group
-        provider_and_system_group_options = $('#provider_and_system_group_options').val()
-        $initialManagementGroup.empty().append(provider_and_system_group_options)

--- a/app/controllers/provider_identity_permissions_controller.rb
+++ b/app/controllers/provider_identity_permissions_controller.rb
@@ -43,9 +43,6 @@ class ProviderIdentityPermissionsController < ManageCmrController
     # assemble provider permissions for the table of checkboxes
     @group_provider_permissions = assemble_permissions_for_table(permissions: group_provider_permissions_list, type: 'provider', group_id: @group_id)
 
-    # get assembled group management permissions for table
-    @group_management_permissions = set_group_management_permissions_for_table(@group_id)
-
     group_response = cmr_client.get_group(@group_id, token)
     if group_response.success?
       @group = group_response.body
@@ -61,12 +58,9 @@ class ProviderIdentityPermissionsController < ManageCmrController
   def update
     @group_id = params[:id]
     permissions_params = params[:provider_permissions]
-    group_management_params = params[:group_management]
+    redirect_to provider_identity_permissions_path and return if permissions_params.nil?
 
-    redirect_to provider_identity_permissions_path and return if permissions_params.nil? && group_management_params.nil?
-
-    permissions_params ||= {} # permissions_params might be nil even if group_management_params are not
-    permissions_params.each { |_target, perms| perms.delete('') } unless permissions_params.nil?
+    permissions_params.each { |_target, perms| perms.delete('') }
     all_provider_permissions = get_permissions_for_identity_type(type: 'provider')
     # assemble permissions so they can be sorted and updated
     selective_provider_permission_info = assemble_permissions_for_updating(
@@ -103,19 +97,6 @@ class ProviderIdentityPermissionsController < ManageCmrController
       targets_to_remove_group: targets_to_remove_group,
       type: 'provider',
       group_id: @group_id,
-      successes: successes,
-      fails: fails
-    )
-
-    group_management_params.each { |_concept, perms| perms.delete('') } unless group_management_params.nil?
-    all_group_management_permissions_list = get_permissions_for_identity_type(type: 'single_instance')
-    group_management_perms_to_update = assemble_new_group_management_perms(
-                                        all_group_management_perms: all_group_management_permissions_list,
-                                        group_management_params: group_management_params,
-                                        group_id: @group_id
-                                       )
-    update_group_management_permissions(
-      group_management_perms: group_management_perms_to_update,
       successes: successes,
       fails: fails
     )

--- a/app/controllers/system_identity_permissions_controller.rb
+++ b/app/controllers/system_identity_permissions_controller.rb
@@ -42,9 +42,6 @@ class SystemIdentityPermissionsController < ManageCmrController
     # assemble system permissions for the table of checkboxes
     @group_system_permissions = assemble_permissions_for_table(permissions: group_system_permissions_list, type: 'system', group_id: @group_id)
 
-    # get assembled group management permissions for table
-    @group_management_permissions = set_group_management_permissions_for_table(@group_id)
-
     group_response = cmr_client.get_group(@group_id, token)
     if group_response.success?
       @group = group_response.body
@@ -60,12 +57,9 @@ class SystemIdentityPermissionsController < ManageCmrController
   def update
     @group_id = params[:id]
     permissions_params = params[:system_permissions]
-    group_management_params = params[:group_management]
+    redirect_to system_identity_permissions_path and return if permissions_params.nil?
 
-    redirect_to system_identity_permissions_path and return if permissions_params.nil? && group_management_params.nil?
-
-    permissions_params ||= {} # permissions_params might be nil even if group_management_params are not
-    permissions_params.each { |_target, perms| perms.delete('') } unless permissions_params.nil?
+    permissions_params.each { |_target, perms| perms.delete('') }
     all_system_permissions = get_permissions_for_identity_type(type: 'system')
     # assemble permissions so they can be sorted and updated
     selective_full_system_permission_info = assemble_permissions_for_updating(
@@ -102,19 +96,6 @@ class SystemIdentityPermissionsController < ManageCmrController
       targets_to_remove_group: targets_to_remove_group,
       type: 'system',
       group_id: @group_id,
-      successes: successes,
-      fails: fails
-    )
-
-    group_management_params.each { |_concept, perms| perms.delete('') } unless group_management_params.nil?
-    all_group_management_permissions_list = get_permissions_for_identity_type(type: 'single_instance')
-    group_management_perms_to_update = assemble_new_group_management_perms(
-                                        all_group_management_perms: all_group_management_permissions_list,
-                                        group_management_params: group_management_params,
-                                        group_id: @group_id
-                                       )
-    update_group_management_permissions(
-      group_management_perms: group_management_perms_to_update,
       successes: successes,
       fails: fails
     )

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -10,32 +10,4 @@ module GroupsHelper
   def group_provider(group)
     check_if_system_group?(group, group['concept_id']) ? 'CMR' : group['provider_id']
   end
-
-  def set_group_options(option_list, groups)
-    groups.each do |group|
-      concept_id = group['concept_id']
-      name = group['name']
-      name += ' (System Group)' if check_if_system_group?(group, concept_id)
-      group_option = [name, concept_id]
-
-      option_list << group_option
-    end
-  end
-
-  def set_system_group_options
-    system_group_options = []
-    set_group_options(system_group_options, @system_groups)
-
-    system_group_options.unshift(['Select an Initial Management Group', nil])
-    system_group_options
-  end
-
-  def set_provider_and_system_group_options
-    provider_and_system_group_options = []
-    set_group_options(provider_and_system_group_options, @provider_groups)
-    set_group_options(provider_and_system_group_options, @system_groups)
-
-    provider_and_system_group_options.unshift(['Select an Initial Management Group', nil])
-    provider_and_system_group_options
-  end
 end

--- a/app/helpers/single_instance_identity_permissions_helper.rb
+++ b/app/helpers/single_instance_identity_permissions_helper.rb
@@ -1,3 +1,0 @@
-module SingleInstanceIdentityPermissionsHelper
-  GROUP_MANAGEMENT_PERMISSIONS = %w(update delete)
-end

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -30,20 +30,6 @@
 </fieldset>
 
 <fieldset>
-  <div class="row">
-    <%= label_tag('group[initial_management_group]', 'Initial Management Group', class: 'eui-required-o') %>
-    <%= select_tag('group[initial_management_group]', options_for_select(set_provider_and_system_group_options, @management_group_concept_id),
-                   class: 'initial-management-group-select required', disabled: !new_form ) %>
-    <p class="form-description">Initial Management Group cannot be modified after creation.</p>
-
-    <% if new_form %>
-      <%= hidden_field_tag('system_group_options', options_for_select(set_system_group_options)) %>
-      <%= hidden_field_tag('provider_and_system_group_options', options_for_select(set_provider_and_system_group_options)) %>
-    <% end %>
-  </div>
-</fieldset>
-
-<fieldset>
   <h3>Members</h3>
 
   <div class="row space-bot">

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -9,13 +9,6 @@
 
     <p><%= @group.fetch('description') %></p>
 
-    <h4>Management Groups</h4>
-    <% if @management_groups.blank? %>
-      <p>No Management Groups found.</p>
-    <% else %>
-      <p><%= @management_groups.map { |group| group['name'] }.to_sentence %></p>
-    <% end %>
-
     <h4>Associated Permissions</h4>
     <% if @permissions.blank? %>
       <p>No associated permissions found.</p>

--- a/app/views/provider_identity_permissions/_form.html.erb
+++ b/app/views/provider_identity_permissions/_form.html.erb
@@ -44,33 +44,6 @@
           <% end %>
         </tr>
       <% end %>
-
-      <% @group_management_permissions.each do |group_management_permission| %>
-        <!-- Group Management (Single Instance Identity) Permissions -->
-        <tr>
-          <td><%= "Group Management for [#{group_management_permission['name']}]" %></td>
-
-          <% ProviderIdentityPermissionsHelper::PermissionsOptions.each do |permission_option| %>
-            <% if SingleInstanceIdentityPermissionsHelper::GROUP_MANAGEMENT_PERMISSIONS.include?(permission_option) %>
-              <td class="align-c">
-                <% if group_management_permission['granted_permissions'].include?(permission_option) %>
-                  <%= check_box_tag("group_management[#{group_management_permission['concept_id']}][]", permission_option, true) %>
-                <% else %>
-                  <%= check_box_tag("group_management[#{group_management_permission['concept_id']}][]", permission_option, false) %>
-                <% end %>
-              </td>
-            <% else %>
-              <td class="align-c disabled">
-                <%= check_box_tag("group_management[#{group_management_permission['concept_id']}][]", permission_option, false, disabled: true) %>
-              </td>
-            <% end %>
-          <% end %>
-
-          <% unless group_management_permission['granted_permissions'].blank? %>
-            <%= hidden_field_tag("group_management[#{group_management_permission['concept_id']}][]", '') %>
-          <% end %>
-        </tr>
-      <% end %>
     </tbody>
   </table>
 </fieldset>

--- a/app/views/system_identity_permissions/_form.html.erb
+++ b/app/views/system_identity_permissions/_form.html.erb
@@ -44,33 +44,6 @@
           <% end %>
         </tr>
       <% end %>
-
-      <% @group_management_permissions.each do |group_management_permission| %>
-        <!-- Group Management (Single Instance Identity) Permissions -->
-        <tr>
-          <td><%= "Group Management for [#{group_management_permission['name']}]" %></td>
-
-          <% SystemIdentityPermissionsHelper::PermissionsOptions.each do |permission_option| %>
-            <% if SingleInstanceIdentityPermissionsHelper::GROUP_MANAGEMENT_PERMISSIONS.include?(permission_option) %>
-              <td class="align-c">
-                <% if group_management_permission['granted_permissions'].include?(permission_option) %>
-                  <%= check_box_tag("group_management[#{group_management_permission['concept_id']}][]", permission_option, true) %>
-                <% else %>
-                  <%= check_box_tag("group_management[#{group_management_permission['concept_id']}][]", permission_option, false) %>
-                <% end %>
-              </td>
-            <% else %>
-              <td class="align-c disabled">
-                <%= check_box_tag("group_management[#{group_management_permission['concept_id']}][]", permission_option, false, disabled: true) %>
-              </td>
-            <% end %>
-          <% end %>
-
-          <% unless group_management_permission['granted_permissions'].blank? %>
-            <%= hidden_field_tag("group_management[#{group_management_permission['concept_id']}][]", '') %>
-          <% end %>
-        </tr>
-      <% end %>
     </tbody>
   </table>
 </fieldset>

--- a/spec/features/groups/create_group_spec.rb
+++ b/spec/features/groups/create_group_spec.rb
@@ -1,13 +1,6 @@
 require 'rails_helper'
 
 describe 'Groups', reset_provider: true do
-  before :all do
-    @group = create_group(
-      name: 'Generic Initial Management Group for Tests',
-      description: 'Group for Initial Managment Group'
-    )
-  end
-
   context 'when visiting the new group form' do
     before do
       login
@@ -20,7 +13,6 @@ describe 'Groups', reset_provider: true do
 
       expect(page).to have_field('Name', type: 'text')
       expect(page).to have_field('Description', type: 'textarea')
-      expect(page).to have_field('Initial Management Group', type: 'select')
 
       expect(page).to have_no_unchecked_field('System Level Group?')
     end
@@ -35,7 +27,6 @@ describe 'Groups', reset_provider: true do
       it 'displays validation errors within the form' do
         expect(page).to have_content('Name is required.')
         expect(page).to have_content('Description is required.')
-        expect(page).to have_content('Initial Management Group is required.')
       end
     end
 
@@ -43,12 +34,10 @@ describe 'Groups', reset_provider: true do
       context 'when submitting the form with members', js: true do
         let(:group_name)        { 'NASA Test Group With Members' }
         let(:group_description) { 'NASA is seriously the coolest, with the coolest members!' }
-        let(:initial_management_group) { 'Generic Initial Management Group for Tests' }
 
         before do
           fill_in 'Name', with: group_name
           fill_in 'Description', with: group_description
-          select(initial_management_group, from: 'Initial Management Group')
 
           select('Marsupial Narwal', from: 'Members Directory')
           select('Quail Racoon', from: 'Members Directory')
@@ -64,7 +53,6 @@ describe 'Groups', reset_provider: true do
 
         it 'saves the group with members' do
           expect(page).to have_content('Group was successfully created.')
-          expect(page).to have_content(initial_management_group)
 
           within '#group-members' do
             expect(page).to have_selector('tbody > tr', count: 3)
@@ -73,14 +61,12 @@ describe 'Groups', reset_provider: true do
       end
 
       context 'when submitting the form without members' do
-        let(:group_name)        { 'NASA Test Group' }
+        let(:group_name)        { 'NASA Test Group no members' }
         let(:group_description) { 'NASA is seriously the coolest.' }
-        let(:initial_management_group) { 'Generic Initial Management Group for Tests' }
 
         before do
           fill_in 'Name', with: group_name
           fill_in 'Description', with: group_description
-          select(initial_management_group, from: 'Initial Management Group')
 
           within '.group-form' do
             click_on 'Submit'
@@ -92,77 +78,8 @@ describe 'Groups', reset_provider: true do
         it 'saves the group without members' do
           expect(page).to have_content('Group was successfully created.')
 
-          expect(page).to have_content(initial_management_group)
-
           expect(page).not_to have_selector('table.group-members')
           expect(page).to have_content("#{group_name} has no members.")
-        end
-      end
-
-      context 'when there is an error creating the single instance identity acl' do
-        let(:group_name) { random_group_name }
-        let(:group_description) { random_group_description }
-        let(:initial_management_group) { 'Generic Initial Management Group for Tests' }
-
-        before do
-          fill_in 'Name', with: group_name
-          fill_in 'Description', with: group_description
-          select(initial_management_group, from: 'Initial Management Group')
-
-          # mock for error creating single instance identity acl
-          mock_group_management_error = '{"errors":["The Acl Identity [single-instance:ag1200000180-mmt_1:group_management] must be unique. The following concepts with the same acl identity were found: [ACL1200000181-CMR]."]}'
-          management_group_response = Cmr::Response.new(Faraday::Response.new(status: 401, body: JSON.parse(mock_group_management_error)))
-          allow_any_instance_of(Cmr::CmrClient).to receive(:add_group_permissions).and_return(management_group_response)
-
-          within '.group-form' do
-            click_on 'Submit'
-          end
-
-          wait_for_cmr
-        end
-
-        it 'shows the form for a new group with the previously entered data' do
-          expect(page).to have_field('Name', with: group_name, readonly: false)
-          expect(page).to have_field('Description', with: group_description)
-          expect(page).to have_select('Initial Management Group', disabled: false)
-          expect(page).to have_select('Initial Management Group', selected: 'Generic Initial Management Group for Tests')
-        end
-
-      end
-
-      context 'when there is an error creating the single instance identity acl AND then deleting the group' do
-        let(:group_name) { random_group_name }
-        let(:group_description) { random_group_description }
-        let(:initial_management_group) { 'Generic Initial Management Group for Tests' }
-
-        before do
-          fill_in 'Name', with: group_name
-          fill_in 'Description', with: group_description
-          select(initial_management_group, from: 'Initial Management Group')
-
-          # mock for error creating single instance identity acl
-          mock_group_management_error = '{"errors":["The Acl Identity [single-instance:ag1200000180-mmt_1:group_management] must be unique. The following concepts with the same acl identity were found: [ACL1200000181-CMR]."]}'
-          management_group_response = Cmr::Response.new(Faraday::Response.new(status: 401, body: JSON.parse(mock_group_management_error)))
-          allow_any_instance_of(Cmr::CmrClient).to receive(:add_group_permissions).and_return(management_group_response)
-
-          # mock for error deleting group
-          mock_group_delete_error = '{"errors":["You do not have permission to delete access control group [Test Groupy Group]."]}'
-          group_delete_response = Cmr::Response.new(Faraday::Response.new(status: 401, body: JSON.parse(mock_group_delete_error)))
-          allow_any_instance_of(Cmr::CmrClient).to receive(:delete_group).and_return(group_delete_response)
-
-          within '.group-form' do
-            click_on 'Submit'
-          end
-
-          wait_for_cmr
-        end
-
-        it 'redirects to the created group but displays an error message' do
-          expect(page).to have_content(group_name)
-          expect(page).to have_content(group_description)
-
-          expect(page).to have_content('was created but there were issues with the Initial Management Group permissions. Please delete this group and try again.')
-          expect(page).to have_no_content(initial_management_group)
         end
       end
     end

--- a/spec/features/groups/system_level/create_group_spec.rb
+++ b/spec/features/groups/system_level/create_group_spec.rb
@@ -2,13 +2,6 @@
 require 'rails_helper'
 
 describe 'Creating System Level Groups', reset_provider: true do
-  before :all do
-    @group_name = 'Generic Provider Initial Management Group for Tests'
-    @group = create_group(
-      name: @group_name,
-      description: 'Group for Initial Managment Group'
-    )
-  end
 
   context 'when viewing new groups form as an admin user' do
     before do
@@ -22,10 +15,6 @@ describe 'Creating System Level Groups', reset_provider: true do
       expect(page).to have_unchecked_field('system_group')
     end
 
-    it 'shows provider and system level groups in the Inital Management Group select dropdown' do
-      expect(page).to have_select('Initial Management Group', with_options: ['Administrators', 'Administrators_2', @group_name])
-    end
-
     context 'when clicking the system group checkbox', js: true do
       before do
         check 'System Level Group?'
@@ -35,14 +24,6 @@ describe 'Creating System Level Groups', reset_provider: true do
         expect(page).to have_content('New CMR Group')
         expect(page).to have_content('SYS')
         expect(page).to have_css('span.eui-badge--sm')
-      end
-
-      it 'changes the Initial Management Group options to only have system groups' do
-        expect(page).to have_select('Initial Management Group', with_options: ['Administrators', 'Administrators_2'])
-
-        within '#group_initial_management_group' do
-          expect(page).to have_no_content(@group_name)
-        end
       end
     end
 
@@ -58,7 +39,6 @@ describe 'Creating System Level Groups', reset_provider: true do
         fill_in 'Name', with: group_name
         check 'System Level Group?'
         fill_in 'Description', with: group_description
-        select('Administrators_2', from: 'Initial Management Group')
 
         # choose users
         select('Alien Bobcat', from: 'Members Directory')
@@ -77,7 +57,6 @@ describe 'Creating System Level Groups', reset_provider: true do
 
         expect(page).to have_content(group_name)
         expect(page).to have_content(group_description)
-        expect(page).to have_content('Administrators_2')
 
         # SYS badge
         expect(page).to have_content('SYS')

--- a/spec/features/groups/system_level/update_group_spec.rb
+++ b/spec/features/groups/system_level/update_group_spec.rb
@@ -14,7 +14,6 @@ describe 'Updating System Level Groups', js: true do
         admin: true,
         members: %w(abcd mnop qrst uvw)
       )
-      # default management group for create_group is 'Administrators_2'
     end
 
     after :all do
@@ -38,12 +37,6 @@ describe 'Updating System Level Groups', js: true do
       expect(page).to have_field('Name', with: @group_name)
       expect(page).to have_checked_field('System Level Group?')
       expect(page).to have_field('Description', with: @group_description)
-
-      expect(page).to have_select('Initial Management Group', disabled: true)
-      # since Initial Management Group is disabled, cannot match value using 'selected' or 'with'
-      within '#group_initial_management_group' do
-        have_css('option', value: 'AG1200000001-CMR', selected: true)
-      end
     end
 
     it 'has the approprate fields disabled' do
@@ -53,8 +46,6 @@ describe 'Updating System Level Groups', js: true do
       uncheck 'System Level Group?'
 
       expect(page).to have_checked_field('System Level Group?')
-
-      expect(page).to have_select('Initial Management Group', disabled: true)
     end
 
     context 'when updating the system level group' do
@@ -75,7 +66,6 @@ describe 'Updating System Level Groups', js: true do
 
         expect(page).to have_content(@group_name)
         expect(page).to have_content(new_group_description)
-        expect(page).to have_content('Administrators_2')
 
         # SYS badge
         expect(page).to have_content('SYS')

--- a/spec/features/groups/update_group_spec.rb
+++ b/spec/features/groups/update_group_spec.rb
@@ -14,9 +14,8 @@ describe 'Updating groups', reset_provider: true, js: true do
       visit edit_group_path(@group['concept_id'])
     end
 
-    it 'the name and initial management group fields are disabled' do
+    it 'the name field is disabled' do
       expect(page).to have_field('group_name', readonly: true)
-      expect(page).to have_field('Initial Management Group', disabled: true)
     end
 
     context 'when modifying the description' do

--- a/spec/features/provider_identity_permissions/changing_removing_provider_permissions_spec.rb
+++ b/spec/features/provider_identity_permissions/changing_removing_provider_permissions_spec.rb
@@ -11,15 +11,6 @@ describe 'Changing or Removing Provider Identity Permissions', reset_provider: t
 
     wait_for_cmr
 
-    @managed_group_name = 'Managed Group for Provider Object Permissions'
-    @managed_group = create_group(
-      name: @managed_group_name,
-      description: 'Group 2 for provider object permissions management',
-      management_group: @group['concept_id']
-    )
-
-    wait_for_cmr
-
     provider_perm_1 = {
       'group_permissions' => [{
         'group_id' => @group['concept_id'],
@@ -59,7 +50,7 @@ describe 'Changing or Removing Provider Identity Permissions', reset_provider: t
     wait_for_cmr
   end
 
-  context 'when visiting the provider object permissions page for the group that manages another group' do
+  context 'when visiting the provider object permissions page for the group' do
     before do
       login
 
@@ -73,19 +64,11 @@ describe 'Changing or Removing Provider Identity Permissions', reset_provider: t
       expect(page).to have_checked_field('provider_permissions_AUTHENTICATOR_DEFINITION_', with: 'delete')
     end
 
-    it 'has the single instance identity group management permissions checked' do
-      expect(page).to have_checked_field("group_management_#{@managed_group['concept_id']}_", with: 'update')
-      expect(page).to have_checked_field("group_management_#{@managed_group['concept_id']}_", with: 'delete')
-    end
-
     context 'when changing and removing provider permissions' do
       before do
         uncheck('provider_permissions_AUTHENTICATOR_DEFINITION_', option: 'delete')
         uncheck('provider_permissions_PROVIDER_ORDER_TRACKING_ID_', option: 'update')
         uncheck('provider_permissions_OPTION_ASSIGNMENT_', option: 'read')
-
-        uncheck("group_management_#{@managed_group['concept_id']}_", option: 'update')
-        uncheck("group_management_#{@managed_group['concept_id']}_", option: 'delete')
 
         check('provider_permissions_OPTION_ASSIGNMENT_', option: 'delete')
         check('provider_permissions_INGEST_MANAGEMENT_ACL_', option: 'read')

--- a/spec/features/provider_identity_permissions/provider_identity_permissions_form_spec.rb
+++ b/spec/features/provider_identity_permissions/provider_identity_permissions_form_spec.rb
@@ -13,15 +13,6 @@ describe 'Provider Identity Permissions pages and form', reset_provider: true do
     )
 
     wait_for_cmr
-
-    @managed_group_name = 'Managed Group for Provider Object Permissions'
-    @managed_group = create_group(
-      name: @managed_group_name,
-      description: 'Group 2 for provider object permissions management',
-      management_group: @group['concept_id']
-    )
-
-    wait_for_cmr
   end
 
   context 'when viewing the provider identities permisisons index page as an administrator' do
@@ -34,7 +25,6 @@ describe 'Provider Identity Permissions pages and form', reset_provider: true do
     it 'shows the table with system and provider groups' do
       within '.provider-permissions-group-table' do
         expect(page).to have_content(@group_name)
-        expect(page).to have_content(@management_group_name)
 
         # these are the bootstrapped CMR Administrators group, and the system groups we create on cmr setup
         expect(page).to have_content('Administrators')
@@ -80,41 +70,14 @@ describe 'Provider Identity Permissions pages and form', reset_provider: true do
       end
     end
 
-    context 'when visiting the provider identities form for the group that manages another group' do
+    context 'when visiting the provider identities form for the group' do
       before do
         visit edit_provider_identity_permission_path(@group['concept_id'])
       end
 
-      it 'displays the page with the form and table of provider and group management targets' do
+      it 'displays the page with the form and table of provider targets' do
         expect(page).to have_content("#{@group_name} Provider Object Permissions")
         expect(page).to have_content("Set permissions for the #{@group_name} group by checking the appropriate boxes below and clicking 'Submit'.")
-
-        within '.provider-permissions-table' do
-          expect(page).to have_css('tbody > tr', count: (ProviderIdentityPermissionsHelper::PROVIDER_TARGETS.count + 1))
-          expect(page).to have_css('input[type=checkbox]', count: 104) # all checkboxes
-          expect(page).to have_css('input[type=checkbox][checked]', count: 2)
-          expect(page).to have_css('input[type=checkbox][disabled]', count: 56)
-          expect(page).to have_css('input[type=checkbox]:not([disabled])', count: 48)
-          expect(page).to have_css('input[type=checkbox]:not([checked])', count: 102)
-
-          expect(page).to have_content("Group Management for [#{@managed_group_name}]")
-        end
-      end
-
-      it 'displays the checked single instance identity group management permissions' do
-        expect(page).to have_checked_field("group_management_#{@managed_group['concept_id']}_", with: 'update')
-        expect(page).to have_checked_field("group_management_#{@managed_group['concept_id']}_", with: 'delete')
-      end
-    end
-
-    context 'when visiting the provider identities form for the group that does not manage another group' do
-      before do
-        visit edit_provider_identity_permission_path(@managed_group['concept_id'])
-      end
-
-      it 'displays the page with the form and table of provider targets' do
-        expect(page).to have_content("#{@managed_group_name} Provider Object Permissions")
-        expect(page).to have_content("Set permissions for the #{@managed_group_name} group by checking the appropriate boxes below and clicking 'Submit'.")
 
         within '.provider-permissions-table' do
           expect(page).to have_css('tbody > tr', count: ProviderIdentityPermissionsHelper::PROVIDER_TARGETS.count)
@@ -123,6 +86,8 @@ describe 'Provider Identity Permissions pages and form', reset_provider: true do
           expect(page).to have_css('input[type=checkbox][disabled]', count: 54)
           expect(page).to have_css('input[type=checkbox]:not([disabled])', count: 46)
           expect(page).to have_css('input[type=checkbox]:not([checked])', count: 100)
+
+          expect(page).to have_no_content('Group Management for')
         end
       end
 

--- a/spec/features/system_identity_permissions/changing_removing_system_permissions_spec.rb
+++ b/spec/features/system_identity_permissions/changing_removing_system_permissions_spec.rb
@@ -13,15 +13,6 @@ describe 'Changing or Removing System Identity Permissions' do
 
     wait_for_cmr
 
-    @managed_group_name = 'Managed Group for System Object Permissions'
-    @managed_group = create_group(
-      name: @managed_group_name,
-      description: 'Group 2 for system object permissions management',
-      management_group: @group_response['concept_id']
-    )
-
-    wait_for_cmr
-
     system_perm_1 = {
       'group_permissions' => [{
         'group_id'    => @group_response['concept_id'],
@@ -68,10 +59,9 @@ describe 'Changing or Removing System Identity Permissions' do
     permissions_response_items.each { |perm_item| cmr_client.delete_permission(perm_item['concept_id'], 'access_token_admin') }
 
     delete_group(concept_id: @group_response['concept_id'], admin: true)
-    delete_group(concept_id: @managed_group['concept_id'], admin: true)
   end
 
-  context 'when visiting the system object permissions page for a system group that manages another group' do
+  context 'when visiting the system object permissions page for a system group' do
     before do
       login_admin
 
@@ -85,11 +75,6 @@ describe 'Changing or Removing System Identity Permissions' do
       expect(page).to have_checked_field('system_permissions_SYSTEM_OPTION_DEFINITION_', with: 'delete')
     end
 
-    it 'has the single instance identity group management permissions checked' do
-      expect(page).to have_checked_field("group_management_#{@managed_group['concept_id']}_", with: 'update')
-      expect(page).to have_checked_field("group_management_#{@managed_group['concept_id']}_", with: 'delete')
-    end
-
     context 'when changing and removing system permissions' do
       before do
         check('system_permissions_SYSTEM_CALENDAR_EVENT_', option: 'create')
@@ -97,9 +82,6 @@ describe 'Changing or Removing System Identity Permissions' do
 
         uncheck('system_permissions_SYSTEM_INITIALIZER_', option: 'create')
         uncheck('system_permissions_SYSTEM_OPTION_DEFINITION_', option: 'delete')
-
-        uncheck("group_management_#{@managed_group['concept_id']}_", option: 'update')
-        uncheck("group_management_#{@managed_group['concept_id']}_", option: 'delete')
 
         within '.system-permissions-form' do
           click_on 'Submit'

--- a/spec/features/system_identity_permissions/system_identity_permissions_form_spec.rb
+++ b/spec/features/system_identity_permissions/system_identity_permissions_form_spec.rb
@@ -4,41 +4,7 @@ require 'rails_helper'
 
 describe 'System Identity Permissions pages and form' do
   # concept_id for Administrators_2 group created on cmr setup
-  # let(:concept_id) { 'AG1200000001-CMR' }
-
-  before :all do
-    @group_name = random_group_name
-    group_description = random_group_description
-    @group = create_group(
-      name: @group_name,
-      description: group_description,
-      provider_id: nil,
-      admin: true
-    )
-    # default management group for create_group is 'Administrators_2'
-
-    wait_for_cmr
-
-    @managed_group_name = random_group_name
-    managed_group_description = random_group_description
-
-    @managed_group = create_group(
-      name: @managed_group_name,
-      description: managed_group_description,
-      provider_id: nil, # System Level groups do not have a provider_id
-      management_group: @group['concept_id'],
-      admin: true
-    )
-
-    wait_for_cmr
-  end
-
-  after :all do
-    # System level groups need to be cleaned up to avoid attempting to create
-    # a group with the same name in another test (Random names don't seem to be reliable)
-    delete_group(concept_id: @group['concept_id'], admin: true)
-    delete_group(concept_id: @managed_group['concept_id'], admin: true)
-  end
+  let(:concept_id) { 'AG1200000001-CMR' }
 
   context 'when logging in as a regular user' do
     before do
@@ -77,8 +43,6 @@ describe 'System Identity Permissions pages and form' do
             expect(page).to have_content('Administrators_2')
             expect(page).to have_content('MMT Admins')
             expect(page).to have_content('MMT Users')
-            expect(page).to have_content(@group_name)
-            expect(page).to have_content(@managed_group_name)
           end
         end
       end
@@ -98,49 +62,22 @@ describe 'System Identity Permissions pages and form' do
       end
     end
 
-    context 'when visiting the system identities form for the System Group that manages another group' do
+    context 'when visiting the system identities form for a System Group' do
       before do
-        visit edit_system_identity_permission_path(@group['concept_id'])
-      end
-
-      it 'displays the page with the form and table of system and group management targets' do
-        expect(page).to have_content("#{@group_name} System Object Permissions")
-        expect(page).to have_content("Set permissions for the #{@group_name} group by checking the appropriate boxes below and clicking 'Submit'.")
-
-        within '.system-permissions-table' do
-          expect(page).to have_css('tbody > tr', count: (SystemIdentityPermissionsHelper::SYSTEM_TARGETS.count + 1))
-          expect(page).to have_css('input[type=checkbox]', count: 96) # all checkboxes
-          expect(page).to have_css('input[type=checkbox][checked]', count: 2)
-          expect(page).to have_css('input[type=checkbox][disabled]', count: 56)
-          expect(page).to have_css('input[type=checkbox]:not([disabled])', count: 40)
-          expect(page).to have_css('input[type=checkbox]:not([checked])', count: 94)
-
-          expect(page).to have_content("Group Management for [#{@managed_group_name}]")
-        end
-      end
-
-      it 'displays the checked single instance identity group management permissions' do
-        expect(page).to have_checked_field("group_management_#{@managed_group['concept_id']}_", with: 'update')
-        expect(page).to have_checked_field("group_management_#{@managed_group['concept_id']}_", with: 'delete')
-      end
-    end
-
-    context 'when visiting the system identities form for the System Group that does not manage another group' do
-      before do
-        visit edit_system_identity_permission_path(@managed_group['concept_id'])
+        visit edit_system_identity_permission_path(concept_id)
       end
 
       it 'displays the form and table of system targets' do
-        expect(page).to have_content("#{@managed_group_name} System Object Permissions")
-        expect(page).to have_content("Set permissions for the #{@managed_group_name} group by checking the appropriate boxes below and clicking 'Submit'.")
+        expect(page).to have_content('Administrators_2 System Object Permissions')
+        expect(page).to have_content("Set permissions for the Administrators_2 group by checking the appropriate boxes below and clicking 'Submit'.")
 
         within '.system-permissions-table' do
           expect(page).to have_css('tbody > tr', count: SystemIdentityPermissionsHelper::SYSTEM_TARGETS.count)
           expect(page).to have_css('input[type=checkbox]', count: 92) # all checkboxes
-          expect(page).to have_css('input[type=checkbox][checked]', count: 0)
+          expect(page).to have_css('input[type=checkbox][checked]', count: 6) # Administrators_2 should have ANY_ACL and GROUP permissions
           expect(page).to have_css('input[type=checkbox][disabled]', count: 54)
           expect(page).to have_css('input[type=checkbox]:not([disabled])', count: 38)
-          expect(page).to have_css('input[type=checkbox]:not([checked])', count: 92)
+          expect(page).to have_css('input[type=checkbox]:not([checked])', count: 86)
 
           expect(page).to have_no_content('Group Management for')
         end

--- a/spec/support/group_helper.rb
+++ b/spec/support/group_helper.rb
@@ -1,6 +1,6 @@
 module Helpers
   module GroupHelper
-    def create_group(provider_id: 'MMT_2', name: random_group_name, description: random_group_description, management_group: 'AG1200000001-CMR', members: [], admin: false)
+    def create_group(provider_id: 'MMT_2', name: random_group_name, description: random_group_description, members: [], admin: false)
       ActiveSupport::Notifications.instrument 'mmt.performance', activity: 'Helpers::GroupHelper#create_group' do
         group_params = {
           'name'        => name,
@@ -15,24 +15,6 @@ module Helpers
         group_response = cmr_client.create_group(group_params, admin ? 'access_token_admin' : 'access_token')
 
         raise Array.wrap(group_response.body['errors']).join(' /// ') if group_response.body.key?('errors')
-
-        concept_id = group_response.body['concept_id']
-
-        single_instance_identity_object = {
-          'group_permissions' => [{
-            'group_id' => management_group, # default management group is Administrators_2 created on setup cmr
-            'permissions' => %w(update delete)
-          }],
-          'single_instance_identity' => {
-            'target' => 'GROUP_MANAGEMENT',
-            'target_id' => concept_id
-          }
-        }
-
-        # create the single_instance_identity acl for the initial management group for the group
-        management_group_response = cmr_client.add_group_permissions(single_instance_identity_object, admin ? 'access_token_admin' : 'access_token')
-
-        raise Array.wrap(management_group_response.body['errors']).join(' /// ') if management_group_response.body.key?('errors')
 
         wait_for_cmr
 


### PR DESCRIPTION
…ler methods. remove 'Group Management for...' in provider and system identity permissions tables. remove tests, coffeescript, helper, etc references to management groups or single instance acls