### PR TITLE
MMT-875: Add bulk updates listings to Manage Metadata 'dashboard'

### DIFF
--- a/app/concerns/bulk_updates.rb
+++ b/app/concerns/bulk_updates.rb
@@ -1,0 +1,17 @@
+# :nodoc:
+module BulkUpdates
+  extend ActiveSupport::Concern
+
+  def retrieve_bulk_updates
+    bulk_updates_list_response = cmr_client.get_bulk_updates(current_user.provider_id, token)
+
+    bulk_updates = if bulk_updates_list_response.success?
+                     bulk_updates_list_response.body.fetch('tasks', [])
+                   else
+                     Rails.logger.error("Error retrieving Bulk Updates Jobs List: #{bulk_updates_list_response.inspect}")
+                     []
+                   end
+
+    bulk_updates
+  end
+end

--- a/app/controllers/bulk_updates_controller.rb
+++ b/app/controllers/bulk_updates_controller.rb
@@ -5,15 +5,7 @@ class BulkUpdatesController < ManageMetadataController
   add_breadcrumb 'Bulk Updates', :bulk_updates_path
 
   def index
-    @tasks = []
-
-    bulk_updates_list_response = cmr_client.get_bulk_updates(current_user.provider_id, token)
-
-    if bulk_updates_list_response.success?
-      @tasks = bulk_updates_list_response.body.fetch('tasks', [])
-    else
-      Rails.logger.error("Error retrieving Bulk Updates Jobs List: #{bulk_updates_list_response.inspect}")
-    end
+    @tasks = retrieve_bulk_updates
   end
 
   def show

--- a/app/controllers/manage_metadata_controller.rb
+++ b/app/controllers/manage_metadata_controller.rb
@@ -1,15 +1,21 @@
 # :nodoc:
 class ManageMetadataController < PagesController
+  include BulkUpdates
+
   before_filter :set_notifications
 
   layout 'manage_metadata'
 
   def show
-    # If you change this number you must also change it in the corresponding test file - features/drafts/open_drafts_spec.rb.
+    # If you change this number you must also change it in the corresponding test file - features/manage_metadata/open_drafts_spec.rb.
     @draft_display_max_count = 5
 
     @drafts = current_user.drafts.where(provider_id: current_user.provider_id)
                           .order('updated_at DESC')
                           .limit(@draft_display_max_count + 1)
+
+    # with the dummy data response, we can't currently limit the number of responses, but we
+    # should do so when it is available and try to sort by most recent as well
+    @bulk_updates = retrieve_bulk_updates.take(@draft_display_max_count + 1)
   end
 end

--- a/app/views/manage_metadata/show.html.erb
+++ b/app/views/manage_metadata/show.html.erb
@@ -71,14 +71,36 @@
     <% if Rails.configuration.bulk_updates_enabled %>
       <section class="eui-callout-box col-left">
         <h3 class="eui-callout-box__title">Your Bulk Updates</h3>
-        <div class="eui-callout-box__list">
+        <div class="eui-callout-box__list bulk-update-callout">
           <div class="question-group">
             <div class="row">
-              <%= link_to 'Bulk Updates', bulk_updates_path %>
+              <ul>
+                <% if @bulk_updates.blank? %>
+                  <%= current_user.provider_id %> has no bulk updates to display.
+                <% else %>
+                  <% @bulk_updates[0..@draft_display_max_count].each do |bulk_update| %>
+                    <li>
+                      <p>
+                        <%= link_to bulk_update['task-id'], bulk_update_path(bulk_update['task-id']) %> |
+                        <%= bulk_update['status'] %>
+                      </p>
+                    </li>
+                  <% end %>
+                  <!-- because of the fixed response, this conditional is disabled to
+                        access the link, and should be enabled when the responses are using real data -->
+                  <%# if @bulk_updates.size > @draft_display_max_count %>
+                    <li>
+                      <%= link_to 'More', bulk_updates_path %>
+                    </li>
+                  <%# end %>
+                <% end %>
+              </ul>
             </div>
           </div>
 
-          <%= link_to 'Initiate a Bulk Update', new_bulk_updates_search_path, class: 'eui-btn--blue space-top' %>
+          <div class="row">
+            <%= link_to 'Initiate a Bulk Update', new_bulk_updates_search_path, class: 'eui-btn--blue space-top' %>
+          </div>
         </div>
       </section>
     <% end %>

--- a/app/views/manage_metadata/show.html.erb
+++ b/app/views/manage_metadata/show.html.erb
@@ -70,7 +70,7 @@
 
     <% if Rails.configuration.bulk_updates_enabled %>
       <section class="eui-callout-box col-left">
-        <h3 class="eui-callout-box__title">Your Bulk Updates</h3>
+        <h3 class="eui-callout-box__title">Your <%= current_user.provider_id %> Bulk Updates</h3>
         <div class="eui-callout-box__list bulk-update-callout">
           <div class="question-group">
             <div class="row">

--- a/lib/test_cmr/test_data.json
+++ b/lib/test_cmr/test_data.json
@@ -170,7 +170,7 @@
   "granule": null
 }, {
   // 35
-  "collection": "https://cmr.earthdata.nasa.gov:443/search/concepts/C1000000300-LARC/13.echo10",
+  "collection": "https://cmr.earthdata.nasa.gov:443/search/concepts/C43677707-LARC/24.echo10",
   "ingest_count": 1,
   "granule": null
 }, {
@@ -195,7 +195,7 @@
   "granule": null
 }, {
   // 40
-  "collection": "https://cmr.earthdata.nasa.gov:443/search/concepts/C1000000282-LARC/13.echo10",
+  "collection": "https://cmr.earthdata.nasa.gov:443/search/concepts/C66215277-LARC/24.echo10",
   "ingest_count": 1,
   "granule": null
 }, {
@@ -205,7 +205,7 @@
   "granule": null
 }, {
   // 42
-  "collection": "https://cmr.earthdata.nasa.gov:443/search/concepts/C1000000283-LARC/13.echo10",
+  "collection": "https://cmr.earthdata.nasa.gov:443/search/concepts/C73016614-LARC/23.echo10",
   "ingest_count": 1,
   "granule": null
 }, {

--- a/spec/controllers/bulk_updates_controller_spec.rb
+++ b/spec/controllers/bulk_updates_controller_spec.rb
@@ -60,15 +60,15 @@ describe BulkUpdatesController, reset_provider: true do
 
         # this is what we need to test against because of the response dummy data
         expect(assigns(:task)).to eq(
-        {
-          'status' => 200,
-          'task-status' => 'COMPLETE',
-          'status-message' => 'The bulk update completed with 2 errors',
-          'collection-statuses' => [
-            { 'concept-id' => 'C1-PROV','status-message' => 'Missing required properties' },
-            {'concept-id' => 'C2-PROV','status-message' => 'Invalid XML' }
-          ]
-        }
+          {
+            'status' => 200,
+            'task-status' => 'COMPLETE',
+            'status-message' => 'The bulk update completed with 2 errors',
+            'collection-statuses' => [
+              { 'concept-id' => 'C1-PROV', 'status-message' => 'Missing required properties' },
+              { 'concept-id' => 'C2-PROV', 'status-message' => 'Invalid XML' }
+            ]
+          }
         )
       end
     end

--- a/spec/controllers/manage_metadata_controller_spec.rb
+++ b/spec/controllers/manage_metadata_controller_spec.rb
@@ -2,12 +2,36 @@ require 'rails_helper'
 
 describe ManageMetadataController do
   describe 'GET #show' do
-    it 'renders the #show view' do
+    before do
       sign_in
 
       get :show
 
+    end
+
+    it 'renders the #show view' do
       expect(response).to render_template(:show)
+    end
+
+    it 'sets the drafts size limit instance variable' do
+      expect(assigns(:draft_display_max_count)).to eq(5)
+    end
+
+    it 'sets the drafts instance variable' do
+      expect(assigns(:drafts)).to eq([])
+    end
+
+    it 'sets the bulk updates instance variable' do
+      # expect(assigns(:bulk_updates)).to eq([]) # this should be the test when the dummy response data is removed
+
+      # this is what we need to test against because of the response dummy data
+      expect(assigns(:bulk_updates)).to eq(
+        [
+          { 'task-id' => 'ABCDEF123', 'status' => 'IN_PROGRESS' },
+          { 'task-id' => '12345678', 'status' => 'COMPLETE' },
+          { 'task-id' => 'XYZ123456', 'status' => 'COMPLETE' }
+        ]
+      )
     end
   end
 end

--- a/spec/features/manage_metadata/bulk_updates_list_spec.rb
+++ b/spec/features/manage_metadata/bulk_updates_list_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe 'Bulk Updates callout box on the Manage Metadata page' do
+  draft_display_max_count = 5 # Should agree with @draft_display_max_count found in manage_metadata_controller
+
+  before do
+    login
+
+    visit manage_metadata_path
+  end
+
+  context 'when there are bulk updates' do
+    it 'displays the bulk updates' do
+      expect(page).to have_content('ABCDEF123 | IN_PROGRESS')
+      expect(page).to have_content('12345678 | COMPLETE')
+      expect(page).to have_content('12345678 | COMPLETE')
+    end
+
+    context "when more than #{draft_display_max_count} bulk updates exist" do
+      it 'displays the "More" link for bulk updates' do
+        within '.bulk-update-callout' do
+          expect(page).to have_link('More')
+        end
+      end
+
+      context 'when clicking on the "More" link for bulk updates' do
+        before do
+          within '.bulk-update-callout' do
+            click_on 'More'
+          end
+        end
+
+        it 'displays the Bulk Updates Index page' do
+          expect(page).to have_content('MMT_2 Bulk Updates')
+          expect(page).to have_css('table.bulk-updates-list-table')
+        end
+      end
+
+    end
+  end
+
+  context 'when clicking on the "Initiate a Bulk Update" button' do
+    before do
+      within '.bulk-update-callout' do
+        click_on 'Initiate a Bulk Update'
+      end
+    end
+
+    it 'displays the Bulk Update Collection Search page' do
+      expect(page).to have_content('MMT_2 Bulk Update Collection Search')
+
+      expect(page).to have_css('form#bulk-updates-search')
+    end
+  end
+
+  # We should test this scenario when the bulk updates response endpoint is functional
+  # and does not return a fixed response
+  # context 'when no bulk updates exist'
+end

--- a/spec/features/manage_metadata/open_drafts_spec.rb
+++ b/spec/features/manage_metadata/open_drafts_spec.rb
@@ -1,12 +1,11 @@
 # MMT-57
 
 require 'rails_helper'
-
-draft_display_max_count = 5 # Should agree with @draft_display_max_count found in pages_controller
-
 # Basic draft creation and retrieval via the list on the Manage Metadata page are tested in draft_creation_spec.rb
 
-describe 'Open Drafts listings' do
+describe 'Open Drafts listings on the Manage Metadata page', reset_provider: true do
+  draft_display_max_count = 5 # Should agree with @draft_display_max_count found in manage_metadata_controller
+
   before do
     login
   end
@@ -27,18 +26,18 @@ describe 'Open Drafts listings' do
         create(:draft, user_id: current_user_id)
       end
 
-      visit '/manage_metadata'
+      visit manage_metadata_path
     end
 
     it '"More" is displayed' do
       within('.open-drafts') do
-        expect(page).to have_content('More')
+        expect(page).to have_link('More')
       end
     end
 
     context 'when "More" is clicked on' do
       before do
-        within('.open-drafts') do
+        within '.open-drafts' do
           click_on 'More'
         end
       end


### PR DESCRIPTION
- add bulk updates listings to callout box on Manage Metadata 'dashboard'
- move getting bulk updates list to a concern to use in manage_metadata and bulk_updates controllers
- add controller test
- add feature test, and move drafts listing test to manage_metadata folder