### PR TITLE
MMT-837, MMT-940, MMT-941, MMT-942: Collection Permission Updates

### DIFF
--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -9,7 +9,7 @@ handleCollectionOptions = (selectedCollections) ->
   $('#chooser-widget :input').attr('disabled', !selectedCollections)
   
   if selectedCollections
-    $('#chooser-widget').removeClass('is_hidden').fadeIn(100)
+    $('#chooser-widget').fadeIn(100)
   else
     $('#chooser-widget').fadeOut(100)
 
@@ -18,8 +18,6 @@ $(document).ready ->
     widgets: ['zebra', 'filter']
     headers:
       2:
-        sorter: 'text'
-      3:
         sorter: 'text'
 
   # 'Toggle Collection Highlighting' button functionality for the
@@ -32,11 +30,8 @@ $(document).ready ->
     $.each $('#permission-collection-list').find('td.access-constraint'), (index, element) ->
       constraintValue = parseFloat($(element).html())
 
-      # If the minimum and maximum are the same, and the value matches
-      if (constraintMinimum == constraintMaximum && constraintValue == constraintMinimum) ||
-
-          # If the minimum and maximum are not the same but the value is in between them
-          (constraintValue >= constraintMinimum & constraintValue <= constraintMaximum) ||
+      # If the minimum and maximum are the same or are between the min and max values
+      if (constraintValue >= constraintMinimum && constraintValue <= constraintMaximum) ||
 
           # If including undefined values and value is undefined
           (includeUndefinedValue && isNaN(constraintValue))
@@ -64,7 +59,6 @@ $(document).ready ->
         toLabel: 'Selected Collections',
         uniqueMsg: 'Collection already added',
         attachTo: $('#collection_selections'),
-        delimiter: "%%__%%",
         addButton: {
           cssClass: 'eui-btn nowrap',
           arrowCssClass: 'fa fa-plus',
@@ -124,12 +118,6 @@ $(document).ready ->
       $('#' + $(this).data('container') + ' :checkbox').attr('checked', false)
       
       event.preventDefault()
-
-    $('#granule_options').on 'change', ->
-      if $(this).val() == 'all-granules'
-        $('#granule_constraint_values').removeClass 'is-hidden'
-      else
-        $('#granule_constraint_values').addClass 'is-hidden'
 
     # add or remove required icons for access value min and max fields if at least one has an input value
     $('.min-max-value').on 'blur', ->
@@ -244,7 +232,7 @@ $(document).ready ->
     $.validator.addMethod 'greaterThanOrEqual', (value, elem, arg) ->
       # the built in max and min methods didn't seem to work with the depends
       # condition or possibly with comparing values dynamically, so here we
-      # are defining our own method to ensure the Max is greater than the Min
+      # are defining our own method to ensure the Max is greater than or equal to the Min
       $minInput = arg
       minimum = arg.val()
 

--- a/app/assets/stylesheets/components/_tables.scss
+++ b/app/assets/stylesheets/components/_tables.scss
@@ -24,6 +24,15 @@ table {
   th[colspan] {
     text-align: center;
   }
+
+  th {
+    white-space: nowrap;
+  }
+
+  tr.selected {
+    border-left: 3px solid $ocean-blue;
+    font-weight: bold;
+  }
 }
 
 .cell-primary-cta {

--- a/app/concerns/chooser_endpoints.rb
+++ b/app/concerns/chooser_endpoints.rb
@@ -3,6 +3,24 @@
 module ChooserEndpoints
   extend ActiveSupport::Concern
 
+  def render_collections_by_entry_title_for_chooser(collections)
+    # The chooser expects an array of arrays, so that's what we'll give it
+    items = collections.fetch('items', [])
+
+    render json: {
+      'hits': collections.fetch('hits', 0),
+      'items': items.map do |collection|
+        [
+          collection.fetch('umm', {}).fetch('entry-title'),
+          [
+            collection.fetch('umm', {}).fetch('entry-id'),
+            collection.fetch('umm', {}).fetch('entry-title')
+          ].join(' | ')
+        ]
+      end
+    }
+  end
+
   def render_collections_for_chooser(collections)
     # The chooser expects an array of arrays, so that's what we'll give it
     items = collections.fetch('items', [])

--- a/app/controllers/manage_cmr_controller.rb
+++ b/app/controllers/manage_cmr_controller.rb
@@ -19,6 +19,15 @@ class ManageCmrController < PagesController
 
   def show; end
 
+  # JSON representation of the get_entry_title_collections_collections method for use with the Chooser
+  def entry_title_collections(options = {})
+    collections = get_provider_collections(params.merge(options).permit(:provider, :keyword, :page_size, :page_num, :short_name, entry_title: []))
+
+    render_collections_by_entry_title_for_chooser(collections)
+  rescue
+    collections
+  end
+
   # JSON representation of the get_provider_collections method for use with the Chooser
   def provider_collections(options = {})
     collections = get_provider_collections(params.merge(options).permit(:provider, :keyword, :page_size, :page_num, :short_name, concept_id: []))

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -301,7 +301,7 @@ class PermissionsController < ManageCmrController
     req_obj
   end
 
-  # Groups can refer to actual groups or the user type `Guest Users` and `Registers Users`
+  # Groups can refer to actual groups or the user type `Guest Users` and `Registered Users`
   # so we need to ensure that we distinguish between the two. When using the pseudo
   # groups mentioned the key for the group permission is `user_type` vs the
   # standard `group_id`

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -3,7 +3,7 @@ class PermissionsController < ManageCmrController
   include PermissionManagement
   include GroupsHelper
 
-  skip_before_filter :is_logged_in, only: [:get_all_collections]
+  before_filter :groups_for_permissions, only: [:new, :edit, :update, :create]
 
   add_breadcrumb 'Collection Permissions', :permissions_path
 
@@ -14,17 +14,17 @@ class PermissionsController < ManageCmrController
     page = params.fetch('page', 1)
 
     @opts = {
-      'provider' => current_user.provider_id,
-      'page_num' => page,
-      'page_size' => RESULTS_PER_PAGE,
-      'identity_type' => 'catalog_item',
+      'provider'         => current_user.provider_id,
+      'page_num'         => page,
+      'page_size'        => RESULTS_PER_PAGE,
+      'identity_type'    => 'catalog_item',
       'include_full_acl' => true
     }
 
     permissions_response = cmr_client.get_permissions(@opts, token)
 
     @permissions = if permissions_response.success?
-                     construct_permissions_summaries(permissions_response.body['items'])
+                     permissions_response.body['items']
                    else
                      []
                    end
@@ -33,69 +33,37 @@ class PermissionsController < ManageCmrController
   end
 
   def show
+    @permission = {}
     @permission_concept_id = params[:id]
-    @search_and_order_groups = []
-    @search_groups = []
 
     permission_response = cmr_client.get_permission(@permission_concept_id, token)
 
     if permission_response.success?
-      permission = permission_response.body
+      @permission = permission_response.body
 
-      # sets @permission_name, @collection_options, @granule_options, @collection_entry_ids,
-      # @permission_provider, @collection_access_value, and @granule_access_value
-      set_catalog_item_identity(permission)
+      hydrate_groups(@permission)
 
-      add_breadcrumb @permission_name, permissions_path(@permission_concept_id)
-
-      # separate search_groups and search_and_order_groups from acl group_permissions
-      search_groups_list, search_and_order_groups_list, hidden_search_groups, hidden_search_and_order_groups = parse_group_permission_ids(permission['group_permissions'])
-
-      @permission_type = 'Search' unless search_groups_list.blank? && hidden_search_groups.blank?
-      @permission_type = 'Search & Order' unless search_and_order_groups_list.blank? && hidden_search_and_order_groups.blank?
-
-      group_retrieval_error_messages = []
-
-      search_and_order_groups_list.each do |search_and_order_group_id|
-        search_and_order_group, error_message = construct_permission_group_for_show(search_and_order_group_id)
-
-        @search_and_order_groups << search_and_order_group if search_and_order_group
-        group_retrieval_error_messages << error_message if error_message
-      end
-
-      search_groups_list.each do |search_group_id|
-        search_group, error_message = construct_permission_group_for_show(search_group_id)
-
-        @search_groups << search_group if search_group
-        group_retrieval_error_messages << error_message if error_message
-      end
-
-      flash[:error] = group_retrieval_error_messages.join('; ') if group_retrieval_error_messages.length > 0
+      add_breadcrumb @permission.fetch('catalog_item_identity', {})['name'], permission_path(@permission_concept_id)
     else
       Rails.logger.error("Error retrieving a permission: #{permission_response.inspect}")
-      error = Array.wrap(permission_response.body['errors'])[0]
-      flash[:error] = error.capitalize
     end
   end
 
   def new
-    @collection_access_value = {}
-    @granule_access_value = {}
-    @groups = get_groups_for_permissions # check comments in methods. want to try and consolidate what is used for other controllers
+    @permission = {}
 
     add_breadcrumb 'New', new_permissions_path
   end
 
   def create
-    request_object = construct_request_object(current_user.provider_id)
-    response = cmr_client.add_group_permissions(request_object, token)
+    @permission = construct_request_object(current_user.provider_id)
+
+    response = cmr_client.add_group_permissions(@permission, token)
 
     if response.success?
-      flash[:success] = 'Collection Permission was successfully created.'
       Rails.logger.info("#{current_user.urs_uid} CREATED catalog item ACL (Collection Permission) for #{current_user.provider_id}. #{response.body}")
 
-      concept_id = response.body['concept_id']
-      redirect_to permission_path(concept_id)
+      redirect_to permission_path(response.body['concept_id']), flash: { success: 'Collection Permission was successfully created.' }
     else
       Rails.logger.error("Collection Permission Creation Error: #{response.inspect}")
 
@@ -104,84 +72,53 @@ class PermissionsController < ManageCmrController
       permission_creation_error = PermissionsHelper::ErrorCodeMessages[response.status]
       permission_creation_error ||= Array.wrap(response.body['errors'])[0]
 
-      flash.now[:error] = permission_creation_error.capitalize
-
-      @permission_name = params[:permission_name]
-
-      @collection_options = params[:collection_options]
-      @collection_selections = params[:collection_selections]
-      @granule_options = params[:granule_options]
-
-      @collection_access_value = params[:collection_access_value] || {}
-      @granule_access_value = params[:granule_access_value] || {}
-
-      @groups = get_groups_for_permissions
-      @search_groups = params[:search_groups]
-      @search_and_order_groups = params[:search_and_order_groups]
+      flash.now[:error] = permission_creation_error
 
       render :new
     end
   end
 
   def edit
+    @permission = {}
+
     @permission_concept_id = params[:id]
     permission_response = cmr_client.get_permission(@permission_concept_id, token)
 
     if permission_response.success?
-      permission = permission_response.body
+      @permission = permission_response.body
 
-      set_catalog_item_identity(permission)
-
-      add_breadcrumb @permission_name, permissions_path(@permission_concept_id)
+      add_breadcrumb @permission.fetch('catalog_item_identity', {})['name'], permission_path(@permission_concept_id)
       add_breadcrumb 'Edit', edit_permission_path(@permission_concept_id)
 
-      @search_groups, @search_and_order_groups, @hidden_search_groups, @hidden_search_and_order_groups = parse_group_permission_ids(permission['group_permissions'])
-      @groups = get_groups_for_permissions
+      hydrate_groups(@permission)
     else
       Rails.logger.error("Error retrieving a permission: #{permission_response.inspect}")
-      flash[:error] = Array.wrap(permission_response.body['errors'])[0].capitalize
-      redirect_to permissions_path
     end
   end
 
   def update
+    @permission = {}
     @permission_concept_id = params[:id]
     permission_provider = params[:permission_provider]
 
-    request_object = construct_request_object(permission_provider)
-    update_response = cmr_client.update_permission(request_object, @permission_concept_id, token)
+    @permission = construct_request_object(permission_provider)
+
+    update_response = cmr_client.update_permission(@permission, @permission_concept_id, token)
 
     if update_response.success?
-      flash[:success] = 'Collection Permission was successfully updated.'
       Rails.logger.info("#{current_user.urs_uid} UPDATED catalog item ACL (Collection Permission) for #{permission_provider}. #{response.body}")
 
-      redirect_to permission_path(@permission_concept_id)
+      redirect_to permission_path(@permission_concept_id), flash: { success: 'Collection Permission was successfully updated.' }
     else
+      hydrate_groups(@permission)
+
       Rails.logger.error("Collection Permission Update Error: #{update_response.inspect}")
       permission_update_error = Array.wrap(update_response.body['errors'])[0]
 
       if permission_update_error == 'Permission to update ACL is denied'
-        flash[:error] = 'You are not authorized to update permissions. Please contact your system administrator.'
-        # opt1 send back to show page
-        redirect_to permission_path(@permission_concept_id)
+        redirect_to permission_path(@permission_concept_id), flash: { error: 'You are not authorized to update permissions. Please contact your system administrator.' }
       else
-        flash[:error] = permission_update_error.capitalize
-        # opt2 parse/grab data, render edit with flash message
-        @permission_name = params[:permission_name]
-
-        @collection_options = params[:collection_options]
-        @collection_selections = params[:collection_selections]
-        @hidden_entry_titles = params[:hidden_collections]
-        @granule_options = params[:granule_options]
-
-        @collection_access_value = params[:collection_access_value] || {}
-        @granule_access_value = params[:granule_access_value] || {}
-
-        @groups = get_groups_for_permissions
-        @search_groups = params[:search_groups]
-        @search_and_order_groups = params[:search_and_order_groups]
-        @hidden_search_groups = params[:hidden_search_groups].split('; ') if params[:hidden_search_groups]
-        @hidden_search_and_order_groups = params[:hidden_search_and_order_groups].split('; ') if params[:hidden_search_and_order_groups]
+        flash[:error] = permission_update_error
 
         render :edit
       end
@@ -190,6 +127,7 @@ class PermissionsController < ManageCmrController
 
   def destroy
     response = cmr_client.delete_permission(params[:id], token)
+
     if response.success?
       flash[:success] = 'Collection Permission was successfully deleted.'
       Rails.logger.info("#{current_user.urs_uid} DELETED catalog item ACL for #{current_user.provider_id}. #{response.body}")
@@ -197,85 +135,58 @@ class PermissionsController < ManageCmrController
     else
       Rails.logger.error("Permission Deletion Error: #{response.inspect}")
       permission_deletion_error = Array.wrap(response.body['errors'])[0]
-      flash[:error] = permission_deletion_error.capitalize
+      flash[:error] = permission_deletion_error
       render :show
-    end
-  end
-
-  def get_all_collections
-    collections, @errors, hits = get_collections_for_provider(params)
-
-    @option_data = []
-    collections.each do |collection|
-      opt = [collection['umm']['entry-title'], collection['umm']['entry-id'] + ' | ' + collection['umm']['entry-title']]
-      @option_data << opt
-    end
-
-    if @errors.length > 0
-      render json: { success: false }
-    else
-      respond_to do |format|
-        format.json { render json: { hits: hits, items: @option_data } }
-      end
     end
   end
 
   private
 
-  def get_collections_for_provider(params)
-    # page_size default is 10, max is 2000
+  # Iterates through the groups associated with the provided collection
+  # and hydrates the `group` key with the group details and `is_hidden`
+  # with a boolean representing the users ability to see this group
+  def hydrate_groups(permission)
+    permission.fetch('group_permissions', []).each do |group_permission|
+      next unless group_permission.key?('group_id')
 
-    query = { 'provider' => current_user.provider_id,
-              'page_size' => 25 }
+      group_response = cmr_client.get_group(group_permission['group_id'], token)
 
-    query['keyword'] = params['entry_id'] + '*' if params.key?('entry_id')
+      hydrate_group_permissions(group_permission)
 
-    if params.key?('short_name')
-      query['short_name'] = params['short_name'].concat('*')
+      group_permission['group'] = group_response.body if group_response.success?
 
-      # In order to search with the wildcard parameter we need to tell CMR to use it
-      query['options'] = {
-        'short_name' => {
-          'pattern' => true
-        }
-      }
+      # If this user does not have access to view this group mark it for hiding
+      group_permission['is_hidden'] = true if group_permission['group_id'] =~ /(-CMR)$/ && !policy(:system_group).read?
     end
-
-    query['page_num'] = params['page_num'] if params.key?('page_num')
-
-    collections_response = cmr_client.get_collections_by_post(query, token).body
-    parse_get_collections_response(collections_response)
   end
 
-  def get_collections_by_entry_titles(entry_titles, provider_id)
-    # page_size default is 10, max is 2000
-    query = {
-      'page_size' => entry_titles.count,
-      'entry_title' => entry_titles,
-      'provider_id' => provider_id
-    }
+  def hydrate_group_permissions(group_permission)
+    # If order is given, read (search) is assumed, but this isn't always reflected in the data
+    # so we'll create that data here
+    group_permission.fetch('permissions', []) | ['read'] if group_permission.fetch('permissions', []).include?('order')
 
-    collections_response = cmr_client.get_collections_by_post(query, token)
-    parse_get_collections_response(collections_response.body)
+    # Ignore any other permissions that could be in this value from legacy data
+    group_permission['permissions'].delete_if { |permission| !%w(read order).include?(permission) }
   end
 
-  def parse_get_collections_response(response)
-    hits = response['hits'].to_i
-    errors = response.fetch('errors', [])
-    collections = response.fetch('items', [])
-
-    [collections, errors, hits]
+  # CMR requires that these values be as primitive values instead of string
+  # so we'll convert the few values we need to before sending to the API
+  def hydrate_constraint_values(constraints)
+    constraints.each do |key, val|
+      constraints[key] = if val == 'true'
+                           true
+                         else
+                           val.to_f
+                         end
+    end
   end
 
   def get_groups
-    # we need to specify page_size, otherwise the default is 10
-    # the maximum number of groups we expect from one provider and all system groups is ~40
     all_groups = []
-    groups_for_permissions_select = []
 
     filters = {
-      'provider' => current_user.provider_id,
-      'page_num' => 1,
+      'provider'  => current_user.provider_id,
+      'page_num'  => 1,
       'page_size' => 50
     }
 
@@ -302,286 +213,109 @@ class PermissionsController < ManageCmrController
       groups_response = cmr_client.get_cmr_groups(filters, token)
     end
 
-    all_groups.each do |group|
-      group['name'] += ' (SYS)' if check_if_system_group?(group, group['concept_id'])
-      group_option = [group['name'], group['concept_id']]
-      groups_for_permissions_select << group_option
-    end
-
-    groups_for_permissions_select
+    all_groups
   end
 
-  def get_groups_for_permissions
-    groups_for_permissions_select = get_groups
+  def groups_for_permissions
+    all_groups = get_groups
+
+    all_groups.each do |group|
+      group['name'] += ' (SYS)' if check_if_system_group?(group, group['concept_id'])
+    end
+
+    @groups = all_groups.map { |group| [group['name'], group['concept_id']] }
 
     # add options for registered users and guest users
-    groups_for_permissions_select.unshift(['All Registered Users', 'registered'])
-    groups_for_permissions_select.unshift(['All Guest Users', 'guest'])
-
-    groups_for_permissions_select
+    @groups.unshift(['All Registered Users', 'registered'])
+    @groups.unshift(['All Guest Users', 'guest'])
   end
 
   def construct_request_object(provider)
-    collection_applicable = if params[:collection_options] == 'all-collections' || params[:collection_options] == 'selected-ids-collections'
-                              true
-                            else # 'no-access'
-                              false
-                            end
+    collection_applicable = params[:collection_applicable] == 'true'
 
-    granule_applicable = params[:granule_options] == 'all-granules' ? true : false
+    granule_applicable = params[:granule_applicable] == 'true'
 
     req_obj = {
       'group_permissions' => [],
       'catalog_item_identity' => {
-        'name' => params[:permission_name],
-        'provider_id' => provider,
-        'granule_applicable' => granule_applicable,
+        'name'                  => params[:permission_name],
+        'provider_id'           => provider,
+        'granule_applicable'    => granule_applicable,
         'collection_applicable' => collection_applicable
       }
     }
 
-    # set collection_identifier
-    collection_identifier = req_obj.fetch('catalog_item_identity', {}).fetch('collection_identifier', {})
-    if params[:collection_options] == 'selected-ids-collections'
-      # The split character below is determined by the Chooser widget configuration. We are using this unusual
-      # delimiter because collection entry titles could contain commas.
-      raw_collection_selections = params[:collection_selections].split('%%__%%')
-      entry_titles = []
-      raw_collection_selections.each do |collection_selection|
-        # collection_selections come from widget as 'entry_id | entry_title',
-        # so we need to split them up and pass just entry title values
-        parts = collection_selection.split('|')
-        entry_titles << parts[1].strip
+    collection_access_constraints = params[:collection_access_value].delete_if { |_key, value| value.blank? }
+
+    if params.fetch(:collectionsChooser_toList, []).any? || params.fetch(:hidden_collections, []).any? || collection_access_constraints.any?
+      # Create an empty hash for the nested key that we'll populate below
+      req_obj['catalog_item_identity']['collection_identifier'] = {}
+
+      # Selected collections as well as hidden collections
+      selected_collections = params.fetch(:collectionsChooser_toList, []) + params.fetch(:hidden_collections, [])
+
+      if selected_collections.any?
+        req_obj['catalog_item_identity']['collection_identifier'] = {
+          'entry_titles' => selected_collections
+        }
       end
 
-      collection_identifier['entry_titles'] = entry_titles
-      collection_identifier['entry_titles'] += params.fetch('hidden_collections', [])
-    end
-
-    if collection_applicable
-      @collection_access_value = params[:collection_access_value] || {}
-      @collection_access_value.each do |key, val|
-        if val.blank?
-          @collection_access_value.delete(key)
-        elsif val == 'true'
-          @collection_access_value[key] = true
-        else
-          @collection_access_value[key] = val.to_f
-        end
+      if collection_access_constraints.any?
+        req_obj['catalog_item_identity']['collection_identifier']['access_value'] = hydrate_constraint_values(collection_access_constraints)
       end
-      collection_identifier['access_value'] = @collection_access_value unless @collection_access_value.blank?
-      req_obj['catalog_item_identity']['collection_identifier'] = collection_identifier unless collection_identifier.blank?
     end
 
     if granule_applicable
-      @granule_access_value = params[:granule_access_value] || {}
-      granule_identifier = req_obj.fetch('catalog_item_identity', {}).fetch('granule_identifier', {})
-      @granule_access_value.each do |key, val|
-        if val.blank?
-          @granule_access_value.delete(key)
-        elsif val == 'true'
-          @granule_access_value[key] = true
-        else
-          @granule_access_value[key] = val.to_f
-        end
+      granule_access_constraints = params[:granule_access_value].delete_if { |_key, value| value.blank? }
+
+      if granule_access_constraints.any?
+        req_obj['catalog_item_identity']['granule_identifier'] = {
+          'access_value' => hydrate_constraint_values(granule_access_constraints)
+        }
       end
-      granule_identifier['access_value'] = @granule_access_value unless @granule_access_value.blank?
-      req_obj['catalog_item_identity']['granule_identifier'] = granule_identifier unless granule_identifier.blank?
     end
 
     search_groups = params[:search_groups] || []
-    # if there are hidden groups, add them
-    hidden_search_groups = params[:hidden_search_groups].split('; ') if params[:hidden_search_groups]
-    search_groups += hidden_search_groups if hidden_search_groups
-
     search_and_order_groups = params[:search_and_order_groups] || []
-    # if there are hidden groups, add them
-    hidden_search_and_order_groups = params[:hidden_search_and_order_groups].split('; ') if params[:hidden_search_and_order_groups]
-    search_and_order_groups += hidden_search_and_order_groups if hidden_search_and_order_groups
+
+    # Append any groups with search access that the user does not have access to see
+    search_groups += params.fetch(:hidden_search_groups, [])
+
+    # Append any groups with search and order access that the user does not have access to see
+    search_and_order_groups += params.fetch(:hidden_search_and_order_groups, [])
 
     search_groups.each do |search_group|
       # we are preventing a user from selecting a group for both search AND search & order
       # if that still happens, we should only keep the group as a search_and_order_group in the ACL
       next if search_and_order_groups.include?(search_group)
 
-      req_obj['group_permissions'] << construct_request_group_permission(search_group, ['read']) # aka 'search'
+      req_obj['group_permissions'] << construct_request_group_permission(search_group, %w(read)) # aka 'search'
     end
 
     search_and_order_groups.each do |search_and_order_group|
       # PUMP allows for other permissions (Create, Update, Delete) but we don't use them
       # because those permissions are actually controlled by INGEST_MANAGEMENT_ACL
-      req_obj['group_permissions'] << construct_request_group_permission(search_and_order_group, %w(read order)) # aka 'search'
+      req_obj['group_permissions'] << construct_request_group_permission(search_and_order_group, %w(read order)) # aka 'search and order'
     end
 
     req_obj
   end
 
+  # Groups can refer to actual groups or the user type `Guest Users` and `Registers Users`
+  # so we need to ensure that we distinguish between the two. When using the pseudo
+  # groups mentioned the key for the group permission is `user_type` vs the
+  # standard `group_id`
   def construct_request_group_permission(group_id, permissions)
-    group_permission = {}
+    group_permission = {
+      'permissions' => permissions
+    }
 
-    if group_id == 'guest' || group_id == 'registered'
+    if %w(guest registered).include?(group_id)
       group_permission['user_type'] = group_id
     else
       group_permission['group_id'] = group_id
     end
 
-    group_permission['permissions'] = permissions
-
     group_permission
-  end
-
-  # create summary for Index table (Search or Search & Order)
-  def construct_permissions_summaries(permissions)
-    permissions.each do |perm|
-      is_search_perm = false
-      is_search_and_order_perm = false
-
-      group_permissions = perm['acl']['group_permissions']
-      group_permissions.each do |group_perm|
-        perm_list = group_perm['permissions']
-        if perm_list.include?('order')
-          # we only need to check for 'order', because PUMP allows for assigning a group only 'order' permissions,
-          # and we should assume that group also has 'search' (aka 'read') permissions
-          is_search_and_order_perm = true
-        elsif perm_list.include?('read')
-          is_search_perm = true
-        end
-      end
-
-      perm['permission_summary'] = 'Search' if is_search_perm
-      perm['permission_summary'] = 'Search & Order' if is_search_and_order_perm
-    end
-
-    permissions
-  end
-
-  # separate search_groups and search_and_order_groups from acl group_permissions
-  def parse_group_permission_ids(group_permissions)
-    search_groups = []
-    search_and_order_groups = []
-
-    # we need hidden groups if the user is updating a group with system groups
-    # and they don't have READ access for system groups
-    hidden_search_groups = []
-    hidden_search_and_order_groups = []
-
-    group_permissions.each do |group_perm|
-      if !(group_perm['group_id'] =~ /(-CMR)$/) || (group_perm['user_type']) || (group_perm['group_id'] =~ /(-CMR)$/ && policy(:system_group).read?)
-        # group is not a system group
-        # OR group is guest or registered
-        # OR group is a system group and user has READ access
-        if group_perm['permissions'].include?('order')
-          # we only need to check for 'order', because PUMP allows for assigning a group only 'order' permissions,
-          # and we should assume that group also has 'search' (aka 'read') permissions
-          search_and_order_groups << (group_perm['group_id'] || group_perm['user_type'])
-        elsif group_perm['permissions'].include?('read')
-          search_groups << (group_perm['group_id'] || group_perm['user_type'])
-        end
-      else
-        # group is a system group and user does NOT have READ access
-        if group_perm['permissions'].include?('order')
-          # we only need to check for 'order', because PUMP allows for assigning a group only 'order' permissions,
-          # and we should assume that group also has 'search' (aka 'read') permissions
-          hidden_search_and_order_groups << (group_perm['group_id'])
-        elsif group_perm['permissions'].include?('read')
-          hidden_search_groups << (group_perm['group_id'])
-        end
-      end
-    end
-
-    [search_groups, search_and_order_groups, hidden_search_groups, hidden_search_and_order_groups]
-  end
-
-  # set up group hash for show page
-  def construct_permission_group_for_show(group_id)
-    group = {}
-
-    if group_id == 'guest'
-      group[:name] = 'All Guest Users'
-    elsif group_id == 'registered'
-      group[:name] = 'All Registered Users'
-    else
-      group_response = cmr_client.get_group(group_id, token)
-      if group_response.success?
-        group = group_response.body
-        group[:name] = group['name']
-        group[:concept_id] = group_id
-        group[:num_members] = group['num_members']
-        retrieval_error_message = nil
-      else
-        retrieval_error_message = Array.wrap(group_response.body['errors'])[0]
-        group = nil
-      end
-    end
-
-    [group, retrieval_error_message]
-  end
-
-  def set_catalog_item_identity(permission)
-    show = params[:action] == 'show' ? true : false
-
-    catalog_item_identity = permission.fetch('catalog_item_identity', {})
-    @permission_name = catalog_item_identity['name']
-
-    @permission_provider = catalog_item_identity['provider_id']
-
-    if show
-      @collection_options = catalog_item_identity['collection_applicable']
-      @granule_options = catalog_item_identity['granule_applicable']
-    else
-      # set options to populate edit form dropdowns
-      @collection_options = if catalog_item_identity['collection_applicable'] == true
-                              if catalog_item_identity.fetch('collection_identifier', {}).fetch('entry_titles', nil)
-                                'selected-ids-collections'
-                              else
-                                'all-collections'
-                              end
-                            else
-                              'no-access'
-                            end
-
-      @granule_options = catalog_item_identity['granule_applicable'] ? 'all-granules' : 'no-access'
-    end
-
-    collection_identifier = catalog_item_identity.fetch('collection_identifier', {})
-    @collection_access_value = collection_identifier.fetch('access_value', {})
-    entry_titles = collection_identifier.fetch('entry_titles', nil)
-    unless entry_titles.blank?
-      collections, _errors, _hits = get_collections_by_entry_titles(entry_titles, @permission_provider)
-
-      retrieved_collections = []
-
-      if show
-        @collection_entry_ids = []
-        collections.each do |collection|
-          # we need to compare entry titles that we retrieved to compare against what was provided by the collection permission
-          # because it is currently possible that a user editing the collection permission does not have access to all collections it applies to
-          retrieved_collections << collection['umm']['entry-title']
-
-          @collection_entry_ids << collection['umm']['entry-id']
-        end
-      else
-        selected_collections = []
-        delimiter = '%%__%%'
-
-        collections.each do |collection|
-          # we need to compare entry titles that we retrieved to compare against what was provided by the collection permission
-          # because it is currently possible that a user editing the collection permission does not have access to all collections it applies to
-          retrieved_collections << collection['umm']['entry-title']
-
-          # widget needs entry_id | entry_title
-          opt = collection['umm']['entry-id'] + ' | ' + collection['umm']['entry-title']
-          selected_collections << opt
-        end
-
-        # the hidden input can only handle text, so the widget is currently using the delimiter to separate the
-        # collection display values
-        @collection_selections = selected_collections.join(delimiter)
-      end
-
-      @hidden_entry_titles = entry_titles - retrieved_collections
-    end
-
-    @granule_access_value = catalog_item_identity.fetch('granule_identifier', {}).fetch('access_value', {})
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ module ApplicationHelper
   end
 
   # Returns an appropriate TH tag for the provided actions that are provided
-  # given a users access. 
+  # given a users access.
   def actions_table_header(actions)
     return if actions.empty?
 

--- a/app/helpers/permissions_helper.rb
+++ b/app/helpers/permissions_helper.rb
@@ -25,14 +25,11 @@ module PermissionsHelper
     filters.join(' ')
   end
 
-  def hide_access_constraint_values?(option_value)
-    option_value.nil? || option_value == 'no-access' ? 'is-hidden' : nil
-  end
-
   def collection_constraint_summary(permission)
     collection_applicable = permission.fetch('catalog_item_identity', {}).fetch('collection_applicable', false)
 
     collection_entry_titles = permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', [])
+    puts collection_entry_titles
 
     sentence_fragments = ['This permission']
 
@@ -82,7 +79,7 @@ module PermissionsHelper
 
     return {} unless entry_titles.any?
 
-    collection_response = cmr_client.get_collections_by_post({ entry_title: entry_titles, page_size: entry_titles.count }, token, 'umm_json')
+    collection_response = cmr_client.get_collections_by_post({ provider_id: permission['provider_id'], entry_title: entry_titles, page_size: entry_titles.count }, token, 'umm_json')
 
     return {} unless collection_response.success?
     

--- a/app/helpers/permissions_helper.rb
+++ b/app/helpers/permissions_helper.rb
@@ -29,7 +29,6 @@ module PermissionsHelper
     collection_applicable = permission.fetch('catalog_item_identity', {}).fetch('collection_applicable', false)
 
     collection_entry_titles = permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', [])
-    puts collection_entry_titles
 
     sentence_fragments = ['This permission']
 
@@ -91,6 +90,6 @@ module PermissionsHelper
 
     permitted_collections = permission_collections(permission).fetch('items', []).map { |collection| collection.fetch('umm', {}).fetch('EntryTitle') }
 
-    entry_titles.reject { |entry_title| permitted_collections.include?(entry_titles) }
+    (entry_titles - permitted_collections)
   end
 end

--- a/app/helpers/permissions_helper.rb
+++ b/app/helpers/permissions_helper.rb
@@ -1,34 +1,99 @@
+# :nodoc:
 module PermissionsHelper
-  CollectionsOptions = [
-    ['All Collections', 'all-collections'],
-    ['Selected Collections', 'selected-ids-collections'],
-    ['No Access to Collections', 'no-access']
-  ].freeze
-
-  GranulesOptions = [
-    ['All Granules', 'all-granules'],
-    ['No Access to Granules', 'no-access']
-  ].freeze
-
   ErrorCodeMessages = {
     409 => 'This permission could not be created because there is already another permission with the same name.',
     403 => 'You are not authorized to create a permission. Please contact your system administrator.'
   }.freeze
 
   def display_access_constraints(access_value)
-    display_text = 'Access Constraint Filter: '
+    return unless access_value.any?
 
-    filters = []
+    filters = ['which have access constraint values']
+
     if access_value['min_value'] && access_value['max_value']
-      filters << "Match range #{access_value['min_value']} to #{access_value['max_value']}"
-    end
-    filters << 'Include Undefined' if access_value['include_undefined_value'] == true
+      filters << if access_value['min_value'] == access_value['max_value']
+                   "equal to #{access_value['min_value']}"
+                 else
+                   "between #{access_value['min_value']} and #{access_value['max_value']}"
+                 end
 
-    display_text << filters.join(', ')
-    display_text
+      filters << '(or are undefined)' if access_value['include_undefined_value'] == true
+    elsif access_value['include_undefined_value']
+      filters << 'that are undefined'
+    end
+
+    filters.join(' ')
   end
 
   def hide_access_constraint_values?(option_value)
     option_value.nil? || option_value == 'no-access' ? 'is-hidden' : nil
+  end
+
+  def collection_constraint_summary(permission)
+    collection_applicable = permission.fetch('catalog_item_identity', {}).fetch('collection_applicable', false)
+
+    collection_entry_titles = permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', [])
+
+    sentence_fragments = ['This permission']
+
+    if collection_applicable
+      sentence_fragments << if collection_entry_titles.any?
+                              "grants its assigned groups access to #{pluralize(collection_entry_titles.count, 'collection')}"
+                            else
+                              'grants its assigned groups access to all of it\'s collections'
+                            end
+
+      sentence_fragments << display_access_constraints(permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('access_value', {}))
+    else
+      sentence_fragments << 'does not grant access to collections'
+    end
+
+    "#{sentence_fragments.join(' ')}."
+  end
+
+  def granule_constraint_summary(permission)
+    granule_applicable = permission.fetch('catalog_item_identity', {}).fetch('granule_applicable', false)
+
+    collection_entry_titles = permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', [])
+
+    sentence_fragments = ['This permission']
+
+    if granule_applicable
+      sentence_fragments << 'grants its assigned groups access to the granules'
+
+      sentence_fragments << display_access_constraints(permission.fetch('catalog_item_identity', {}).fetch('granule_identifier', {}).fetch('access_value', {}))
+
+      sentence_fragments << if collection_entry_titles.any?
+                              "that belong to the #{pluralize(collection_entry_titles.count, 'selected collection')}"
+                            else
+                              'that belong to any of its collections'
+                            end
+
+      sentence_fragments << display_access_constraints(permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('access_value', {}))
+    else
+      sentence_fragments << 'does not grant access to granules'
+    end
+
+    "#{sentence_fragments.join(' ')}."
+  end
+
+  def permission_collections(permission)
+    entry_titles = permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', [])
+
+    return {} unless entry_titles.any?
+
+    collection_response = cmr_client.get_collections_by_post({ entry_title: entry_titles, page_size: entry_titles.count }, token, 'umm_json')
+
+    return {} unless collection_response.success?
+    
+    collection_response.body
+  end
+
+  def unauthorized_permission_collections(permission)
+    entry_titles = permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', [])
+
+    permitted_collections = permission_collections(permission).fetch('items', []).map { |collection| collection.fetch('umm', {}).fetch('EntryTitle') }
+
+    entry_titles.reject { |entry_title| permitted_collections.include?(entry_titles) }
   end
 end

--- a/app/views/permissions/_form.html.erb
+++ b/app/views/permissions/_form.html.erb
@@ -50,7 +50,7 @@
 
   <!-- Hidden fields that represent the underlying array of selected collections -->
   <% Array.wrap(@permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', [])).each do |collection| %>
-  <%= hidden_field_tag('collection_selections[]', collection, class: 'selected-collection') %>
+    <%= hidden_field_tag('collection_selections[]', collection, class: 'selected-collection') %>
   <% end %>
 
   <!-- Hidden fields that represent the underlying array of selected collections that the user doesn't have access to -->
@@ -60,7 +60,7 @@
   <div id="chooser-widget"></div>
 </fieldset>
 
-<fieldset id="granule_constraint_values">
+<fieldset>
   <h3>Access Constraint Filter</h3>
 
   <div class="row">

--- a/app/views/permissions/_form.html.erb
+++ b/app/views/permissions/_form.html.erb
@@ -2,70 +2,126 @@
 
 <fieldset>
   <div class="row">
-    <%= label_tag 'permission_name', 'Name', class: 'required eui-required-o' %>
-    <%= text_field_tag 'permission_name', @permission_name, class: 'full-width', readonly: !new_form, maxlength: 100 %>
+    <div class="col-7">
+      <%= label_tag 'permission_name', 'Name', class: 'required eui-required-o' %>
+      <%= text_field_tag 'permission_name', @permission.fetch('catalog_item_identity', {})['name'], class: 'full-width', readonly: !new_form, maxlength: 100 %>
+    </div>
+    <div class="col-5">
+      <%= label_tag 'acl_applies_to', 'Apply Permission To:', class: 'required eui-required-o' %>
+      <div class="row checkbox-group space-top">
+        <div class="col-6">
+          <%= label_tag 'collection_applicable' do %>
+            <%= check_box_tag 'collection_applicable', true, @permission.fetch('catalog_item_identity', {}).fetch('collection_applicable', false) %>
+            Collections
+          <% end %>
+          
+        </div>
+        <div class="col-6">
+          <%= label_tag 'granule_applicable' do %>
+            <%= check_box_tag 'granule_applicable', true, @permission.fetch('catalog_item_identity', {}).fetch('granule_applicable', false) %>
+            Granules
+          <% end %>
+        </div>
+      </div>
+
+    </div>
   </div>
 </fieldset>
 
 <fieldset>
-  <%= label_tag 'collection_options', 'Collections', class: 'required eui-required-o' %>
-  <%= select_tag 'collection_options', options_for_select(PermissionsHelper::CollectionsOptions, @collection_options), class: 'full-width', prompt: '-- Select an Option --' %>
-  <%= hidden_field_tag 'collection_selections', @collection_selections %>
-  <div id="chooser-widget" class="is-hidden"></div>
+  <label class="required eui-required-o">Collection Selection</label>
+  <div class="row checkbox-group space-bot">
+    <div class="col-6">
+      <%= label_tag 'collection_option_all' do %>
+        <%= radio_button_tag 'collection_option', 'all', @permission.empty? ? true : @permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', []).empty? %>
+        All Collections
+      <% end %>
+      <p class="form-description">If any access constraints are applied it will filter all available collections.</p>
+    </div>
 
-  <% Array.wrap(@hidden_entry_titles).each do |entry_title| %>
+    <div class="col-6">
+      <%= label_tag 'collection_option_selected' do %>
+        <%= radio_button_tag 'collection_option', 'selected', @permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', []).any? %>
+        Selected Collections
+      <% end %>
+      <p class="form-description">If any access constraints are applied it will filter the selected collections further.</p>
+    </div>
+  </div>
+
+  <!-- Hidden fields that represent the underlying array of selected collections -->
+  <% Array.wrap(@permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', [])).each do |collection| %>
+  <%= hidden_field_tag('collection_selections[]', collection, class: 'selected-collection') %>
+  <% end %>
+
+  <!-- Hidden fields that represent the underlying array of selected collections that the user doesn't have access to -->
+  <% Array.wrap(unauthorized_permission_collections(@permission)).each do |entry_title| %>
     <%= hidden_field_tag('hidden_collections[]', entry_title, class: 'hidden-collection') %>
   <% end %>
+  <div id="chooser-widget"></div>
 </fieldset>
 
-<fieldset id="collection_constraint_values" class="<%= hide_access_constraint_values?(@collection_options) %>">
-  <h3 class="space-bot">Collections Access Constraint Filter</h3>
-  <div class="row min-max-row">
-    <div class="col-6 min-max-col">
-      <%= label_tag 'collection_access_value[min_value]', 'Minimum Access Constraint Value' %>
-      <%= text_field_tag 'collection_access_value[min_value]', @collection_access_value['min_value'], class: 'full-width min-max-value collection-access-value-group' %>
+<fieldset id="granule_constraint_values">
+  <h3>Access Constraint Filter</h3>
+
+  <div class="row">
+    <div class="col-6">
+      <div id="collection-access-constraints-container">
+        <h4 class="space-bot"><i class="eui-icon eui-collection"></i> Collections</h4>
+        <div class="row min-max-row">
+          <div class="col-6 min-max-col">
+            <%= label_tag 'collection_access_value[min_value]', 'Minimum Value' %>
+            <%= text_field_tag 'collection_access_value[min_value]', @permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('access_value', {})['min_value'], class: 'full-width min-max-value collection-access-value-group' %>
+          </div>
+          <div class="col-6 min-max-col">
+            <%= label_tag 'collection_access_value[max_value]', 'Maximum Value' %>
+            <%= text_field_tag 'collection_access_value[max_value]', @permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('access_value', {})['max_value'], class: 'full-width min-max-value collection-access-value-group' %>
+          </div>
+        </div>
+        <div class="row checkbox-group">
+          <div class="col-6">
+          <%= label_tag 'collection_access_value[include_undefined_value]' do %>
+            <%= check_box_tag 'collection_access_value[include_undefined_value]', true, @permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('access_value', {})['include_undefined_value'] %>
+            Include Undefined
+          <% end %>
+          </div>
+          <div class="col-6 align-r">
+            <%= button_tag 'Clear Collection Filters', class: 'eui-btn eui-btn--sm clear-filters', data: { container: 'collection-access-constraints-container' } %>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="col-6 min-max-col">
-      <%= label_tag 'collection_access_value[max_value]', 'Maximum Access Constraint Value' %>
-      <%= text_field_tag 'collection_access_value[max_value]', @collection_access_value['max_value'], class: 'full-width min-max-value collection-access-value-group' %>
+    <div class="col-6">
+      <div id="granule-access-constraints-container">
+        <h4 class="space-bot"><i class="eui-icon eui-granule"></i> Granules</h4>
+        <div class="row min-max-row">
+          <div class="col-6 min-max-col">
+            <%= label_tag 'granule_access_value[min_value]', 'Minimum Value' %>
+            <%= text_field_tag 'granule_access_value[min_value]', @permission.fetch('catalog_item_identity', {}).fetch('granule_identifier', {}).fetch('access_value', {})['min_value'], class: 'full-width min-max-value granule-access-value-group' %>
+          </div>
+          <div class="col-6 min-max-col">
+            <%= label_tag 'granule_access_value[max_value]', 'Maximum Value' %>
+            <%= text_field_tag 'granule_access_value[max_value]', @permission.fetch('catalog_item_identity', {}).fetch('granule_identifier', {}).fetch('access_value', {})['max_value'], class: 'full-width min-max-value granule-access-value-group' %>
+          </div>
+        </div>
+        <div class="row checkbox-group">
+          <div class="col-6">
+          <%= label_tag 'granule_access_value[include_undefined_value]' do %>
+            <%= check_box_tag 'granule_access_value[include_undefined_value]', true, @permission.fetch('catalog_item_identity', {}).fetch('granule_identifier', {}).fetch('access_value', {})['include_undefined_value'] %>
+            Include Undefined
+          <% end %>
+          </div>
+          <div class="col-6 align-r">
+            <%= button_tag 'Clear Granule Filters', class: 'eui-btn eui-btn--sm clear-filters', data: { container: 'granule-access-constraints-container' } %>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="row checkbox-group">
-    <%= label_tag 'collection_access_value[include_undefined_value]' do %>
-      <%= check_box_tag 'collection_access_value[include_undefined_value]', true, @collection_access_value['include_undefined_value'] %>
-      Include Undefined
-    <% end %>
   </div>
 </fieldset>
 
 <fieldset>
-  <%= label_tag 'granule_options', 'Granules', class: 'required eui-required-o' %>
-  <%= select_tag 'granule_options', options_for_select(PermissionsHelper::GranulesOptions, @granule_options), class: 'full-width', prompt: '-- Select an Option --' %>
-</fieldset>
-
-<fieldset id="granule_constraint_values" class="<%= hide_access_constraint_values?(@granule_options) %>">
-  <h3 class="space-bot">Granules Access Constraint Filter</h3>
-  <div class="row min-max-row">
-    <div class="col-6 min-max-col">
-      <%= label_tag 'granule_access_value[min_value]', 'Minimum Access Constraint Value' %>
-      <%= text_field_tag 'granule_access_value[min_value]', @granule_access_value['min_value'], class: 'full-width min-max-value granule-access-value-group' %>
-    </div>
-    <div class="col-6 min-max-col">
-      <%= label_tag 'granule_access_value[max_value]', 'Maximum Access Constraint Value' %>
-      <%= text_field_tag 'granule_access_value[max_value]', @granule_access_value['max_value'], class: 'full-width min-max-value granule-access-value-group' %>
-    </div>
-  </div>
-  <div class="row checkbox-group">
-    <%= label_tag 'granule_access_value[include_undefined_value]' do %>
-      <%= check_box_tag 'granule_access_value[include_undefined_value]', true, @granule_access_value['include_undefined_value'] %>
-      Include Undefined
-    <% end %>
-  </div>
-</fieldset>
-
-<fieldset>
-  <table class="space-top align-c" id="permission-form-groups-table">
-    <caption class="required eui-required-o">Group Permissions</caption>
+  <table class="align-c" id="permission-form-groups-table">
+    <caption class="required space-bot eui-required-o">Group Permissions</caption>
     <thead>
       <tr>
         <th class="align-c half-width"><label for="search_groups_">Search</label></th>
@@ -75,24 +131,28 @@
     <tbody>
       <tr>
         <td id="search_groups_cell">
-          <%= select_tag 'search_groups[]', options_for_select(@groups, @search_groups), multiple: 'multiple', class: 'permission-group required'  %>
+          <%= select_tag 'search_groups[]', options_for_select(@groups, @permission.fetch('group_permissions', []).reject { |group| group['is_hidden'] == true }.select { |group| !group['permissions'].include?('order') }.map { |group| group['group_id'] || group['user_type']}), multiple: 'multiple', class: 'permission-group required'  %>
         </td>
         <td id="search_and_order_groups_cell">
-          <%= select_tag 'search_and_order_groups[]', options_for_select(@groups, @search_and_order_groups), multiple: 'multiple', class: 'permission-group required'  %>
+          <%= select_tag 'search_and_order_groups[]', options_for_select(@groups, @permission.fetch('group_permissions', []).reject { |group| group['is_hidden'] == true }.select { |group| group['permissions'].include?('order') }.map { |group| group['group_id'] || group['user_type']}), multiple: 'multiple', class: 'permission-group required'  %>
         </td>
       </tr>
     </tbody>
   </table>
 
-  <% unless @hidden_search_groups.blank? %>
-    <%= hidden_field_tag('hidden_search_groups', @hidden_search_groups.join('; ')) %>
-  <% end %>
-  <% unless @hidden_search_and_order_groups.blank? %>
-    <%= hidden_field_tag('hidden_search_and_order_groups', @hidden_search_and_order_groups.join('; ')) %>
+  <% @permission.fetch('group_permissions', []).select { |group| group['is_hidden'] == true }.group_by { |permission| permission.fetch('permissions', []).join('|') }.each do |permissions, groups| %>
+
+    <% groups.each do |group| %>
+      <% if permissions.split('|').include?('order') %>
+        <%= hidden_field_tag('hidden_search_and_order_groups[]', group['group_id']) %>
+      <% else %>
+        <%= hidden_field_tag('hidden_search_groups[]', group['group_id']) %>
+      <% end %>
+    <% end %>
   <% end %>
 </fieldset>
 
 <fieldset>
-  <%= submit_tag 'Submit', class: 'eui-btn--blue', id: 'permissions-save-button' %>
+  <%= submit_tag 'Submit', class: 'eui-btn--blue' %>
   <%= link_to 'Cancel', :back, class: 'eui-btn' %>
 </fieldset>

--- a/app/views/permissions/edit.html.erb
+++ b/app/views/permissions/edit.html.erb
@@ -1,9 +1,9 @@
 <div class="row row-content">
   <section>
-    <h2>Edit <%= @permission_name %></h2>
+    <h2>Edit <%= @permission.fetch('catalog_item_identity', {})['name'] %></h2>
 
     <%= form_tag(permission_path(@permission_concept_id), method: :put, class: 'permission-form') do %>
-      <%= hidden_field_tag 'permission_provider', @permission_provider %>
+      <%= hidden_field_tag 'permission_provider', @permission.fetch('catalog_item_identity', {})['provider_id'] %>
       <%= render partial: 'form', locals: { new_form: false } %>
     <% end %>
   </section>

--- a/app/views/permissions/index.html.erb
+++ b/app/views/permissions/index.html.erb
@@ -12,14 +12,13 @@
       <thead>
         <tr>
           <th>Permission Name</th>
-          <th>Permission Type</th>
           <th colspan="2">Actions</th>
         </tr>
       </thead>
       <tbody>
         <% if @permissions.blank? %>
           <tr>
-            <td colspan="4">No permissions found.</td>
+            <td colspan="3">No permissions found.</td>
           </tr>
         <% else %>
           <% @permissions.each_with_index do |permission, index| %>
@@ -27,11 +26,8 @@
               <td>
                 <%= link_to permission['name'], permission_path(permission['concept_id'])  %>
               </td>
-              <td>
-                <%= permission['permission_summary'] %>
-              </td>
-              <td><%= link_to 'Edit', edit_permission_path(permission['concept_id']) %></td>
-              <td>
+              <td class="align-c"><%= link_to 'Edit', edit_permission_path(permission['concept_id']) %></td>
+              <td class="align-c">
                 <%= link_to 'Delete', "#delete-permission-modal-#{index}", class: 'display-modal' %>
 
                 <div id='delete-permission-modal-<%= index %>' class="eui-modal-content">

--- a/app/views/permissions/show.html.erb
+++ b/app/views/permissions/show.html.erb
@@ -1,34 +1,6 @@
 <div class="row row-content">
   <section>
-    <h2><%= @permission_name %></h2>
-
-    <p>
-      <b>Permission Type | <%= " #{@permission_type || 'No Permission Type Selected'} | #{@permission_provider || '<provider>'}" %></b>
-    </p>
-    <p>
-      <b>Collections |
-        <% if @collection_options %>
-          <%= @collection_entry_ids.blank? && @hidden_entry_titles.blank? ? 'All Collections' : "#{@collection_entry_ids.count} Selected Collections" %>
-        <% else %>
-          No Access to Collections
-        <% end %>
-      </b>
-      <br>
-      <%= @collection_entry_ids.to_sentence unless @collection_entry_ids.blank? %>
-      <p>
-        <% unless @collection_access_value.blank? %>
-          Collections <%= display_access_constraints(@collection_access_value) %>
-        <% end %>
-      </p>
-    </p>
-    <p>
-      <b>Granules | <%= @granule_options ? 'All Granules in Selected Collection Records' : 'No Access to Granules' %></b>
-      <p>
-        <% unless @granule_access_value.blank? %>
-          Granules <%= display_access_constraints(@granule_access_value) %>
-        <% end %>
-      </p>
-    </p>
+    <h2><%= @permission.fetch('catalog_item_identity', {})['name'] %></h2>
 
     <table class="space-top space-bot align-c" id="permission-groups-table">
       <thead>
@@ -39,55 +11,89 @@
         </tr>
       </thead>
       <tbody>
-        <% if @search_groups.blank? && @search_and_order_groups.blank? %>
+        <% if @permission.fetch('group_permissions', []).blank? %>
           <tr>
             <td colspan="3">
               No Groups listed.
             </td>
           </tr>
         <% else %>
+          <% @permission.fetch('group_permissions', []).select { |permission, groups| (%w(read order) & permission.fetch('permissions', {})).any? }.group_by { |permission| permission.fetch('permissions', []) }.each do |permissions, groups| %>
 
-          <!-- Search & Order groups -->
-          <% @search_and_order_groups.each do |search_and_order_group| %>
-            <tr>
-              <td class="cell-primary-cta">
-                <% if search_and_order_group[:concept_id] %>
-                  <%= link_to search_and_order_group[:name], group_path(search_and_order_group[:concept_id]) %>
-                  <% if check_if_system_group?(search_and_order_group, search_and_order_group[:concept_id]) %>
-                    <span class="eui-badge--sm">SYS</span>
+            <% groups.select { |group| group.key?('user_type') || group.key?('group') }.each do |group| %>
+              <tr>
+                <td class="cell-primary-cta">
+                  <% if group.key?('group_id') %>
+                    <%= link_to group['group']['name'], group_path(group['group_id']) %>
+
+                    <% if check_if_system_group?(group, group['group_id']) %>
+                      <span class="eui-badge--sm">SYS</span>
+                    <% end %>
+                  <% else %>
+                    <% if group['user_type'] == 'guest' %>
+                    All Guest Users
+                    <% elsif group['user_type'] == 'registered' %>
+                    All Registered Users
+                    <% end %>
                   <% end %>
-                  (<%= search_and_order_group[:num_members] %>)
-                <% else %>
-                  <%= search_and_order_group[:name] %>
-                <% end %>
-              </td>
-              <td><i class="eui-icon eui-check-o icon-green icon--md"><span class="is-invisible">Search allowed for this group</span></i></td>
-              <td><i class="eui-icon eui-check-o icon-green icon--md"><span class="is-invisible">Order is also allowed for this group</span></i></td>
-            </tr>
-          <% end %>
-
-          <!-- Search Groups -->
-          <% @search_groups.each do |search_group| %>
-            <tr>
-              <td class="cell-primary-cta">
-                <% if search_group[:concept_id] %>
-                  <%= link_to search_group[:name], group_path(search_group[:concept_id]) %>
-                  <% if check_if_system_group?(search_group, search_group[:concept_id]) %>
-                    <span class="eui-badge--sm">SYS</span>
+                </td>
+                <td>
+                  <% if permissions.include?('read') || permissions.include?('order') %>
+                    <i class="eui-icon eui-check-o icon-green icon--md"><span class="is-invisible">Search allowed for this group</span></i>
                   <% end %>
-                  (<%= search_group[:num_members] %>)
-                <% else %>
-                  <%= search_group[:name] %>
-                <% end %>
-              </td>
-              <td><i class="eui-icon eui-check-o icon-green icon--md"><span class="is-invisible">Only search is allowed for this group</span></i></td>
-              <td><span class="is-invisible">Order is not allowed for this group</span></td>
-            </tr>
-          <% end %>
+                </td>
+                <td>
+                  <% if permissions.include?('order') %>
+                    <i class="eui-icon eui-check-o icon-green icon--md"><span class="is-invisible">Order is also allowed for this group</span></i>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
 
+          <% end %>
         <% end %>
       </tbody>
     </table>
+
+    <div class="row">
+      <div class="col-6" id="collection-constraint-summary">
+        <label>Collections</label>
+        <p><%= collection_constraint_summary(@permission) %></p>
+
+        <% if @permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('access_value', {}).any? && @permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', []).any? %>
+          <%= button_tag 'Toggle Collection Highlighting', class: 'eui-btn eui-btn--sm highlight-collections', title: 'Toggle the highlighting of collections that satisfy the constraint filters.', data: @permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('access_value', {}) %>
+        <% end %>
+      </div>
+      
+      <div class="col-6" id="granule-constraint-summary">
+        <label>Granules</label>
+        <p><%= granule_constraint_summary(@permission) %></p>
+      </div>
+    </div>
+
+    <% if @permission.fetch('catalog_item_identity', {}).fetch('collection_identifier', {}).fetch('entry_titles', []).any? %>
+    <table id="permission-collection-list">
+      <thead>
+        <tr>
+          <th>Collection</th>
+          <th>Short Name</th>
+          <th>Version</th>
+          <th>Access Constraint</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        <% permission_collections(@permission).fetch('items', []).each do |collection| %>
+        <tr>
+          <td><%= link_to collection.fetch('umm', {})['EntryTitle'], collection_path(collection.fetch('meta', {})['concept-id']), target: '_blank' %></td>
+          <td><%= collection.fetch('umm', {})['ShortName'] %></td>
+          <td><%= collection.fetch('umm', {})['Version'] %></td>
+          <td class="access-constraint"><%= collection.fetch('umm', {}).fetch('AccessConstraints', {})['Value'] %></td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <% end %>
 
     <%= link_to 'Edit', edit_permission_path(@permission_concept_id), class: 'eui-btn' %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Rails.application.routes.draw do
 
   # PUMPness
   resources :permissions
-  get '/permission/all_collections' => 'permissions#get_all_collections'
 
   resources :system_identity_permissions, only: [:index, :edit, :update]
   resources :provider_identity_permissions, only: [:index, :edit, :update]
@@ -75,6 +74,11 @@ Rails.application.routes.draw do
   # API Endpoints for Chooser implementations
   get 'provider_collections' => 'manage_cmr#provider_collections'
   post 'provider_collections' => 'manage_cmr#provider_collections'
+
+  # These two endpoints exist ONLY for permissions (CMR-3858 will solve this)
+  get 'entry_title_collections' => 'manage_cmr#entry_title_collections'
+  post 'entry_title_collections' => 'manage_cmr#entry_title_collections'
+
   get 'service_implementations_with_datasets' => 'manage_cmr#service_implementations_with_datasets'
   get 'datasets_for_service_implementation' => 'manage_cmr#datasets_for_service_implementation'
 

--- a/lib/cmr/cmr_client.rb
+++ b/lib/cmr/cmr_client.rb
@@ -15,21 +15,21 @@ module Cmr
 
     # umm-json gives us shorter version of metadata in the 'umm' portion. but it has entry-id
     # umm_json gives us the metadata record in the 'umm' portion. but that does not include entry-id
-    def get_collections(options = {}, token = nil)
+    def get_collections(options = {}, token = nil, format = 'umm-json')
       if Rails.env.development? || Rails.env.test?
-        url = 'http://localhost:3003/collections.umm-json'
+        url = "http://localhost:3003/collections.#{format}"
       else
-        url = '/search/collections.umm-json'
+        url = "/search/collections.#{format}"
       end
       get(url, options, token_header(token))
     end
 
-    def get_collections_by_post(query, token = nil)
+    def get_collections_by_post(query, token = nil, format = 'umm-json')
       # search collections via POST
       if Rails.env.development? || Rails.env.test?
-        url = 'http://localhost:3003/collections.umm-json'
+        url = "http://localhost:3003/collections.#{format}"
       else
-        url = '/search/collections.umm-json'
+        url = "/search/collections.#{format}"
       end
 
       headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }

--- a/spec/controllers/permissions_controller_spec.rb
+++ b/spec/controllers/permissions_controller_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+describe PermissionsController, reset_provider: true do
+  describe 'GET #index' do
+    before do
+      sign_in
+    end
+
+    it 'renders the #index view' do
+      get :index
+
+      expect(response).to render_template(:index)
+    end
+
+    it 'sets the permissions instance variable' do
+      get :index
+
+      expect(assigns(:permissions)).to be_an(Array)
+    end
+
+    it 'requests groups from cmr' do
+      expect_any_instance_of(Cmr::CmrClient).to receive('get_permissions').and_call_original
+
+      get :index
+    end
+  end
+
+  describe 'GET #show' do
+    before :all do
+      @group_name = 'Permissions Controller Test Group'
+      @group = create_group(name: @group_name, members: ['testuser'])
+
+      @permission_name = 'Permissions Permission Name'
+
+      permission = {
+        group_permissions: [{
+          group_id: @group['concept_id'],
+          permissions: %w(read order)
+        }, {
+          user_type: 'registered',
+          permissions: %w(read order)
+        }, {
+          user_type: 'guest',
+          permissions: %w(read)
+        }],
+        catalog_item_identity: {
+          name: @permission_name,
+          provider_id: 'MMT_2',
+          granule_applicable: true,
+          collection_applicable: true
+        }
+      }
+
+      @permission = add_group_permissions(permission)
+    end
+
+    before do
+      sign_in
+    end
+
+    it 'renders the #show view' do
+      get :show, id: @permission['concept_id']
+
+      expect(response).to render_template(:show)
+    end
+
+    it 'sets the permission instance variable' do
+      get :show, id: @permission['concept_id']
+
+      expect(assigns(:permission).keys).to eq(%w(group_permissions catalog_item_identity))
+    end
+
+    it 'requests groups from cmr' do
+      expect_any_instance_of(Cmr::CmrClient).to receive('get_permission').and_call_original
+
+      get :show, id: @permission['concept_id']
+    end
+  end
+
+  describe 'GET #new' do
+    before do
+      sign_in
+
+      get :new
+    end
+
+    it 'renders the #new view' do
+      expect(response).to render_template(:new)
+    end
+
+    it 'sets the permission instance variable' do
+      expect(assigns(:permission)).to eq({})
+    end
+  end
+end

--- a/spec/features/groups/group_list_permission_spec.rb
+++ b/spec/features/groups/group_list_permission_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 describe 'Group list permissions', reset_provider: true do
-  modal_text = 'requires you change your provider context to MMT_2'
+  let(:modal_text) { 'requires you change your provider context to MMT_2' }
 
   before :all do
-    edit_group_name = 'Test Group For New Invites 1'
+    @edit_group_name = 'Test Group For New Invites 1'
     edit_group_description = 'Group to invite users to'
     @provider_id = 'MMT_2'
 
     @edit_group = create_group(
-      name: edit_group_name,
+      name: @edit_group_name,
       description: edit_group_description,
       provider_id: @provider_id
     )
@@ -40,8 +40,10 @@ describe 'Group list permissions', reset_provider: true do
         before do
           visit groups_path
 
-          within all('.groups-table tbody tr').first do
-            click_on 'Edit'
+          within '.groups-table' do
+            within 'tbody > tr:nth-child(1)' do
+              click_on 'Edit'
+            end
           end
         end
 
@@ -70,8 +72,10 @@ describe 'Group list permissions', reset_provider: true do
         before do
           visit groups_path
 
-          within all('.groups-table tbody tr').last do
-            click_on 'Delete'
+          within '.groups-table' do
+            within 'tbody > tr:nth-child(2)' do
+              click_on 'Delete'
+            end
           end
         end
 

--- a/spec/features/permissions/collection_permissions_list_spec.rb
+++ b/spec/features/permissions/collection_permissions_list_spec.rb
@@ -1,4 +1,3 @@
-
 require 'rails_helper'
 
 describe 'Collection Permissions Index page', reset_provider: true do
@@ -39,124 +38,27 @@ describe 'Collection Permissions Index page', reset_provider: true do
         end
       end
 
-      context 'when the collection permissions only have Read and Order permissions' do
+      context 'when there are permissions' do
         before do
-          collection_permission_1 = add_associated_permissions_to_group(group_id: group1_id, name: 'Testing Collection Permission Index Regular 01', permissions: [ 'read' ])
-          collection_permission_2 = add_associated_permissions_to_group(group_id: group2_id, name: 'Testing Collection Permission Index Regular 02', permissions: [ 'read', 'order' ])
-          collection_permission_3 = add_associated_permissions_to_group(group_id: group3_id, name: 'Testing Collection Permission Index Regular 03', permissions: [ 'read', 'order' ])
+          add_associated_permissions_to_group(group_id: group1_id, name: 'Testing Collection Permission Index Regular 01', permissions: %w(read))
+          add_associated_permissions_to_group(group_id: group2_id, name: 'Testing Collection Permission Index Regular 02', permissions: %w(read order))
+          add_associated_permissions_to_group(group_id: group3_id, name: 'Testing Collection Permission Index Regular 03', permissions: %w(read order))
 
           visit permissions_path
         end
 
-        it 'displays the table of collection permissions with the correct summaries' do
+        it 'displays the table of collection permissions' do
           within '#custom-permissions-table' do
             within 'tbody > tr:nth-child(1)' do
               expect(page).to have_content('Testing Collection Permission Index Regular 01')
-
-              within 'td:nth-child(2)' do
-                expect(page).to have_content('Search')
-                expect(page).to have_no_content('Order')
-              end
             end
 
             within 'tbody > tr:nth-child(2)' do
               expect(page).to have_content('Testing Collection Permission Index Regular 02')
-              within 'td:nth-child(2)' do
-                expect(page).to have_content('Search & Order')
-              end
             end
 
             within 'tbody > tr:nth-child(3)' do
               expect(page).to have_content('Testing Collection Permission Index Regular 03')
-              within 'td:nth-child(2)' do
-                expect(page).to have_content('Search & Order')
-              end
-            end
-          end
-        end
-
-        context 'when the collection permissions also have Create, Update, and Delete permissions, permissions in alternative order, and empty permissions' do
-          before do
-            collection_permission_4 = add_associated_permissions_to_group(group_id: group1_id, name: 'Testing Collection Permission Index empty permissions 01', permissions: [ ])
-            collection_permission_5 = add_associated_permissions_to_group(group_id: group2_id, name: 'Testing Collection Permission Index Permutations 02', permissions: [ 'order', 'read', 'create' ])
-            collection_permission_6 = add_associated_permissions_to_group(group_id: group3_id, name: 'Testing Collection Permission Index Permutations 03', permissions: [ 'read' ])
-            collection_permission_7 = add_associated_permissions_to_group(group_id: group1_id, name: 'Testing Collection Permission Index Permutations 04', permissions: [ 'delete', 'update', 'order', 'read', 'create' ])
-            collection_permission_8 = add_associated_permissions_to_group(group_id: group2_id, name: 'Testing Collection Permission Index Permutations 05', permissions: [ 'order' ])
-
-            visit permissions_path
-          end
-
-          it 'displays the table of collections with the correct summaries' do
-            within '#custom-permissions-table' do
-              within 'tbody > tr:nth-child(1)' do
-                expect(page).to have_content('Testing Collection Permission Index empty permissions 01')
-
-                within 'td:nth-child(2)' do
-                  expect(page).to have_no_content('Search')
-                  expect(page).to have_no_content('Order')
-                end
-              end
-
-              within 'tbody > tr:nth-child(2)' do
-                expect(page).to have_content('Testing Collection Permission Index Permutations 02')
-
-                within 'td:nth-child(2)' do
-                  expect(page).to have_content('Search & Order')
-                end
-              end
-
-              within 'tbody > tr:nth-child(3)' do
-                expect(page).to have_content('Testing Collection Permission Index Permutations 03')
-
-                within 'td:nth-child(2)' do
-                  expect(page).to have_content('Search')
-                  expect(page).to have_no_content('Order')
-                end
-              end
-
-              within 'tbody > tr:nth-child(4)' do
-                expect(page).to have_content('Testing Collection Permission Index Permutations 04')
-
-                within 'td:nth-child(2)' do
-                  expect(page).to have_content('Search & Order')
-                  expect(page).to have_no_content('Create')
-                  expect(page).to have_no_content('Update')
-                  expect(page).to have_no_content('Delete')
-                end
-              end
-
-              within 'tbody > tr:nth-child(5)' do
-                expect(page).to have_content('Testing Collection Permission Index Permutations 05')
-
-                within 'td:nth-child(2)' do
-                  expect(page).to have_content('Search & Order')
-                end
-              end
-
-              within 'tbody > tr:nth-child(6)' do
-                expect(page).to have_content('Testing Collection Permission Index Regular 01')
-
-                within 'td:nth-child(2)' do
-                  expect(page).to have_content('Search')
-                  expect(page).to have_no_content('Order')
-                end
-              end
-
-              within 'tbody > tr:nth-child(7)' do
-                expect(page).to have_content('Testing Collection Permission Index Regular 02')
-
-                within 'td:nth-child(2)' do
-                  expect(page).to have_content('Search & Order')
-                end
-              end
-
-              within 'tbody > tr:nth-child(8)' do
-                expect(page).to have_content('Testing Collection Permission Index Regular 03')
-
-                within 'td:nth-child(2)' do
-                  expect(page).to have_content('Search & Order')
-                end
-              end
             end
           end
         end

--- a/spec/features/permissions/updating_permission_with_restricted_collections_spec.rb
+++ b/spec/features/permissions/updating_permission_with_restricted_collections_spec.rb
@@ -119,8 +119,6 @@ describe 'Updating Collection Permissions when collections are not accessible by
 
           expect(page).to have_content(@collection_permission_all_restricted_name)
 
-          # expect(page).to have_content('Collections | 0 Selected Collections')
-
           # we should not see the entry ids of selected collections in the collection permission
           expect(page).to have_no_content('MYD29E1D 5')
           expect(page).to have_no_content('AE_SI12 3')
@@ -150,7 +148,6 @@ describe 'Updating Collection Permissions when collections are not accessible by
 
             expect(page).to have_content(@collection_permission_all_restricted_name)
 
-            # expect(page).to have_content('Collections | 1 Selected Collections')
             # new entry id that we expect to see
             expect(page).to have_content('NISE 4')
 
@@ -178,7 +175,6 @@ describe 'Updating Collection Permissions when collections are not accessible by
       it 'displays the collection permission with 1 of 3 selected collection' do
         expect(page).to have_field('Name', with: @collection_permission_some_restricted_name, readonly: true)
 
-        # expect(page).to have_select('Collections', selected: 'Selected Collections')
         expect(page).to have_checked_field('Selected Collections')
         expect(page).to have_checked_field('Granules')
 
@@ -211,15 +207,12 @@ describe 'Updating Collection Permissions when collections are not accessible by
 
           expect(page).to have_content(@collection_permission_some_restricted_name)
 
-          # expect(page).to have_content('Collections | 1 Selected Collections')
           # entry id that we expect to see
           expect(page).to have_content('NISE 4')
 
           # entry ids in the collection permission we do not expect to see
           expect(page).to have_no_content('MYD29E1D 5')
           expect(page).to have_no_content('AE_SI12 3')
-
-          # expect(page).to have_content('Granules | All Granules in Selected Collection Records')
 
           within '#permission-groups-table' do
             expect(page).to have_content('All Registered Users')
@@ -244,7 +237,6 @@ describe 'Updating Collection Permissions when collections are not accessible by
       it 'displays the collection permission with 3 of 3 selected collection' do
         expect(page).to have_field('Name', with: @collection_permission_some_restricted_name, readonly: true)
 
-        # expect(page).to have_select('Collections', selected: 'Selected Collections')
         expect(page).to have_checked_field('Selected Collections')
         expect(page).to have_checked_field('Granules')
 
@@ -257,8 +249,6 @@ describe 'Updating Collection Permissions when collections are not accessible by
         expect(page).to have_css('#collectionsChooser_toList option', text: "#{entry_id_visible_to_all} | #{entry_title_visible_to_all}")
         expect(page).to have_css('#collectionsChooser_toList option', text: "#{restricted_entry_id_1} | #{restricted_entry_title_1}")
         expect(page).to have_css('#collectionsChooser_toList option', text: "#{restricted_entry_id_2} | #{restricted_entry_title_2}")
-
-        # expect(page).to have_select('Granules', selected: 'All Granules')
 
         within '#search_and_order_groups_cell' do
           expect(page).to have_css('li.select2-selection__choice', text: 'All Registered Users')
@@ -274,13 +264,10 @@ describe 'Updating Collection Permissions when collections are not accessible by
       it 'displays the collection permission information with 3 of 3 selected collections' do
         expect(page).to have_content(@collection_permission_some_restricted_name)
 
-        # expect(page).to have_content('Collections | 3 Selected Collections')
         # we should see all 3 entry ids
         expect(page).to have_content('NISE 4')
         expect(page).to have_content('MYD29E1D 5')
         expect(page).to have_content('AE_SI12 3')
-
-        # expect(page).to have_content('Granules | All Granules in Selected Collection Records')
 
         within '#permission-groups-table' do
           expect(page).to have_content('All Registered Users')

--- a/spec/features/permissions/updating_permission_with_restricted_collections_spec.rb
+++ b/spec/features/permissions/updating_permission_with_restricted_collections_spec.rb
@@ -83,7 +83,10 @@ describe 'Updating Collection Permissions when collections are not accessible by
       it 'displays the collection permission edit form with 0 of 2 selected collections' do
         expect(page).to have_field('Name', with: @collection_permission_all_restricted_name, readonly: true)
 
-        expect(page).to have_select('Collections', selected: 'Selected Collections')
+        expect(page).to have_checked_field('Collections')
+        expect(page).to have_unchecked_field('Granules')
+
+        expect(page).to have_checked_field('Selected Collections')
 
         # we should only see the open access collection in the Available Collections
         expect(page).to have_css('#collectionsChooser_fromList option', text: "#{entry_id_visible_to_all} | #{entry_title_visible_to_all}")
@@ -98,8 +101,6 @@ describe 'Updating Collection Permissions when collections are not accessible by
         # we should not see the restricted collections in the Selected Collections
         expect(page).to have_no_css('#collectionsChooser_toList option', text: "#{restricted_entry_id_1} | #{restricted_entry_title_1}")
         expect(page).to have_no_css('#collectionsChooser_toList option', text: "#{restricted_entry_id_2} | #{restricted_entry_title_2}")
-
-        expect(page).to have_select('Granules', selected: 'No Access to Granules')
 
         within '#search_and_order_groups_cell' do
           expect(page).to have_css('li.select2-selection__choice', text: 'All Registered Users')
@@ -118,13 +119,15 @@ describe 'Updating Collection Permissions when collections are not accessible by
 
           expect(page).to have_content(@collection_permission_all_restricted_name)
 
-          expect(page).to have_content('Collections | 0 Selected Collections')
+          # expect(page).to have_content('Collections | 0 Selected Collections')
 
           # we should not see the entry ids of selected collections in the collection permission
-          expect(page).to have_no_content(restricted_entry_id_1)
-          expect(page).to have_no_content(restricted_entry_id_2)
+          expect(page).to have_no_content('MYD29E1D 5')
+          expect(page).to have_no_content('AE_SI12 3')
 
-          expect(page).to have_content('Granules | No Access to Granules')
+          within '#granule-constraint-summary' do
+            expect(page).to have_content('This permission does not grant access to granules.')
+          end
 
           within '#permission-groups-table' do
             expect(page).to have_content('All Registered Users')
@@ -135,7 +138,8 @@ describe 'Updating Collection Permissions when collections are not accessible by
           before do
             visit edit_permission_path(@collection_permission_all_restricted['concept_id'])
 
-            select('NISE_4', from: 'Available collections')
+            select('NISE_4', from: 'Available Collections')
+
             find('button[title=add]').click
 
             click_on 'Submit'
@@ -146,15 +150,17 @@ describe 'Updating Collection Permissions when collections are not accessible by
 
             expect(page).to have_content(@collection_permission_all_restricted_name)
 
-            expect(page).to have_content('Collections | 1 Selected Collections')
+            # expect(page).to have_content('Collections | 1 Selected Collections')
             # new entry id that we expect to see
-            expect(page).to have_content(entry_id_visible_to_all)
+            expect(page).to have_content('NISE 4')
 
             # entry ids in the collection permission we do not expect to see
-            expect(page).to have_no_content(restricted_entry_id_1)
-            expect(page).to have_no_content(restricted_entry_id_2)
+            expect(page).to have_no_content('MYD29E1D 5')
+            expect(page).to have_no_content('AE_SI12 3')
 
-            expect(page).to have_content('Granules | No Access to Granules')
+            within '#granule-constraint-summary' do
+              expect(page).to have_content('This permission does not grant access to granules.')
+            end
 
             within '#permission-groups-table' do
               expect(page).to have_content('All Registered Users')
@@ -172,7 +178,9 @@ describe 'Updating Collection Permissions when collections are not accessible by
       it 'displays the collection permission with 1 of 3 selected collection' do
         expect(page).to have_field('Name', with: @collection_permission_some_restricted_name, readonly: true)
 
-        expect(page).to have_select('Collections', selected: 'Selected Collections')
+        # expect(page).to have_select('Collections', selected: 'Selected Collections')
+        expect(page).to have_checked_field('Selected Collections')
+        expect(page).to have_checked_field('Granules')
 
         # we should only see the open access collection in the Available Collections
         expect(page).to have_css('#collectionsChooser_fromList option', text: "#{entry_id_visible_to_all} | #{entry_title_visible_to_all}")
@@ -187,8 +195,6 @@ describe 'Updating Collection Permissions when collections are not accessible by
         # we should not see the restricted collections in the Selected Collections
         expect(page).to have_no_css('#collectionsChooser_toList option', text: "#{restricted_entry_id_1} | #{restricted_entry_title_1}")
         expect(page).to have_no_css('#collectionsChooser_toList option', text: "#{restricted_entry_id_2} | #{restricted_entry_title_2}")
-
-        expect(page).to have_select('Granules', selected: 'All Granules')
 
         within '#search_and_order_groups_cell' do
           expect(page).to have_css('li.select2-selection__choice', text: 'All Registered Users')
@@ -205,15 +211,15 @@ describe 'Updating Collection Permissions when collections are not accessible by
 
           expect(page).to have_content(@collection_permission_some_restricted_name)
 
-          expect(page).to have_content('Collections | 1 Selected Collections')
+          # expect(page).to have_content('Collections | 1 Selected Collections')
           # entry id that we expect to see
-          expect(page).to have_content(entry_id_visible_to_all)
+          expect(page).to have_content('NISE 4')
 
           # entry ids in the collection permission we do not expect to see
-          expect(page).to have_no_content(restricted_entry_id_1)
-          expect(page).to have_no_content(restricted_entry_id_2)
+          expect(page).to have_no_content('MYD29E1D 5')
+          expect(page).to have_no_content('AE_SI12 3')
 
-          expect(page).to have_content('Granules | All Granules in Selected Collection Records')
+          # expect(page).to have_content('Granules | All Granules in Selected Collection Records')
 
           within '#permission-groups-table' do
             expect(page).to have_content('All Registered Users')
@@ -238,7 +244,9 @@ describe 'Updating Collection Permissions when collections are not accessible by
       it 'displays the collection permission with 3 of 3 selected collection' do
         expect(page).to have_field('Name', with: @collection_permission_some_restricted_name, readonly: true)
 
-        expect(page).to have_select('Collections', selected: 'Selected Collections')
+        # expect(page).to have_select('Collections', selected: 'Selected Collections')
+        expect(page).to have_checked_field('Selected Collections')
+        expect(page).to have_checked_field('Granules')
 
         # we should see all 3 collections in the Available Collections
         expect(page).to have_css('#collectionsChooser_fromList option', text: "#{entry_id_visible_to_all} | #{entry_title_visible_to_all}")
@@ -250,7 +258,7 @@ describe 'Updating Collection Permissions when collections are not accessible by
         expect(page).to have_css('#collectionsChooser_toList option', text: "#{restricted_entry_id_1} | #{restricted_entry_title_1}")
         expect(page).to have_css('#collectionsChooser_toList option', text: "#{restricted_entry_id_2} | #{restricted_entry_title_2}")
 
-        expect(page).to have_select('Granules', selected: 'All Granules')
+        # expect(page).to have_select('Granules', selected: 'All Granules')
 
         within '#search_and_order_groups_cell' do
           expect(page).to have_css('li.select2-selection__choice', text: 'All Registered Users')
@@ -266,13 +274,13 @@ describe 'Updating Collection Permissions when collections are not accessible by
       it 'displays the collection permission information with 3 of 3 selected collections' do
         expect(page).to have_content(@collection_permission_some_restricted_name)
 
-        expect(page).to have_content('Collections | 3 Selected Collections')
+        # expect(page).to have_content('Collections | 3 Selected Collections')
         # we should see all 3 entry ids
-        expect(page).to have_content(entry_id_visible_to_all)
-        expect(page).to have_content(restricted_entry_id_1)
-        expect(page).to have_content(restricted_entry_id_2)
+        expect(page).to have_content('NISE 4')
+        expect(page).to have_content('MYD29E1D 5')
+        expect(page).to have_content('AE_SI12 3')
 
-        expect(page).to have_content('Granules | All Granules in Selected Collection Records')
+        # expect(page).to have_content('Granules | All Granules in Selected Collection Records')
 
         within '#permission-groups-table' do
           expect(page).to have_content('All Registered Users')

--- a/spec/features/permissions/viewing_permissions_spec.rb
+++ b/spec/features/permissions/viewing_permissions_spec.rb
@@ -72,54 +72,15 @@ describe 'Viewing Collection Permissions', reset_provider: true do
 
       it 'displays the permission show page with appropriate information and groups' do
         expect(page).to have_content(@collection_permission_1_name)
-        expect(page).to have_content('Permission Type | Search & Order | MMT_2')
 
-        expect(page).to have_content('Collections | All Collections')
-        expect(page).to have_no_content('Collections Access Constraint Filter')
-
-        expect(page).to have_content('Granules | All Granules in Selected Collection Records')
-        expect(page).to have_content('Granules Access Constraint Filter: Match range 1.1 to 8.8, Include Undefined')
+        within '#granule-constraint-summary' do
+          expect(page).to have_content('between 1.1 and 8.8')
+          expect(page).to have_content('(or are undefined)')
+        end
 
         within '#permission-groups-table' do
-          # Search and Order groups
-          within 'tbody > tr:nth-child(1)' do
-            within 'td:nth-child(1)' do
-              expect(page).to have_content('All Registered Users')
-            end
-            within 'td:nth-child(2)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-            within 'td:nth-child(3)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-          end
-
-          within 'tbody > tr:nth-child(2)' do
-            within 'td:nth-child(1)' do
-              expect(page).to have_content('Group 1 (2)')
-            end
-            within 'td:nth-child(2)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-            within 'td:nth-child(3)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-          end
-
-          within 'tbody > tr:nth-child(3)' do
-            within 'td:nth-child(1)' do
-              expect(page).to have_content('Group 3 (4)')
-            end
-            within 'td:nth-child(2)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-            within 'td:nth-child(3)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-          end
-
           # Search only groups
-          within 'tbody > tr:nth-child(4)' do
+          within 'tbody > tr:nth-child(1)' do
             within 'td:nth-child(1)' do
               expect(page).to have_content('All Guest Users')
             end
@@ -131,15 +92,52 @@ describe 'Viewing Collection Permissions', reset_provider: true do
             end
           end
 
-          within 'tbody > tr:nth-child(5)' do
+          within 'tbody > tr:nth-child(2)' do
             within 'td:nth-child(1)' do
-              expect(page).to have_content('Group 2 (8)')
+              expect(page).to have_content('Group 2')
             end
             within 'td:nth-child(2)' do
               expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
             end
             within 'td:nth-child(3)' do
               expect(page).to have_no_css('i.eui-icon.eui-check-o.icon-green')
+            end
+          end
+
+          # Search and Order groups
+          within 'tbody > tr:nth-child(3)' do
+            within 'td:nth-child(1)' do
+              expect(page).to have_content('All Registered Users')
+            end
+            within 'td:nth-child(2)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+            within 'td:nth-child(3)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+          end
+
+          within 'tbody > tr:nth-child(4)' do
+            within 'td:nth-child(1)' do
+              expect(page).to have_content('Group 1')
+            end
+            within 'td:nth-child(2)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+            within 'td:nth-child(3)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+          end
+
+          within 'tbody > tr:nth-child(5)' do
+            within 'td:nth-child(1)' do
+              expect(page).to have_content('Group 3')
+            end
+            within 'td:nth-child(2)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+            within 'td:nth-child(3)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
             end
           end
         end
@@ -206,57 +204,14 @@ describe 'Viewing Collection Permissions', reset_provider: true do
 
       it 'displays the permission show page with appropriate information and groups' do
         expect(page).to have_content(@collection_permission_2_name)
-        expect(page).to have_content('Permission Type | Search & Order | MMT_2')
 
-        expect(page).to have_content('Collections | 3 Selected Collections')
-        expect(page).to have_content("#{@concept_response_1.body['ShortName']}_#{@concept_response_1.body['Version']}")
-        expect(page).to have_content("#{@concept_response_2.body['ShortName']}_#{@concept_response_2.body['Version']}")
-        expect(page).to have_content("#{@concept_response_3.body['ShortName']}_#{@concept_response_3.body['Version']}")
-        expect(page).to have_content('Collections Access Constraint Filter: Match range 5.0 to 25.0, Include Undefined')
-
-        expect(page).to have_content('Granules | No Access to Granules')
-        expect(page).to have_no_content('Granules Access Constraint Filter')
+        within '#granule-constraint-summary' do
+          expect(page).to have_content('This permission does not grant access to granules.')
+        end
 
         within '#permission-groups-table' do
-          # Search and Order groups
-          within 'tbody > tr:nth-child(1)' do
-            within 'td:nth-child(1)' do
-              expect(page).to have_content('All Registered Users')
-            end
-            within 'td:nth-child(2)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-            within 'td:nth-child(3)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-          end
-
-          within 'tbody > tr:nth-child(2)' do
-            within 'td:nth-child(1)' do
-              expect(page).to have_content('Group 3 (4)')
-            end
-            within 'td:nth-child(2)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-            within 'td:nth-child(3)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-          end
-
-          within 'tbody > tr:nth-child(3)' do
-            within 'td:nth-child(1)' do
-              expect(page).to have_content('Group 1 (2)')
-            end
-            within 'td:nth-child(2)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-            within 'td:nth-child(3)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-          end
-
           # Search only groups
-          within 'tbody > tr:nth-child(4)' do
+          within 'tbody > tr:nth-child(1)' do
             within 'td:nth-child(1)' do
               expect(page).to have_content('All Guest Users')
             end
@@ -268,8 +223,45 @@ describe 'Viewing Collection Permissions', reset_provider: true do
             end
           end
 
+          # Search and Order groups
+          within 'tbody > tr:nth-child(2)' do
+            within 'td:nth-child(1)' do
+              expect(page).to have_content('All Registered Users')
+            end
+            within 'td:nth-child(2)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+            within 'td:nth-child(3)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+          end
+
+          within 'tbody > tr:nth-child(3)' do
+            within 'td:nth-child(1)' do
+              expect(page).to have_content('Group 3')
+            end
+            within 'td:nth-child(2)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+            within 'td:nth-child(3)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+          end
+
+          within 'tbody > tr:nth-child(4)' do
+            within 'td:nth-child(1)' do
+              expect(page).to have_content('Group 1')
+            end
+            within 'td:nth-child(2)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+            within 'td:nth-child(3)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+          end
+
           within 'tbody' do
-            expect(page).to have_no_content('Group 2 (8)')
+            expect(page).to have_no_content('Group 2')
           end
         end
       end
@@ -307,16 +299,27 @@ describe 'Viewing Collection Permissions', reset_provider: true do
 
       it 'displays the permission show page with appropriate information and groups' do
         expect(page).to have_content(@collection_permission_3_name)
-        expect(page).to have_content('Permission Type | Search & Order | MMT_2')
 
-        expect(page).to have_content('Collections | No Access to Collections')
-        expect(page).to have_no_content('Collections Access Constraint Filter')
-
-        expect(page).to have_content('Granules | All Granules in Selected Collection Records')
+        within '#collection-constraint-summary' do
+          expect(page).to have_content('This permission does not grant access to collections.')
+        end
 
         within '#permission-groups-table' do
-          # Search and Order groups
+          # Search only groups
           within 'tbody > tr:nth-child(1)' do
+            within 'td:nth-child(1)' do
+              expect(page).to have_content('All Guest Users')
+            end
+            within 'td:nth-child(2)' do
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
+            end
+            within 'td:nth-child(3)' do
+              expect(page).to have_no_css('i.eui-icon.eui-check-o.icon-green')
+            end
+          end
+
+          # Search and Order groups
+          within 'tbody > tr:nth-child(2)' do
             within 'td:nth-child(1)' do
               expect(page).to have_content('All Registered Users')
             end
@@ -328,28 +331,15 @@ describe 'Viewing Collection Permissions', reset_provider: true do
             end
           end
 
-          within 'tbody > tr:nth-child(2)' do
-            within 'td:nth-child(1)' do
-              expect(page).to have_content('Group 3 (4)')
-            end
-            within 'td:nth-child(2)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-            within 'td:nth-child(3)' do
-              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
-            end
-          end
-
-          # Search only groups
           within 'tbody > tr:nth-child(3)' do
             within 'td:nth-child(1)' do
-              expect(page).to have_content('All Guest Users')
+              expect(page).to have_content('Group 3')
             end
             within 'td:nth-child(2)' do
               expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
             end
             within 'td:nth-child(3)' do
-              expect(page).to have_no_css('i.eui-icon.eui-check-o.icon-green')
+              expect(page).to have_css('i.eui-icon.eui-check-o.icon-green')
             end
           end
         end

--- a/spec/features/service_entries/update_service_entry_spec.rb
+++ b/spec/features/service_entries/update_service_entry_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
 
 describe 'Updating a Service Entry', reset_provider: true do
+  let(:guid) { 'E7B6371A-31CD-0AAC-FF18-78A78289BD65' }
+
   before :all do
     # create a group
     @service_entry_group = create_group(name: 'Service Entry Group', members: ['testuser'])
+
+    wait_for_cmr
   end
 
   after :all do
@@ -11,7 +15,6 @@ describe 'Updating a Service Entry', reset_provider: true do
   end
 
   before do
-    # collections_response = Cmr::Response.new(Faraday::Response.new(status: 200, body: JSON.parse(File.read('spec/fixtures/cmr_search.json'))))
     collections_response = cmr_success_response(File.read('spec/fixtures/cmr_search.json'))
     allow_any_instance_of(Cmr::CmrClient).to receive(:get_collections_by_post).and_return(collections_response)
 
@@ -19,8 +22,6 @@ describe 'Updating a Service Entry', reset_provider: true do
   end
 
   context 'when viewing the edit service entry form' do
-    let(:guid) { 'E7B6371A-31CD-0AAC-FF18-78A78289BD65' }
-
     context 'when the user does not have the required permissions' do
       before do
         VCR.use_cassette('echo_soap/service_management_service/service_entries/edit', record: :none) do

--- a/spec/support/cmr_helper.rb
+++ b/spec/support/cmr_helper.rb
@@ -15,7 +15,7 @@ module Helpers
 
         # Refresh the ElasticSearch index
         elastic_conn = Faraday.new(url: 'http://localhost:9210')
-        elastic_response = elastic_conn.get('_refresh')
+        elastic_response = elastic_conn.post('_refresh')
 
         Rails.logger.error "Error refreshing ElasticSearch [#{elastic_response.status}] #{elastic_response.body}" unless elastic_response.success?
       end

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -1,11 +1,14 @@
 module Helpers
   # :nodoc:
   module ControllerHelpers
-    def sign_in(as = nil)
+    def sign_in(as: nil, token: 'access_token')
       allow(controller).to receive(:logged_in?).and_return(true)
 
       # Anything greater than 0 will do the trick
       allow(controller).to receive(:server_session_expires_in).and_return(1)
+
+      # Current users' access token
+      allow(controller).to receive(:token).and_return(token)
 
       user = as || FactoryGirl.build(:user)
       allow(controller).to receive(:current_user).and_return(user)


### PR DESCRIPTION
MMT-837: Updates the display of collections to an easier to read,
sortable table format.
MMT-940: Allow access constraint min and max to be equal
MMT-941: Allow for display and saving of granule only permissions
MMT-942: Removes Permission Type from the permissions index page