### PR TITLE
MMT-1898 Data Center Contact without Data Center Short Name

### DIFF
--- a/app/models/collection_draft.rb
+++ b/app/models/collection_draft.rb
@@ -376,6 +376,25 @@ class CollectionDraft < Draft
           # no match, so draft_data_center is not in the params
           # if there are no contact persons or groups, no problem
           # if there are contact persons or groups - what to do? keep the contacts or no?
+
+          # MMT-1898 assign ContactPersons and ContactGroups in case draft_data_center created with
+          # only ContactPersons and/or ContactGroups but without data center ShortName
+          if short_name.nil?
+            if !draft_data_center['ContactPersons'].nil?
+              if !json_params['DataCenters'].first['ContactPersons'].nil?
+                json_params['DataCenters'].first['ContactPersons'].concat(draft_data_center['ContactPersons'])
+              else
+                json_params['DataCenters'].first['ContactPersons'] = draft_data_center['ContactPersons']
+              end
+            end
+            if !draft_data_center['ContactGroups'].nil?
+              if !json_params['DataCenters'].first['ContactGroups'].nil?
+                json_params['DataCenters'].first['ContactGroups'].concat(draft_data_center['ContactGroups'])
+              else
+                json_params['DataCenters'].first['ContactGroups'] = draft_data_center['ContactGroups']
+              end
+            end
+          end
         end
       end
     end

--- a/app/models/collection_draft.rb
+++ b/app/models/collection_draft.rb
@@ -377,24 +377,16 @@ class CollectionDraft < Draft
           # if there are no contact persons or groups, no problem
           # if there are contact persons or groups - what to do? keep the contacts or no?
 
-          # MMT-1898 assign ContactPersons and ContactGroups in case draft_data_center created with
+          # MMT-1898 preserve ContactPersons and ContactGroups in case draft_data_center created with
           # only ContactPersons and/or ContactGroups but without data center ShortName
           if short_name.nil?
-            if !draft_data_center['ContactPersons'].nil?
-              if !json_params['DataCenters'].first['ContactPersons'].nil?
-                json_params['DataCenters'].first['ContactPersons'].concat(draft_data_center['ContactPersons'])
-              else
-                json_params['DataCenters'].first['ContactPersons'] = draft_data_center['ContactPersons']
-              end
-            end
-            if !draft_data_center['ContactGroups'].nil?
-              if !json_params['DataCenters'].first['ContactGroups'].nil?
-                json_params['DataCenters'].first['ContactGroups'].concat(draft_data_center['ContactGroups'])
-              else
-                json_params['DataCenters'].first['ContactGroups'] = draft_data_center['ContactGroups']
-              end
+            if !json_params['DataCenters'].nil?
+              json_params['DataCenters'] << draft_data_center
+            else
+              json_params['DataCenters'] = [draft_data_center]
             end
           end
+
         end
       end
     end

--- a/spec/features/collection_drafts/forms/saving_data_centers_data_contacts_spec.rb
+++ b/spec/features/collection_drafts/forms/saving_data_centers_data_contacts_spec.rb
@@ -128,13 +128,52 @@ describe 'Saving Data Contacts and Data Centers', js: true do
 
         expect(page).to have_content('Metadata Fields')
         find('.tab-label', text: 'Additional Information').click
-        save_screenshot '/tmp/2.png'
       end
 
       it 'displays the Data Contact on the preview page' do
         within '.data-contacts-preview' do
           expect(page).to have_content('Test First Name')
           expect(page).to have_content('Test First Name')
+        end
+      end
+    end
+
+    context 'when adding a Data Center Contact Group without Data Center Short Name' do
+      before do
+        click_on 'Data Contacts', match: :first
+
+        select 'Data Center Contact Group', from: 'Data Contact Type'
+
+        within '.multiple.data-contacts' do
+          select 'Technical Contact', from: 'Role'
+          fill_in 'Group Name', with: 'Test Group Name'
+        end
+
+        within '.nav-top' do
+          click_on 'Done'
+        end
+
+        click_on 'Yes'
+
+        expect(page).to have_content('Metadata Fields')
+        find('.tab-label', text: 'Additional Information').click
+        click_on 'Data Centers', match: :first
+        within '.multiple.data-centers > .multiple-item-1' do
+          fill_in 'Service Hours', with: '9 - 5'
+        end
+        within '.nav-top' do
+          click_on 'Done'
+        end
+
+        click_on 'Yes'
+
+        expect(page).to have_content('Metadata Fields')
+        find('.tab-label', text: 'Additional Information').click
+      end
+
+      it 'displays the Data Contact on the preview page' do
+        within '.data-contacts-preview' do
+          expect(page).to have_content('Test Group Name')
         end
       end
     end

--- a/spec/features/collection_drafts/forms/saving_data_centers_data_contacts_spec.rb
+++ b/spec/features/collection_drafts/forms/saving_data_centers_data_contacts_spec.rb
@@ -95,5 +95,49 @@ describe 'Saving Data Contacts and Data Centers', js: true do
       end
 
     end
+
+    context 'when adding a Data Center Contact Person without Data Center Short Name' do
+      before do
+        click_on 'Data Contacts', match: :first
+
+        select 'Data Center Contact Person', from: 'Data Contact Type'
+
+        within '.multiple.data-contacts' do
+          select 'Technical Contact', from: 'Role'
+          fill_in 'First Name', with: 'Test First Name'
+          fill_in 'Last Name', with: 'Test First Name'
+        end
+
+        within '.nav-top' do
+          click_on 'Done'
+        end
+
+        click_on 'Yes'
+
+        expect(page).to have_content('Metadata Fields')
+        find('.tab-label', text: 'Additional Information').click
+        click_on 'Data Centers', match: :first
+        within '.multiple.data-centers > .multiple-item-1' do
+          fill_in 'Service Hours', with: '9 - 5'
+        end
+        within '.nav-top' do
+          click_on 'Done'
+        end
+
+        click_on 'Yes'
+
+        expect(page).to have_content('Metadata Fields')
+        find('.tab-label', text: 'Additional Information').click
+        save_screenshot '/tmp/2.png'
+      end
+
+      it 'displays the Data Contact on the preview page' do
+        within '.data-contacts-preview' do
+          expect(page).to have_content('Test First Name')
+          expect(page).to have_content('Test First Name')
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Fixed issue: Data Contact without Data Center Short Name was removed when updating Data Center.