### PR TITLE
Mmt-1886 Updating chooser widgets to remove some unexpected behaviors

### DIFF
--- a/app/assets/javascripts/data_management.coffee
+++ b/app/assets/javascripts/data_management.coffee
@@ -56,7 +56,8 @@ $(document).ready ->
         definition_guid:
           required: true
         'catalog_item_guid_toList[]':
-          required: true
+          required: ->
+            $('.___toList option').length == 0
 
       messages:
         definition_guid:

--- a/app/assets/javascripts/order_option_assignments.coffee
+++ b/app/assets/javascripts/order_option_assignments.coffee
@@ -71,8 +71,8 @@ $(document).ready ->
 
       rules:
         'order_option_assignment[]':
-          required: ->
-            $('.___toList option').length == 0
+          required: true
+          
       messages:
         'order_option_assignment[]':
           'You must select at least 1 assignment.'

--- a/app/assets/javascripts/order_option_assignments.coffee
+++ b/app/assets/javascripts/order_option_assignments.coffee
@@ -39,7 +39,8 @@ $(document).ready ->
     $('#order-option-assignments-form').validate
       rules:
         'collectionsChooser_toList[]':
-          required: true
+          required: ->
+            $('.___toList option').length == 0
       messages:
         'collectionsChooser_toList[]':
           'You must select at least 1 collection.'
@@ -70,7 +71,8 @@ $(document).ready ->
 
       rules:
         'order_option_assignment[]':
-          required: true
+          required: ->
+            $('.___toList option').length == 0
       messages:
         'order_option_assignment[]':
           'You must select at least 1 assignment.'
@@ -136,7 +138,8 @@ $(document).ready ->
         'order-options':
           required: true
         'collectionsChooser_toList[]':
-          required: true
+          required: ->
+            $('.___toList option').length == 0
 
       messages:
         'order-options':

--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -127,7 +127,7 @@ $(document).ready ->
     # a user can remove items from the selected box without being able to see
     # that it is currently selected.
     $('#to-filter').on 'focus', ->
-      $('#collectionsChooser_toList').val('')
+      $('.___toList').val('')
 
     # add or remove required icons for access value min and max fields if at least one has an input value
     $('.min-max-value').on 'blur', ->
@@ -177,7 +177,6 @@ $(document).ready ->
         'collectionsChooser_toList[]':
           required: ->
             $('input[name=collection_option]:checked').val() == 'selected' && $('#collectionsChooser_toList').find('option').length == 0 && $('.hidden-collection').length == 0
-#            $('input[name=collection_option]:checked').val() == 'selected' && $('.hidden-collection').length == 0
         'collection_access_value[min_value]':
           required: (element) ->
             # field should be required if min has a value

--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -7,7 +7,7 @@ handleGranuleConstraintState = (granulesEnabled) ->
 # Handle the hiding and showing of the collection chooser
 handleCollectionOptions = (selectedCollections) ->
   $('#chooser-widget :input').attr('disabled', !selectedCollections)
-  
+
   if selectedCollections
     $('#chooser-widget').fadeIn(100)
   else
@@ -96,7 +96,7 @@ $(document).ready ->
       # Not providing any concept ids will result in all items coming back, avoid that
       $.ajax '/provider_collections',
         method: 'POST'
-        data: 
+        data:
           concept_id: selectedValues
           page_size: selectedValues.length
         success: (data) ->
@@ -120,8 +120,14 @@ $(document).ready ->
     $('.clear-filters').on 'click', (event) ->
       $('#' + $(this).data('container') + ' :input').val('')
       $('#' + $(this).data('container') + ' :checkbox').attr('checked', false)
-      
+
       event.preventDefault()
+
+    # Clear a user's selection when they try to filter something.  Otherwise,
+    # a user can remove items from the selected box without being able to see
+    # that it is currently selected.
+    $('.to-filter').on 'focus', ->
+      $('#collectionsChooser_toList').val('')
 
     # add or remove required icons for access value min and max fields if at least one has an input value
     $('.min-max-value').on 'blur', ->

--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -176,7 +176,8 @@ $(document).ready ->
             !$('input[name=collection_applicable]').is(':checked')
         'collectionsChooser_toList[]':
           required: ->
-            $('input[name=collection_option]:checked').val() == 'selected' && $('.hidden-collection').length == 0
+            $('input[name=collection_option]:checked').val() == 'selected' && $('#collectionsChooser_toList').find('option').length == 0 && $('.hidden-collection').length == 0
+#            $('input[name=collection_option]:checked').val() == 'selected' && $('.hidden-collection').length == 0
         'collection_access_value[min_value]':
           required: (element) ->
             # field should be required if min has a value

--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -304,9 +304,3 @@ $(document).ready ->
       toggleSelectOption('#search_and_order_groups_', $(option).val(), 'disable')
     $selectedSearchOrderGroupOptions.each (index, option) ->
       toggleSelectOption('#search_groups_', $(option).val(), 'disable')
-
-  # Clear a user's selection when they try to filter something.  Otherwise,
-  # a user can remove items from the selected box without being able to see
-  # that it is currently selected.
-  $('#to-filter').on 'focus', ->
-    $('.___toList').val('')

--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -123,12 +123,6 @@ $(document).ready ->
 
       event.preventDefault()
 
-    # Clear a user's selection when they try to filter something.  Otherwise,
-    # a user can remove items from the selected box without being able to see
-    # that it is currently selected.
-    $('#to-filter').on 'focus', ->
-      $('.___toList').val('')
-
     # add or remove required icons for access value min and max fields if at least one has an input value
     $('.min-max-value').on 'blur', ->
       $currentAccessVal = $(this)
@@ -310,3 +304,9 @@ $(document).ready ->
       toggleSelectOption('#search_and_order_groups_', $(option).val(), 'disable')
     $selectedSearchOrderGroupOptions.each (index, option) ->
       toggleSelectOption('#search_groups_', $(option).val(), 'disable')
+
+  # Clear a user's selection when they try to filter something.  Otherwise,
+  # a user can remove items from the selected box without being able to see
+  # that it is currently selected.
+  $('#to-filter').on 'focus', ->
+    $('.___toList').val('')

--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -126,7 +126,7 @@ $(document).ready ->
     # Clear a user's selection when they try to filter something.  Otherwise,
     # a user can remove items from the selected box without being able to see
     # that it is currently selected.
-    $('.to-filter').on 'focus', ->
+    $('#to-filter').on 'focus', ->
       $('#collectionsChooser_toList').val('')
 
     # add or remove required icons for access value min and max fields if at least one has an input value

--- a/app/assets/javascripts/service_management.coffee
+++ b/app/assets/javascripts/service_management.coffee
@@ -282,9 +282,3 @@ $(document).ready ->
     # Update the Chooser when the service interface is modified
     $('#service_entry_guid').on 'change', ->
       populateDynamicChooser(serviceOptionAssignmentCollectionsChooser, $(this).val())
-
-  # Clear a user's selection when they try to filter something.  Otherwise,
-  # a user can remove items from the selected box without being able to see
-  # that it is currently selected.
-  $('#to-filter').on 'focus', ->
-    $('.___toList').val('')

--- a/app/assets/javascripts/service_management.coffee
+++ b/app/assets/javascripts/service_management.coffee
@@ -150,6 +150,7 @@ $(document).ready ->
         toLabel: 'Selected Service Implementations',
         uniqueMsg: 'Service Implementation is already selected.',
         attachTo: $('#service-entry-selections'),
+        tooltipObject: 'Service Implementations'
         toMax: 100,
         addButton: {
           cssClass: 'eui-btn nowrap',

--- a/app/assets/javascripts/service_management.coffee
+++ b/app/assets/javascripts/service_management.coffee
@@ -206,8 +206,7 @@ $(document).ready ->
 
       rules:
         'service_option_assignment[]':
-          required:  ->
-            $('.___toList option').length == 0
+          required:  true
 
       messages:
         'service_option_assignment[]':
@@ -283,3 +282,9 @@ $(document).ready ->
     # Update the Chooser when the service interface is modified
     $('#service_entry_guid').on 'change', ->
       populateDynamicChooser(serviceOptionAssignmentCollectionsChooser, $(this).val())
+
+  # Clear a user's selection when they try to filter something.  Otherwise,
+  # a user can remove items from the selected box without being able to see
+  # that it is currently selected.
+  $('#to-filter').on 'focus', ->
+    $('.___toList').val('')

--- a/app/assets/javascripts/service_management.coffee
+++ b/app/assets/javascripts/service_management.coffee
@@ -184,7 +184,8 @@ $(document).ready ->
     $('#service-option-assignments-form').validate
       rules:
         'service_entries_toList[]':
-          required: true
+          required: ->
+            $('.___toList option').length == 0
 
       messages:
         'service_entries_toList[]':
@@ -205,7 +206,8 @@ $(document).ready ->
 
       rules:
         'service_option_assignment[]':
-          required: true
+          required:  ->
+            $('.___toList option').length == 0
 
       messages:
         'service_option_assignment[]':
@@ -220,7 +222,8 @@ $(document).ready ->
         'service_option_definition_guid':
           required: true
         'service_option_assignment_catalog_guid_toList[]':
-          required: true
+          required: ->
+            $('.___toList option').length == 0
 
       messages:
         'service_entry_guid':

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -401,6 +401,9 @@ window.Chooser = (config) ->
   # Filter the TO side of the chooser
   # This only fiters based on the visible text
   initToFilter = ->
+    # Clear the selected values first so that the user cannot have options
+    # that are both selected and invisible because they've been filtered.
+    $('.___toList').val('')
     SELF.toFilter($(this).val())
     $(TO_LIST).trigger 'change'
 

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -2,7 +2,7 @@
 #
 # Chooser - dynamic, AJAX-enabled pick-list
 #
-# @author James LastName
+# @author James Pino
 # v2.0 (rewritten in CoffeeScript)
 #
 # Configuration parameters:
@@ -110,6 +110,7 @@ window.Chooser = (config) ->
     setDefault('endlessScroll', false)
     setDefault('uniqueMsg', 'Value already added')
     setDefault('delimiter', ',')
+    setDefault('tooltipObject', 'Collections')
 
     # Construct each component
     OUTER_CONTAINER = $('<div>').addClass('Chooser').attr('id', config.id)
@@ -121,13 +122,13 @@ window.Chooser = (config) ->
 
     addButtonText = if hasProp('addButton', 'object') then config.addButton.text else '&#x2192;'
     addButtonCssClass = if hasProp('addButton', 'object') then config.addButton.cssClass else ''
-    ADD_BUTTON = $('<button>').attr('title', 'add').addClass(addButtonCssClass).addClass('add_button').text(addButtonText)
+    ADD_BUTTON = $('<button>').attr('title', "Add highlighted items to 'Selected #{config.tooltipObject}'").attr('type', 'button').addClass(addButtonCssClass).addClass('add_button').text(addButtonText)
     if hasProp('addButton') and config.addButton.arrowCssClass
       $(ADD_BUTTON).append('<span>').addClass(config.addButton.arrowCssClass)
 
     delButtonText = if hasProp('delButton', 'object') then config.delButton.text else '&#x2190;'
     delButtonCssClass = if hasProp('delButton', 'object') then config.delButton.cssClass else ''
-    REMOVE_BUTTON = $('<button>').attr('title', 'remove').addClass(delButtonCssClass).addClass('remove_button').text(delButtonText)
+    REMOVE_BUTTON = $('<button>').attr('title', "Remove highlighted items from 'Selected #{config.tooltipObject}'").attr('type', 'button').addClass(delButtonCssClass).addClass('remove_button').text(delButtonText)
     if hasProp('delButton') and config.delButton.arrowCssClass
       $(REMOVE_BUTTON).prepend('<span>').addClass(config.delButton.arrowCssClass)
 
@@ -136,7 +137,7 @@ window.Chooser = (config) ->
       delAllButtonText = if hasProp('delAllButton', 'object') then config.delAllButton.text else '&#x2190;'
       delAllButtonCssClass = if hasProp('delAllButton', 'object') then config.delAllButton.cssClass else ''
 
-      REMOVE_ALL_BUTTON = $('<button>').attr('title', 'remove all').addClass(delAllButtonCssClass).addClass('remove_all_button').text(delAllButtonText)
+      REMOVE_ALL_BUTTON = $('<button>').attr('title', "Remove all entries from 'Selected #{config.tooltipObject}'").attr('type', 'button').addClass(delAllButtonCssClass).addClass('remove_all_button').text(delAllButtonText)
       if hasProp('delAllButton') and config.delAllButton.arrowCssClass
         $(REMOVE_ALL_BUTTON).prepend('<span>').addClass(config.delAllButton.arrowCssClass)
 
@@ -144,10 +145,10 @@ window.Chooser = (config) ->
     TO_LIST = $('<select>').addClass('___toList').attr('name', config.id + '_toList[]').attr('id', config.id + '_toList').attr('multiple', true).attr('size', config.size)
 
     fromPlaceHolderText = if hasProp('fromFilterText', 'string') then config.fromFilterText else 'filter'
-    FROM_FILTER_TEXTBOX = $('<input>').attr('type', 'text').attr('placeholder', fromPlaceHolderText)
+    FROM_FILTER_TEXTBOX = $('<input>').attr('type', 'text').attr('placeholder', fromPlaceHolderText).attr('class', 'filter from-filter')
 
     toPlaceHolderText = if hasProp('toFilterText', 'string') then config.toFilterText else 'filter'
-    TO_FILTER_TEXTBOX = $('<input>').attr('type', 'text').attr('placeholder', toPlaceHolderText)
+    TO_FILTER_TEXTBOX = $('<input>').attr('type', 'text').attr('placeholder', toPlaceHolderText).attr('class', 'filter to-filter')
 
     if !config.hasOwnProperty('resetSize')
       config.resetSize = 50
@@ -494,8 +495,8 @@ window.Chooser = (config) ->
       sortOptions(TO_LIST)
 
       # This is a hack in order to accommodate picky libraries like validate
-      $(TO_LIST).find('option:first').prop 'selected', true
-      $(TO_LIST).find('option:first').click()
+  #    $(TO_LIST).find('option:first').prop 'selected', true
+  #    $(TO_LIST).find('option:first').click()
       return
 
     return
@@ -535,8 +536,8 @@ window.Chooser = (config) ->
     sortOptions(TO_LIST)
 
     # This is a hack in order to accommodate picky libraries like validate
-    $(TO_LIST).find('option:first').prop 'selected', true
-    $(TO_LIST).find('option:first').click()
+#    $(TO_LIST).find('option:first').prop 'selected', true
+#    $(TO_LIST).find('option:first').click()
     $(TO_LIST).focus()
     return
 

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -2,7 +2,7 @@
 #
 # Chooser - dynamic, AJAX-enabled pick-list
 #
-# @author James Pino
+# @author James LastName
 # v2.0 (rewritten in CoffeeScript)
 #
 # Configuration parameters:

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -494,11 +494,7 @@ window.Chooser = (config) ->
       # Sort the list every time
       sortOptions(TO_LIST)
 
-      # This is a hack in order to accommodate picky libraries like validate
-  #    $(TO_LIST).find('option:first').prop 'selected', true
-  #    $(TO_LIST).find('option:first').click()
-      $(TO_LIST).focus()
-      $(FROM_LIST).focus()
+      $(TO_LIST).blur()
       return
 
     return
@@ -537,11 +533,7 @@ window.Chooser = (config) ->
     # Sort the list every time
     sortOptions(TO_LIST)
 
-    # This is a hack in order to accommodate picky libraries like validate
-#    $(TO_LIST).find('option:first').prop 'selected', true
-#    $(TO_LIST).find('option:first').click()
-    $(TO_LIST).focus()
-    $(FROM_LIST).focus()
+    $(TO_LIST).blur()
     return
 
   removeAllButtonClick = (e) ->

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -145,10 +145,10 @@ window.Chooser = (config) ->
     TO_LIST = $('<select>').addClass('___toList').attr('name', config.id + '_toList[]').attr('id', config.id + '_toList').attr('multiple', true).attr('size', config.size)
 
     fromPlaceHolderText = if hasProp('fromFilterText', 'string') then config.fromFilterText else 'filter'
-    FROM_FILTER_TEXTBOX = $('<input>').attr('type', 'text').attr('placeholder', fromPlaceHolderText).attr('class', 'filter from-filter')
+    FROM_FILTER_TEXTBOX = $('<input>').attr('type', 'text').attr('placeholder', fromPlaceHolderText).attr('id', 'from-filter')
 
     toPlaceHolderText = if hasProp('toFilterText', 'string') then config.toFilterText else 'filter'
-    TO_FILTER_TEXTBOX = $('<input>').attr('type', 'text').attr('placeholder', toPlaceHolderText).attr('class', 'filter to-filter')
+    TO_FILTER_TEXTBOX = $('<input>').attr('type', 'text').attr('placeholder', toPlaceHolderText).attr('id', 'to-filter')
 
     if !config.hasOwnProperty('resetSize')
       config.resetSize = 50

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -497,6 +497,8 @@ window.Chooser = (config) ->
       # This is a hack in order to accommodate picky libraries like validate
   #    $(TO_LIST).find('option:first').prop 'selected', true
   #    $(TO_LIST).find('option:first').click()
+      $(TO_LIST).focus()
+      $(FROM_LIST).focus()
       return
 
     return
@@ -539,6 +541,7 @@ window.Chooser = (config) ->
 #    $(TO_LIST).find('option:first').prop 'selected', true
 #    $(TO_LIST).find('option:first').click()
     $(TO_LIST).focus()
+    $(FROM_LIST).focus()
     return
 
   removeAllButtonClick = (e) ->

--- a/app/controllers/data_quality_summary_assignments_controller.rb
+++ b/app/controllers/data_quality_summary_assignments_controller.rb
@@ -23,7 +23,7 @@ class DataQualitySummaryAssignmentsController < ManageCmrController
       success_count += 1 unless response.error?
       error_count += 1 if response.error?
     end
-    
+
     flash_messages = {}
     flash_messages[:success] = "#{success_count} #{'data quality summary assignment'.pluralize(success_count)} created successfully." if success_count > 0
     flash_messages[:error] = "#{error_count} #{'data quality summary assignment'.pluralize(error_count)} failed to save." if error_count > 0
@@ -52,7 +52,7 @@ class DataQualitySummaryAssignmentsController < ManageCmrController
         Array.wrap(assignment.parsed_body.fetch('Item', []))
       rescue
         Rails.logger.error "Error retrieving data quality summary assignment for collection with guid '#{collection_guid}'"
-        
+
         # In the event of an error set assignments to an empty array
         []
       end
@@ -77,7 +77,7 @@ class DataQualitySummaryAssignmentsController < ManageCmrController
 
       @assignments << collection
     end
- 
+
     render action: :edit
   end
 

--- a/app/views/permissions/_form.html.erb
+++ b/app/views/permissions/_form.html.erb
@@ -14,7 +14,7 @@
             <%= check_box_tag 'collection_applicable', true, @permission.fetch('catalog_item_identity', {}).fetch('collection_applicable', false) %>
             Collections
           <% end %>
-          
+
         </div>
         <div class="col-6">
           <%= label_tag 'granule_applicable' do %>

--- a/spec/features/chooser/chooser_expected_behavior_spec.rb
+++ b/spec/features/chooser/chooser_expected_behavior_spec.rb
@@ -1,0 +1,48 @@
+describe 'Chooser expected behaviors', js: true do
+  context 'when using the chooser' do
+    before do
+      login
+      visit new_permission_path
+      find('#collection_option_selected').click()
+    end
+
+    it 'does not click the + button when pressing enter in the left filter box' do
+      fill_in('from-filter', with: '\n')
+      expect(page).to have_select('Selected Collections', options: [])
+    end
+
+    it 'does not click the + button when pressing enter in the right filter box' do
+      fill_in('to-filter', with: '\n')
+      expect(page).to have_select('Selected Collections', options: [])
+    end
+  end
+
+  context 'when selecting a collection in the chooser' do
+    before do
+      ingest_response, concept_response_1 = publish_collection_draft
+      @entry_id_1 = "#{concept_response_1.body['ShortName']}_#{concept_response_1.body['Version']} | #{concept_response_1.body['EntryTitle']}"
+      login
+      visit new_permission_path
+      find('#collection_option_selected').click()
+
+      within '#collectionsChooser' do
+        select(@entry_id_1, from: 'Available Collections')
+        find('.add_button').click
+      end
+    end
+
+    it 'does not highlight an entry in the right column after using +/-' do
+      expect(page).to have_select('Selected Collections', options: [@entry_id_1], selected: [])
+      expect(page).to have_no_content('You must select at least 1 collection.')
+    end
+
+    it 'does not have an entry highlighted after filling in the filter' do
+      within '#collectionsChooser' do
+        select(@entry_id_1, from: 'Selected Collections')
+      end
+      fill_in('to-filter', with: @entry_id_1)
+
+      expect(page).to have_select('Selected Collections', options: [@entry_id_1], selected: [])
+    end
+  end
+end

--- a/spec/features/order_option_assignments/create_order_option_assignments_spec.rb
+++ b/spec/features/order_option_assignments/create_order_option_assignments_spec.rb
@@ -26,7 +26,7 @@ describe 'Viewing and Creating Order Option Assignments' do
         select('lorem_223 | ipsum', from: 'Available Collections')
 
         within '.button-container' do
-          find('button[title=add]').click
+          find('.add_button').click
         end
       end
 
@@ -60,7 +60,7 @@ describe 'Viewing and Creating Order Option Assignments' do
         end
 
         within '.button-container' do
-          find('button[title=add]').click
+          find('.add_button').click
         end
       end
 
@@ -237,7 +237,7 @@ describe 'Viewing and Creating Order Option Assignments' do
         select('lorem_223 | ipsum', from: 'Available Collections')
 
         within '.button-container' do
-          find('button[title=add]').click
+          find('.add_button').click
         end
       end
 

--- a/spec/features/order_option_assignments/delete_order_option_assignments_spec.rb
+++ b/spec/features/order_option_assignments/delete_order_option_assignments_spec.rb
@@ -13,7 +13,7 @@ describe 'Deleting Order Option Assignments' do
       select('lorem_223 | ipsum', from: 'Available Collections')
 
       within '.button-container' do
-        find('button[title=add]').click
+        find('.add_button').click
       end
     end
 

--- a/spec/features/permissions/create_update_delete_permissions_spec.rb
+++ b/spec/features/permissions/create_update_delete_permissions_spec.rb
@@ -188,13 +188,13 @@ describe 'Collection Permissions', reset_provider: true, js: true do
             within '#collectionsChooser' do
               # selecting each individually as it seems more robust.
               select(@entry_id_1, from: 'Available Collections')
-              find('button[title=add]').click
+              find('.add_button').click
 
               select(@entry_id_2, from: 'Available Collections')
-              find('button[title=add]').click
+              find('.add_button').click
 
               select(@entry_id_3, from: 'Available Collections')
-              find('button[title=add]').click
+              find('.add_button').click
             end
 
             within '#search_and_order_groups_cell' do

--- a/spec/features/permissions/permissions_form_spec.rb
+++ b/spec/features/permissions/permissions_form_spec.rb
@@ -1,8 +1,6 @@
 # test for new permissions form and validation, implemented in MMT-507 and 152/153
 # 509, 512
 
-require 'rails_helper'
-
 describe 'Collection Permissions form', js: true do
   context 'when visiting new collection permission page as a regular user' do
     before do
@@ -192,53 +190,6 @@ describe 'Collection Permissions form', js: true do
       within '#search_and_order_groups_cell' do
         expect(page).to have_select('search_and_order_groups_', with_options: ['Administrators', 'Administrators_2'])
       end
-    end
-  end
-
-  context 'when using the chooser' do
-    before do
-      login
-      visit new_permission_path
-      find('#collection_option_selected').click()
-    end
-
-    it 'does not click the + button when pressing enter in the left filter box' do
-      fill_in('from-filter', with: '\n')
-      expect(page).to have_select('Selected Collections', options: [])
-    end
-
-    it 'does not click the + button when pressing enter in the right filter box' do
-      fill_in('to-filter', with: '\n')
-      expect(page).to have_select('Selected Collections', options: [])
-    end
-  end
-
-  context 'when selecting a collection in the chooser' do
-    before do
-      ingest_response, concept_response_1 = publish_collection_draft
-      @entry_id_1 = "#{concept_response_1.body['ShortName']}_#{concept_response_1.body['Version']} | #{concept_response_1.body['EntryTitle']}"
-      login
-      visit new_permission_path
-      find('#collection_option_selected').click()
-
-      within '#collectionsChooser' do
-        select(@entry_id_1, from: 'Available Collections')
-        find('.add_button').click
-      end
-    end
-
-    it 'does not highlight an entry in the right column after using +/-' do
-      expect(page).to have_select('Selected Collections', options: [@entry_id_1], selected: [])
-      expect(page).to have_no_content('You must select at least 1 collection.')
-    end
-
-    it 'does not have an entry highlighted after filling in the filter' do
-      within '#collectionsChooser' do
-        select(@entry_id_1, from: 'Selected Collections')
-      end
-      fill_in('to-filter', with: @entry_id_1)
-
-      expect(page).to have_select('Selected Collections', options: [@entry_id_1], selected: [])
     end
   end
 end

--- a/spec/features/permissions/permissions_form_spec.rb
+++ b/spec/features/permissions/permissions_form_spec.rb
@@ -215,21 +215,30 @@ describe 'Collection Permissions form', js: true do
 
   context 'when selecting a collection in the chooser' do
     before do
-      publish_collection_draft(short_name: 'RM Test', entry_title: 'Test 1')
+      ingest_response, concept_response_1 = publish_collection_draft
+      @entry_id_1 = "#{concept_response_1.body['ShortName']}_#{concept_response_1.body['Version']} | #{concept_response_1.body['EntryTitle']}"
       login
       visit new_permission_path
       find('#collection_option_selected').click()
+
+      within '#collectionsChooser' do
+        select(@entry_id_1, from: 'Available Collections')
+        find('.add_button').click
+      end
     end
 
     it 'does not highlight an entry in the right column after using +/-' do
-      within '#collectionsChooser' do
-        # selecting each individually as it seems more robust.
-        select('RM Test_1 | Test 1', from: 'Available Collections')
-        find('.add_button').click
-      end
-
-      expect(page).to have_select('Selected Collections', options: ['RM Test_1 | Test 1'], selected: [])
+      expect(page).to have_select('Selected Collections', options: [@entry_id_1], selected: [])
       expect(page).to have_no_content('You must select at least 1 collection.')
+    end
+
+    it 'does not have an entry highlighted after filling in the filter' do
+      within '#collectionsChooser' do
+        select(@entry_id_1, from: 'Selected Collections')
+      end
+      fill_in('to-filter', with: @entry_id_1)
+
+      expect(page).to have_select('Selected Collections', options: [@entry_id_1], selected: [])
     end
   end
 end

--- a/spec/features/permissions/permissions_form_spec.rb
+++ b/spec/features/permissions/permissions_form_spec.rb
@@ -194,4 +194,42 @@ describe 'Collection Permissions form', js: true do
       end
     end
   end
+
+  context 'when using the chooser' do
+    before do
+      login
+      visit new_permission_path
+      find('#collection_option_selected').click()
+    end
+
+    it 'does not click the + button when pressing enter in the left filter box' do
+      fill_in('from-filter', with: '\n')
+      expect(page).to have_select('Selected Collections', options: [])
+    end
+
+    it 'does not click the + button when pressing enter in the right filter box' do
+      fill_in('to-filter', with: '\n')
+      expect(page).to have_select('Selected Collections', options: [])
+    end
+  end
+
+  context 'when selecting a collection in the chooser' do
+    before do
+      publish_collection_draft(short_name: 'RM Test', entry_title: 'Test 1')
+      login
+      visit new_permission_path
+      find('#collection_option_selected').click()
+    end
+
+    it 'does not highlight an entry in the right column after using +/-' do
+      within '#collectionsChooser' do
+        # selecting each individually as it seems more robust.
+        select('RM Test_1 | Test 1', from: 'Available Collections')
+        find('.add_button').click
+      end
+
+      expect(page).to have_select('Selected Collections', options: ['RM Test_1 | Test 1'], selected: [])
+      expect(page).to have_no_content('You must select at least 1 collection.')
+    end
+  end
 end

--- a/spec/features/service_entries/update_service_entry_spec.rb
+++ b/spec/features/service_entries/update_service_entry_spec.rb
@@ -84,18 +84,18 @@ describe 'Updating a Service Entry', reset_provider: true do
         before do
           # Remove and add back the first option
           select "ID_1 | Mark's Test", from: 'tag_guids_fromList'
-          find('button[title=remove]').click
+          find('.remove_button').click
           select "ID_1 | Mark's Test", from: 'tag_guids_toList'
-          find('button[title=add]').click
+          find('.add_button').click
 
           # Remove and add back the second option
           # also, press esc after select to hide tool tip, it blocks button
           select "lorem_223 | ipsum", from: 'tag_guids_fromList'
           page.find('body').native.send_keys :escape
-          find('button[title=remove]').click
+          find('.remove_button').click
 
           select "lorem_223 | ipsum", from: 'tag_guids_toList'
-          find('button[title=add]').click
+          find('.add_button').click
         end
 
         it 'maintains the sort order on the right panel of the chooser widget' do

--- a/spec/features/service_option_assignments/create_service_option_assignments_spec.rb
+++ b/spec/features/service_option_assignments/create_service_option_assignments_spec.rb
@@ -170,28 +170,6 @@ describe 'Creating a Service Option Assignment', reset_provider: true, js: true 
               expect(page).to have_content('Service Option Assignments successfully created')
             end
           end
-
-          context 'when using the chooser' do
-            before do
-              within '#service_option_assignment_catalog_guid_toList' do
-                find('option[value="C1200019403-MMT_2"]').select_option
-              end
-            end
-
-            it 'clears selections when the filter box is used' do
-              fill_in('to-filter', with: 'C1200019403-MMT_2')
-
-              expect(page).to have_select('Selected Collections', options: ["ID_1 | Mark's Test", "Matthew'sTest_2 | Matthew's Test"], selected: [])
-            end
-
-            it 'does not highlight things on the right side when the +/- buttons are used' do
-              within '.button-container' do
-                find('.remove_button').click
-              end
-
-              expect(page).to have_select('Selected Collections', options: ["ID_1 | Mark's Test"], selected: [])
-            end
-          end
         end
       end
     end

--- a/spec/features/service_option_assignments/create_service_option_assignments_spec.rb
+++ b/spec/features/service_option_assignments/create_service_option_assignments_spec.rb
@@ -155,16 +155,42 @@ describe 'Creating a Service Option Assignment', reset_provider: true, js: true 
             within '.button-container' do
               find('.add_button').click
             end
+          end
 
-            VCR.use_cassette('echo_soap/service_management_service/service_option_assignments/create', record: :none) do
-              within '#new-service-option-assignment-form' do
-                click_on 'Submit'
+          context 'when submitting the form' do
+            before do
+              VCR.use_cassette('echo_soap/service_management_service/service_option_assignments/create', record: :none) do
+                within '#new-service-option-assignment-form' do
+                  click_on 'Submit'
+                end
               end
+            end
+
+            it 'creates the assignment and displays a confirmation message' do
+              expect(page).to have_content('Service Option Assignments successfully created')
             end
           end
 
-          it 'creates the assignment and displays a confirmation message' do
-            expect(page).to have_content('Service Option Assignments successfully created')
+          context 'when using the chooser' do
+            before do
+              within '#service_option_assignment_catalog_guid_toList' do
+                find('option[value="C1200019403-MMT_2"]').select_option
+              end
+            end
+
+            it 'clears selections when the filter box is used' do
+              fill_in('to-filter', with: 'C1200019403-MMT_2')
+
+              expect(page).to have_select('Selected Collections', options: ["ID_1 | Mark's Test", "Matthew'sTest_2 | Matthew's Test"], selected: [])
+            end
+
+            it 'does not highlight things on the right side when the +/- buttons are used' do
+              within '.button-container' do
+                find('.remove_button').click
+              end
+
+              expect(page).to have_select('Selected Collections', options: ["ID_1 | Mark's Test"], selected: [])
+            end
           end
         end
       end


### PR DESCRIPTION
Updated tooltip text.
Using a + or - button no longer automatically selects something from the right side.
Pressing enter no longer clicks the + button.
Selecting the right filter box clears selections from the right list of entries.  This removes the possibility of a user using the - button to remove an entry they could no longer see.