### PR TITLE
pulling in the most recent preview change from the most recent CMR change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'whenever', require: false
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
 # make sure to delete the local config when done making changes to merge into master
 # bundle config --delete local.cmr_metadata_preview
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '26a7403fbae'
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: 'a3d370d2e34'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: 26a7403fbaefd6281b65dd854bf9b23c63d08db6
-  ref: 26a7403fbae
+  revision: a3d370d2e34d98be3d1d0152bb1d6d2432f392f8
+  ref: a3d370d2e34
   specs:
     cmr_metadata_preview (0.0.1)
       georuby (~> 2.5.2)


### PR DESCRIPTION
CMR made a change, related to FTP, this merge is simply moving up to the version they committed.