### PR TITLE
Use latest API URL for launch pad

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Depending on your version of Ruby, you may need to install ruby rdoc/ri data:
      = 1.9.1 : gem install rdoc-data; rdoc-data --install
     >= 1.9.2 : you're good to go!
 
+#### Aditional Install Steps
+Some operating systems may require additional steps.
+
+Mac OS X 10.14.6 moved some required libraries around which has been known to cause nokogiri to not install, if you have errors with that gem, you may need to run the following:
+
+    open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
+
+Details can be found on nokogiri's [site](https://nokogiri.org/tutorials/installing_nokogiri.html#macos).
+
+#### Database
+
 Check your `/config/` directory for a `database.yml` file (with no additional extensions). If you do not have one, duplicate* the `database.yml.example` file and then rename it to `database.yml`.
 
 *_Note: Do not simply rename the `database.yml.example` file as it is being tracked in Git and has its own history._
@@ -33,6 +44,8 @@ Next, create your database by running the standard rails command:
 And then to migrate the database schema, run the standard rails command:
 
     rake db:migrate
+
+#### Other Steps
 
 Finally, create an `application.yml` file in your `/config/` directory. The contents of this file will be supplied by an MMT developer
 

--- a/lib/cmr/launchpad_client.rb
+++ b/lib/cmr/launchpad_client.rb
@@ -2,7 +2,9 @@ module Cmr
   # this client connects to the launchpad `apps` subdomain for the keep alive endpoint
   class LaunchpadClient < BaseClient
     def keep_alive(token)
-      get('/icam/api/sm/v1/keepalive', {}, 'Origin' => ENV['SAML_SP_ISSUER_BASE'], 'cookie' => "#{Rails.configuration.launchpad_cookie_name}=#{token}")
+      # .../pub/... should be availible from 2019-09-03 in SBX and OPS till 
+      # the end of 2019-09-11
+      get('/icam/api/pub/sm/v1/keepalive', {}, 'Origin' => ENV['SAML_SP_ISSUER_BASE'], 'cookie' => "#{Rails.configuration.launchpad_cookie_name}=#{token}")
     end
 
     def launchpad_healthcheck

--- a/lib/cmr/launchpad_client.rb
+++ b/lib/cmr/launchpad_client.rb
@@ -2,7 +2,7 @@ module Cmr
   # this client connects to the launchpad `apps` subdomain for the keep alive endpoint
   class LaunchpadClient < BaseClient
     def keep_alive(token)
-      # .../pub/... should be availible from 2019-09-03 in SBX and OPS till 
+      # .../pub/... should be availible from 2019-08-03 in SBX and OPS till 
       # the end of 2019-09-11
       get('/icam/api/pub/sm/v1/keepalive', {}, 'Origin' => ENV['SAML_SP_ISSUER_BASE'], 'cookie' => "#{Rails.configuration.launchpad_cookie_name}=#{token}")
     end


### PR DESCRIPTION
* Updated the URL for the keep alive API
* Updated readme to add tip on how to install a gem