### PR TITLE
MMT-1594: redirect user to log in if refresh_token fails.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -119,23 +119,6 @@ class ApplicationController < ActionController::Base
     session[:name] = profile['first_name'].nil? ? uid : "#{profile['first_name']} #{profile['last_name']}"
     session[:urs_uid] = profile['uid'] || uid
     session[:email_address] = profile['email_address']
-
-    # Echo Id is not being used, so this should be removed as part of MMT-1446
-    # Also, CMR can't get a user's Echo Id from their launchpad token
-    # Store ECHO ID
-    # if current_user.echo_id.nil?
-    #   puts "echo id is nil"
-    #   response = cmr_client.get_current_user(token)
-    #   if response.success?
-    #     Rails.logger.info "echo user response in store_profile: #{response.inspect}"
-    #     echo_user = response.body
-    #
-    #     current_user.update(echo_id: echo_user.fetch('user', {}).fetch('id'))
-    #   end
-    # end
-    #
-    # # With no echo_id we cannot request providers for the user, no sense in continuing
-    # return if current_user.echo_id.nil?
   end
 
   def store_oauth_token(oauth_response)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -115,18 +115,28 @@ class UsersController < ApplicationController
   private
 
   def finish_successful_login(profile)
+    # there is additional logging for Launchpad and URS
+    # once Launchpad has been live and stable in production for a while
+    # the Launchpad logging (`log_all_session_keys`) can be removed with MMT-1615
+    # once the URS refresh token issue has been diagnosed or resolved,
+    # the URS logging (`log_urs_session_keys`) can be removed with MMT-1616
     Rails.logger.debug '>>>>> running store_profile'
     # Stores additional information in the session pertaining to the user
     store_profile(profile)
+    Rails.logger.debug "Successful URS Login by user #{authenticated_urs_uid}" if session[:login_method] == 'urs'
+    log_urs_session_keys
     log_all_session_keys
+
     Rails.logger.debug '>>>>> running set_available_providers'
     # Updates the user's available providers
     current_user.set_available_providers(token)
     log_all_session_keys
+
     Rails.logger.debug '>>>>> running get_providers'
     # Refresh (force retrieve) the list of all providers
     cmr_client.get_providers(true)
     log_all_session_keys
+
     # Redirects the user to an appropriate location
     redirect_after_login
   end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,6 +2,7 @@ class WelcomeController < ApplicationController
   include ProviderHoldings
 
   skip_before_action :ensure_user_is_logged_in, :setup_query
+  skip_before_action :refresh_launchpad_if_needed, only: [:index]
 
   before_action :redirect_if_logged_in
 
@@ -25,6 +26,6 @@ class WelcomeController < ApplicationController
   protected
 
   def redirect_if_logged_in
-    return redirect_to manage_collections_path if logged_in?
+    return redirect_to manage_collections_path if logged_in? && server_session_expires_in > 0
   end
 end

--- a/lib/cmr/base_client.rb
+++ b/lib/cmr/base_client.rb
@@ -5,7 +5,9 @@ module Cmr
                               events: Cmr::ClientMiddleware::EventMiddleware)
   class BaseClient
     # include Cmr::QueryTransformations
-    CLIENT_ID = 'MMT'
+    include Cmr::Util
+
+    CLIENT_ID = 'MMT'.freeze
 
     def connection
       @connection ||= build_connection
@@ -18,8 +20,8 @@ module Cmr
 
     protected
 
-    # ABC-1: Admin
-    # ABC-2: Typical
+    # Token "ABC-1" is created on local cmr start up for Admin user
+    # Token "ABC-2" is created on local cmr start up for Typical user
     def token_header(token, use_real = false)
       if (Rails.env.development? || Rails.env.test?) && !use_real
         mock_token = 'ABC-2'
@@ -106,23 +108,6 @@ module Cmr
 
         conn.adapter Faraday.default_adapter
       end
-    end
-
-    def valid_uri?(uri)
-      !!URI.parse(uri)
-    rescue URI::InvalidURIError
-      false
-    end
-
-    def encode_if_needed(url_fragment)
-      valid_uri?(url_fragment) ? url_fragment : URI.encode(url_fragment)
-    end
-
-    private
-
-    def is_urs_token?(token)
-      # URS token max length is 100, Launchpad token is much longer
-      token.length <= 100 ? true : false
     end
   end
 end

--- a/lib/cmr/cmr_client.rb
+++ b/lib/cmr/cmr_client.rb
@@ -516,5 +516,17 @@ module Cmr
 
       get(url, options, headers.merge(token_header(token)))
     end
+
+    private
+
+    def valid_uri?(uri)
+      !!URI.parse(uri)
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def encode_if_needed(url_fragment)
+      valid_uri?(url_fragment) ? url_fragment : URI.encode(url_fragment)
+    end
   end
 end

--- a/lib/cmr/response.rb
+++ b/lib/cmr/response.rb
@@ -2,6 +2,8 @@ module Cmr
   # Wraps a Faraday::Response object with helper methods and methods specific to
   # interpreting ECHO responses
   class Response
+    include Cmr::Util
+
     def initialize(faradayResponse)
       @response = faradayResponse
     end
@@ -78,7 +80,10 @@ module Cmr
       if faraday_response.env.fetch(:request_headers, {})['Echo-Token']
         clean_response = faraday_response.deep_dup
 
-        echo_token_snippet = clean_response.env[:request_headers].delete('Echo-Token').split(':').map { |token_part| token_part.truncate(token_part.length / 4 + 3) }.join(':')
+        echo_token = clean_response.env[:request_headers].delete('Echo-Token')
+
+        echo_token_snippet = truncate_token(echo_token)
+
         clean_response.env[:request_headers]['Echo-Token-snippet'] = echo_token_snippet
 
         clean_response.inspect

--- a/lib/cmr/util.rb
+++ b/lib/cmr/util.rb
@@ -30,14 +30,4 @@ module Cmr
       end
     end
   end
-
-  def valid_uri?(uri)
-    !!URI.parse(uri)
-  rescue URI::InvalidURIError
-    false
-  end
-
-  def encode_if_needed(url_fragment)
-    valid_uri?(url_fragment) ? url_fragment : URI.encode(url_fragment)
-  end
 end

--- a/lib/cmr/util.rb
+++ b/lib/cmr/util.rb
@@ -11,5 +11,33 @@ module Cmr
         logger.info("#{message} [#{Time.now - start}s]")
       end
     end
+
+    # checks if a token is an URS token
+    def is_urs_token?(token)
+      # URS token max length is 100, Launchpad token is much longer
+      token.length <= 100 ? true : false
+    end
+
+    def truncate_token(token)
+      return nil if token.nil?
+
+      token_parts = token.split(':')
+      if is_urs_token?(token_parts.first)
+        token_parts.map { |token_part| token_part.truncate([token_part.length / 4 + 3, 8].max) }.join(':')
+      else
+        # launchpad tokens should not have a client_id
+        token_parts.first.truncate(50)
+      end
+    end
+  end
+
+  def valid_uri?(uri)
+    !!URI.parse(uri)
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def encode_if_needed(url_fragment)
+    valid_uri?(url_fragment) ? url_fragment : URI.encode(url_fragment)
   end
 end

--- a/spec/cmr/client_spec.rb
+++ b/spec/cmr/client_spec.rb
@@ -37,12 +37,12 @@ describe Cmr::Client do
       expect(response.errors).to eq(['There was an error with the operation you were trying to perform. There may be an issue with one of the services we depend on. Please contact your provider administrator or the CMR OPS team.'])
     end
 
-    context 'response logging using `clean_inspect`' do
+    context 'error logging' do
       let(:collection_search_url) { 'http://localhost:3003/collections.umm-json' }
 
-      it 'clean_inspect does not contain the full token' do
-        allow_any_instance_of(Cmr::BaseClient).to receive(:token_header).with('bad-bad-bad-token-bad-bad-bad-token:somethingsomethingso').and_return('Echo-Token' => 'bad-bad-bad-token-bad-bad-bad-token:somethingsomethingso')
+      before { allow_any_instance_of(Cmr::BaseClient).to receive(:token_header).with('bad-bad-bad-token-bad-bad-bad-token:somethingsomethingso').and_return('Echo-Token' => 'bad-bad-bad-token-bad-bad-bad-token:somethingsomethingso') }
 
+      it '`clean_inspect` does not contain the full token' do
         response = cmr_client.get_collections({ 'short_name' => 'term' }, 'bad-bad-bad-token-bad-bad-bad-token:somethingsomethingso')
 
         expect(response.clean_inspect).to include('Echo-Token-snippet')
@@ -52,6 +52,17 @@ describe Cmr::Client do
         # TODO: we should not be logging the full token, but it comes back with
         # the cmr response body. the message containing tokens may change with CMR-5274
         # expect(response.clean_inspect).not_to include('bad-bad-bad-token-bad-bad-bad-token:somethingsomethingso')
+      end
+
+      it 'the first error logging only contains the response body' do
+        # TODO: we should not be logging the full token, but it comes back with
+        # the cmr response body. the message containing tokens may change with CMR-5274
+
+        # for testing logs, we need to put the expectation before the message is logged
+        # the first error logging happens in base_client, with just the response body
+        expect(Rails.logger).to receive(:error).with("Cmr::CmrClient Response Error: \"{\\\"errors\\\":[\\\"Token [bad-bad-bad-token-bad-bad-bad-token:somethingsomethingso] does not exist\\\"]}\"")
+
+        response = cmr_client.get_collections({ 'short_name' => 'term' }, 'bad-bad-bad-token-bad-bad-bad-token:somethingsomethingso')
       end
     end
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -28,9 +28,5 @@ FactoryGirl.define do
     trait :multiple_providers do
       available_providers %w(MMT_1 MMT_2 LARC SEDAC)
     end
-
-    trait :with_echo_id do
-      echo_id { Faker::Crypto.md5 }
-    end
   end
 end

--- a/spec/features/groups/groups_list_spec.rb
+++ b/spec/features/groups/groups_list_spec.rb
@@ -79,12 +79,12 @@ describe 'Groups list page', reset_provider: true do
         context 'when there are paginated groups' do
           before do
             # mock for group list page 1
-            groups_page_1_response = Cmr::Response.new(Faraday::Response.new(status: 200, body: JSON.parse(File.read('spec/fixtures/groups/groups_index_page_1.json'))))
+            groups_page_1_response = cmr_success_response(File.read('spec/fixtures/groups/groups_index_page_1.json'))
             page_1_options = { page_size: 25, page_num: 1 }
             allow_any_instance_of(Cmr::CmrClient).to receive(:get_cmr_groups).with(page_1_options, 'access_token').and_return(groups_page_1_response)
 
             # mock for group list page 2
-            groups_page_2_response = Cmr::Response.new(Faraday::Response.new(status: 200, body: JSON.parse(File.read('spec/fixtures/groups/groups_index_page_2.json'))))
+            groups_page_2_response = cmr_success_response(File.read('spec/fixtures/groups/groups_index_page_2.json'))
             page_2_options = { page_size: 25, page_num: 2 }
             allow_any_instance_of(Cmr::CmrClient).to receive(:get_cmr_groups).with(page_2_options, 'access_token').and_return(groups_page_2_response)
 

--- a/spec/features/provider_context/provider_context_spec.rb
+++ b/spec/features/provider_context/provider_context_spec.rb
@@ -20,11 +20,6 @@ describe 'Provider context', reset_provider: true, js: true do
     end
 
     context 'when a user logs in for the first time' do
-      # this should be removed with MMT-1446
-      # it 'saves the users echo_id' do
-      #   expect(User.first.echo_id).to eq('user-echo-token')
-      # end
-
       it 'saves the users available providers' do
         expect(User.first.available_providers).to eq(%w(MMT_1 MMT_2))
       end

--- a/spec/features/users/user_login_spec.rb
+++ b/spec/features/users/user_login_spec.rb
@@ -43,7 +43,8 @@ describe 'User login' do
 
     context 'when the user token is expiring' do
       before do
-        visit_with_expiring_token('/manage_collections')
+        make_token_expiring
+        visit manage_collections_path
       end
 
       it 'allows access to the manage collections' do
@@ -53,6 +54,17 @@ describe 'User login' do
 
       it 'refreshes the user token' do
         expect(page.get_rack_session_key('access_token')).to eql('new_access_token')
+      end
+    end
+
+    context 'when the user token is expiring and refreshing the token fails', js: true do
+      before do
+        make_token_refresh_fail
+        visit manage_collections_path
+      end
+
+      it 'redirects them to URS to login' do
+        expect(page).to have_content('EARTHDATA LOGIN')
       end
     end
   end

--- a/spec/support/cmr_helper.rb
+++ b/spec/support/cmr_helper.rb
@@ -25,8 +25,9 @@ module Helpers
       Cmr::Response.new(Faraday::Response.new(status: 200, body: JSON.parse(response_body)))
     end
 
-    def cmr_fail_response(response_body)
-      Cmr::Response.new(Faraday::Response.new(status: 400, body: JSON.parse(response_body), response_headers: {}))
+    def cmr_fail_response(response_body, status = nil)
+      status = status.nil? ? 400 : status
+      Cmr::Response.new(Faraday::Response.new(status: status, body: JSON.parse(response_body), response_headers: {}))
     end
 
     def create_provider(provider_name)

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -213,14 +213,21 @@ module Helpers
       click_on 'Launchpad Test Login'
     end
 
-    def visit_with_expiring_token(path)
+    def make_token_expiring
       token_response = Cmr::Response.new(Faraday::Response.new(status: 200, body: token_body(expiring: true)))
       allow_any_instance_of(Cmr::UrsClient).to receive(:refresh_token).and_return(token_response)
 
       # Tell the test that the token is expired
       allow_any_instance_of(ApplicationController).to receive(:server_session_expires_in).and_return(-5)
+    end
 
-      visit path
+    def make_token_refresh_fail
+      refresh_response_body = '{"error": "invalid_grant", "error_description": "Refresh token is invalid."}'
+      refresh_response = cmr_fail_response(refresh_response_body, 401)
+      allow_any_instance_of(Cmr::UrsClient).to receive(:refresh_token).and_return(refresh_response)
+
+      # Tell the test that the token is expired
+      allow_any_instance_of(ApplicationController).to receive(:server_session_expires_in).and_return(-5)
     end
 
     def add_provider_context_permission(provider_ids)


### PR DESCRIPTION
* add logging for URS login and refresh token
* add and update tests
* add server session time check to redirect_if_logged_in

MMT-1446: remove use of echo_id