### PR TITLE
MMT-1477 added description link to top level field 'Processing Level'

### DIFF
--- a/app/views/collection_drafts/forms/_data_identification.html.erb
+++ b/app/views/collection_drafts/forms/_data_identification.html.erb
@@ -58,7 +58,8 @@
     <h3 class="eui-accordion__title eui-required-o">Processing Level</h3>
     <%= mmt_help_icon(
       title: 'Processing Level',
-      help: 'properties/ProcessingLevel'
+      help: 'properties/ProcessingLevel',
+      help_url: 'Processing+Level'
     ) %>
     <div class="eui-accordion__icon" tabindex="0">
       <i class="eui-icon eui-fa-chevron-circle-down"></i>


### PR DESCRIPTION
This change should remove the link from the sub fields under Processing Level. The branch name is not of the ticket number on advice from Jon on how to process patches in Bamboo.