### PR TITLE
MMT-1286 SAML Base

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,11 @@ gem 'rails', '4.2.7.1'
 # deployment support
 gem 'sprockets', '~> 2.8'
 
-gem 'faraday'
-gem 'faraday_middleware', '<= 0.9.0'
-gem 'multi_xml'
-
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
+gem 'bourbon'
+gem 'neat'
+
 
 # Use Autoprefixer for prefixing styles
 gem 'autoprefixer-rails'
@@ -37,19 +36,33 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Unicorn as the app server
 gem 'unicorn'
 
-gem 'bourbon'
-gem 'neat'
-gem 'font-awesome-rails'
+gem 'faraday'
+gem 'faraday_middleware', '<= 0.9.0'
 
-gem 'momentjs-rails'
+gem 'awrence' # convert snake_case hash keys to CamelCase hash keys
 gem 'bootstrap3-datetimepicker-rails'
 gem 'breadcrumbs_on_rails'
-
+gem 'builder'
+gem 'carmen' # countries and subdivisions
+gem 'database_cleaner' # added to provide a solution to Capybara's problems with js=>true
+gem 'factory_girl_rails'
 gem 'faker'
-
+gem 'figaro'
+gem 'font-awesome-rails'
+gem 'json-schema'
+gem 'kaminari'
+gem 'momentjs-rails' # js lib for dates
 gem 'pundit'
 
+gem 'ruby-saml', '~> 1.4.2'
+
 gem 'libxml-to-hash', git: 'https://github.com/johannesthoma/libxml-to-hash'
+gem 'multi_xml'
+
+# collections metadata preview
+# run this command to work from a local copy of the gem's repo
+# bundle config local.cmr_metadata_preview /path/to/local/git/repository
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', branch: 'master'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -58,10 +71,10 @@ group :development, :test do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   # gem 'spring'
 
-  gem 'sqlite3'
-  gem 'rspec-rails'
-  gem 'vcr'
   gem 'jshint'
+  gem 'rspec-rails'
+  gem 'sqlite3'
+  gem 'vcr'
 end
 
 group :development do
@@ -90,16 +103,3 @@ end
 group :production do
   gem 'pg'
 end
-
-gem 'figaro'
-gem 'json-schema'
-gem 'awrence' # convert snake_case hash keys to CamelCase hash keys
-gem 'database_cleaner' # added to provide a solution to Capybara's problems with js=>true
-gem 'kaminari'
-gem 'carmen' # countries and subdivisions
-gem 'factory_girl_rails'
-gem 'builder'
-
-# run this command to work from a local copy of the gem's repo
-# bundle config local.cmr_metadata_preview /path/to/local/git/repository
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', branch: 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'kaminari'
 gem 'momentjs-rails' # js lib for dates
 gem 'pundit'
 
-gem 'ruby-saml', '~> 1.4.2'
+gem 'ruby-saml', '>= 1.7.0'
 
 gem 'libxml-to-hash', git: 'https://github.com/johannesthoma/libxml-to-hash'
 gem 'multi_xml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
-    ruby-saml (1.4.2)
+    ruby-saml (1.7.2)
       nokogiri (>= 1.5.10)
     sass (3.4.21)
     sass-rails (5.0.4)
@@ -345,7 +345,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   rubocop
-  ruby-saml (~> 1.4.2)
+  ruby-saml (>= 1.7.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,8 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    ruby-saml (1.4.2)
+      nokogiri (>= 1.5.10)
     sass (3.4.21)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -343,6 +345,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   rubocop
+  ruby-saml (~> 1.4.2)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   simplecov

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -1,0 +1,111 @@
+class SamlController < UsersController
+  # skip urs login requirements application controller
+  skip_before_action :is_logged_in
+  skip_before_action :setup_query
+  skip_before_action :refresh_urs_if_needed, except: [:logout, :refresh_token]
+  skip_before_action :provider_set?
+
+  # skip_before_action :require_launchpad_authorization
+
+  def index
+    @attrs = {}
+  end
+
+  # Single Sign On
+  def sso
+    # Unsanitized URL parameters!
+    authn_context = (params[:authn_context].nil? ? get_authn_context : params[:authn_context])
+
+    # This needs to go away and be replaced with a parse of the SAML response down in the acs method, because right now it's making a dangerous assumption about the current state of the authenticated user within the application session context.
+    case authn_context
+    when "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
+      session[:auth_level] = 20
+    when "urn:oasis:names:tc:SAML:2.0:ac:classes:TimeSyncToken"
+      session[:auth_level] = 30
+    when "urn:oasis:names:tc:SAML:2.0:ac:classes:SmartcardPKI"
+      session[:auth_level] = 40
+    else
+      session[:auth_level] = 0
+    end
+
+    settings = Account.get_saml_settings(get_url_base, authn_context)
+
+    if settings.nil?
+      @errors = ['No SP/IDP settings found.']
+
+      logger.info "Settings error. Errors: #{response.errors}"
+
+      render action: :failure
+    end
+
+    request = OneLogin::RubySaml::Authrequest.new
+
+    redirect_to request.create(settings)
+  end
+
+  # Assertion Consumer Service
+  def acs
+    settings = Account.get_saml_settings(get_url_base, get_authn_context)
+
+    @response = OneLogin::RubySaml::Response.new(params[:SAMLResponse], settings: settings)
+
+    if @response.is_valid?
+      # TODO params[:SAMLResponse] _should be_ what CMR wants us to pass as a token
+      # However, currently this is causing a ActionDispatch::Cookies::CookieOverflow
+      # problem. We may want to use https://github.com/rails/activerecord-session_store
+      # to store and pass it
+      # TODO since the SAML library is able to decrypt SAMLResponse to data we can use,
+      # can it also re-encrypt it?
+      # session[:launchpad_response_string] = params[:SAMLResponse]
+
+      attributes = @response.attributes
+      session[:auid] = attributes[:auid]
+      # session[:email] = attributes[:email]
+      # TODO need to verify and set what other session info is needed
+
+      redirect_from_urs
+    else
+      @errors = @response.errors
+
+      Rails.logger.error "Response invalid. Errors: #{@response.errors}"
+
+      # Status App runs `raise ForbiddenError.new`, but this is what the NASA github example does
+      render :failure
+    end
+  end
+
+  def metadata
+    settings = Account.get_saml_settings(get_url_base)
+
+    meta = OneLogin::RubySaml::Metadata.new
+
+    render xml: meta.generate(settings, true)
+  end
+
+  def logout
+    reset_session
+  end
+
+  # def sp_logout_request
+  # end
+  #
+  # def process_logout_response
+  # end
+  #
+  # def idp_logout_request
+  # end
+
+  def get_url_base
+    Figaro.env.SAML_SP_ISSUER_BASE
+  end
+
+  def get_authn_context
+    if session[:auth_level].nil? || session[:auth_level] < 30
+      "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
+    elsif session[:auth_level].between?(30, 39)
+      "urn:oasis:names:tc:SAML:2.0:ac:classes:TimeSyncToken"
+    elsif 40 <= session[:auth_level]
+      "urn:oasis:names:tc:SAML:2.0:ac:classes:SmartcardPKI"
+    end
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,0 +1,56 @@
+# Modified from https://github.com/onelogin/ruby-saml-example/blob/master/app/models/account.rb
+
+class Account < ActiveRecord::Base
+  def self.get_saml_settings(url_base = 'https://mmt.test', authn_context = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport")
+    # url_base ||= 'http://localhost:3000'
+
+    settings = OneLogin::RubySaml::Settings.new
+
+    # When disabled, SAML validation errors will raise an exception.
+    settings.soft = false
+
+    # AuthnContext
+    #"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
+    #"urn:oasis:names:tc:SAML:2.0:ac:classes:TimeSyncToken"
+    #"urn:oasis:names:tc:SAML:2.0:ac:classes:SmartcardPKI"
+    settings.authn_context = authn_context
+
+    # SP section
+    # certificate and private_key not used in Status App
+    # settings.certificate = ENV["certificate"] # Figaro.env.certificate
+    # settings.private_key = ENV["private_key"] # Figaro.env.private_key
+
+    settings.issuer = Figaro.env.SAML_SP_ISSUER
+    settings.assertion_consumer_service_url = Figaro.env.SAML_SP_ACS_URL
+    #settings.assertion_consumer_logout_service_url = url_base + "/saml/logout"
+
+    # IDP section
+    settings.idp_entity_id = Figaro.env.SAML_IDP_ENTITY_ID
+    settings.idp_sso_target_url = Figaro.env.SAML_IDP_SSO_TARGET_URL
+
+    #settings.idp_slo_target_url = ""
+    settings.idp_cert = Figaro.env.SAML_IDP_CERT
+
+    # idp_cert_fingerprint not used in Status App
+    # settings.idp_cert_fingerprint = ENV["idp_cert_fingerprint"] # Figaro.env.idp_cert_fingerprint
+
+    settings.idp_cert_fingerprint_algorithm = XMLSecurity::Document::SHA1
+
+    # settings.name_identifier_format = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+    settings.name_identifier_format = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+
+    settings.assertion_consumer_service_binding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+    settings.protocol_binding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+
+    # Security section
+    settings.security[:authn_requests_signed] = true
+    #settings.security[:logout_requests_signed] = false
+    #settings.security[:logout_responses_signed] = false
+    settings.security[:metadata_signed] = true
+    settings.security[:digest_method] = XMLSecurity::Document::SHA256
+    settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
+    settings.security[:embed_sign] = false
+
+    settings
+  end
+end

--- a/app/views/saml/failure.html.erb
+++ b/app/views/saml/failure.html.erb
@@ -1,0 +1,17 @@
+<main class="internal" role="main">
+  <header>
+    <h2>SAML Authentication Failure</h2>
+  </header>
+
+  <section>
+    <div class="row row-content">
+      <h3>Errors</h3>
+
+      <ul>
+        <% @errors.each do |error| %>
+          <li><%= error %></li>
+        <% end %>
+      </ul>
+    </div>
+  </section>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,12 @@ Rails.application.routes.draw do
   get 'urs_callback' => 'oauth_tokens#urs_callback'
   get 'provider_context' => 'users#provider_context', as: 'provider_context'
 
+  # SAML login
+  get 'saml/sso', to: 'saml#sso', as: :sso
+  post 'saml/acs', to: 'saml#acs', as: :acs
+  get 'saml/metadata', to: 'saml#metadata', as: :saml_metadata
+  get 'saml/logout', to: 'saml#logout', as: :saml_logout
+
   post 'convert' => 'conversions#convert'
 
   post 'set_provider' => 'users#set_provider', as: 'set_provider'


### PR DESCRIPTION
- Add SamlController, Account model, and routes for the SAML endpoints
- does not run the controller methods, but allows the routes to be checked by launchpad 