### PR TITLE
MMT 1525 - Tooltips for long short and long names on manage X screens

### DIFF
--- a/app/assets/stylesheets/components/_callout-box.scss
+++ b/app/assets/stylesheets/components/_callout-box.scss
@@ -41,6 +41,12 @@
     margin: 0;
   }
 
+  .drafts {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   ul {
     margin-top: 0.5em;
     padding-left: 0;
@@ -114,4 +120,17 @@
       margin-left: 1.5625em;
     }
   }
+}
+
+.ui-tooltip {
+  white-space: wrap;
+  // An arbitrary width, but not wider than twice the current box size.
+  max-width: 600px;
+  word-wrap: break-word;
+}
+
+.ui-helper-hidden-accessible {
+  position: absolute;
+  left: -9999px;
+  bottom: 0%;
 }

--- a/app/views/manage_collections/show.html.erb
+++ b/app/views/manage_collections/show.html.erb
@@ -24,10 +24,11 @@
             <% end %>
             <% @drafts[0..@draft_display_max_count-1].each do |draft| %>
               <li>
-                <p>
+                <p class="drafts">
                   <%= time_tag draft.updated_at, draft.updated_at.to_s(:date) %> |
-                  <%= link_to draft.display_short_name, collection_draft_path(draft) %> </br>
-                  &nbsp;<%= draft.display_entry_title.truncate(32) %>
+                  <%= link_to draft.display_short_name, collection_draft_path(draft), title: draft.display_short_name %>
+                  <br>
+                  <%= content_tag(:span, draft.display_entry_title, title: draft.display_entry_title) %>
                 </p>
               </li>
             <% end %>

--- a/app/views/manage_services/show.html.erb
+++ b/app/views/manage_services/show.html.erb
@@ -24,10 +24,11 @@
             <% end %>
             <% @drafts[0..@draft_display_max_count-1].each do |draft| %>
               <li>
-                <p>
+                <p class="drafts">
                   <%= time_tag draft.updated_at, draft.updated_at.to_s(:date) %> |
-                  <%= link_to draft.display_short_name, service_draft_path(draft) %> </br>
-                  &nbsp;<%= draft.display_entry_title.truncate(32) %>
+                  <%= link_to draft.display_short_name, service_draft_path(draft), title: draft.display_short_name %>
+                  <br>
+                  <%= content_tag(:span, draft.display_entry_title, title: draft.display_entry_title) %>
                 </p>
               </li>
             <% end %>

--- a/app/views/manage_variables/show.html.erb
+++ b/app/views/manage_variables/show.html.erb
@@ -24,10 +24,11 @@
             <% end %>
             <% @drafts[0..@draft_display_max_count-1].each do |draft| %>
               <li>
-                <p>
+                <p class="drafts">
                   <%= time_tag draft.updated_at, draft.updated_at.to_s(:date) %> |
-                  <%= link_to draft.display_short_name, variable_draft_path(draft) %> </br>
-                  &nbsp;<%= draft.display_entry_title.truncate(32) %>
+                  <%= link_to draft.display_short_name, variable_draft_path(draft), title: draft.display_short_name %>
+                  <br>
+                  <%= content_tag(:span, draft.display_entry_title, title: draft.display_entry_title) %>
                 </p>
               </li>
             <% end %>
@@ -43,7 +44,7 @@
 
     <% if Rails.configuration.uvg_enabled %>
       <section class="eui-callout-box col-left">
-        <h3 class="eui-callout-box__title">UMM Variable Generation</h3>
+        <h3 class="eui-callout-box__title green">UMM Variable Generation</h3>
         <div class="eui-callout-box__list bulk-update-callout">
           <div class="question-group">
             <div class="row">


### PR DESCRIPTION
Hid short and long names that were overflowing their callout boxes and added tooltips to display short and long names on mouseover.  No tests were added.  Additionally, fixed color mismatch on variables generation callout box.  