### PR TITLE
MMT 1819 - Preventing Submission of Hidden Fields

### DIFF
--- a/app/assets/javascripts/drafts.coffee
+++ b/app/assets/javascripts/drafts.coffee
@@ -338,3 +338,13 @@ $(document).ready ->
     if event.keyCode == 13
       event.preventDefault()
       false
+
+  # Necessary to prevent submission of auto-completed hidden fields.
+  $('.metadata-form, .umm-form').on 'submit', (event) ->
+      # Within the content forms on drafts pages...
+      $('.metadata-form, .umm-form')
+        # Find children tags which have display: none;, but are not eui-accordion__body and
+        # have not been intentionally hidden with type='hidden'
+        .find(':not("[type=\'hidden\']"):not(".eui-accordion__body")[style$="display: none;"]')
+        # Find input children that have not been intentionally hidden with type='hidden'
+        .find(':not("[type=\'hidden\']")input').val("")

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -25,7 +25,8 @@ module FormHelper
       class: classes.join(' '),
       data: { level: data_level,
               required_level: options[:required_level] },
-      readonly: options[:readonly]
+      readonly: options[:readonly],
+      autocomplete: options[:autocomplete]
     )
 
     mmt_label(options) + mmt_help_icon(options) + text_field_html

--- a/app/views/collection_drafts/forms/fields/_get_service_fields.html.erb
+++ b/app/views/collection_drafts/forms/fields/_get_service_fields.html.erb
@@ -36,7 +36,9 @@
       value: get_service['FullName'],
       help: 'definitions/GetServiceType/properties/FullName',
       validate: true,
-      required: true
+      required: true,
+      # Sometimes solves the problem of autocompleting hidden fields.
+      autocomplete: 'off'
     ) %>
 
     <%= mmt_text_field(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
       get 'edit', path: 'edit(/:form)'
     end
   end
+
   resources :collection_drafts, controller: 'collection_drafts', draft_type: 'CollectionDraft', as: 'collection_drafts' do
     member do
       get 'edit', path: 'edit(/:form)'

--- a/lib/assets/schemas/services/umm-s-form.json
+++ b/lib/assets/schemas/services/umm-s-form.json
@@ -1409,7 +1409,7 @@
             },
             {
               "type": "section",
-              "items": [{"key": "/FullName", "field": true}]
+              "items": [{"key": "/FullName", "field": true, "autocomplete": true}]
             },
             {
               "type": "section",

--- a/lib/json_schema_form/umm_form.rb
+++ b/lib/json_schema_form/umm_form.rb
@@ -431,11 +431,12 @@ class UmmFormElement < UmmForm
 
   def element_properties(element)
     readonly = parsed_json['readonly'].nil? ? {} : { readonly: true }
-
+    autocomplete = parsed_json['autocomplete'].nil? ? {} : { autocomplete: "off" }
     {
       class: element_classes(element),
       data: element_data
     }
+      .deep_merge(autocomplete)
       .deep_merge(readonly)
       .deep_merge(validation_properties(element))
   end

--- a/spec/features/service_drafts/service_draft_creation_spec.rb
+++ b/spec/features/service_drafts/service_draft_creation_spec.rb
@@ -37,6 +37,41 @@ describe 'Service Draft creation' do
       it 'displays a confirmation message' do
         expect(page).to have_content('Service Draft Created Successfully!')
       end
+
+      context 'when filling in hidden fields' do
+        before do
+          visit service_draft_path(ServiceDraft.first)
+          click_on 'Service Contacts'
+
+          # Expand all accordions, fill in the group name (which should be saved), and select a
+          # Distribution URL for URL content type so that 'Get Service' may be chosen from the type element
+          # Fill in the full name field in get service, then change the URL content type so that get service
+          # is no longer a valid option.  This will result in the fields becoming rehidden (rather than in
+          # a closed accordion).  This field should not be saved.
+          click_on 'Expand All'
+          fill_in 'service_draft_draft_contact_groups_0_group_name', with: 'test service group name'
+          select('Distribution URL', from: 'service_draft_draft_contact_persons_0_contact_information_related_urls_0_url_content_type')
+          select('Get Service', from: 'service_draft_draft_contact_persons_0_contact_information_related_urls_0_type')
+          fill_in 'service_draft_draft_contact_persons_0_contact_information_related_urls_0_get_service_full_name', with: 'Hidden Full Name'
+          select('Collection URL', from: 'service_draft_draft_contact_persons_0_contact_information_related_urls_0_url_content_type')
+          click_on 'Collapse All'
+
+          within '.nav-top' do
+            click_on 'Save'
+          end
+
+          click_link 'invalid-draft-accept'
+          click_link 'Expand All'
+        end
+
+        it 'does not save the hidden fields' do
+          expect(page).not_to have_xpath('//input[@value="Hidden Full Name"]')
+        end
+
+        it 'does save fields in closed accordians' do
+          expect(page).to have_xpath('//input[@value="test service group name"]')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Caught an error in last the last iteration where closed accordion bodies were being wiped out before submission too.  Investigated "is-invisible", but did not find use cases in the current draft forms.  Fixed spec test and added one for the closed accordion body case.  