### PR TITLE
MMT-1605 - updating the Loofah GEM

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       addressable (~> 2.3)
     libv8 (3.16.14.19)
     libxml-ruby (3.0.0)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)


### PR DESCRIPTION
This version of loofah is safer