### PR TITLE
MMT-1467: revise local cmr setup to create ACLs in CMR Access Control instead of Mock Echo.

### DIFF
--- a/doc/local_cmr_documentation.md
+++ b/doc/local_cmr_documentation.md
@@ -1,0 +1,60 @@
+## Documentation for the local CMR
+MMT uses a local version of the CMR for our development and test environments. Downloading it is described in our main Readme. Our local CMR setup is run through our rake tasks described also in the Readme file.
+The main file that is run by that rake task is `lib/test_cmr/load_data.rb`.
+
+### This Document is currently a DRAFT
+This should be more fully fleshed out with MMT-1517 to refactor the files described here
+
+### CMR ports
+These are the main ports we use in local setup
+  1. http://localhost:3002
+    * Ingest
+    * Documentation at https://cmr.sit.earthdata.nasa.gov/ingest/site/docs/ingest
+    * providers created here
+  2. http://localhost:3008
+    * Mock Echo
+    * a RESTful API for Echo, supposed to work locally and give same basic functionality as ECHO
+  3. http://localhost:3011
+    * Access Control - ACLs and Groups
+    * Documentation at https://cmr.sit.earthdata.nasa.gov/access-control/site/docs/access-control/
+
+
+### ACLs
+ACLs, or Access Control Lists, are how CMR sets user permissions to have CRUD (and a few other actions) access to CMR resources/data. ACLs are granted to groups, and users have to be in a group to have rights granted by any ACL. Tokens are how CMR identifies a user and determines their groups and ACLs.
+SIDS (may need a better explanation) link a user to ACLs.
+See the documentation linked above for more detailed information on CMR Access Control
+
+### `load_data.rb`
+This is the main script that runs and sets up our local CMR environment. It has three main methods that it runs:
+
+#### 1. `setup_cmr`
+This sets up all the initial user tokens, providers, groups, and ACLs.
+  1. Set up the user tokens: user `admin` will be assigned token `ABC-1` and user `typical` will be assigned token `ABC-2`
+  2. Create Providers in CMR
+  3. Create the same Providers in Mock Echo. These providers need to be created in both places
+  4. Create Groups in CMR Access Control to use for ACLs
+  5. Add ACLs for all providers for 'guest' and 'registered' users to access collections and granules (collection permissions, aka CATALOG_ITEM_ACLs) and ingest (INGEST_MANAGEMENT_ACL)
+  6. Add ACLs for the providers. These include rights to take actions for GROUP, CATALOG_ITEM_ACL, and PROVIDER_OBJECT_ACL.
+
+#### 2. `insert_metadata`
+This ingests all the collection metadata for initial setup. We are loading the data from `.yml` files in `lib/test_cmr/data/`.
+
+We have the data stored as yaml files so it isn't necessary to re-download the metadata each time we are running the local CMR setup.
+If changes to these collections need to be made, the list of data we should be loading is listed in `lib/test_cmr/test_data.json`, and the `save_data` method will download and serialize the data as yaml files.
+
+#### 3. `additional_cmr_setup`
+After all the initial CMR setup is done and collections are ingested, this script adds a Collection Permission (catalog item acl) for a single collection for a provider that is used for a specific test.
+
+#### `reset_provider`
+This method is used by our tests. It tears down a provider (almost always MMT_2) and recreates that provider (with the same provider_id) and recreates the group and ACLs we create in the regular CMR setup in `load_data`
+
+### non public CMR API calls
+There are some calls in `load_data.rb` to CMR that are not public API calls. They are needed to make sure the local setup and testing correctly _____ like reindexing, clearing the cache, and tearing down and standing up providers. ___
+
+- `clear_cache`
+This call is the bootstrap clear_cache call. It clears out the ACL cache because sometimes there is a discrepancy between the cache and what ACL has
+- `reindex_permitted_groups`
+go through all collections and check ACLs which group ids have permissions and puts it in the elastic document for collections (collection index)
+  ACLs and Collections each have their own elastic index
+- `wait_for_indexing`
+  These calls wait for the CMR queue to be empty and refreshes the ElasticSearch Index

--- a/lib/tasks/acls.rake
+++ b/lib/tasks/acls.rake
@@ -1,5 +1,7 @@
 # require 'rake'
-
+# TODO need to make sure we are getting the right groups in a non-hardcoded way
+# with MMT-1517 for refactoring the local cmr setup
+# the commented out tasks will need those group concept ids or to have the groups changed
 namespace :acls do
   namespace :users do
     desc 'Add a provided username to CMR'
@@ -14,12 +16,14 @@ namespace :acls do
       print_result(cmr_client.add_group_members(args.group_concept_id, [args.username], get_acls_token))
     end
 
-    desc 'Add a user to the User Group'
+    # this should be changed to the 'MMT Admin Group'
+    desc 'Add a user to the User Group' # guidMMTUser
     task :mmt_users, [:username] => :environment do |_task, args|
       print_result(cmr_client.add_group_members('AG1200000005-CMR', [args.username], get_acls_token(admin: true)), "Added #{args.username} to MMT Users")
     end
 
-    desc 'Add a user to the Admin Group'
+    # we don't need to add the user to this group, we should just add them to Administrators_2 below
+    desc 'Add a user to the Admin Group' # guidMMTAdmin
     task :admins, [:username] => :environment do |_task, args|
       print_result(cmr_client.add_group_members('AG1200000004-CMR', [args.username, 'typical'], get_acls_token(admin: true)), "Added #{args.username} to MMT Admins")
     end

--- a/lib/test_cmr/load_data.rb
+++ b/lib/test_cmr/load_data.rb
@@ -10,6 +10,8 @@ require 'multi_xml'
 
 module Cmr
   class Local
+    attr_accessor :nsidc_test_case_collection
+
     def initialize
     end
 
@@ -66,6 +68,10 @@ module Cmr
     end
 
     def setup_cmr
+      ###
+      ### Create Users (and their tokens) in Mock Echo
+      ###
+
       # Create user 'admin' that has token ABC-1
       resp = connection.post do |req|
         req.url('http://localhost:3008/tokens')
@@ -85,7 +91,11 @@ module Cmr
 
       clear_cache
 
-      ### Creating a Provider in CMR
+      ###
+      ### Create Providers
+      ###
+
+      ## Create Providers in CMR
       # Provider SEDAC
       connection.post do |req|
         req.url('http://localhost:3002/providers')
@@ -122,7 +132,7 @@ module Cmr
         req.body = '{"provider-id": "NSIDC_ECS", "short-name": "NSIDC_ECS", "cmr-only": true}'
       end
 
-      ### Create a provider in Mock Echo
+      ## Create providers in Mock Echo
       # Provider SEDAC
       connection.post do |req|
         req.url('http://localhost:3008/providers')
@@ -161,300 +171,360 @@ module Cmr
 
       clear_cache
 
-      ### Adding ACLs
-      # Provider SEDAC
-      connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "GUEST"}}},{"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}],"catalog_item_identity": {"collection_applicable": true,"granule_applicable": true,"provider_guid": "provguid1"}}}'
-      end
-      connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["UPDATE","READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "GUEST"}}},{"permissions": ["UPDATE","READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}],"provider_object_identity": {"provider_guid": "provguid1","target": "INGEST_MANAGEMENT_ACL"}}}'
-      end
-      # Provider LARC
-      # ACL to give all guest and all registered users READ access on LARC collections, through a collection permission (catalog item acl) in mock echo
-      connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "GUEST"}}},{"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}],"catalog_item_identity": {"collection_applicable": true,"granule_applicable": true,"provider_guid": "provguid2"}}}'
-      end
-      connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["UPDATE","READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "GUEST"}}},{"permissions": ["UPDATE","READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}],"provider_object_identity": {"provider_guid": "provguid2","target": "INGEST_MANAGEMENT_ACL"}}}'
-      end
-      # Provider MMT_1
-      connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "GUEST"}}},{"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}],"catalog_item_identity": {"collection_applicable": true,"granule_applicable": true,"provider_guid": "provguid3"}}}'
-      end
-      connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["UPDATE","READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "GUEST"}}},{"permissions": ["UPDATE","READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}],"provider_object_identity": {"provider_guid": "provguid3","target": "INGEST_MANAGEMENT_ACL"}}}'
-      end
-      # Provider MMT_2
-      connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "GUEST"}}},{"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}],"catalog_item_identity": {"collection_applicable": true,"granule_applicable": true,"provider_guid": "provguid4"}}}'
-      end
-      connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["UPDATE","READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "GUEST"}}},{"permissions": ["UPDATE","READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}],"provider_object_identity": {"provider_guid": "provguid4","target": "INGEST_MANAGEMENT_ACL"}}}'
-      end
-      # Provider NSIDC_ECS
-      # ACL to give admin user read on NSIDC_ECS collections
-      resp = connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ"],"sid": {"group_sid": {"group_guid": "guidMMTAdmin"}}}],"catalog_item_identity": {"collection_applicable": true,"granule_applicable": true,"provider_guid": "provguid5"}}}'
-      end
-      puts "ACL for admin user to read collections for NSIDC_ECS, via mock echo #{resp.inspect}"
+      ###
+      ### Create System and Provider Groups
+      ###
 
-      clear_cache
-
-      ## ACLs for System level groups
-      ## these ACLs need groups in the access control groups api (3011) for sids lookup to work properly for the tokens created at the beginning of this setup
-      # these ACLs create permisisons for system level groups on the mock echo side, currently which are the only ones that are honored
-      # currently ACLs for system level groups created on the cmr/new access control side (3011) do not propogate to the mock echo side and so are not honored by the system
-      # admin user
-      resp = connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ","CREATE"],"sid": {"group_sid": {"group_guid": "guidMMTAdmin"}}}],"system_object_identity": {"target": "GROUP"}}}'
-      end
-      puts "ACL for system group access for admin user in mock echo: #{resp.body}"
-      # mock-echo-system-token
-      resp = connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ","CREATE"],"sid": {"group_sid": {"group_guid": "mock-admin-group-guid"}}}],"system_object_identity": {"target": "GROUP"}}}'
-      end
-      puts "ACL for system group access for mock-echo-system-token in mock echo: #{resp.body}"
-
-      clear_cache
-
-      # there is now a default group with name 'Administrators' in CMR
       # Create system level group
+      # By default CMR creates a system group 'Administrators' but we should create our own
       resp = connection.post do |req|
         req.url('http://localhost:3011/groups')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
         req.body = '{"name": "Administrators_2", "description": "The group of users that manages the CMR."}'
       end
-      puts "Created system level group in access control: #{resp.body}"
+      admin_group_concept = JSON.parse(resp.body)['concept_id']
+      puts "Created system level group Administrators_2 in access control: #{resp.body}, with concept_id #{admin_group_concept}"
       # Create SEDAC group
       resp = connection.post do |req|
         req.url('http://localhost:3011/groups')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"name": "SEDAC Test Group", "description": "Test group for provider", "provider_id": "SEDAC"}'
+        req.body = '{"name": "SEDAC Admin Group", "description": "Test group for provider", "provider_id": "SEDAC"}'
       end
-      puts "Created SEDAC group in access control: #{resp.body}"
+      sedac_group_concept = JSON.parse(resp.body)['concept_id']
+      puts "Created SEDAC group in access control: #{resp.body}, with concept_id #{sedac_group_concept}"
+      # Create LARC group
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/groups')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"name": "LARC Admin Group", "description": "Test group for provider", "provider_id": "LARC"}'
+      end
+      larc_group_concept = JSON.parse(resp.body)['concept_id']
+      puts "Created LARC group in access control: #{resp.body}, with concept_id #{larc_group_concept}"
+      # Create MMT_1 group
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/groups')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"name": "MMT_1 Admin Group", "description": "Test group for provider", "provider_id": "MMT_1"}'
+      end
+      mmt_1_group_concept = JSON.parse(resp.body)['concept_id']
+      puts "Created MMT_1 group in access control: #{resp.body}, with concept_id #{mmt_1_group_concept}"
+      # Create MMT_2 group
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/groups')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"name": "MMT_2 Admin Group", "description": "Test group for provider", "provider_id": "MMT_2"}'
+      end
+      mmt_2_group_concept = JSON.parse(resp.body)['concept_id']
+      puts "Created MMT_2 group in access control: #{resp.body}, with concept_id #{mmt_2_group_concept}"
+      # Create NSIDC_ECS group
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/groups')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"name": "NSIDC_ECS Admin Group", "description": "Test group for provider", "provider_id": "NSIDC_ECS"}'
+      end
+      nsidc_group_concept = JSON.parse(resp.body)['concept_id']
+      puts "Created NSIDC_ECS group in access control: #{resp.body}, with concept_id #{nsidc_group_concept}"
 
       clear_cache
 
-      ### These calls were all added because of various issues with permissions with groups
-      ### and ACLs. I would like to keep these in as reference until all the issues are resolved
+      ###
+      ### Add collection permissions, aka CATALOG_ITEM_ACLs, and INGEST_MANAGEMENT_ACLs for providers
+      ###
 
-      ## Add administrative and regular users to the locally mocked URS, so they can be added to groups for ACLs and permissions
-      ## and given appropriate permissions for groups, permissions, etc.
+      # Provider SEDAC
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"permissions": ["read"], "user_type": "guest"}, {"permissions": ["read"], "user_type": "registered"}], "catalog_item_identity": {"name": "SEDAC All Collections and Granules", "provider_id": "SEDAC", "collection_applicable": true, "granule_applicable": true}}'
+      end
+      puts "Catalog Item ACL for guest and registered users for SEDAC #{resp.body}"
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"user_type": "guest", "permissions": ["read", "update"]}, {"user_type": "registered", "permissions": ["read", "update"]}], "provider_identity": {"target": "INGEST_MANAGEMENT_ACL", "provider_id": "SEDAC"}}'
+      end
+      puts "ACL for INGEST_MANAGEMENT_ACL for guest and registered users for SEDAC #{resp.body}"
+      # Provider LARC
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"permissions": ["read"], "user_type": "guest"}, {"permissions": ["read"], "user_type": "registered"}], "catalog_item_identity": {"name": "LARC All Collections and Granules", "provider_id": "LARC", "collection_applicable": true, "granule_applicable": true}}'
+      end
+      puts "Catalog Item ACL for guest and registered users for LARC #{resp.body}"
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"user_type": "guest", "permissions": ["read", "update"]}, {"user_type": "registered", "permissions": ["read", "update"]}], "provider_identity": {"target": "INGEST_MANAGEMENT_ACL", "provider_id": "LARC"}}'
+      end
+      puts "ACL for INGEST_MANAGEMENT_ACL for guest and registered users for LARC #{resp.body}"
+      # Provider MMT_1
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"permissions": ["read"], "user_type": "guest"}, {"permissions": ["read"], "user_type": "registered"}], "catalog_item_identity": {"name": "MMT_1 All Collections and Granules", "provider_id": "MMT_1", "collection_applicable": true, "granule_applicable": true}}'
+      end
+      puts "Catalog Item ACL for guest and registered users for MMT_1 #{resp.body}"
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"user_type": "guest", "permissions": ["read", "update"]}, {"user_type": "registered", "permissions": ["read", "update"]}], "provider_identity": {"target": "INGEST_MANAGEMENT_ACL", "provider_id": "MMT_1"}}'
+      end
+      puts "ACL for INGEST_MANAGEMENT_ACL for guest and registered users for MMT_1 #{resp.body}"
+      # Provider MMT_2
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"permissions": ["read"], "user_type": "guest"}, {"permissions": ["read"], "user_type": "registered"}], "catalog_item_identity": {"name": "MMT_2 All Collections and Granules", "provider_id": "MMT_2", "collection_applicable": true, "granule_applicable": true}}'
+      end
+      puts "Catalog Item ACL for guest and registered users for MMT_2 #{resp.body}"
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"user_type": "guest", "permissions": ["read", "update"]}, {"user_type": "registered", "permissions": ["read", "update"]}], "provider_identity": {"target": "INGEST_MANAGEMENT_ACL", "provider_id": "MMT_2"}}'
+      end
+      puts "ACL for INGEST_MANAGEMENT_ACL for guest and registered users for MMT_2 #{resp.body}"
+
+      clear_cache
+
+      ###
+      ### Add users to groups
+      ###
+
+      # for the local CMR, we need to add the users to the locally mocked URS
+      # (in mock echo) before adding them into groups
+      #
+      ## Add administrative and regular users to the locally mocked URS, so they
+      ## can be added to groups for ACLs and permissions and given appropriate
+      ## permissions for groups, permissions, etc.
+      #
       # Users 'admin' and 'typical' are created first above with tokens ABC-1 and ABC-2
       # Users 'adminuser' and 'testuser' are the urs_uids used in our tests
       connection.post do |req|
         req.url('http://localhost:3008/urs/users')
         req.headers['Content-Type'] = 'application/json'
-        req.body = '[{"username": "admin", "password": "admin"}, {"username": "typical", "password":"password"}, {"username": "adminuser", "password": "admin"}, {"username": "testuser", "password":"password"}]'
+        req.body = '[{"username": "admin", "password": "admin"}, {"username": "typical", "password": "password"}, {"username": "adminuser", "password": "admin"}, {"username": "testuser", "password": "password"}]'
       end
-      # add admin and adminuser to our Administrators_2 group (usu AG1200000001-CMR)
+
+      # add admin users to Administrators_2 group
       resp = connection.post do |req|
-        req.url('http://localhost:3011/groups/AG1200000001-CMR/members')
+        req.url("http://localhost:3011/groups/#{admin_group_concept}/members")
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
         req.body = '["admin", "adminuser"]'
       end
       puts "add admin and adminuser to Administrators_2: #{resp.body}"
+      # add admin users to SEDAC group
+      resp = connection.post do |req|
+        req.url("http://localhost:3011/groups/#{sedac_group_concept}/members")
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '["admin", "adminuser"]'
+      end
+      puts "add admin and adminuser to SEDAC group: #{resp.body}"
+      # add typical users to LARC group
+      resp = connection.post do |req|
+        req.url("http://localhost:3011/groups/#{larc_group_concept}/members")
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '["typical", "testuser"]'
+      end
+      puts "add typical and testuser to LARC group: #{resp.body}"
+      # add typical users to MMT_1 group
+      resp = connection.post do |req|
+        req.url("http://localhost:3011/groups/#{mmt_1_group_concept}/members")
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '["typical", "testuser"]'
+      end
+      puts "add typical and testuser to MMT_1 group: #{resp.body}"
+      # add typical users to MMT_2 group
+      resp = connection.post do |req|
+        req.url("http://localhost:3011/groups/#{mmt_2_group_concept}/members")
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '["typical", "testuser"]'
+      end
+      puts "add typical and testuser to MMT_2 group: #{resp.body}"
+      # add typical users to NSIDC_ECS group
+      resp = connection.post do |req|
+        req.url("http://localhost:3011/groups/#{nsidc_group_concept}/members")
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '["typical", "testuser"]'
+      end
+      puts "add typical and testuser to NSIDC_ECS group: #{resp.body}"
+
+      clear_cache
+
+      ###
+      ### Create ACLs
+      ###
+
+      # ACL for CRUD for ACLs for Administrators_2, read access for registered users
+      # read access means they can query/see any ACL and get a response
+      # this means all registered users don't need to add read rights for
+      # PROVIDER_OBJECT_ACL for a user to see if they have that PROVIDER_CONTEXT
+      # also any user in Administrators_2 has full access to any ACL in the system
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"group_id": "' + admin_group_concept + '", "permissions": ["read", "create", "update", "delete"]}, {"user_type":"registered", "permissions":["read"]}], "system_identity": {"target": "ANY_ACL"}}'
+      end
+      puts "ANY_ACL CRUD access for Administrators_2 and read for registered users: #{resp.body}"
+
+      # ACL for admin and typical user to have provider context for MMT_2
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"group_id": "' + mmt_2_group_concept + '", "permissions": ["read"]}, {"group_id": "' + admin_group_concept + '", "permissions": ["read"]}], "provider_identity": {"target": "PROVIDER_CONTEXT", "provider_id": "MMT_2"}}'
+      end
+      puts "ACL for admin and typical user to read PROVIDER_CONTEXT for MMT_2 #{resp.body}"
+
+      ##
+      ## ACLs for Groups
+      ##
+
       # create ACL for system level groups for Administrators_2
       resp = connection.post do |req|
         req.url('http://localhost:3011/acls')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"group_permissions": [{"group_id": "AG1200000001-CMR","permissions": ["read", "create"]}], "system_identity": {"target": "GROUP"}}'
+        req.body = '{"group_permissions": [{"group_id": "' + admin_group_concept + '","permissions": ["read", "create"]}], "system_identity": {"target": "GROUP"}}'
       end
       puts "acl for system level groups for Administrators_2 in access control #{resp.body}"
-
-      clear_cache
-
-      ## Add groups into access control so it can provide the SIDS
-      # Administrative Users, that use token ABC-1
-      resp = connection.post do |req|
-        req.url('http://localhost:3011/groups')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"name": "MMT Admins", "description": "MMT admin group", "legacy_guid": "guidMMTAdmin", "members": ["admin", "adminuser"]}'
-      end
-      puts "add group for admin for sids: #{resp.body}"
-      # Regular Users, that use token ABC-2
-      resp = connection.post do |req|
-        req.url('http://localhost:3011/groups')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"name": "MMT Users", "description": "MMT users group", "legacy_guid": "guidMMTUser", "members": ["typical", "testuser"]}'
-      end
-      puts "add group for typical user for sids: #{resp.body}"
-
-      clear_cache
-
-      ### ACLs for provider groups
-      # Admin access to SEDAC
-      resp = connection.post do |req| # this is not working properly
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ","CREATE"],"sid": {"group_sid": {"group_guid": "guidMMTAdmin"}}}],"provider_object_identity": {"provider_guid": "provguid1","target": "GROUP"}}}'
-      end
-      puts "ACL for admin access to SEDAC provider groups in mock echo: #{resp.body}"
-
-      # ACL for typical user for MMT_1 groups
-      connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ","CREATE"],"sid": {"group_sid": {"group_guid": "guidMMTUser"}}}],"provider_object_identity": {"provider_guid": "provguid3","target": "GROUP"}}}'
-      end
-      # ACL for typical user for MMT_2 groups
-      connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ","CREATE"],"sid": {"group_sid": {"group_guid": "guidMMTUser"}}}],"provider_object_identity": {"provider_guid": "provguid4","target": "GROUP"}}}'
-      end
-      # ACL for typical user for NSIDC_ECS groups
-      connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ","CREATE"],"sid": {"group_sid": {"group_guid": "guidMMTUser"}}}],"provider_object_identity": {"provider_guid": "provguid5","target": "GROUP"}}}'
-      end
-
-      clear_cache
-
-      ## ACLs for permissions for ACLs
-      ## temporary fix: we are using the legacy_guid used in the groups we created for the sids
-      ## it should have been the concept_id of the group but that was not working. what we use will change in the near future
-
-      # ACL for read and create access for ACLs for admin user, read access for registered users
-      # resp = connection.post do |req|
-      #   req.url('http://localhost:3011/acls')
-      #   req.headers['Content-Type'] = 'application/json'
-      #   req.headers['Echo-token'] = 'mock-echo-system-token'
-      #   req.body = '{"group_permissions": [{"group_id": "guidMMTAdmin", "permissions": ["read", "create", "update", "delete"]}, {"user_type":"registered", "permissions":["read"]}], "system_identity": {"target": "ANY_ACL"}}'
-      # end
-      # puts "ANY_ACL read and create access for admin user (guidMMTAdmin) and registered users: #{resp.body}"
-      # NOTE TEMP ACL for CRUD for ACLs for Administrators_2, read access for registered users
+      # create ACL for SEDAC groups for admin users
       resp = connection.post do |req|
         req.url('http://localhost:3011/acls')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"group_permissions": [{"group_id": "AG1200000001-CMR", "permissions": ["read", "create", "update", "delete"]}, {"user_type":"registered", "permissions":["read"]}], "system_identity": {"target": "ANY_ACL"}}'
+        req.body = '{"group_permissions": [{"group_id": "' + sedac_group_concept + '", "permissions": ["read", "create"]}], "provider_identity": {"target": "GROUP", "provider_id": "SEDAC"}}'
       end
-      puts "ANY_ACL CRUD access for Administrators_2 and read for registered users: #{resp.body}"
+      puts "ACL for Provider Identity GROUP for admin users for SEDAC #{resp.body}"
+      # ACL for typical users for LARC groups
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"group_id": "' + larc_group_concept + '", "permissions": ["read", "create"]}], "provider_identity": {"target": "GROUP", "provider_id": "LARC"}}'
+      end
+      puts "ACL for Provider Identity GROUP for typical and testuser for LARC #{resp.body}"
+      # ACL for typical users for MMT_1 groups
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"group_id": "' + mmt_1_group_concept + '", "permissions": ["read", "create"]}], "provider_identity": {"target": "GROUP", "provider_id": "MMT_1"}}'
+      end
+      puts "ACL for Provider Identity GROUP for typical users for MMT_1 #{resp.body}"
+      # ACL for typical users for MMT_2 groups
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"group_id": "' + mmt_2_group_concept + '", "permissions": ["read", "create"]}], "provider_identity": {"target": "GROUP", "provider_id": "MMT_2"}}'
+      end
+      puts "ACL for Provider Identity GROUP for typical users for MMT_2 #{resp.body}"
+      # ACL for typical users for NSIDC_ECS groups
+      resp = connection.post do |req|
+        req.url('http://localhost:3011/acls')
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Echo-token'] = 'mock-echo-system-token'
+        req.body = '{"group_permissions": [{"group_id": "' + nsidc_group_concept + '", "permissions": ["read", "create"]}], "provider_identity": {"target": "GROUP", "provider_id": "NSIDC_ECS"}}'
+      end
+      puts "ACL for Provider Identity GROUP for typical users for NSIDC_ECS #{resp.body}"
+
+      clear_cache
+
+      ###
+      ### ACL to manage Provider Identity ACLs (PROVIDER_OBJECT_ACL)
+      ###
 
       # ACL for regular users to manage Provider Identity ACLs for MMT_1
       resp = connection.post do |req|
         req.url('http://localhost:3011/acls')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"group_permissions": [{"group_id": "guidMMTUser", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "PROVIDER_OBJECT_ACL", "provider_id": "MMT_1"}}'
+        req.body = '{"group_permissions": [{"group_id": "' + mmt_1_group_concept + '", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "PROVIDER_OBJECT_ACL", "provider_id": "MMT_1"}}'
       end
-      puts "ACL for CRUD permissions for typical user on Provider Identity ACLs for MMT_1 #{resp.body}"
-
+      puts "ACL for CRUD permissions for typical users on Provider Identity ACLs for MMT_1 #{resp.body}"
       # ACL for regular users to manage Provider Identity ACLs for MMT_2
       resp = connection.post do |req|
         req.url('http://localhost:3011/acls')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"group_permissions": [{"group_id": "guidMMTUser", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "PROVIDER_OBJECT_ACL", "provider_id": "MMT_2"}}'
+        req.body = '{"group_permissions": [{"group_id": "' + mmt_2_group_concept + '", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "PROVIDER_OBJECT_ACL", "provider_id": "MMT_2"}}'
       end
-      puts "ACL for CRUD permissions for typical user on Provider Identity ACLs for MMT_2 #{resp.body}"
-
-      # ACL for admin and regular users to manage Provider Identity ACLs for NSIDC_ECS
+      puts "ACL for CRUD permissions for typical users on Provider Identity ACLs for MMT_2 #{resp.body}"
+      # ACL for admin and typical user to manage Provider Identity ACLs for NSIDC_ECS
       resp = connection.post do |req|
         req.url('http://localhost:3011/acls')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"group_permissions": [{"group_id": "guidMMTUser", "permissions": ["read", "create", "update", "delete"]}, {"group_id": "guidMMTAdmin", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "PROVIDER_OBJECT_ACL", "provider_id": "NSIDC_ECS"}}'
+        req.body = '{"group_permissions": [{"group_id": "' + nsidc_group_concept + '", "permissions": ["read", "create", "update", "delete"]}, {"group_id": "AG1200000001-CMR", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "PROVIDER_OBJECT_ACL", "provider_id": "NSIDC_ECS"}}'
       end
-      puts "ACL for CRUD permissions for typical user on Provider Identity ACLs for NSIDC_ECS #{resp.body}"
+      puts "ACL for CRUD permissions for admin and typical user on Provider Identity ACLs for NSIDC_ECS #{resp.body}"
 
-      # ACL for typical user to create catalog item ACLs for MMT_1
+      clear_cache
+
+      ###
+      ### ACLs for collection permissions (CATALOG_ITEM_ACL)
+      ###
+
+      # ACL for typical users to create catalog item ACLs for LARC
       resp = connection.post do |req|
         req.url('http://localhost:3011/acls')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"group_permissions": [{"group_id": "guidMMTUser", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "CATALOG_ITEM_ACL", "provider_id": "MMT_1"}}'
+        req.body = '{"group_permissions": [{"group_id": "' + larc_group_concept + '", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "CATALOG_ITEM_ACL", "provider_id": "LARC"}}'
       end
-      puts "ACL for typical user to read and create catalog item ACLs for MMT_1 #{resp.body}"
-
-      # ACL for typical user to create catalog item ACLs for MMT_2
+      puts "ACL for typical users to read and create catalog item ACLs for LARC #{resp.body}"
+      # ACL for typical users to create catalog item ACLs for MMT_1
       resp = connection.post do |req|
         req.url('http://localhost:3011/acls')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"group_permissions": [{"group_id": "guidMMTUser", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "CATALOG_ITEM_ACL", "provider_id": "MMT_2"}}'
+        req.body = '{"group_permissions": [{"group_id": "' + mmt_1_group_concept + '", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "CATALOG_ITEM_ACL", "provider_id": "MMT_1"}}'
       end
-      puts "ACL for typical user to read and create catalog item ACLs for MMT_2 #{resp.body}"
-
-      # ACL for typical user to have provider context for MMT_2
+      puts "ACL for typical users to read and create catalog item ACLs for MMT_1 #{resp.body}"
+      # ACL for typical users to create catalog item ACLs for MMT_1
       resp = connection.post do |req|
         req.url('http://localhost:3011/acls')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"group_permissions": [{"group_id": "guidMMTUser", "permissions": ["read"]}, {"group_id": "guidMMTAdmin", "permissions": ["read"]}], "provider_identity": {"target": "PROVIDER_CONTEXT", "provider_id": "MMT_2"}}'
+        req.body = '{"group_permissions": [{"group_id": "' + mmt_2_group_concept + '", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "CATALOG_ITEM_ACL", "provider_id": "MMT_2"}}'
       end
-      puts "ACL for typical user to read PROVIDER_CONTEXT for MMT_2 #{resp.body}"
-
-      ## this is temporary and for Permissions tests
-      # ACL for typical user to create groups (access control groups) for LARC
-      resp = connection.post do |req|
-        req.url('http://localhost:3008/acls')
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ","CREATE"],"sid": {"group_sid": {"group_guid": "guidMMTUser"}}}],"provider_object_identity": {"provider_guid": "provguid2","target": "GROUP"}}}'
-      end
-      puts "ACL for typical user to read and create groups for LARC #{resp.body}"
-
-      # ACL for typical user to create catalog item ACLs for LARC
+      puts "ACL for typical users to read and create catalog item ACLs for MMT_2 #{resp.body}"
+      # Provider NSIDC_ECS
+      # ACL to give admin user read on NSIDC_ECS collections
       resp = connection.post do |req|
         req.url('http://localhost:3011/acls')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"group_permissions": [{"group_id": "guidMMTUser", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "CATALOG_ITEM_ACL", "provider_id": "LARC"}}'
+        req.body = '{"group_permissions": [{"permissions": ["read"], "group_id": "' + admin_group_concept + '"}], "catalog_item_identity": {"name": "NSIDC_ECS All Collections and Granules for admins", "provider_id": "NSIDC_ECS", "collection_applicable": true, "granule_applicable": true}}'
       end
-      puts "ACL for typical user to read and create catalog item ACLs for LARC #{resp.body}"
-
+      puts "Catalog Item ACL for admin users for NSIDC_ECS #{resp.body}"
       # ACL in access control for admin and typical user to create catalog item ACLs for NSIDC_ECS
       resp = connection.post do |req|
         req.url('http://localhost:3011/acls')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"group_permissions": [{"group_id": "guidMMTUser", "permissions": ["read", "create", "update", "delete"]}, {"group_id": "guidMMTAdmin", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "CATALOG_ITEM_ACL", "provider_id": "NSIDC_ECS"}}'
+        req.body = '{"group_permissions": [{"group_id": "' + nsidc_group_concept + '", "permissions": ["read", "create", "update", "delete"]}, {"group_id": "' + admin_group_concept + '", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "CATALOG_ITEM_ACL", "provider_id": "NSIDC_ECS"}}'
       end
       puts "ACL for admin and typical user to read and create catalog item ACLs for NSIDC_ECS, via access control #{resp.body}"
 
@@ -473,10 +543,10 @@ module Cmr
 
       # ACL (collection permission, aka catalog item acl) for NSIDC_ECS for access to a single entry title for all guest and all registered users, via access control
       resp = connection.post do |req|
-        req.url('http://localhost:3008/acls')
+        req.url('http://localhost:3011/acls')
         req.headers['Content-Type'] = 'application/json'
         req.headers['Echo-token'] = 'mock-echo-system-token'
-        req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}, {"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "GUEST"}}}],"catalog_item_identity": {"collection_applicable": true,"granule_applicable": true,"provider_guid": "provguid5", "collection_identifier": { "collection_ids": [ { "data_set_id": "Near-Real-Time SSMIS EASE-Grid Daily Global Ice Concentration and Snow Extent V004" } ] }}}}'
+        req.body = '{"group_permissions": [{"permissions": ["read"], "user_type": "guest"}, {"permissions": ["read"], "user_type": "registered"}], "catalog_item_identity": {"name": "NSIDC_ECS single collection", "provider_id": "NSIDC_ECS", "collection_applicable": true, "granule_applicable": true, "collection_identifier": {"concept_ids": ["' + @nsidc_test_case_collection + '"]}}}'
       end
       puts "Collection Permission for single entry title for NSIDC_ECS, via access control #{resp.inspect}"
 
@@ -501,7 +571,7 @@ module Cmr
         req.url('http://localhost:3002/jobs/reindex-collection-permitted-groups')
         req.headers['Echo-token'] = 'mock-echo-system-token'
       end
-      puts "Reindexing permitted groups: #{resp.inspect}"
+      # puts "Reindexing permitted groups: #{resp.inspect}"
     end
 
     def wait_for_indexing
@@ -512,14 +582,14 @@ module Cmr
         req.url('http://localhost:2999/message-queue/wait-for-terminal-states')
         req.headers['Echo-token'] = 'mock-echo-system-token'
       end
-      puts "Waiting for CMR queue to empty: #{resp.inspect}"
+      # puts "Waiting for CMR queue to empty: #{resp.inspect}"
 
       # Refresh the ElasticSearch index
       resp = connection.post do |req|
         req.url('http://localhost:9210/_refresh')
         req.headers['Echo-token'] = 'mock-echo-system-token'
       end
-      puts "Refreshing the ElasticSearch index: #{resp.inspect}"
+      # puts "Refreshing the ElasticSearch index: #{resp.inspect}"
     end
 
     def insert_metadata
@@ -535,6 +605,7 @@ module Cmr
               req.url("http://localhost:3002/providers/LARC/collections/#{encoded_bad_native_id}")
             elsif data['collection_uri'].include? 'NSIDC_ECS'
               req.url("http://localhost:3002/providers/NSIDC_ECS/collections/collection#{index}")
+              req.headers['Accept'] = 'application/json'
             elsif data['collection_uri'].include? 'SEDAC'
               req.url("http://localhost:3002/providers/SEDAC/collections/collection#{index}")
             else # data['collection_uri'].include? 'LARC'
@@ -561,12 +632,20 @@ module Cmr
           if response.success?
             added += 1
             puts "Loaded #{added} collections#{data['test_case']}"
+            set_concept_if_nsidc_test_case(data, response)
           else
-            puts response.inspect
+            puts "Error ingesting a collection: #{response.inspect}"
           end
         end
       end
       puts 'Done!'
+    end
+
+    def set_concept_if_nsidc_test_case(data, response)
+      return if !(data['collection_uri'].include?('NSIDC_ECS') && data['metadata'].include?('Near-Real-Time SSMIS EASE-Grid Daily Global Ice Concentration and Snow Extent V004'))
+
+      @nsidc_test_case_collection = JSON.parse(response.body)['concept-id']
+      puts "nsidc test case concept: #{@nsidc_test_case_collection}"
     end
 
     def reset_data
@@ -592,55 +671,99 @@ module Cmr
 
         guid = "prov-guid-#{Time.now.to_i}"
 
-        # Create provider
-        connection.post do |req|
+        # Recreate provider in Ingest
+        resp = connection.post do |req|
           req.url('http://localhost:3002/providers')
           req.headers['Content-Type'] = 'application/json'
           req.headers['Echo-token'] = 'mock-echo-system-token'
           req.body = '{"provider-id": "' + provider_id + '", "short-name": "' + provider_id + '", "cmr-only": true}'
         end
-        connection.post do |req|
+        puts "recreate provider in CMR ingest: #{resp.body}"
+        # Recreate provider in Mock Echo
+        resp = connection.post do |req|
           req.url('http://localhost:3008/providers')
           req.headers['Content-Type'] = 'application/json'
           req.headers['Echo-token'] = 'mock-echo-system-token'
           req.body = '[{"provider":{"id":"' + guid + '","provider_id":"' + provider_id + '"}}]'
         end
-        connection.post do |req|
-          req.url('http://localhost:3008/acls')
+        puts "recreate provider in mock echo: #{resp.body}"
+
+        # Create provider acl group
+        group_resp = connection.post do |req|
+          req.url('http://localhost:3011/groups')
           req.headers['Content-Type'] = 'application/json'
           req.headers['Echo-token'] = 'mock-echo-system-token'
-          req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "GUEST"}}},{"permissions": ["READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}],"catalog_item_identity": {"collection_applicable": true,"granule_applicable": true,"provider_guid": "' + guid + '"}}}'
+          req.body = '{"name": "' + provider_id + ' Admin Group", "description": "Test group for provider", "provider_id": "' + provider_id + '"}'
         end
+        # get the new provider group's concept id
+        group_concept_id = JSON.parse(group_resp.body)['concept_id']
+        puts "group added for recreated provider. concept: #{group_concept_id}; response: #{group_resp.body}"
+
+        # add typical user to new provider group
         connection.post do |req|
-          req.url('http://localhost:3008/acls')
+          req.url("http://localhost:3011/groups/#{group_concept_id}/members")
           req.headers['Content-Type'] = 'application/json'
           req.headers['Echo-token'] = 'mock-echo-system-token'
-          req.body = '{"acl": {"access_control_entries": [{"permissions": ["UPDATE","READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "GUEST"}}},{"permissions": ["UPDATE","READ"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}],"provider_object_identity": {"provider_guid": "' + guid + '","target": "INGEST_MANAGEMENT_ACL"}}}'
+          req.body = '["typical", "testuser"]'
         end
-        connection.post do |req|
-          req.url('http://localhost:3008/acls')
+
+        # recreate guest and registered user read permissions on collections (catalog item acls) in access control
+        resp = connection.post do |req|
+          req.url('http://localhost:3011/acls')
           req.headers['Content-Type'] = 'application/json'
           req.headers['Echo-token'] = 'mock-echo-system-token'
-          req.body = '{"acl": {"access_control_entries": [{"permissions": ["READ","CREATE"],"sid": {"user_authorization_type_sid": {"user_authorization_type": "REGISTERED"}}}],"provider_object_identity": {"provider_guid": "' + guid + '","target": "GROUP"}}}'
+          req.body = '{"group_permissions": [{"permissions": ["read"], "user_type": "guest"}, {"permissions": ["read"], "user_type": "registered"}], "catalog_item_identity": {"name": "' + provider_id + ' All Collections and Granules", "provider_id": "' + provider_id + '", "collection_applicable": true, "granule_applicable": true}}'
         end
+        # puts "recreate collection permissions for guest and registered users for #{provider_id} #{resp.body}"
+
+        # recreate guest and registered user ingest permissions in access control
+        resp = connection.post do |req|
+          req.url('http://localhost:3011/acls')
+          req.headers['Content-Type'] = 'application/json'
+          req.headers['Echo-token'] = 'mock-echo-system-token'
+          req.body = '{"group_permissions": [{"user_type": "guest", "permissions": ["read", "update"]}, {"user_type": "registered", "permissions": ["read", "update"]}], "provider_identity": {"target": "INGEST_MANAGEMENT_ACL", "provider_id": "' + provider_id + '"}}'
+        end
+        # puts "ACL for INGEST_MANAGEMENT_ACL for guest and registered users for #{provider_id} #{resp.body}"
+
+        # recreate provider group permissions for typical users in access control
         connection.post do |req|
           req.url('http://localhost:3011/acls')
           req.headers['Content-Type'] = 'application/json'
           req.headers['Echo-token'] = 'mock-echo-system-token'
-          req.body = '{"group_permissions": [{"group_id": "guidMMTUser", "permissions": ["read"]}, {"group_id": "guidMMTAdmin", "permissions": ["read"]}], "provider_identity": {"target": "PROVIDER_CONTEXT", "provider_id": "' + provider_id + '"}}'
+          req.body = '{"group_permissions": [{"group_id": "' + group_concept_id + '", "permissions": ["read", "create"]}], "provider_identity": {"target": "GROUP", "provider_id": "' + provider_id + '"}}'
         end
+
+        # recreate provider context permissions for admin and typical users in access control
         connection.post do |req|
           req.url('http://localhost:3011/acls')
           req.headers['Content-Type'] = 'application/json'
           req.headers['Echo-token'] = 'mock-echo-system-token'
-          req.body = '{"group_permissions": [{"group_id": "guidMMTUser", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "PROVIDER_OBJECT_ACL", "provider_id": "' + provider_id + '"}}'
+          req.body = '{"group_permissions": [{"group_id": "' + group_concept_id + '", "permissions": ["read"]}, {"group_id": "' + 'AG1200000001-CMR' + '", "permissions": ["read"]}], "provider_identity": {"target": "PROVIDER_CONTEXT", "provider_id": "' + provider_id + '"}}'
         end
-        connection.post do |req|
+
+        # recreate provider acl permissions for typical users in access control
+        resp = connection.post do |req|
           req.url('http://localhost:3011/acls')
           req.headers['Content-Type'] = 'application/json'
           req.headers['Echo-token'] = 'mock-echo-system-token'
-          req.body = '{"group_permissions": [{"group_id": "guidMMTUser", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "CATALOG_ITEM_ACL", "provider_id": "' + provider_id + '"}}'
+          req.body = '{"group_permissions": [{"group_id": "' + group_concept_id + '", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "PROVIDER_OBJECT_ACL", "provider_id": "' + provider_id + '"}}'
         end
+
+        # recreate provider catalog item acl permissions for typical users in access control
+        resp = connection.post do |req|
+          req.url('http://localhost:3011/acls')
+          req.headers['Content-Type'] = 'application/json'
+          req.headers['Echo-token'] = 'mock-echo-system-token'
+
+          req.body = '{"group_permissions": [{"group_id": "' + group_concept_id + '", "permissions": ["read", "create", "update", "delete"]}], "provider_identity": {"target": "CATALOG_ITEM_ACL", "provider_id": "' + provider_id + '"}}'
+        end
+        # puts "recreate CATALOG_ITEM_ACL permissions for typical users in #{provider_id}: #{resp.body}"
+
+        wait_for_indexing
+
+        reindex_permitted_groups
+
+        wait_for_indexing
 
         clear_cache
       end

--- a/lib/test_cmr/test_data.json
+++ b/lib/test_cmr/test_data.json
@@ -279,7 +279,8 @@
   // 55
   "collection": "https://cmr.earthdata.nasa.gov/search/concepts/C184437554-NSIDC_ECS/75",
   "ingest_count": 1,
-  "granule": null
+  "granule": null,
+  "test_case": " NSIDC_ECS restricted collection"
 }, {
   // 56
   "collection": "https://cmr.earthdata.nasa.gov/search/concepts/C115003861-NSIDC_ECS/76",

--- a/spec/features/collections/empty_response_when_setting_collection_spec.rb
+++ b/spec/features/collections/empty_response_when_setting_collection_spec.rb
@@ -8,7 +8,7 @@ describe 'Viewing a collection', js: true do
 
   let(:short_name_with_granules)  { 'MIRCCMF' }
   let(:entry_title_with_granules) { 'MISR FIRSTLOOK radiometric camera-by-camera Cloud Mask V001' }
-  concept_id_with_granules = 'C1200000044-LARC'
+  let(:concept_id_with_granules) { collection_concept_from_keyword('MIRCCMF') }
 
   before :all do
     @ingest_response, @concept_response = publish_collection_draft(revision_count: 3)

--- a/spec/features/groups/group_list_permission_spec.rb
+++ b/spec/features/groups/group_list_permission_spec.rb
@@ -14,12 +14,12 @@ describe 'Group list permissions', reset_provider: true do
       provider_id: @provider_id
     )
 
-    delete_group_name = 'Test Group For New Invites 2'
+    @delete_group_name = 'Test Group For New Invites 2'
     delete_group_description = 'Group to invite users to'
     @provider_id = 'MMT_2'
 
     @delete_group = create_group(
-      name: delete_group_name,
+      name: @delete_group_name,
       description: delete_group_description,
       provider_id: @provider_id
     )
@@ -27,7 +27,7 @@ describe 'Group list permissions', reset_provider: true do
 
   context 'when viewing the groups list' do
     before do
-      login(provider: 'MMT_1', providers: %w(MMT_1 MMT_2))
+      login(provider: 'MMT_1', providers: %w[MMT_1 MMT_2])
     end
 
     context 'when the groups provider is in the users available providers', js: true do
@@ -36,7 +36,7 @@ describe 'Group list permissions', reset_provider: true do
           visit groups_path
 
           within '.groups-table' do
-            within 'tbody > tr:nth-child(1)' do
+            within('tr', text: @edit_group_name) do
               click_on 'Edit'
             end
           end
@@ -68,7 +68,7 @@ describe 'Group list permissions', reset_provider: true do
           visit groups_path
 
           within '.groups-table' do
-            within 'tbody > tr:nth-child(2)' do
+            within('tr', text: @delete_group_name) do
               click_on 'Delete'
             end
           end

--- a/spec/features/permissions/collection_permissions_list_spec.rb
+++ b/spec/features/permissions/collection_permissions_list_spec.rb
@@ -29,6 +29,10 @@ describe 'Collection Permissions Index page', reset_provider: true do
 
     context 'when there are no permissions' do
       before do
+        empty = '{"hits": 0, "took": 7, "items": []}'
+        empty_response = cmr_success_response(empty)
+        allow_any_instance_of(Cmr::CmrClient).to receive(:get_permissions).and_return(empty_response)
+
         visit permissions_path
       end
 
@@ -37,30 +41,22 @@ describe 'Collection Permissions Index page', reset_provider: true do
           expect(page).to have_content('No permissions found.')
         end
       end
+    end
 
-      context 'when there are permissions' do
-        before do
-          add_associated_permissions_to_group(group_id: group1_id, name: 'Testing Collection Permission Index Regular 01', permissions: %w(read))
-          add_associated_permissions_to_group(group_id: group2_id, name: 'Testing Collection Permission Index Regular 02', permissions: %w(read order))
-          add_associated_permissions_to_group(group_id: group3_id, name: 'Testing Collection Permission Index Regular 03', permissions: %w(read order))
+    context 'when there are permissions' do
+      before do
+        add_associated_permissions_to_group(group_id: group1_id, name: 'Testing Collection Permission Index Regular 01', permissions: %w(read))
+        add_associated_permissions_to_group(group_id: group2_id, name: 'Testing Collection Permission Index Regular 02', permissions: %w(read order))
+        add_associated_permissions_to_group(group_id: group3_id, name: 'Testing Collection Permission Index Regular 03', permissions: %w(read order))
 
-          visit permissions_path
-        end
+        visit permissions_path
+      end
 
-        it 'displays the table of collection permissions' do
-          within '#custom-permissions-table' do
-            within 'tbody > tr:nth-child(1)' do
-              expect(page).to have_content('Testing Collection Permission Index Regular 01')
-            end
-
-            within 'tbody > tr:nth-child(2)' do
-              expect(page).to have_content('Testing Collection Permission Index Regular 02')
-            end
-
-            within 'tbody > tr:nth-child(3)' do
-              expect(page).to have_content('Testing Collection Permission Index Regular 03')
-            end
-          end
+      it 'displays the table of collection permissions' do
+        within '#custom-permissions-table' do
+          expect(page).to have_content('Testing Collection Permission Index Regular 01')
+          expect(page).to have_content('Testing Collection Permission Index Regular 02')
+          expect(page).to have_content('Testing Collection Permission Index Regular 03')
         end
       end
     end

--- a/spec/features/permissions/create_update_delete_permissions_spec.rb
+++ b/spec/features/permissions/create_update_delete_permissions_spec.rb
@@ -1,4 +1,3 @@
-# MMT-507, 508, 152, 153, 170, 171, 509, 512
 # tests for create, show, edit, update, delete
 
 require 'rails_helper'
@@ -39,7 +38,12 @@ describe 'Collection Permissions', reset_provider: true, js: true do
         check('Include Undefined')
       end
 
-      uncheck('Granules')
+      check('Granules')
+      within '#granule-access-constraints-container' do
+        fill_in('Minimum Value', with: 1.1)
+        fill_in('Maximum Value', with: 8.8)
+        check('Include Undefined')
+      end
 
       within '#permission-form-groups-table' do
         select('All Guest Users', from: 'Search')
@@ -63,7 +67,8 @@ describe 'Collection Permissions', reset_provider: true, js: true do
       end
 
       within '#granule-constraint-summary' do
-        expect(page).to have_content('This permission does not grant access to granules.')
+        expect(page).to have_content('between 1.1 and 8.8')
+        expect(page).to have_content('(or are undefined)')
       end
 
       within '#permission-groups-table' do
@@ -91,14 +96,20 @@ describe 'Collection Permissions', reset_provider: true, js: true do
           'name': 'Collection Permission to Edit 01',
           'provider_id': 'MMT_2',
           'granule_applicable': false,
-          'collection_applicable': true,
-          'collection_identifier': {
-            'access_value': {
-              'min_value': 5.0,
-              'max_value': 25.0,
-              'include_undefined_value': true
-            }
-          }
+          'collection_applicable': true
+
+          # the collection identifier is temporarily being left out because it caused an issue with CMRs handling of access constraints. This will be added back with ticket MMT-1516 after CMR-5039 is resolved
+          # TODO add back the collection identifier and make sure this test passes
+          # also make sure we have tests for access constraint values to see if
+          # collections are visible or not
+
+          # 'collection_identifier': {
+          #   'access_value': {
+          #     'min_value': 5.0,
+          #     'max_value': 55.0,
+          #     'include_undefined_value': true
+          #   }
+          # }
         }
       }
 
@@ -148,7 +159,6 @@ describe 'Collection Permissions', reset_provider: true, js: true do
           within '#granule-access-constraints-container' do
             fill_in('Minimum Value', with: 1.1)
             fill_in('Maximum Value', with: 8.8)
-            check('Include Undefined')
           end
 
           select('Group 2', from: 'Search and Order')
@@ -167,7 +177,6 @@ describe 'Collection Permissions', reset_provider: true, js: true do
 
           within '#granule-constraint-summary' do
             expect(page).to have_content('between 1.1 and 8.8')
-            expect(page).to have_content('(or are undefined)')
           end
 
           within '#permission-groups-table' do

--- a/spec/features/permissions/updating_permission_with_restricted_collections_spec.rb
+++ b/spec/features/permissions/updating_permission_with_restricted_collections_spec.rb
@@ -16,6 +16,11 @@ describe 'Updating Collection Permissions when collections are not accessible by
   let(:restricted_entry_id_2) { 'AE_SI12_3' }
 
   before :all do
+    # grab the concept ids of these collections. some are restricted, so we need the admin token
+    concept_visible_to_all = collection_concept_from_keyword('NISE_4', 'access_token_admin')
+    restricted_concept_1 = collection_concept_from_keyword('MYD29E1D_5', 'access_token_admin')
+    restricted_concept_2 = collection_concept_from_keyword('AE_SI12_3', 'access_token_admin')
+
     @group_name = "Test Group NSIDC_ECS #{rand(100)}"
     @group = create_group(
       name: @group_name,
@@ -38,9 +43,9 @@ describe 'Updating Collection Permissions when collections are not accessible by
         "granule_applicable": true,
         "collection_identifier": {
           "concept_ids": [
-            "C1200000068-NSIDC_ECS",
-            "C1200000069-NSIDC_ECS",
-            "C1200000070-NSIDC_ECS"
+            restricted_concept_1,
+            restricted_concept_2,
+            concept_visible_to_all
           ]
         }
       }
@@ -64,8 +69,8 @@ describe 'Updating Collection Permissions when collections are not accessible by
         "granule_applicable": false,
         "collection_identifier": {
           "concept_ids": [
-            "C1200000068-NSIDC_ECS",
-            "C1200000070-NSIDC_ECS"
+            restricted_concept_1,
+            restricted_concept_2
           ]
         }
       }

--- a/spec/features/permissions/updating_permission_with_system_groups_spec.rb
+++ b/spec/features/permissions/updating_permission_with_system_groups_spec.rb
@@ -5,6 +5,7 @@ describe 'Updating Collection Permissions with System Groups', reset_provider: t
   before :all do
     @group_name = random_group_name
     @group = create_group(name: @group_name, admin: false)
+    admin_2_group_concept = group_concept_from_name('Administrators_2', 'access_token_admin')
 
     wait_for_cmr
 
@@ -14,10 +15,10 @@ describe 'Updating Collection Permissions with System Groups', reset_provider: t
         group_id: @group['concept_id'],
         permissions: %w(read order)
       }, {
-        group_id: 'AG1200000000-CMR', # Administrators
+        group_id: 'AG1200000000-CMR', # default CMR Administrators group
         permissions: %w(read order)
       }, {
-        group_id: 'AG1200000001-CMR', # Administrators_2
+        group_id: admin_2_group_concept, # Administrators_2
         permissions: ['read']
       }],
       catalog_item_identity: {

--- a/spec/features/provider_identity_permissions/provider_identity_permissions_form_spec.rb
+++ b/spec/features/provider_identity_permissions/provider_identity_permissions_form_spec.rb
@@ -29,8 +29,7 @@ describe 'Provider Identity Permissions pages and form', reset_provider: true do
         # these are the bootstrapped CMR Administrators group, and the system groups we create on cmr setup
         expect(page).to have_content('Administrators')
         expect(page).to have_content('Administrators_2')
-        expect(page).to have_content('MMT Admins')
-        expect(page).to have_content('MMT Users')
+        expect(page).to have_content('MMT_2 Admin Group')
       end
     end
   end

--- a/spec/features/system_identity_permissions/system_identity_permissions_form_spec.rb
+++ b/spec/features/system_identity_permissions/system_identity_permissions_form_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'System Identity Permissions pages and form' do
   # concept_id for Administrators_2 group created on cmr setup
-  let(:concept_id) { 'AG1200000001-CMR' }
+  let(:concept_id) { group_concept_from_name('Administrators_2', 'access_token_admin') }
 
   context 'when logging in as a regular user' do
     before do
@@ -41,8 +41,6 @@ describe 'System Identity Permissions pages and form' do
             # these are the bootstrapped CMR Administrators group, and the system groups we create on cmr setup
             expect(page).to have_content('Administrators')
             expect(page).to have_content('Administrators_2')
-            expect(page).to have_content('MMT Admins')
-            expect(page).to have_content('MMT Users')
           end
         end
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -159,6 +159,7 @@ RSpec.configure do |config|
   config.include Helpers::UserHelpers
   config.include Helpers::BulkUpdateHelper
   config.include Helpers::CollectionAssociationHelper
+  config.include Helpers::ConceptHelper
 
   # Precompile assets before running the test suite
   # config.before(:suite) do

--- a/spec/support/concept_helper.rb
+++ b/spec/support/concept_helper.rb
@@ -1,0 +1,27 @@
+module Helpers
+  # :nodoc:
+  module ConceptHelper
+    def group_concept_from_path
+      current_path.sub('/groups/', '')
+    end
+
+    def group_concept_from_name(name, token = 'access_token')
+      filter = { 'name' => name }
+      group_response = cmr_client.get_cmr_groups(filter, token)
+
+      raise Array.wrap(ingest_response.body['errors']).join(' /// ') unless group_response.success?
+
+      group_response.body.fetch('items', [{}]).first['concept_id']
+    end
+
+    def collection_concept_from_keyword(keyword, token = 'access_token')
+      query = { 'keyword' => keyword }
+      search_response = cmr_client.get_collections_by_post(query, token)
+
+      raise Array.wrap(ingest_response.body['errors']).join(' /// ') unless search_response.success?
+
+      record = search_response.body.fetch('items', [{}]).first
+      record.fetch('meta', {}).fetch('concept-id', nil)
+    end
+  end
+end

--- a/spec/support/group_helper.rb
+++ b/spec/support/group_helper.rb
@@ -45,10 +45,6 @@ module Helpers
       Faker::Lorem.sentence
     end
 
-    def group_concept_from_path
-      current_path.sub('/groups/', '')
-    end
-
     def add_group_permissions(permission_params)
       ActiveSupport::Notifications.instrument 'mmt.performance', activity: 'Helpers::GroupHelper#add_group_permissions' do
         response = cmr_client.add_group_permissions(permission_params, 'access_token')

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -195,7 +195,6 @@ module Helpers
         user.save
       end
 
-      # page.driver.browser.post('/saml/acs', SAMLResponse: ENV['launchpad_saml_response'])
       visit root_path
       # this button sends a post request (which Capybara cannot do) to SAML#acs,
       # the return endpoint after a successful Launchpad authentication.
@@ -214,13 +213,18 @@ module Helpers
 
     def add_provider_context_permission(provider_ids)
       ActiveSupport::Notifications.instrument 'mmt.performance', activity: 'Helpers::UserHelpers#add_provider_context_permission' do
+
+        sys_admin_group_concept = group_concept_from_name('Administrators_2', 'access_token_admin')
+
         Array.wrap(provider_ids).each do |provider_id|
+          provider_group_concept = group_concept_from_name("#{provider_id} Admin Group", 'access_token_admin')
+
           permission_params = {
             group_permissions: [{
-              group_id: 'guidMMTUser',
+              group_id: provider_group_concept,
               permissions: ['read']
             }, {
-              group_id: 'guidMMTAdmin',
+              group_id: sys_admin_group_concept,
               permissions: ['read']
             }],
             provider_identity: {
@@ -229,7 +233,7 @@ module Helpers
             }
           }
 
-          cmr_client.add_group_permissions(permission_params, 'access_token')
+          cmr_client.add_group_permissions(permission_params, 'access_token_admin')
         end
 
         wait_for_cmr


### PR DESCRIPTION
* adjust calls in cmr startup script file
* add more comments
* change the way concept ids are used in ACLs
* modify tests and helpers
* modify the way concept ids are used in some tests
* add draft readme for local cmr setup
* add comments in acl rake tasks file