### PR TITLE
MMT-926: prevent destructive inadvertent removal of collections from …

### DIFF
--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -49,7 +49,7 @@ $(document).ready ->
         $('#collectionsChooser_toList').rules 'add',
             required:
               depends: ->
-                if $('#collection_options').val() == 'selected-ids-collections'
+                if $('#collection_options').val() == 'selected-ids-collections' && $('#hidden_collections').length == 0
                   return true
                 return false
             messages:
@@ -59,7 +59,7 @@ $(document).ready ->
     # show the Chooser widget if a refresh of the page has "selected collections" as the dropdown value
     setTimeout ( ->
       if $('#collection_options').val() == 'selected-ids-collections'
-        $('#chooser-widget').show()
+        $('#chooser-widget').removeClass 'is-hidden'
         start_widget()
 
         if $('#collection_selections').val()? && $('#collection_selections').val().length > 0
@@ -76,14 +76,14 @@ $(document).ready ->
       collectionOptions = $(this).val()
 
       if collectionOptions == 'selected-ids-collections'
-        $('#chooser-widget').show()
+        $('#chooser-widget').removeClass 'is-hidden'
         start_widget()
         $('#collection_constraint_values').removeClass 'is-hidden'
       else if collectionOptions == 'all-collections'
-        $('#chooser-widget').hide()
+        $('#chooser-widget').addClass 'is-hidden'
         $('#collection_constraint_values').removeClass 'is-hidden'
       else
-        $('#chooser-widget').hide()
+        $('#chooser-widget').addClass 'is-hidden'
         $('#collection_constraint_values').addClass 'is-hidden'
 
     $('#granule_options').on 'change', ->

--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -49,7 +49,7 @@ $(document).ready ->
         $('#collectionsChooser_toList').rules 'add',
             required:
               depends: ->
-                if $('#collection_options').val() == 'selected-ids-collections' && $('#hidden_collections').length == 0
+                if $('#collection_options').val() == 'selected-ids-collections' && $('.hidden-collection').length == 0
                   return true
                 return false
             messages:

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -171,6 +171,7 @@ class PermissionsController < ManageCmrController
 
         @collection_options = params[:collection_options]
         @collection_selections = params[:collection_selections]
+        @hidden_entry_titles = params[:hidden_collections]
         @granule_options = params[:granule_options]
 
         @collection_access_value = params[:collection_access_value] || {}
@@ -354,9 +355,7 @@ class PermissionsController < ManageCmrController
       end
 
       collection_identifier['entry_titles'] = entry_titles
-      if params[:hidden_collections]
-        collection_identifier['entry_titles'] += params[:hidden_collections].split(';;; ')
-      end
+      collection_identifier['entry_titles'] += params.fetch('hidden_collections', [])
     end
 
     if collection_applicable

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -62,8 +62,9 @@ class SearchController < ApplicationController
     unless query['keyword'] && query['keyword'].empty?
       query['keyword'] = query['keyword'].strip.gsub(/\s+/, '* ') + '*'
     end
-    
-    collections = cmr_client.get_collections(query, token).body
+
+    collections = cmr_client.get_collections_by_post(query, token).body
+
     hits = collections['hits'].to_i
     if collections['errors']
       errors = collections['errors']

--- a/app/views/order_policies/_form.html.erb
+++ b/app/views/order_policies/_form.html.erb
@@ -52,9 +52,9 @@
 
   <!-- Hidden fields that represent the underlying array of selected collections -->
   <% Array.wrap(@policy.fetch('CollectionsSupportingDuplicateOrderItems', [])).each do |collection| %>
-  <%= hidden_field_tag('collections_supporting_duplicate_order_items[]', collection, class: 'selected-collection') %>
+    <%= hidden_field_tag('collections_supporting_duplicate_order_items[]', collection, class: 'selected-collection') %>
   <% end %>
-  
+
   <div id="order-policies-chooser-widget"></div>
 
   <div class="row">

--- a/app/views/permissions/_form.html.erb
+++ b/app/views/permissions/_form.html.erb
@@ -13,8 +13,8 @@
   <%= hidden_field_tag 'collection_selections', @collection_selections %>
   <div id="chooser-widget" class="is-hidden"></div>
 
-  <% unless @hidden_entry_titles.blank? %>
-    <%= hidden_field_tag('hidden_collections', @hidden_entry_titles.join(';;; ')) %>
+  <% Array.wrap(@hidden_entry_titles).each do |entry_title| %>
+    <%= hidden_field_tag('hidden_collections[]', entry_title, class: 'hidden-collection') %>
   <% end %>
 </fieldset>
 

--- a/app/views/permissions/_form.html.erb
+++ b/app/views/permissions/_form.html.erb
@@ -11,7 +11,11 @@
   <%= label_tag 'collection_options', 'Collections', class: 'required eui-required-o' %>
   <%= select_tag 'collection_options', options_for_select(PermissionsHelper::CollectionsOptions, @collection_options), class: 'full-width', prompt: '-- Select an Option --' %>
   <%= hidden_field_tag 'collection_selections', @collection_selections %>
-  <div id="chooser-widget" class="is_hidden"></div>
+  <div id="chooser-widget" class="is-hidden"></div>
+
+  <% unless @hidden_entry_titles.blank? %>
+    <%= hidden_field_tag('hidden_collections', @hidden_entry_titles.join(';;; ')) %>
+  <% end %>
 </fieldset>
 
 <fieldset id="collection_constraint_values" class="<%= hide_access_constraint_values?(@collection_options) %>">

--- a/app/views/permissions/_hidden_collections_notification.html.erb
+++ b/app/views/permissions/_hidden_collections_notification.html.erb
@@ -1,0 +1,7 @@
+<% unless @hidden_entry_titles.blank? %>
+  <div class="eui-banner--info">
+    <p class="eui-banner__message">
+      There are selected collections not shown because you do not have acccess.
+    </p>
+  </div>
+<% end %>

--- a/app/views/permissions/_hidden_collections_notification.html.erb
+++ b/app/views/permissions/_hidden_collections_notification.html.erb
@@ -1,7 +1,0 @@
-<% unless @hidden_entry_titles.blank? %>
-  <div class="eui-banner--info">
-    <p class="eui-banner__message">
-      There are selected collections not shown because you do not have acccess.
-    </p>
-  </div>
-<% end %>

--- a/app/views/permissions/edit.html.erb
+++ b/app/views/permissions/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render 'hidden_collections_notification' %>
+
 <div class="row row-content">
   <section>
     <h2>Edit <%= @permission_name %></h2>

--- a/app/views/permissions/edit.html.erb
+++ b/app/views/permissions/edit.html.erb
@@ -1,5 +1,3 @@
-<%= render 'hidden_collections_notification' %>
-
 <div class="row row-content">
   <section>
     <h2>Edit <%= @permission_name %></h2>

--- a/app/views/permissions/show.html.erb
+++ b/app/views/permissions/show.html.erb
@@ -1,3 +1,5 @@
+<%= render 'hidden_collections_notification' %>
+
 <div class="row row-content">
   <section>
     <h2><%= @permission_name %></h2>
@@ -8,7 +10,7 @@
     <p>
       <b>Collections |
         <% if @collection_options %>
-          <%= @collection_entry_ids.blank? ? 'All Collections' : "#{@collection_entry_ids.count} Selected Collections" %>
+          <%= @collection_entry_ids.blank? && @hidden_entry_titles.blank? ? 'All Collections' : "#{@collection_entry_ids.count + @hidden_entry_titles.count} Selected Collections" %>
         <% else %>
           No Access to Collections
         <% end %>

--- a/app/views/permissions/show.html.erb
+++ b/app/views/permissions/show.html.erb
@@ -1,5 +1,3 @@
-<%= render 'hidden_collections_notification' %>
-
 <div class="row row-content">
   <section>
     <h2><%= @permission_name %></h2>
@@ -10,7 +8,7 @@
     <p>
       <b>Collections |
         <% if @collection_options %>
-          <%= @collection_entry_ids.blank? && @hidden_entry_titles.blank? ? 'All Collections' : "#{@collection_entry_ids.count + @hidden_entry_titles.count} Selected Collections" %>
+          <%= @collection_entry_ids.blank? && @hidden_entry_titles.blank? ? 'All Collections' : "#{@collection_entry_ids.count} Selected Collections" %>
         <% else %>
           No Access to Collections
         <% end %>

--- a/lib/test_cmr/test_data.json
+++ b/lib/test_cmr/test_data.json
@@ -270,4 +270,19 @@
   "ingest_count": 1,
   "granule": null,
   "type": "dif10"
+}, {
+  // 54
+  "collection": "https://cmr.earthdata.nasa.gov/search/concepts/C1000000560-NSIDC_ECS/75",
+  "ingest_count": 1,
+  "granule": null
+}, {
+  // 55
+  "collection": "https://cmr.earthdata.nasa.gov/search/concepts/C184437554-NSIDC_ECS/75",
+  "ingest_count": 1,
+  "granule": null
+}, {
+  // 56
+  "collection": "https://cmr.earthdata.nasa.gov/search/concepts/C115003861-NSIDC_ECS/76",
+  "ingest_count": 1,
+  "granule": null
 }]

--- a/spec/features/permissions/updating_permission_with_restricted_collections_spec.rb
+++ b/spec/features/permissions/updating_permission_with_restricted_collections_spec.rb
@@ -4,7 +4,7 @@
 
 require 'rails_helper'
 
-describe 'Updating Collection Permissions when collections are not accessible by the user', js: true do
+describe 'Updating Collection Permissions when collections are not accessible by the user' do
   # this collection should be visible to all Registered users
   let(:entry_title_visible_to_all) { 'Near-Real-Time SSMIS EASE-Grid Daily Global Ice Concentration and Snow Extent V004' }
   let(:entry_id_visible_to_all) { 'NISE_4' }
@@ -77,7 +77,7 @@ describe 'Updating Collection Permissions when collections are not accessible by
       User.first.update(provider_id: 'NSIDC_ECS')
     end
 
-    context 'when updating a collection permission and the user has no access to any of the selected collections' do
+    context 'when updating a collection permission and the user has no access to any of the selected collections', js: true do
       before do
         visit edit_permission_path(@collection_permission_all_restricted['concept_id'])
       end
@@ -108,17 +108,9 @@ describe 'Updating Collection Permissions when collections are not accessible by
         end
       end
 
-      it 'displays a notification that there are undisplayed collections' do
-        expect(page).to have_css('.eui-banner--info', text: 'There are selected collections not shown because you do not have acccess.')
-      end
-
       context 'when updating the collection permission with no changes' do
         before do
           click_on 'Submit'
-        end
-
-        it 'displays a notification that there are undisplayed collections' do
-          expect(page).to have_css('.eui-banner--info', text: 'There are selected collections not shown because you do not have acccess.')
         end
 
         it 'successfully updates the collection permission without a validation error and redirects to the show page and displaying the collection permission information with 0 of 2 selected collections' do
@@ -128,7 +120,7 @@ describe 'Updating Collection Permissions when collections are not accessible by
 
           expect(page).to have_content(@collection_permission_all_restricted_name)
 
-          expect(page).to have_content('Collections | 2 Selected Collections')
+          expect(page).to have_content('Collections | 0 Selected Collections')
 
           # we should not see the entry ids of selected collections in the collection permission
           expect(page).to have_no_content(restricted_entry_id_1)
@@ -152,13 +144,11 @@ describe 'Updating Collection Permissions when collections are not accessible by
           end
 
           it 'successfully updates the collection permission and redirects to the show page and displaying the collection permission information with 1 of 3 collections' do
-            expect(page).to have_css('.eui-banner--info', text: 'There are selected collections not shown because you do not have acccess.')
-
             expect(page).to have_content('Collection Permission was successfully updated.')
 
             expect(page).to have_content(@collection_permission_all_restricted_name)
 
-            expect(page).to have_content('Collections | 3 Selected Collections')
+            expect(page).to have_content('Collections | 1 Selected Collections')
             # new entry id that we expect to see
             expect(page).to have_content(entry_id_visible_to_all)
 
@@ -176,7 +166,7 @@ describe 'Updating Collection Permissions when collections are not accessible by
       end
     end
 
-    context 'when updating a collection permission and the user has access to some of the selected collections' do
+    context 'when updating a collection permission and the user has access to some of the selected collections', js: true do
       before do
         visit edit_permission_path(@collection_permission_some_restricted['concept_id'])
       end
@@ -207,17 +197,9 @@ describe 'Updating Collection Permissions when collections are not accessible by
         end
       end
 
-      it 'displays a notification that there are undisplayed collections' do
-        expect(page).to have_css('.eui-banner--info', text: 'There are selected collections not shown because you do not have acccess.')
-      end
-
       context 'when updating the collection permission with no changes' do
         before do
           click_on 'Submit'
-        end
-
-        it 'displays a notification that there are undisplayed collections' do
-          expect(page).to have_css('.eui-banner--info', text: 'There are selected collections not shown because you do not have acccess.')
         end
 
         it 'successfully updates the collection permission and redirects to the show page and displaying the collection permission information with 1 of 3 selected collections' do
@@ -225,7 +207,7 @@ describe 'Updating Collection Permissions when collections are not accessible by
 
           expect(page).to have_content(@collection_permission_some_restricted_name)
 
-          expect(page).to have_content('Collections | 3 Selected Collections')
+          expect(page).to have_content('Collections | 1 Selected Collections')
           # entry id that we expect to see
           expect(page).to have_content(entry_id_visible_to_all)
 
@@ -250,7 +232,7 @@ describe 'Updating Collection Permissions when collections are not accessible by
       User.first.update(provider_id: 'NSIDC_ECS')
     end
 
-    context 'when viewing the edit form of the collection permission that has some restricted collections' do
+    context 'when viewing the edit form of the collection permission that has some restricted collections', js: true do
       before do
         visit edit_permission_path(@collection_permission_some_restricted['concept_id'])
       end
@@ -276,19 +258,11 @@ describe 'Updating Collection Permissions when collections are not accessible by
           expect(page).to have_css('li.select2-selection__choice', text: 'All Registered Users')
         end
       end
-
-      it 'does not display a notification that there are undisplayed collections' do
-        expect(page).to have_no_css('.eui-banner--info', text: 'There are selected collections not shown because you do not have acccess.')
-      end
     end
 
     context 'when viewing the show page of the collection permission that has some restricted collections' do
       before do
         visit permission_path(@collection_permission_some_restricted['concept_id'])
-      end
-
-      it 'does not display a notification that there are undisplayed collections' do
-        expect(page).to have_no_css('.eui-banner--info', text: 'There are selected collections not shown because you do not have acccess.')
       end
 
       it 'displays the collection permission information with 3 of 3 selected collections' do

--- a/spec/features/permissions/updating_permission_with_restricted_collections_spec.rb
+++ b/spec/features/permissions/updating_permission_with_restricted_collections_spec.rb
@@ -68,8 +68,6 @@ describe 'Updating Collection Permissions when collections are not accessible by
     wait_for_cmr
   end
 
-  # need to delete?
-
   context 'when logging in as a user that has restricted access to the provider collections' do
     before do
       login


### PR DESCRIPTION
…collection permissions upon update, when user does not have access to see the collection.

- keep collections that are not retrieved by search, and make sure they are passed to update call
- add notification when there are collections not shown for collection permissions
- add collections to ingest for provider to use in tests
- add ACLs in cmr setup to create scenario to test when user may not have access to all collections in a collection permission
- add tests