### PR TITLE
MMT-938: Fix broken test of non-ASCII characters

### DIFF
--- a/lib/test_cmr/load_data.rb
+++ b/lib/test_cmr/load_data.rb
@@ -435,47 +435,39 @@ module Cmr
         collection_uri = obj[:collection]
         metadata = connection.get(collection_uri).body
         obj[:ingest_count].times do
-          if !(collection_uri.include? 'EDF_DEV06')
-            response = connection.put do |req|
-              if collection_uri.include? 'SEDAC'
-                req.url("http://localhost:3002/providers/SEDAC/collections/collection#{index}")
-              else #collection_uri.include? 'LARC'
-                req.url("http://localhost:3002/providers/LARC/collections/collection#{index}")
-              end
-              content_type = 'application/echo10+xml'
-              content_type = 'application/dif10+xml' if obj[:type] == 'dif10'
-              req.headers['Content-Type'] = content_type
-              req.headers['Echo-token'] = 'mock-echo-system-token'
-              req.body = metadata
-            end
-
-            # Ingest a granules if available
-            if obj[:granule]
-              granule_metadata = connection.get(obj[:granule].first).body
-              response = connection.put do |req|
-                req.url("http://localhost:3002/providers/LARC/granules/granule-#{index}")
-                req.headers['Content-Type'] = 'application/echo10+xml'
-                req.headers['Echo-token'] = 'mock-echo-system-token'
-                req.body = granule_metadata
-              end
-            end
-
-            if response.success?
-              added += 1
-              puts "Loaded #{added} collections"
-            else
-              puts response.inspect
-            end
-          else
-            # collection with not url friendly native id
-            encoded_bad_native_id = URI.encode('AMSR-E/Aqua & 5-Day, L3 Global Snow Water Equivalent EASE-Grids V001')
-            response = connection.put do |req|
+          response = connection.put do |req|
+            if collection_uri.include? 'EDF_DEV06'
+              # collection with not url friendly native id
+              encoded_bad_native_id = URI.encode('AMSR-E/Aqua & 5-Day, L3 Global Snow Water Equivalent EASE-Grids V001')
               req.url("http://localhost:3002/providers/LARC/collections/#{encoded_bad_native_id}")
+            elsif collection_uri.include? 'SEDAC'
+              req.url("http://localhost:3002/providers/SEDAC/collections/collection#{index}")
+            else #collection_uri.include? 'LARC'
+              req.url("http://localhost:3002/providers/LARC/collections/collection#{index}")
+            end
+            content_type = 'application/echo10+xml'
+            content_type = 'application/dif10+xml' if obj[:type] == 'dif10'
+            req.headers['Content-Type'] = content_type
+            req.headers['Echo-token'] = 'mock-echo-system-token'
+            req.body = metadata
+          end
+
+          # Ingest a granules if available
+          if obj[:granule]
+            granule_metadata = connection.get(obj[:granule].first).body
+            response = connection.put do |req|
+              req.url("http://localhost:3002/providers/LARC/granules/granule-#{index}")
               req.headers['Content-Type'] = 'application/echo10+xml'
               req.headers['Echo-token'] = 'mock-echo-system-token'
-              req.body = metadata
+              req.body = granule_metadata
             end
-            puts response.success? ? 'added collection with a not url friendly native id' : response.inspect
+          end
+
+          if response.success?
+            added += 1
+            puts "Loaded #{added} collections#{obj[:test_case]}"
+          else
+            puts response.inspect
           end
         end
       end

--- a/lib/test_cmr/test_data.json
+++ b/lib/test_cmr/test_data.json
@@ -245,23 +245,27 @@
   "granule": null
 }, {
   // 50
-  "collection": "https://cmr.sit.earthdata.nasa.gov/search/concepts/C1200060318-DEMO_PROV",
+  // non-ASCII characters collection
+  "collection": "https://cmr.sit.earthdata.nasa.gov/search/concepts/C1200233357-MMT_1/1.dif10",
   "ingest_count": 1,
   "granule": null,
-  "type": "dif10"
-}, {
-  // not url friendly native id
-  "collection": "https://cmr.sit.earthdata.nasa.gov/search/concepts/C1000000279-EDF_DEV06/5",
-  "ingest_count": 1,
-  "granule": null
+  "type": "dif10",
+  "test_case": " non-ASCII characters collection"
 }, {
   // 51
+  // not url friendly native id
+  "collection": "https://cmr.sit.earthdata.nasa.gov/search/concepts/C1000000279-EDF_DEV06/5.echo10",
+  "ingest_count": 1,
+  "granule": null,
+  "test_case": " not url friendly native id"
+}, {
+  // 52
   "collection": "https://cmr.uat.earthdata.nasa.gov/search/concepts/C1215718270-GES_DISC/6",
   "ingest_count": 1,
   "granule": null,
   "type": "dif10"
 }, {
-  // 52
+  // 53
   "collection": "https://cmr.uat.earthdata.nasa.gov/search/concepts/C1215139660-GES_DISC",
   "ingest_count": 1,
   "granule": null,


### PR DESCRIPTION
Updates collections used in test data:
- update collection ingested and used for non-ASCII characters spec
- lightly edit test data file
- lightly refactor script that ingests test data