### PR TITLE
MMT-948: have Collections and Drafts Controllers inherit from ManageMetadataController

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,5 +102,4 @@ gem 'builder'
 
 # run this command to work from a local copy of the gem's repo
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
-# gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', branch: 'master'
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', branch: 'MMT-948'
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', branch: 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -102,4 +102,5 @@ gem 'builder'
 
 # run this command to work from a local copy of the gem's repo
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', branch: 'master'
+# gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', branch: 'master'
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', branch: 'MMT-948'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
   revision: 0211841ad2a9e72070ac759fa50951bd87233933
-  branch: master
+  branch: MMT-948
   specs:
     cmr_metadata_preview (0.0.1)
       georuby (~> 2.5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: 0211841ad2a9e72070ac759fa50951bd87233933
-  branch: MMT-948
+  revision: 9297c2b30534f8b8ddc2a2341cb55d5a480cea44
+  branch: master
   specs:
     cmr_metadata_preview (0.0.1)
       georuby (~> 2.5.2)

--- a/app/assets/stylesheets/components/_navigation.scss
+++ b/app/assets/stylesheets/components/_navigation.scss
@@ -6,7 +6,6 @@
 
 nav {
   @include row();
-  border-bottom: 1px solid $dolphin-grey;
   margin-bottom: 0;
 
   h2 {

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -1,7 +1,11 @@
-class DraftsController < ApplicationController
+class DraftsController < ManageMetadataController
+  include ManageMetadataHelper
+
   before_action :set_draft, only: [:show, :edit, :update, :destroy, :publish]
   before_action :load_umm_schema, only: [:edit, :show]
   before_filter :ensure_correct_draft_provider, only: [:edit, :show]
+
+  add_breadcrumb 'Drafts', :drafts_path
 
   RESULTS_PER_PAGE = 25
 
@@ -21,17 +25,24 @@ class DraftsController < ApplicationController
     set_country_codes
     set_language_codes
     @errors = validate_metadata
+
+    add_breadcrumb display_entry_id(@draft.draft, 'draft'), draft_path(@draft)
   end
 
   # GET /drafts/new
   def new
     @draft = Draft.new(user: current_user, draft: {}, id: 0)
     render :show
+
+    add_breadcrumb 'New', new_draft_path
   end
 
   # GET /drafts/1/edit
   def edit
+    add_breadcrumb display_entry_id(@draft.draft, 'draft'), draft_path(@draft)
+
     Rails.logger.info("Audit Log: User #{current_user.urs_uid} started to modify draft #{@draft.entry_title} for provider #{current_user.provider_id}")
+
     if params[:form]
       @draft_form = params[:form]
       set_science_keywords
@@ -42,6 +53,8 @@ class DraftsController < ApplicationController
       set_temporal_keywords if params[:form] == 'temporal_information'
       set_data_centers if params[:form] == 'data_centers' || params[:form] == 'data_contacts'
       load_data_contacts_schema if params[:form] == 'data_contacts'
+
+      add_breadcrumb @draft_form.titleize, edit_draft_path(@draft)
     else
       render :show
     end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,4 @@
-class SearchController < ApplicationController
+class SearchController < ManageMetadataController
   include SearchHelper
 
   RESULTS_PER_PAGE = 25
@@ -34,6 +34,8 @@ class SearchController < ApplicationController
     @query['search_type'] = search_type
 
     collections, @errors, hits = get_search_results(good_query_params)
+
+    add_breadcrumb 'Search Results', search_path
 
     @collections = Kaminari.paginate_array(collections, total_count: hits).page(page).per(results_per_page)
   end

--- a/app/helpers/manage_metadata_helper.rb
+++ b/app/helpers/manage_metadata_helper.rb
@@ -1,0 +1,11 @@
+module ManageMetadataHelper
+  def display_entry_id(metadata, type)
+    blank_short_name = type == 'draft' ? '<Blank Short Name>' : 'New Collection'
+    short_name = metadata['ShortName'] || blank_short_name
+
+    version = metadata['Version'].nil? ? '' : "_#{metadata['Version']}"
+
+    entry_id = short_name + version
+    entry_id
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,9 @@
 module UsersHelper
+  def current_provider?(provider)
+    current_user.provider_id == provider
+  end
+
+  def available_provider?(provider)
+    current_user.available_providers.include?(provider)
+  end
 end

--- a/app/views/collections/revisions.html.erb
+++ b/app/views/collections/revisions.html.erb
@@ -1,141 +1,122 @@
-<main class="internal" role="main">
-  <header>
-    <div class="content">
-      <div class="eui-breadcrumbs">
-        <ol class="eui-breadcrumbs__list">
-          <li class="eui-breadcrumbs__item">
-            <%= link_to 'Manage Metadata', manage_metadata_path %>
-          </li>
-          <li class="eui-breadcrumbs__item">
-            <%= link_to display_entry_id(@collection, 'collection'), collection_path %>
-          </li>
-          <li class="eui-breadcrumbs__item">
-            Revision History
-          </li>
-        </ol>
+<% content_for :header_title do %>
+  <h2><%= display_entry_id(@collection, 'collection') %></h2>
+  <p class="subtitle"><%= display_collection_entry_title(@collection) %></p>
+<% end %>
+
+<% if @errors && !@errors.empty? %>
+  <section class="errors">
+    <div class="eui-banner--danger">
+      <div class="eui-banner__message">
+        <!-- <i class="fa fa-exclamation-triangle"></i> This revision could not be reverted successfully: -->
+        <ul class="no-bullet">
+          <% @errors.each do |error| %>
+            <li>
+              <%= "#{error[:field]}, " if error[:field] %>
+              <%= error[:error] %>
+              <% if error[:request_id] %>
+                <a href="javascript:feedback.showForm({details: '\nFill in details above this line. Please try to be as specific as possible.\n--------------------\n\nRequest ID: <%= error[:request_id] %>'});">Click here to submit feedback</a>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
       </div>
-      <h2><%= display_entry_id(@collection, 'collection') %></h2>
-      <p class="subtitle"><%= display_collection_entry_title(@collection) %></p>
     </div>
-  </header>
+  </section>
+<% end %>
 
-  <%= render 'shared/flash_messages' %>
-
-  <% if @errors && !@errors.empty? %>
+<div class="row row-content">
+  <section class="heading-group">
+    <h3>Revision History</h3>
+  </section>
+  <% if @error %>
     <section class="errors">
       <div class="eui-banner--danger">
-        <div class="eui-banner__message">
-          <!-- <i class="fa fa-exclamation-triangle"></i> This revision could not be reverted successfully: -->
-          <ul class="no-bullet">
-            <% @errors.each do |error| %>
-              <li>
-                <%= "#{error[:field]}, " if error[:field] %>
-                <%= error[:error] %>
-                <% if error[:request_id] %>
-                  <a href="javascript:feedback.showForm({details: '\nFill in details above this line. Please try to be as specific as possible.\n--------------------\n\nRequest ID: <%= error[:request_id] %>'});">Click here to submit feedback</a>
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
-        </div>
+        <p class="eui-banner__message">
+          <i class="fa fa-exclamation-triangle"></i> This collection could not be updated. You may <%= link_to 'edit', edit_collection_path(revision_id: @revision_id) %> the collection to resolve these issues.
+        </p>
       </div>
     </section>
   <% end %>
+  <div class="row">
+    <section>
+      <table>
+        <thead>
+        <tr>
+          <th>Description</th>
+          <th>Revision Date</th>
+          <th>Action by</th>
+          <th>Review Status</th>
+          <th>Quality Score</th>
+          <th>Revision Notes</th>
+          <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+          <% @revisions.each_with_index do |revision, index| %>
+            <% revision_id = revision['meta']['revision-id'] %>
+            <tr class='<%= cycle("alt", "") %>'>
+              <td>
+                <% title = "View revision #{revision_id}" %>
+                <%= revision_id %> -
+                <% if revision['meta']['deleted'] == true %>
+                  Deleted
+                <% elsif index == 0 %>
+                  Published
+                  <%= link_to 'View', collection_path(revision_id: revision_id), title: title %>
+                <% else %>
+                  Revision
+                  <%= link_to 'View', collection_path(revision_id: revision_id), title: title %>
+                <% end %>
+              </td>
+              <td>
+                <%= revision['meta']['revision-date'] %>
+              </td>
+              <td>
+                <%= revision['meta']['user-id'] %>
+              </td>
+              <td>
+                <span class="disabled">Reviewed</span>
+              </td>
+              <td>
+                <span class="disabled">82</span>
+              </td>
+              <td>
+                <!-- Revision notes -->
+              </td>
+              <td>
+                <% if @revisions.first['meta']['deleted'] == true %>
+                  <% phrase = 'Reinstate' %>
+                  <% confirm_phrase = 'Are you sure you want to reinstate this record?' %>
+                <% else %>
+                  <% phrase = 'Revert to this Revision' %>
+                  <% confirm_phrase = 'Are you sure you want to revert to this revision?' %>
+                <% end %>
 
-  <div class="row row-content">
-    <section class="heading-group">
-      <h3>Revision History</h3>
+                <% unless index == 0 || revision['meta']['deleted'] == true %>
+                  <% if current_provider?(@provider_id) %>
+                    <%= link_to phrase, "#revert-revisions-modal-#{revision_id}", class: 'display-modal' %>
+                  <% elsif available_provider?(@provider_id) %>
+                    <%= link_to phrase, '#not-current-provider-modal', class: 'display-modal not-current-provider', data: { 'provider': @provider_id, record_action: phrase } %>
+                  <% end %>
+                  <div id="revert-revisions-modal-<%= revision_id %>" class="eui-modal-content">
+                    <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
+                    <p><%= confirm_phrase %></p>
+                    <p>
+                      <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
+                      <%= link_to 'Yes', revert_collection_path(revision_id: revision_id), class: 'eui-btn--blue spinner' %>
+                    </p>
+                  </div>
+                  <%= render partial: "shared/not_current_provider_modal", locals: {
+                    options: { revisions: true, collection: @collection,
+                      concept_id: @concept_id, revision_id: revision_id }
+                    } %>
+                  </div>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
     </section>
-    <% if @error %>
-      <section class="errors">
-        <div class="eui-banner--danger">
-          <p class="eui-banner__message">
-            <i class="fa fa-exclamation-triangle"></i> This collection could not be updated. You may <%= link_to 'edit', edit_collection_path(revision_id: @revision_id) %> the collection to resolve these issues.
-          </p>
-        </div>
-      </section>
-    <% end %>
-    <div class="row">
-      <section>
-        <table>
-          <thead>
-          <tr>
-            <th>Description</th>
-            <th>Revision Date</th>
-            <th>Action by</th>
-            <th>Review Status</th>
-            <th>Quality Score</th>
-            <th>Revision Notes</th>
-            <th>Actions</th>
-          </tr>
-          </thead>
-          <tbody>
-            <% @revisions.each_with_index do |revision, index| %>
-              <% revision_id = revision['meta']['revision-id'] %>
-              <tr class='<%= cycle("alt", "") %>'>
-                <td>
-                  <% title = "View revision #{revision_id}" %>
-                  <%= revision_id %> -
-                  <% if revision['meta']['deleted'] == true %>
-                    Deleted
-                  <% elsif index == 0 %>
-                    Published
-                    <%= link_to 'View', collection_path(revision_id: revision_id), title: title %>
-                  <% else %>
-                    Revision
-                    <%= link_to 'View', collection_path(revision_id: revision_id), title: title %>
-                  <% end %>
-                </td>
-                <td>
-                  <%= revision['meta']['revision-date'] %>
-                </td>
-                <td>
-                  <%= revision['meta']['user-id'] %>
-                </td>
-                <td>
-                  <span class="disabled">Reviewed</span>
-                </td>
-                <td>
-                  <span class="disabled">82</span>
-                </td>
-                <td>
-                  <!-- Revision notes -->
-                </td>
-                <td>
-                  <% if @revisions.first['meta']['deleted'] == true %>
-                    <% phrase = 'Reinstate' %>
-                    <% confirm_phrase = 'Are you sure you want to reinstate this record?' %>
-                  <% else %>
-                    <% phrase = 'Revert to this Revision' %>
-                    <% confirm_phrase = 'Are you sure you want to revert to this revision?' %>
-                  <% end %>
-
-                  <% unless index == 0 || revision['meta']['deleted'] == true %>
-                    <% if current_user.provider_id == @provider_id %>
-                      <%= link_to phrase, "#revert-revisions-modal-#{revision_id}", class: 'display-modal' %>
-                    <% elsif current_user.available_providers.include?(@provider_id) %>
-                      <%= link_to phrase, '#not-current-provider-modal', class: 'display-modal not-current-provider', data: { 'provider': @provider_id, record_action: phrase } %>
-                    <% end %>
-                    <div id="revert-revisions-modal-<%= revision_id %>" class="eui-modal-content">
-                      <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-                      <p><%= confirm_phrase %></p>
-                      <p>
-                        <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
-                        <%= link_to 'Yes', revert_collection_path(revision_id: revision_id), class: 'eui-btn--blue spinner' %>
-                      </p>
-                    </div>
-                    <%= render partial: "shared/not_current_provider_modal", locals: {
-                      options: { revisions: true, collection: @collection,
-                        concept_id: @concept_id, revision_id: revision_id }
-                      } %>
-                    </div>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </section>
-    </div>
   </div>
-</main>
+</div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,120 +1,122 @@
-<main class="internal record" role="main">
-  <header>
-    <%= render partial: 'cmr_metadata_preview/metadata_header', locals: {
-      metadata: @collection,
-      is_mmt: true,
-      user_permissions: @user_permissions,
-      current_user: current_user,
-      provider_id: @provider_id,
-      revision_id: @revision_id
-    } %>
-  </header>
+<% content_for :header_title do %>
+  <h2><%= display_entry_id(@collection, 'collection') %></h2>
+  <p class="subtitle"><%= display_collection_entry_title(@collection) %></p>
+<% end %>
 
-  <%= render 'shared/flash_messages' %>
+<% content_for :collection_details do %>
+  <%= render partial: 'shared/preview/collection_details', locals: {
+    metadata: @collection,
+    user_permissions: @user_permissions
+  } %>
+<% end %>
 
-  <% if @user_permissions == 'none' %>
-    <div class="eui-banner--danger">
+<% if @user_permissions == 'none' %>
+  <div class="eui-banner--danger">
+    <p class="eui-banner__message">
+      <%= "You don't have the appropriate permissions to #{@collection_action} this collection." %>
+    </p>
+  </div>
+  <div class="no-access">
+    <h3 class="access-title">Access Denied</h3>
+    <p class="access-message">
+      It appears you do not have access to <%= @collection_action %> this content.<br />
+      If you feel you should have access, please check with your provider manager or ensure you are logged into the correct provider.
+    </p>
+  </div>
+<% elsif @user_permissions == 'wrong_provider' %>
+  <div class="eui-banner--warn">
+    <p class="eui-banner__message">
+      <%= link_to("You need to change your current provider to #{@collection_action} this collection. Click here to change your provider.",
+        "#", id: "change-current-provider-banner-link",
+        data: { "provider": @provider_id, action_link: "change-provider-#{@collection_action}-collection" }) %>
+    </p>
+    <%= render_change_provider_collection_action_link(@collection_action, @concept_id, @revision_id) %>
+  </div>
+<% end %>
+
+<% unless @user_permissions == 'none' %>
+  <% if @old_revision %>
+    <div class="eui-banner--info">
       <p class="eui-banner__message">
-        <%= "You don't have the appropriate permissions to #{@collection_action} this collection." %>
+        <%= link_to 'You are viewing an older revision of this collection. Click here to view the latest published version.', collection_path %>
       </p>
     </div>
-    <div class="no-access">
-      <h3 class="access-title">Access Denied</h3>
-      <p class="access-message">
-        It appears you do not have access to <%= @collection_action %> this content.<br />
-        If you feel you should have access, please check with your provider manager or ensure you are logged into the correct provider.
-      </p>
-    </div>
-  <% elsif @user_permissions == 'wrong_provider' %>
+  <% end %>
+
+  <% if @draft %>
     <div class="eui-banner--warn">
       <p class="eui-banner__message">
-        <%= link_to("You need to change your current provider to #{@collection_action} this collection. Click here to change your provider.",
-          "#", id: "change-current-provider-banner-link",
-          data: { "provider": @provider_id, action_link: "change-provider-#{@collection_action}-collection" }) %>
+        <% if current_provider?(@provider_id) %>
+          <%= link_to 'This collection has an open draft associated with it. Click here to view it.', @draft %>
+        <% elsif available_provider?(@provider_id) %>
+          <%= link_to 'This collection has an open draft associated with it. Click here to view it.', '#not-current-provider-modal', class: 'display-modal not-current-provider', data: { 'provider': @provider_id, record_action: 'view-draft' } %>
+        <% end %>
       </p>
-      <%= render_change_provider_collection_action_link(@collection_action, @concept_id, @revision_id) %>
     </div>
   <% end %>
 
-  <% unless @user_permissions == 'none' %>
-    <% if @old_revision %>
+  <div class="row row-content">
+    <% if @error %>
       <div class="eui-banner--info">
         <p class="eui-banner__message">
-          <%= link_to 'You are viewing an older revision of this collection. Click here to view the latest published version.', collection_path %>
+          <%= @error %>
         </p>
       </div>
-    <% end %>
+    <% else %>
+      <section class="action">
+        <div class="cta">
+          <p>
+            <% if current_provider?(@provider_id) %>
+              <%= link_to 'Edit Record', edit_collection_path(revision_id: @revision_id)%> |
+            <% elsif available_provider?(@provider_id) %>
+              <%= link_to 'Edit Record', '#not-current-provider-modal', class: 'display-modal not-current-provider', data: { 'provider': @provider_id, record_action: 'edit-collection' } %> |
+            <% end %>
+            <% if current_provider?(@provider_id) %>
+              <%= link_to 'Clone this Record', clone_collection_path %> |
+            <% elsif available_provider?(@provider_id) %>
+              <%= link_to 'Clone this Record', '#not-current-provider-modal', class: 'display-modal not-current-provider', data: { 'provider': @provider_id, record_action: 'clone' } %> |
+            <% end %>
+            <%= link_to 'Download XML', '#download-xml-modal', class: 'display-modal download-xml', data: { 'path': @collection_link, token: token_with_client_id } %> |
+            <% if current_provider?(@provider_id) %>
+              <%= link_to 'Delete Record', "#delete-record-modal", class: 'display-modal delete-collection' %>
+            <% elsif available_provider?(@provider_id) %>
+              <%= link_to 'Delete Record', '#not-current-provider-modal', class: 'display-modal not-current-provider', data: { 'provider': @provider_id, record_action: 'delete-collection' } %>
+            <% end %>
+            <div id="delete-record-modal" class="eui-modal-content">
+              <a href="javascript:void(0);" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
+              <p>Are you sure you want to delete this record?</p>
+              <p>
+                <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
+                <%= link_to 'Yes', collection_path, method: :delete, class: 'eui-btn--blue spinner' %>
+              </p>
+            </div>
+            <%= render partial: 'shared/not_current_provider_modal', locals: {
+              options: { collection: @collection, concept_id: @concept_id, revision_id: @revision_id,
+                draft: @draft, draft_id: @draft.try(:id) }
+              } %>
+            <!-- Hidden link to allow modal to be shown -->
+            <a href="#granules-modal" id="display-granules-modal" class="display-modal is-invisible"></a>
+            <div id="granules-modal" class="eui-modal-content">
+              <a href="javascript:void(0);" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
+              <p>Collections with granules cannot be deleted</p>
+              <p>
+                <a href="javascript:void(0)" class="eui-btn modal-close">Ok</a>
+              </p>
+            </div>
 
-    <% if @draft %>
-      <div class="eui-banner--warn">
-        <p class="eui-banner__message">
-          <% if current_user.provider_id == @provider_id %>
-            <%= link_to 'This collection has an open draft associated with it. Click here to view it.', @draft %>
-          <% elsif current_user.available_providers.include?(@provider_id) %>
-            <%= link_to 'This collection has an open draft associated with it. Click here to view it.', '#not-current-provider-modal', class: 'display-modal not-current-provider', data: { 'provider': @provider_id, record_action: 'view-draft' } %>
-          <% end %>
-        </p>
-      </div>
-    <% end %>
-
-    <div class="row row-content">
-      <% if @error %>
-        <div class="eui-banner--info">
-          <p class="eui-banner__message">
-            <%= @error %>
+          </p>
+          <p>
+            <%= link_to "Revisions (#{@revisions.size})", collection_revisions_path %> |
+            <a class="collection-granule-count disabled" href="#">Granules (<%= @num_granules %>)</a> |
+            <a class="disabled" href="#">Save as Template</a>
           </p>
         </div>
-      <% else %>
-        <section class="action">
-          <div class="cta">
-            <p>
-              <a class="disabled" href="#">Save as Template</a> |
-              <% if current_user.provider_id == @provider_id %>
-                <%= link_to 'Clone this Record', clone_collection_path %> |
-              <% elsif current_user.available_providers.include?(@provider_id) %>
-                <%= link_to 'Clone this Record', '#not-current-provider-modal', class: 'display-modal not-current-provider', data: { 'provider': @provider_id, record_action: 'clone' } %> |
-              <% end %>
-              <a class="display-modal download-xml" href="#download-xml-modal" data-path="<%= @collection_link %>" data-token="<%= token_with_client_id %>">Download XML</a>
-              <% if current_user.provider_id == @provider_id %>
-                | <%= link_to 'Delete Record', "#delete-record-modal", class: 'display-modal delete-collection' %>
-              <% elsif current_user.available_providers.include?(@provider_id) %>
-                | <%= link_to 'Delete Record', '#not-current-provider-modal', class: 'display-modal not-current-provider', data: { 'provider': @provider_id, record_action: 'delete-collection' } %>
-              <% end %>
-              <div id="delete-record-modal" class="eui-modal-content">
-                <a href="javascript:void(0);" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-                <p>Are you sure you want to delete this record?</p>
-                <p>
-                  <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
-                  <%= link_to 'Yes', collection_path, method: :delete, class: 'eui-btn--blue spinner' %>
-                </p>
-              </div>
-              <%= render partial: 'shared/not_current_provider_modal', locals: {
-                options: { collection: @collection, concept_id: @concept_id, revision_id: @revision_id,
-                  draft: @draft, draft_id: @draft.try(:id) }
-                } %>
-              <!-- Hidden link to allow modal to be shown -->
-              <a href="#granules-modal" id="display-granules-modal" class="display-modal is-invisible"></a>
-              <div id="granules-modal" class="eui-modal-content">
-                <a href="javascript:void(0);" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-                <p>Collections with granules cannot be deleted</p>
-                <p>
-                  <a href="javascript:void(0)" class="eui-btn modal-close">Ok</a>
-                </p>
-              </div>
 
-            </p>
-            <p>
-              <%= link_to "Revisions (#{@revisions.size})", collection_revisions_path %> |
-              <a class="collection-granule-count disabled" href="#">Granules (<%= @num_granules %>)</a>
-            </p>
-          </div>
+        <%= render partial: 'shared/download_xml', locals: { collection: true } %>
 
-          <%= render partial: 'shared/download_xml', locals: { collection: true } %>
+      </section>
 
-        </section>
-
-        <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @collection, editable: false } %>
-      <% end %>
-    </div>
-  <% end %>
-</main>
+      <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @collection, editable: false } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/drafts/edit.html.erb
+++ b/app/views/drafts/edit.html.erb
@@ -1,102 +1,80 @@
-<main class="internal" role="main">
+<input type='hidden' id='mmt-form-name' value='<%= @draft_form %>'>
 
-  <input type='hidden' id='mmt-form-name' value='<%= @draft_form %>'>
+<% content_for :header_title do %>
+  <h2><%= @draft_form.titleize %></h2>
+<% end %>
 
-  <%= form_tag(draft_path(@draft), method: 'put', class: 'metadata-form', enforce_utf8: false) do %>
-    <%= hidden_field_tag 'commit' %>
+<% if @draft.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@draft.errors.count, 'error') %>) prohibit this draft from being saved:</h2>
+    <ul>
+      <% @draft.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
 
-    <section class="content-header">
-      <div class="content">
-        <div class="eui-breadcrumbs">
-          <ol class="eui-breadcrumbs__list">
-            <li class="eui-breadcrumbs__item">
-              <%= link_to 'Manage Metadata', manage_metadata_path %>
-            </li>
-            <li class="eui-breadcrumbs__item">
-              <%= link_to 'Drafts', drafts_path %>
-            </li>
-            <li class="eui-breadcrumbs__item">
-              <%= link_to display_entry_id(@draft.draft, 'draft'), draft_path(@draft) %>
-            </li>
-            <li class="eui-breadcrumbs__item">
-              <%= @draft_form.titleize %>
-            </li>
-          </ol>
+<%= form_tag(draft_path(@draft), method: 'put', class: 'metadata-form', enforce_utf8: false) do %>
+  <%= hidden_field_tag 'commit' %>
+
+  <div class="row row-content">
+    <section>
+
+      <input type="hidden" name='new_form_name' id="new_form_name" />
+
+      <%= render :partial => 'drafts/forms/form_navigation', :locals => {
+          location: 'top',
+          draft: @draft,
+          draft_form: @draft_form,
+          draft_forms: @draft_forms } %>
+
+      <div class="row">
+        <div class="col-6">
+          <p class="eui-required-o">Indicates required field</p>
         </div>
-        <h2><%= @draft_form.titleize %></h2>
-      </div>
-    </section>
-
-    <%= render 'shared/flash_messages' %>
-
-    <% if @draft.errors.any? %>
-      <div id="error_explanation">
-        <h2><%= pluralize(@draft.errors.count, 'error') %>) prohibit this draft from being saved:</h2>
-        <ul>
-          <% @draft.errors.full_messages.each do |msg| %>
-            <li><%= msg %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
-    <div class="row row-content">
-      <section>
-
-        <input type="hidden" name='new_form_name' id="new_form_name" />
-
-        <%= render :partial => 'drafts/forms/form_navigation', :locals => {
-            location: 'top',
-            draft: @draft,
-            draft_form: @draft_form,
-            draft_forms: @draft_forms } %>
-
-        <div class="row">
+        <!-- Expand All link -->
+        <% unless DraftsHelper::SINGLE_FIELDSET_FORMS.include? @draft_form  %>
           <div class="col-6">
-            <p class="eui-required-o">Indicates required field</p>
+            <p class="align-r">
+              <a href="#" class="expand-accordions">Expand All</a>
+              <a href="#" class="is-invisible collapse-accordions">Collapse All</a>
+            </p>
           </div>
-          <!-- Expand All link -->
-          <% unless DraftsHelper::SINGLE_FIELDSET_FORMS.include? @draft_form  %>
-            <div class="col-6">
-              <p class="align-r">
-                <a href="#" class="expand-accordions">Expand All</a>
-                <a href="#" class="is-invisible collapse-accordions">Collapse All</a>
-              </p>
-            </div>
-          <% end %>
-        </div>
+        <% end %>
+      </div>
 
-        <%= render :partial => "drafts/forms/#{@draft_form}", :locals => { draft: @draft } %>
+      <%= render :partial => "drafts/forms/#{@draft_form}", :locals => { draft: @draft } %>
 
-        <script>
-          // Load json-schema for field validation
-          var globalJsonSchema = <%= raw @json_schema.to_json %>;
+      <script>
+        // Load json-schema for field validation
+        var globalJsonSchema = <%= raw @json_schema.to_json %>;
 
-          var urlContentTypeMap = <%= raw DraftsHelper::URLContentTypeMap.to_json %>;
-        </script>
+        var urlContentTypeMap = <%= raw DraftsHelper::URLContentTypeMap.to_json %>;
+      </script>
 
-        </br>
+      </br>
 
-        <%= render :partial => 'drafts/forms/form_navigation', :locals => {
-            location: 'bottom',
-            draft: @draft,
-            draft_form: @draft_form,
-            draft_forms: @draft_forms } %>
+      <%= render :partial => 'drafts/forms/form_navigation', :locals => {
+          location: 'bottom',
+          draft: @draft,
+          draft_form: @draft_form,
+          draft_forms: @draft_forms } %>
 
-        <!-- Hidden link to allow modal to be shown -->
-        <a href="#invalid-draft-modal" id="display-invalid-draft-modal" class="display-modal is-invisible">Invalid Draft Model</a>
-        <div id="invalid-draft-modal" class="eui-modal-content">
-          <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-          <p>This page has invalid data. Are you sure you want to save it and proceed?</p>
-          <p>
-            <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
-            <a href="javascript:void(0)" id="invalid-draft-accept" class="eui-btn--blue">Yes</a>
-          </p>
-        </div>
+      <!-- Hidden link to allow modal to be shown -->
+      <a href="#invalid-draft-modal" id="display-invalid-draft-modal" class="display-modal is-invisible">Invalid Draft Model</a>
+      <div id="invalid-draft-modal" class="eui-modal-content">
+        <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
+        <p>This page has invalid data. Are you sure you want to save it and proceed?</p>
+        <p>
+          <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
+          <a href="javascript:void(0)" id="invalid-draft-accept" class="eui-btn--blue">Yes</a>
+        </p>
+      </div>
 
-      </section>
-    </div>
-  <% end %>
-</main>
+    </section>
+  </div>
+<% end %>
 
 
 <!-- help modal -->

--- a/app/views/drafts/index.html.erb
+++ b/app/views/drafts/index.html.erb
@@ -1,59 +1,45 @@
-<main class="internal" role="main">
-  <section class="content-header">
-    <div class="content">
-      <div class="eui-breadcrumbs">
-        <ol class="eui-breadcrumbs__list">
-          <li class="eui-breadcrumbs__item">
-            <%= link_to 'Manage Metadata', manage_metadata_path %>
-          </li>
-          <li class="eui-breadcrumbs__item">Drafts</li>
-        </ol>
-      </div>
-    </div>
-  </section>
-  <div class="row row-content">
-    <section>
-      <h2><%= current_user.provider_id %> Drafts</h2>
+<div class="row row-content">
+  <section>
+    <h2><%= current_user.provider_id %> Drafts</h2>
 
-      <% if @drafts.any? %>
-        <p><%= page_entries_info @drafts, entry_name: 'Draft' %></p>
-      <% end %>
+    <% if @drafts.any? %>
+      <p><%= page_entries_info @drafts, entry_name: 'Draft' %></p>
+    <% end %>
 
-      <table id="open_drafts">
-        <thead>
-          <tr>
-            <th>Short Name</th>
-            <th>Entry Title</th>
-            <th>Last Modified</th>
-          </tr>
-        </thead>
-        <tbody>
+    <table id="open_drafts">
+      <thead>
+        <tr>
+          <th>Short Name</th>
+          <th>Entry Title</th>
+          <th>Last Modified</th>
+        </tr>
+      </thead>
+      <tbody>
 
-        <% if @drafts.blank? %>
-          <tr>
-            <td colspan="4">
-              No <%= current_user.provider_id %> Drafts found
+      <% if @drafts.blank? %>
+        <tr>
+          <td colspan="4">
+            No <%= current_user.provider_id %> Drafts found
+          </td>
+        </tr>
+      <% else %>
+        <% @drafts.each do |draft| %>
+          <tr class='<%= cycle("alt", "") %>'>
+            <td>
+              <%= link_to draft.display_short_name, draft_path(draft) %>
+            </td>
+            <td>
+              <%= draft.display_entry_title %>
+            </td>
+            <td>
+              <%= draft.updated_at.strftime("%Y-%m-%d") %>
             </td>
           </tr>
-        <% else %>
-          <% @drafts.each do |draft| %>
-            <tr class='<%= cycle("alt", "") %>'>
-              <td>
-                <%= link_to draft.display_short_name, draft_path(draft) %>
-              </td>
-              <td>
-                <%= draft.display_entry_title %>
-              </td>
-              <td>
-                <%= draft.updated_at.strftime("%Y-%m-%d") %>
-              </td>
-            </tr>
-          <% end %>
         <% end %>
-        </tbody>
-      </table>
+      <% end %>
+      </tbody>
+    </table>
 
-      <%= paginate @drafts %>
-    </section>
-  </div>
-</main>
+    <%= paginate @drafts %>
+  </section>
+</div>

--- a/app/views/drafts/show.html.erb
+++ b/app/views/drafts/show.html.erb
@@ -1,105 +1,103 @@
-<main class="internal record" role="main">
-  <header>
-    <%= render partial: 'cmr_metadata_preview/metadata_header', locals: {
-      metadata: @draft.draft,
-      is_mmt: true,
-      editable: true,
-      draft: @draft,
-      user_permissions: @user_permissions
-    } %>
-  </header>
+<% content_for :header_title do %>
+  <h2><%= display_entry_id(@draft.draft, 'draft') %></h2>
+  <p class="subtitle"><%= display_collection_entry_title(@draft.draft) %></p>
+<% end %>
 
-  <%= render 'shared/flash_messages' %>
+<% content_for :collection_details do %>
+  <%= render partial: 'shared/preview/collection_details', locals: {
+    metadata: @draft.draft,
+    user_permissions: @user_permissions
+  } %>
+<% end %>
 
-  <% if @user_permissions == 'none' %>
-    <div class="eui-banner--danger">
-      <p class="eui-banner__message">
-        <%= "You don't have the appropriate permissions to #{@draft_action} this draft" %>
-      </p>
-    </div>
-    <div class="no-access">
-      <h3 class="access-title">Access Denied</h3>
-      <p class="access-message">
-        It appears you do not have access to this content.<br />
-        If you feel you should have access, please check with your provider manager or ensure you are logged into the correct provider.
-      </p>
-    </div>
-  <% elsif @user_permissions == 'wrong_provider' %>
-    <div class="eui-banner--warn">
-      <p class="eui-banner__message">
-        <%= link_to("You need to change your current provider to #{@draft_action} this draft. Click here to change your provider.",
-          "#", id: "change-current-provider-banner-link",
-          data: { "provider": @draft.provider_id, action_link: "change-provider-#{@draft_action}-draft" }) %>
-      </p>
-      <%= link_to 'View Draft', draft_path(@draft),
-      class: 'is-invisible', id: 'change-provider-view-draft' %>
-      <%= link_to 'Edit Draft', edit_draft_path(@draft, form: @draft_form),
-      class: 'is-invisible', id: 'change-provider-edit-draft' %>
-    </div>
-    <div class="no-access">
-      <h3 class="access-title">Not Current Provider</h3>
-      <p class="access-message">
-        It appears you need to change your current provider to access to this content.<br />
-        Please check the message above to access this content.
-      </p>
-    </div>
-  <% end %>
+<% if @user_permissions == 'none' %>
+  <div class="eui-banner--danger">
+    <p class="eui-banner__message">
+      <%= "You don't have the appropriate permissions to #{@draft_action} this draft" %>
+    </p>
+  </div>
+  <div class="no-access">
+    <h3 class="access-title">Access Denied</h3>
+    <p class="access-message">
+      It appears you do not have access to this content.<br />
+      If you feel you should have access, please check with your provider manager or ensure you are logged into the correct provider.
+    </p>
+  </div>
+<% elsif @user_permissions == 'wrong_provider' %>
+  <div class="eui-banner--warn">
+    <p class="eui-banner__message">
+      <%= link_to("You need to change your current provider to #{@draft_action} this draft. Click here to change your provider.",
+        "#", id: "change-current-provider-banner-link",
+        data: { "provider": @draft.provider_id, action_link: "change-provider-#{@draft_action}-draft" }) %>
+    </p>
+    <%= link_to 'View Draft', draft_path(@draft),
+    class: 'is-invisible', id: 'change-provider-view-draft' %>
+    <%= link_to 'Edit Draft', edit_draft_path(@draft, form: @draft_form),
+    class: 'is-invisible', id: 'change-provider-edit-draft' %>
+  </div>
+  <div class="no-access">
+    <h3 class="access-title">Not Current Provider</h3>
+    <p class="access-message">
+      It appears you need to change your current provider to access to this content.<br />
+      Please check the message above to access this content.
+    </p>
+  </div>
+<% end %>
 
-  <% unless @user_permissions == 'none' || @user_permissions == 'wrong_provider' %>
-    <div class="row row-content">
-      <section class="action">
-        <div class="cta">
-          <% if @draft.new_record? || (@errors && @errors.size > 0) %>
-            <%= link_to 'Publish Draft', '#invalid-draft-modal', class: 'eui-btn--blue display-modal' %>
-            <div id="invalid-draft-modal" class="eui-modal-content">
-              <p>This draft is not ready to be published. Please use the progress indicators on the draft preview page to address incomplete or invalid fields.</p>
-              <p>
-                <a href="javascript:void(0)" class="eui-btn modal-close">Ok</a>
-              </p>
-            </div>
-          <% else %>
-            <%= link_to 'Publish Draft', draft_publish_path(@draft), method: :post, class: 'eui-btn--blue spinner' %>
-          <% end %>
-          <%= link_to 'Delete Draft', "#delete-draft-modal", class: 'display-modal' %>
-          <div id="delete-draft-modal" class="eui-modal-content">
-            <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-            <p>Are you sure you want to delete this draft?</p>
+<% unless @user_permissions == 'none' || @user_permissions == 'wrong_provider' %>
+  <div class="row row-content">
+    <section class="action">
+      <div class="cta">
+        <% if @draft.new_record? || (@errors && @errors.size > 0) %>
+          <%= link_to 'Publish Draft', '#invalid-draft-modal', class: 'eui-btn--blue display-modal' %>
+          <div id="invalid-draft-modal" class="eui-modal-content">
+            <p>This draft is not ready to be published. Please use the progress indicators on the draft preview page to address incomplete or invalid fields.</p>
             <p>
-              <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
-              <%= link_to 'Yes', "/drafts/#{@draft.id}", method: :delete, class: 'eui-btn--blue spinner' %>
+              <a href="javascript:void(0)" class="eui-btn modal-close">Ok</a>
             </p>
           </div>
-        </section>
+        <% else %>
+          <%= link_to 'Publish Draft', draft_publish_path(@draft), method: :post, class: 'eui-btn--blue spinner' %>
+        <% end %>
+        <%= link_to 'Delete Draft', "#delete-draft-modal", class: 'display-modal' %>
+        <div id="delete-draft-modal" class="eui-modal-content">
+          <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
+          <p>Are you sure you want to delete this draft?</p>
+          <p>
+            <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
+            <%= link_to 'Yes', "/drafts/#{@draft.id}", method: :delete, class: 'eui-btn--blue spinner' %>
+          </p>
+        </div>
+      </section>
 
-      <% if @ingest_errors && !@ingest_errors.empty? %>
-        <section class="errors">
-          <div class="eui-banner--danger">
-            <div class="eui-banner__message">
-              <i class="fa fa-exclamation-triangle"></i> This draft has the following errors:
-              <ul class="no-bullet">
-                <% @ingest_errors.each do |error| %>
-                  <li>
-                    <% if error[:field] && error[:page] %>
-                      <%= link_to name_to_title(error[:field]), draft_edit_form_path(@draft, error[:page]) %>
-                    <% else %>
-                      <%= "#{error[:field]}," if error[:field] %>
-                    <% end %>
-                    <%= error[:error] %>
-                    <% if error[:request_id] %>
-                      <a href="javascript:feedback.showForm({details: '\nFill in details above this line. Please try to be as specific as possible.\n--------------------\n\nRequest ID: <%= error[:request_id] %>'});">Click here to submit feedback</a>
-                    <% end %>
-                  </li>
-                <% end %>
-              </ul>
-            </div>
+    <% if @ingest_errors && !@ingest_errors.empty? %>
+      <section class="errors">
+        <div class="eui-banner--danger">
+          <div class="eui-banner__message">
+            <i class="fa fa-exclamation-triangle"></i> This draft has the following errors:
+            <ul class="no-bullet">
+              <% @ingest_errors.each do |error| %>
+                <li>
+                  <% if error[:field] && error[:page] %>
+                    <%= link_to name_to_title(error[:field]), draft_edit_form_path(@draft, error[:page]) %>
+                  <% else %>
+                    <%= "#{error[:field]}," if error[:field] %>
+                  <% end %>
+                  <%= error[:error] %>
+                  <% if error[:request_id] %>
+                    <a href="javascript:feedback.showForm({details: '\nFill in details above this line. Please try to be as specific as possible.\n--------------------\n\nRequest ID: <%= error[:request_id] %>'});">Click here to submit feedback</a>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
           </div>
-        </section>
-      <% end %>
+        </div>
+      </section>
+    <% end %>
 
-      <%= render partial: 'drafts/progress/preview_progress', locals: { draft: @draft, metadata_errors: @errors || @ingest_errors } %>
+    <%= render partial: 'drafts/progress/preview_progress', locals: { draft: @draft, metadata_errors: @errors || @ingest_errors } %>
 
-      <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @draft.draft, editable: true } %>
+    <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @draft.draft, editable: true } %>
 
-    </div>
-  <% end %>
-</main>
+  </div>
+<% end %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -58,7 +58,7 @@
               <td><%= group['description'] %></td>
               <td><%= group_provider(group) %></td>
               <td><%= group['member_count'] %></td>
-              <% if current_user.provider_id == group['provider_id'] || check_if_system_group?(group, group['concept_id']) %>
+              <% if current_provider?(group['provider_id']) || check_if_system_group?(group, group['concept_id']) %>
                 <td><%= link_to 'Edit', edit_group_path(group['concept_id']) %></td>
                 <td>
                   <%= link_to 'Delete', "#delete-group-modal-#{index}", class: 'display-modal' %>
@@ -71,7 +71,7 @@
                     </p>
                   </div>
                 </td>
-              <% elsif current_user.available_providers.include?(group['provider_id']) %>
+              <% elsif available_provider?(group['provider_id']) %>
                 <td>
                   <%= link_to 'Edit', "#not-current-provider-modal-#{index}", class: 'display-modal not-current-provider', data: { 'provider': group['provider_id'], record_action: 'edit-group' } %>
                 </td>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -48,7 +48,7 @@
       <p><%= @group.fetch('name', nil) %> has no members.</p>
     <% end %>
 
-    <% if current_user.provider_id == @group['provider_id'] || check_if_system_group?(@group, @concept_id) %>
+    <% if current_provider?(@group['provider_id']) || check_if_system_group?(@group, @concept_id) %>
       <%= link_to 'Edit', edit_group_path(@concept_id), class: 'eui-btn' %>
       <%= link_to 'Delete', '#delete-group-modal', class: 'display-modal eui-btn eui-btn--red' %>
       <div id='delete-group-modal' class="eui-modal-content">
@@ -59,7 +59,7 @@
           <%= link_to 'Yes', group_path(name: @group['name']), method: :delete, class: 'eui-btn--blue spinner' %>
         </p>
       </div>
-    <% elsif current_user.available_providers.include?(@group['provider_id']) %>
+    <% elsif available_provider?(@group['provider_id']) %>
       <%= link_to 'Edit', '#not-current-provider-modal', class: 'eui-btn display-modal not-current-provider', data: { 'provider': @group['provider_id'], record_action: 'edit-group' } %>
       <%= link_to 'Delete', '#not-current-provider-modal', class: 'eui-btn eui-btn--red display-modal not-current-provider', data: { 'provider': @group['provider_id'], record_action: 'delete-group' } %>
       <%= render partial: 'shared/not_current_provider_modal', locals: {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,11 +23,6 @@
 
     <div id="main-content">
       <main class="internal" role="main">
-        <% if controller.controller_name == 'drafts' || controller.controller_name == 'collections' %>
-          <!-- Earthdata Staus App banner -->
-          <div id="earthdata-notification-banner"></div>
-        <% end %>
-
         <%= yield %>
       </main>
     </div>
@@ -38,10 +33,6 @@
   </div>
 
   <%= render 'shared/footer' %>
-
-  <% if controller.controller_name == 'drafts' || controller.controller_name == 'collections' %>
-    <%= javascript_include_tag "https://status.earthdata.nasa.gov/assets/banner_widget.js" unless Rails.env.test? %>
-  <% end %>
 
   <%= javascript_include_tag "netinsight_2.3/ntpagetag" unless Rails.env.test? || Rails.env.development? %>
 </body>

--- a/app/views/layouts/manage_metadata.html.erb
+++ b/app/views/layouts/manage_metadata.html.erb
@@ -24,16 +24,25 @@
     <div id="main-content">
       <main class="internal" role="main">
         <header>
-          <%= render_breadcrumbs builder: ::EuiBreadcrumbsBuilder %>
+          <div class="row content">
 
-          <nav>
-            <div class="content">
-              <h2 class="current"><%= link_to 'Manage Metadata', manage_metadata_path %></h2>
-              <% if Rails.configuration.groups_enabled %>
-                <h2><%= link_to 'Manage CMR', manage_cmr_path %></h2>
-              <% end %>
+            <div class="collection-basics">
+              <%= render_breadcrumbs builder: ::EuiBreadcrumbsBuilder %>
+
+              <%= yield :header_title %>
+
+              <nav>
+                <div class="content">
+                  <h2 class="current"><%= link_to 'Manage Metadata', manage_metadata_path %></h2>
+                  <% if Rails.configuration.groups_enabled %>
+                  <h2><%= link_to 'Manage CMR', manage_cmr_path %></h2>
+                  <% end %>
+                </div>
+              </nav>
             </div>
-          </nav>
+
+            <%= yield :collection_details %>
+          </div>
         </header>
 
         <!-- Earthdata Staus App banner -->

--- a/app/views/search/_collection_search_results.html.erb
+++ b/app/views/search/_collection_search_results.html.erb
@@ -38,9 +38,9 @@
         <tr class='<%= cycle("alt", "") %>'>
           <td>
             <% if collection['meta']['draft_id'] %>
-              <% if current_user.provider_id == collection['meta']['provider-id'] %>
+              <% if current_provider?(collection['meta']['provider-id']) %>
                 <%= link_to "#{collection['umm']['short-name']} (Draft)", draft_path(collection['meta']['draft_id']) %>
-              <% elsif current_user.available_providers.include?(collection['meta']['provider-id']) %>
+              <% elsif available_provider?(collection['meta']['provider-id']) %>
                 <%= link_to "#{collection['umm']['short-name']} (Draft)", '#not-current-provider-modal', class: 'display-modal not-current-provider', data: { 'provider': collection['meta']['provider-id'], record_action: 'view-draft' } %>
                 <%= render partial: "shared/not_current_provider_modal", locals: {
                   options: { draft: collection, draft_id: collection['meta']['draft_id'] }

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,33 +1,11 @@
-<!-- <input type='hidden' id='results_per_page' value="<%= @results_per_page.to_s %>"> -->
 
-<main class="internal" role="main">
-  <section class="content-header">
-    <div class="content">
-      <div class="eui-breadcrumbs">
-        <ol class="eui-breadcrumbs__list">
-          <li class="eui-breadcrumbs__item">
-            <%= link_to 'Manage Metadata', manage_metadata_path %>
-          </li>
-          <li class="eui-breadcrumbs__item">Search Results</li>
-        </ol>
-      </div>
+<div class="row row-content">
+  <section>
+    <div id="collection_search_criteria">
+      <%= render partial: 'collection_search_criteria' %>
+    </div>
+    <div id="collection_search_results">
+      <%= render partial: 'collection_search_results' %>
     </div>
   </section>
-  <div class="row row-content">
-    <section>
-      <div class="col-3">
-        <!-- Temporarily commented out because this is not a part of the MVP %-->
-        <!--%= render partial: 'filters' %-->
-      </div>
-
-      <!-- Temporarily commented out because this is not a part of the MVP %-->
-      <!--p class="bulk-record-actions"><a href="#" class="eui-btn--blue btn-md">Bulk Edit Records</a> <a href="#" class="eui-btn--blue btn-md">Bulk Delete Records</a></p-->
-      <div id="collection_search_criteria">
-        <%= render partial: 'collection_search_criteria' %>
-      </div>
-      <div id="collection_search_results">
-        <%= render partial: 'collection_search_results' %>
-      </div>
-    </section>
-  </div>
-</main>
+</div>

--- a/app/views/shared/preview/_collection_details.html.erb
+++ b/app/views/shared/preview/_collection_details.html.erb
@@ -1,0 +1,32 @@
+<% unless user_permissions == 'none' %>
+    <div class="collection-details">
+      <!-- Only display version if one exists. -->
+      <% if metadata['Version'] %>
+        <span class="eui-badge version">Version <%= metadata['Version']%></span>
+      <% end %>
+
+      <!-- Only display data language if one exists. -->
+      <% if metadata['DataLanguage'] %>
+        <span class="eui-badge language"><%= metadata['DataLanguage']%></span>
+      <% end %>
+
+      <!-- Only display CollectionDataType if it is NRT. -->
+      <% if metadata['CollectionDataType'] == "NEAR_REAL_TIME" %>
+        <span class="eui-badge nrt">NRT</span>
+      <% end %>
+
+      <div class="quality-score disabled">
+        <div class="badges">
+          <i class="fa fa-star fa-lg"></i>
+          <i class="fa fa-star fa-lg"></i>
+          <i class="fa fa-star fa-lg"></i>
+          <i class="fa fa-star fa-lg"></i>
+          <i class="fa fa-star-o fa-lg"></i>
+        </div>
+        <div class="score-info">
+          <p>Quality Score: <strong>20</strong></p>
+          <p>Required fields not complete</p>
+        </div>
+      </div>
+    </div>
+  <% end %>

--- a/spec/features/collections/collection_permissions_spec.rb
+++ b/spec/features/collections/collection_permissions_spec.rb
@@ -21,9 +21,9 @@ describe 'Collections permissions', js: true do
       end
 
       it 'displays the action links' do
-        expect(page).to have_content('EDIT RECORD')
-        expect(page).to have_content('Clone this Record')
-        expect(page).to have_content('Delete Record')
+        expect(page).to have_link('Edit Record')
+        expect(page).to have_link('Clone this Record')
+        expect(page).to have_link('Delete Record')
       end
 
       context 'when clicking the edit link' do
@@ -156,12 +156,12 @@ describe 'Collections permissions', js: true do
 
           it 'displays warning banner link to change provider' do
             expect(page).to have_css('.eui-banner--warn')
-            expect(page).to have_content("You need to change your current provider to edit this collection")
+            expect(page).to have_content('You need to change your current provider to edit this collection')
           end
 
           context 'when clicking the warning banner link' do
             before do
-              click_link("You need to change your current provider to edit this collection")
+              click_link('You need to change your current provider to edit this collection')
               wait_for_ajax
             end
 
@@ -184,12 +184,12 @@ describe 'Collections permissions', js: true do
 
           it 'displays warning banner link to change provider' do
             expect(page).to have_css('.eui-banner--warn')
-            expect(page).to have_content("You need to change your current provider to clone this collection")
+            expect(page).to have_content('You need to change your current provider to clone this collection')
           end
 
           context 'when clicking the warning banner link' do
             before do
-              click_link("You need to change your current provider to clone this collection")
+              click_link('You need to change your current provider to clone this collection')
               wait_for_ajax
             end
 
@@ -214,9 +214,9 @@ describe 'Collections permissions', js: true do
       end
 
       it 'does not display the action links' do
-        expect(page).to have_no_content('EDIT RECORD')
-        expect(page).to have_no_content('Clone this Record')
-        expect(page).to have_no_content('Delete Record')
+        expect(page).to have_no_link('Edit Record')
+        expect(page).to have_no_link('Clone this Record')
+        expect(page).to have_no_link('Delete Record')
       end
 
       context 'when viewing the revisions page' do

--- a/spec/features/collections/collection_with_draft_spec.rb
+++ b/spec/features/collections/collection_with_draft_spec.rb
@@ -25,7 +25,12 @@ describe 'Collection with draft' do
         end
 
         it 'displays the draft' do
-          expect(page).to have_content("#{@concept_response.body['ShortName']}_1 #{@concept_response.body['EntryTitle']} DRAFT RECORD")
+          within '.eui-breadcrumbs' do
+            expect(page).to have_content('Drafts')
+            expect(page).to have_content("#{@concept_response.body['ShortName']}_1")
+          end
+
+          expect(page).to have_content("#{@concept_response.body['ShortName']}_1 #{@concept_response.body['EntryTitle']}")
         end
       end
     end
@@ -67,7 +72,13 @@ describe 'Collection with draft' do
           end
 
           it 'displays the draft' do
-            expect(page).to have_content("#{@concept_response.body['ShortName']}_1 #{@concept_response.body['EntryTitle']} DRAFT RECORD")
+            within '.eui-breadcrumbs' do
+              expect(page).to have_content('Drafts')
+              expect(page).to have_content("#{@concept_response.body['ShortName']}_1")
+            end
+
+            expect(page).to have_content("#{@concept_response.body['ShortName']}_1 #{@concept_response.body['EntryTitle']}")
+            # expect(page).to have_content("#{@concept_response.body['ShortName']}_1 #{@concept_response.body['EntryTitle']} DRAFT RECORD")
           end
         end
       end

--- a/spec/features/collections/collection_with_draft_spec.rb
+++ b/spec/features/collections/collection_with_draft_spec.rb
@@ -78,7 +78,6 @@ describe 'Collection with draft' do
             end
 
             expect(page).to have_content("#{@concept_response.body['ShortName']}_1 #{@concept_response.body['EntryTitle']}")
-            # expect(page).to have_content("#{@concept_response.body['ShortName']}_1 #{@concept_response.body['EntryTitle']} DRAFT RECORD")
           end
         end
       end

--- a/spec/features/drafts/create_draft_from_cloning_collection_spec.rb
+++ b/spec/features/drafts/create_draft_from_cloning_collection_spec.rb
@@ -37,7 +37,10 @@ describe 'Create new draft from cloning a collection', js: true do
     # end
 
     it 'displays the draft preview page' do
-      expect(page).to have_content('DRAFT RECORD')
+      within '.eui-breadcrumbs' do
+        expect(page).to have_content('Drafts')
+      end
+
       expect(page).to have_content("#{@concept_response.body['EntryTitle']} - Cloned")
     end
 

--- a/spec/features/drafts/draft_creation_spec.rb
+++ b/spec/features/drafts/draft_creation_spec.rb
@@ -72,8 +72,9 @@ describe 'Draft creation', js: true do
             end
           end
 
-          it 'displays the draft record page' do
-            expect(page).to have_content('DRAFT RECORD')
+          it 'displays the drafts preview page' do
+            expect(page).to have_content('Drafts')
+            expect(page).to have_content('123')
           end
         end
       end

--- a/spec/features/drafts/draft_permissions_spec.rb
+++ b/spec/features/drafts/draft_permissions_spec.rb
@@ -46,8 +46,12 @@ describe 'Draft permissions' do
         end
 
         it 'goes to the draft preview page' do
+          within '.eui-breadcrumbs' do
+            expect(page).to have_content('Drafts')
+            expect(page).to have_content("#{short_name}_1")
+          end
+
           expect(page).to have_content("#{short_name}_1")
-          expect(page).to have_content('DRAFT RECORD')
           expect(page).to have_content('Publish Draft')
           expect(page).to have_content('Delete Draft')
         end
@@ -80,7 +84,7 @@ describe 'Draft permissions' do
           within '.eui-breadcrumbs' do
             expect(page).to have_content('Collection Information')
           end
-          within '.content-header h2' do
+          within 'header .collection-basics' do
             expect(page).to have_content('Collection Information')
           end
           expect(page).to have_field('Short Name')

--- a/spec/features/drafts/forms/number_fields_spec.rb
+++ b/spec/features/drafts/forms/number_fields_spec.rb
@@ -96,7 +96,9 @@ describe 'Number fields', js: true do
 
     it 'saves the original string into the database' do
       # wait until page loads to test database
-      expect(page).to have_content('DRAFT RECORD')
+      within '.eui-breadcrumbs' do
+        expect(page).to have_content('Drafts')
+      end
 
       draft_metadata = { 'TemporalExtents' => [{ 'TemporalRangeType' => 'SingleDateTime', 'PrecisionOfSeconds' => 'abcd', 'EndsAtPresentFlag' => false, 'SingleDateTimes' => ['2015-07-01T00:00:00Z'] }] }
       expect(Draft.last.draft).to eq(draft_metadata)

--- a/spec/features/drafts/publish_draft_spec.rb
+++ b/spec/features/drafts/publish_draft_spec.rb
@@ -25,7 +25,10 @@ describe 'Publishing draft records', js: true do
     end
 
     it 'displays the published record page' do
-      expect(page).to have_content 'PUBLISHED RECORD'
+      within '.eui-breadcrumbs' do
+        expect(page).to have_content('Collections')
+        expect(page).to have_content('12345_1')
+      end
     end
 
     it 'displays the published metadata' do
@@ -112,7 +115,7 @@ describe 'Publishing draft records', js: true do
   context 'when publishing a new draft that has a non url encoded native id' do
     before do
       login
-      draft = create(:full_draft, user: User.where(urs_uid: 'testuser').first, native_id: 'not & url, encoded / native id')
+      draft = create(:full_draft, user: User.where(urs_uid: 'testuser').first, native_id: 'not & url, encoded / native id', draft_short_name: 'test short name')
       visit draft_path(draft)
       click_on 'Publish'
       open_accordions
@@ -123,7 +126,10 @@ describe 'Publishing draft records', js: true do
     end
 
     it 'displays the published record page' do
-      expect(page).to have_content 'PUBLISHED RECORD'
+      within '.eui-breadcrumbs' do
+        expect(page).to have_content('Collections')
+        expect(page).to have_content('test short name_1')
+      end
     end
   end
 end

--- a/spec/features/manage_metadata/open_drafts_spec.rb
+++ b/spec/features/manage_metadata/open_drafts_spec.rb
@@ -52,7 +52,9 @@ describe 'Open Drafts listings on the Manage Metadata page', reset_provider: tru
         end
 
         it 'the record is opened for view/edit' do
-          expect(page).to have_content('Draft Record')
+          within '.eui-breadcrumbs' do
+            expect(page).to have_content('Drafts')
+          end
           expect(page).to have_content('Entry Title Not Provided')
         end
       end

--- a/spec/features/search/search_drafts_result_permissions_spec.rb
+++ b/spec/features/search/search_drafts_result_permissions_spec.rb
@@ -6,12 +6,13 @@ describe 'Search results permissions for drafts', js: true do
   let(:short_name)  { 'Climate Change' }
   let(:entry_title) { 'Climate Observation Record' }
   let(:provider)    { 'MMT_2' }
+  let(:version)     { '5' }
 
   context 'when searching drafts' do
     before do
       login
-      
-      create(:full_draft, entry_title: entry_title, short_name: short_name, draft_entry_title: entry_title, draft_short_name: short_name, provider_id: provider)
+
+      create(:full_draft, entry_title: entry_title, short_name: short_name, draft_entry_title: entry_title, draft_short_name: short_name, provider_id: provider, version: version)
     end
 
     context 'when drafts are from current provider' do
@@ -37,7 +38,13 @@ describe 'Search results permissions for drafts', js: true do
         end
 
         it 'allows user to view the draft preview page' do
-          expect(page).to have_content("#{entry_title} DRAFT RECORD")
+          within '.eui-breadcrumbs' do
+            expect(page).to have_content('Drafts')
+            expect(page).to have_content("#{short_name}_#{version}")
+          end
+
+          expect(page).to have_content("#{short_name}_#{version}")
+          expect(page).to have_content(entry_title)
           expect(page).to have_content('Publish Draft')
           expect(page).to have_content('Delete Draft')
         end
@@ -83,7 +90,13 @@ describe 'Search results permissions for drafts', js: true do
           end
 
           it 'shows the draft preview page' do
-            expect(page).to have_content("#{entry_title} DRAFT RECORD")
+            within '.eui-breadcrumbs' do
+              expect(page).to have_content('Drafts')
+              expect(page).to have_content("#{short_name}_#{version}")
+            end
+
+            expect(page).to have_content("#{short_name}_#{version}")
+            expect(page).to have_content(entry_title)
             expect(page).to have_content('Publish Draft')
             expect(page).to have_content('Delete Draft')
           end

--- a/spec/features/search/view_search_results_spec.rb
+++ b/spec/features/search/view_search_results_spec.rb
@@ -15,7 +15,10 @@ describe 'Viewing search results', js: true do
     end
 
     it 'displays the published record page' do
-      expect(page).to have_content('PUBLISHED RECORD')
+      within '.eui-breadcrumbs' do
+        expect(page).to have_content('Collections')
+        expect(page).to have_content(short_name)
+      end
     end
 
     it 'displays the published record metadata' do


### PR DESCRIPTION
 - controllers use header inherited from manage_metadata layout including breadcrumbs
 - views for drafts and collections use breadcrumbs consistent with the rest of the app
 - views that use the cmr_metadata_preview gem don't use the header partial from the gem and move any necessary portions back into MMT
 - minor modifications of nav menus on the show/preview pages of drafts and collections
 - fix tests to align with header changes