### PR TITLE
Mmt-1435 Address concurrency in System/Provider permissions updates

### DIFF
--- a/app/controllers/provider_identity_permissions_controller.rb
+++ b/app/controllers/provider_identity_permissions_controller.rb
@@ -71,24 +71,11 @@ class ProviderIdentityPermissionsController < ManageCmrController
                                            group_id: @group_id
                                          )
 
-    targets_to_add_group, targets_to_update_perms, targets_to_remove_group, targets_to_create, pre_targets_to_delete, targets_to_fail, target_revision_ids = sort_permissions_to_update(assembled_all_permissions: selective_provider_permission_info, permissions_params: permissions_params)
+    targets_to_add_group, targets_to_update_perms, targets_to_remove_group, targets_to_create, targets_to_delete, targets_to_fail, target_revision_ids = sort_permissions_to_update(assembled_all_permissions: selective_provider_permission_info, permissions_params: permissions_params, type: 'provider')
     next_revision_ids = {}
     target_revision_ids.each do |key, value|
       next_revision_ids[key] = (Integer(value) + 1).to_s
     end
-    current_revisions = get_revisions_for_edit(type: 'provider')
-
-    # The CMR does not accept a revision_id for deletes.  This does _not_
-    # close the possible concurrency problem, but it should make it almost non-existent
-    targets_to_delete = []
-    pre_targets_to_delete.each do |target|
-      if current_revisions[target] == Integer(target_revision_ids[target])
-        targets_to_delete << target
-      else
-        targets_to_fail << target
-      end
-    end
-
     successes = []
     overwrite_fails = targets_to_fail
     fails = []

--- a/app/controllers/provider_identity_permissions_controller.rb
+++ b/app/controllers/provider_identity_permissions_controller.rb
@@ -42,6 +42,8 @@ class ProviderIdentityPermissionsController < ManageCmrController
 
     # assemble provider permissions for the table of checkboxes
     @group_provider_permissions = assemble_permissions_for_table(permissions: group_provider_permissions_list, type: 'provider', group_id: @group_id)
+    # assemble a hash of current revision ids
+    @revision_ids = get_revisions_for_edit(type: 'provider')
 
     group_response = cmr_client.get_group(@group_id, token)
     if group_response.success?
@@ -57,10 +59,10 @@ class ProviderIdentityPermissionsController < ManageCmrController
 
   def update
     @group_id = params[:id]
-    permissions_params = params[:provider_permissions]
+    permissions_params = params[:provider_permissions] || {}
     redirect_to provider_identity_permissions_path and return if permissions_params.nil?
 
-    permissions_params.each { |_target, perms| perms.delete('') }
+    permissions_params&.each { |_target, perms| perms.delete('') }
     all_provider_permissions = get_permissions_for_identity_type(type: 'provider')
     # assemble permissions so they can be sorted and updated
     selective_provider_permission_info = assemble_permissions_for_updating(
@@ -69,9 +71,26 @@ class ProviderIdentityPermissionsController < ManageCmrController
                                            group_id: @group_id
                                          )
 
-    targets_to_add_group, targets_to_update_perms, targets_to_remove_group, targets_to_create, targets_to_delete = sort_permissions_to_update(assembled_all_permissions: selective_provider_permission_info, permissions_params: permissions_params)
+    targets_to_add_group, targets_to_update_perms, targets_to_remove_group, targets_to_create, pre_targets_to_delete, targets_to_fail, target_revision_ids = sort_permissions_to_update(assembled_all_permissions: selective_provider_permission_info, permissions_params: permissions_params)
+    next_revision_ids = {}
+    target_revision_ids.each do |key, value|
+      next_revision_ids[key] = (Integer(value) + 1).to_s
+    end
+    current_revisions = get_revisions_for_edit(type: 'provider')
+
+    # The CMR does not accept a revision_id for deletes.  This does _not_
+    # close the possible concurrency problem, but it should make it almost non-existent
+    targets_to_delete = []
+    pre_targets_to_delete.each do |target|
+      if current_revisions[target] == Integer(target_revision_ids[target])
+        targets_to_delete << target
+      else
+        targets_to_fail << target
+      end
+    end
 
     successes = []
+    overwrite_fails = targets_to_fail
     fails = []
 
     create_target_permissions(
@@ -98,11 +117,28 @@ class ProviderIdentityPermissionsController < ManageCmrController
       type: 'provider',
       group_id: @group_id,
       successes: successes,
-      fails: fails
+      fails: fails,
+      overwrite_fails: overwrite_fails,
+      revision_ids: next_revision_ids
     )
 
-    flash[:success] = 'Provider Object Permissions were saved.' unless successes.blank?
-    flash[:error] = "#{fails.join(', ')} permissions were unable to be saved." unless fails.blank?
+    unless successes.blank?
+      flash[:success] = (successes.reduce('') do |memo, target|
+        memo += '<br>' unless memo.blank?
+        memo + "'#{target.titleize}' permissions were saved"
+      end).html_safe
+    end
+    unless fails.blank? && overwrite_fails.blank?
+      error_message = fails.reduce('') do |memo, target|
+        memo += '<br>' unless memo.blank?
+        memo + "'#{target.titleize}' permissions were unable to be saved."
+      end
+      error_message = overwrite_fails.reduce(error_message) do |memo, target|
+        memo += '<br>' unless memo.blank?
+        memo + "'#{target.titleize}' permissions were unable to be saved because another user made changes to those permissions."
+      end
+      flash[:error] = error_message.html_safe
+    end
 
     redirect_to provider_identity_permissions_path
   end

--- a/app/controllers/system_identity_permissions_controller.rb
+++ b/app/controllers/system_identity_permissions_controller.rb
@@ -70,24 +70,11 @@ class SystemIdentityPermissionsController < ManageCmrController
                                               group_id: @group_id
                                             )
 
-    targets_to_add_group, targets_to_update_perms, targets_to_remove_group, targets_to_create, pre_targets_to_delete, targets_to_fail, target_revision_ids = sort_permissions_to_update(assembled_all_permissions: selective_full_system_permission_info, permissions_params: permissions_params)
+    targets_to_add_group, targets_to_update_perms, targets_to_remove_group, targets_to_create, targets_to_delete, targets_to_fail, target_revision_ids = sort_permissions_to_update(assembled_all_permissions: selective_full_system_permission_info, permissions_params: permissions_params, type: 'system')
     next_revision_ids = {}
     target_revision_ids.each do |key, value|
       next_revision_ids[key] = (Integer(value) + 1).to_s
     end
-    current_revisions = get_revisions_for_edit(type: 'system')
-
-    # The CMR does not accept a revision_id for deletes.  This does _not_
-    # close the possible concurrency problem, but it should make it almost non-existent
-    targets_to_delete = []
-    pre_targets_to_delete.each do |target|
-      if current_revisions[target] == Integer(target_revision_ids[target])
-        targets_to_delete << target
-      else
-        targets_to_fail << target
-      end
-    end
-
     successes = []
     fails = []
     overwrite_fails = targets_to_fail

--- a/app/views/provider_identity_permissions/_form.html.erb
+++ b/app/views/provider_identity_permissions/_form.html.erb
@@ -42,6 +42,7 @@
           <% if @group_provider_permissions.keys.include?(provider_target[1]) %>
             <%= hidden_field_tag("provider_permissions[#{provider_target[1]}][]", '') %>
           <% end %>
+          <%= hidden_field_tag("#{provider_target[1]}_revision_id", @revision_ids[provider_target[1]]) unless @revision_ids[provider_target[1]].blank? %>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/system_identity_permissions/_form.html.erb
+++ b/app/views/system_identity_permissions/_form.html.erb
@@ -42,6 +42,7 @@
           <% if @group_system_permissions.keys.include?(system_target[1]) %>
             <%= hidden_field_tag("system_permissions[#{system_target[1]}][]", '') %>
           <% end %>
+          <%= hidden_field_tag("#{system_target[1]}_revision_id", @revision_ids[system_target[1]]) unless @revision_ids[system_target[1]].blank? %>
         </tr>
       <% end %>
     </tbody>

--- a/spec/features/provider_identity_permissions/adding_provider_permissions_spec.rb
+++ b/spec/features/provider_identity_permissions/adding_provider_permissions_spec.rb
@@ -56,8 +56,11 @@ describe 'Saving Provider Identity Permissions', reset_provider: true do
       expect(page).to have_content('Provider Object Permissions')
       expect(page).to have_content('Click on a Group to access the provider object permissions for that group.')
 
-      expect(page).to have_content('Provider Object Permissions were saved.')
-      expect(page).to have_no_content('permissions were unable to be saved.')
+      expect(page).to have_content("'Group' permissions were saved")
+      expect(page).to have_content("'Ingest Management Acl' permissions were saved")
+      expect(page).to have_content("'Option Definition' permissions were saved")
+      expect(page).to have_content("'Provider Policies' permissions were saved")
+      expect(page).to have_no_content('permissions were unable to be saved')
     end
   end
 
@@ -83,8 +86,11 @@ describe 'Saving Provider Identity Permissions', reset_provider: true do
       expect(page).to have_content('Provider Object Permissions')
       expect(page).to have_content('Click on a Group to access the provider object permissions for that group.')
 
-      expect(page).to have_content('Provider Object Permissions were saved.')
-      expect(page).to have_no_content('permissions were unable to be saved.')
+      expect(page).to have_content("'Provider Calendar Event' permissions were saved")
+      expect(page).to have_content("'Ingest Management Acl' permissions were saved")
+      expect(page).to have_content("'Provider Information' permissions were saved")
+      expect(page).to have_content("'Extended Service' permissions were saved")
+      expect(page).to have_no_content('permissions were unable to be saved')
     end
   end
 end

--- a/spec/features/provider_identity_permissions/changing_removing_provider_permissions_spec.rb
+++ b/spec/features/provider_identity_permissions/changing_removing_provider_permissions_spec.rb
@@ -82,8 +82,13 @@ describe 'Changing or Removing Provider Identity Permissions', reset_provider: t
         expect(page).to have_content('Provider Object Permissions')
         expect(page).to have_content('Click on a Group to access the provider object permissions for that group.')
 
-        expect(page).to have_content('Provider Object Permissions were saved.')
-        expect(page).to have_no_content('permissions were unable to be saved.')
+        expect(page).to have_content("'Authenticator Definition' permissions were saved")
+        expect(page).to have_content("'Provider Order Tracking' permissions were saved")
+        expect(page).to have_content("'Option Assignment' permissions were saved")
+        expect(page).to have_content("'Ingest Management Acl' permissions were saved")
+        expect(page).to have_content("'Option Definition' permissions were saved")
+        expect(page).to have_content("'Provider Policies' permissions were saved")
+        expect(page).to have_no_content('permissions were unable to be saved')
       end
     end
   end

--- a/spec/features/provider_identity_permissions/concurrency_handling_spec.rb
+++ b/spec/features/provider_identity_permissions/concurrency_handling_spec.rb
@@ -1,0 +1,88 @@
+describe 'Concurrent Users Editing Provider Permissions', reset_provider: true do
+  before :all do
+    @provider_group = create_group(
+      name: 'Test Group for Creating Provider Object Permissions',
+      description: 'Group for creating provider object permissions',
+      provider_id: 'MMT_2'
+    )
+    @provider_group2 = create_group(
+      name: 'Test Group 2 for Creating Provider Object Permissions',
+      description: 'Group for creating provider object permissions',
+      provider_id: 'MMT_2'
+    )
+
+    wait_for_cmr
+
+    @system_group = create_group(
+      name: 'Test System Group for Provider Permissions',
+      description: 'System Group for creating provider permissions',
+      provider_id: nil,
+      admin: true
+    )
+
+    wait_for_cmr
+  end
+
+  after :all do
+    # retrieve and delete the provider permissions for the system group
+    # (they won't be removed by reset_provider)
+    permissions_options = {
+      'page_size' => 50,
+      'permitted_group' => @system_group['concept_id']
+    }
+
+    permissions_response_items = cmr_client.get_permissions(permissions_options, 'access_token').body.fetch('items', [])
+    permissions_response_items.each { |perm_item| cmr_client.delete_permission(perm_item['concept_id'], 'access_token') }
+
+    # delete the system group
+    delete_group(concept_id: @system_group['concept_id'], admin: true)
+  end
+
+  context 'when incorrectly removing a group' do
+    before do
+      login
+
+      @response = cmr_client.add_group_permissions(
+        { 'group_permissions' =>
+          [{
+            'group_id' => @provider_group2['concept_id'],
+            'permissions' => ['read']
+          }, {
+            'group_id' => @provider_group['concept_id'],
+            'permissions' => ['read']
+          }],
+          'provider_identity' =>
+          {
+            'target' => 'USER',
+            'provider_id' => 'MMT_2'
+          } }, 'access_token_admin'
+      )
+      wait_for_cmr
+      visit edit_provider_identity_permission_path(@provider_group['concept_id'])
+      cmr_client.update_permission(
+        { 'group_permissions' =>
+          [{
+            'group_id' => @provider_group2['concept_id'],
+            'permissions' => ['read']
+          }],
+          'provider_identity' =>
+          {
+            'target' => 'USER',
+            'provider_id' => 'MMT_2'
+          } }, @response.body['concept_id'], 'access_token_admin'
+      )
+
+      uncheck('provider_permissions_USER_', option: 'read')
+
+      click_on 'Submit'
+    end
+
+    it 'does not succeed' do
+      expect(page).to have_content("'User' permissions were unable to be saved because another user made changes to those permissions.")
+    end
+
+    after do
+      cmr_client.delete_permission(@response.body['concept_id'], 'access_token')
+    end
+  end
+end

--- a/spec/features/system_identity_permissions/adding_system_permissions_spec.rb
+++ b/spec/features/system_identity_permissions/adding_system_permissions_spec.rb
@@ -42,8 +42,11 @@ describe 'Saving System Identity Permissions' do
       expect(page).to have_content('System Object Permissions')
       expect(page).to have_content('Click on a System Group to access the system object permissions for that group.')
 
-      expect(page).to have_content('System Object Permissions were saved.')
-      expect(page).to have_no_content('permissions were unable to be saved.')
+      expect(page).to have_content("'System Option Definition' permissions were saved")
+      expect(page).to have_content("'Metric Data Point Sample' permissions were saved")
+      expect(page).to have_content("'Extended Service' permissions were saved")
+      expect(page).to have_content("'Tag Group' permissions were saved")
+      expect(page).to have_no_content('permissions were unable to be saved')
     end
   end
 end

--- a/spec/features/system_identity_permissions/changing_removing_system_permissions_spec.rb
+++ b/spec/features/system_identity_permissions/changing_removing_system_permissions_spec.rb
@@ -90,8 +90,10 @@ describe 'Changing or Removing System Identity Permissions' do
         expect(page).to have_content('System Object Permissions')
         expect(page).to have_content('Click on a System Group to access the system object permissions for that group.')
 
-        expect(page).to have_content('System Object Permissions were saved.')
-        expect(page).to have_no_content('permissions were unable to be saved.')
+        expect(page).to have_content("'System Calendar Event' permissions were saved")
+        expect(page).to have_content("'System Initializer' permissions were saved")
+        expect(page).to have_content("'System Option Definition' permissions were saved")
+        expect(page).to have_no_content('permissions were unable to be saved')
       end
     end
   end

--- a/spec/features/system_identity_permissions/concurrency_handling_spec.rb
+++ b/spec/features/system_identity_permissions/concurrency_handling_spec.rb
@@ -1,0 +1,148 @@
+describe 'Concurrent Users Editing System Permissions', js: true do
+  before do
+    @group_response = create_group(name: 'Test System Permissions Group 1', description: 'Group to test system permissions', provider_id: nil, admin: true)
+    @group_response2 = create_group(name: 'Test System Permissions Group 2', description: 'Group to test system permissions', provider_id: nil, admin: true)
+  end
+
+  after do
+    # delete system permissions for the group
+    permissions_options = {
+      'page_size' => 30,
+      'permitted_group' => @group_response['concept_id']
+    }
+
+    permissions_options2 = {
+      'page_size' => 30,
+      'permitted_group' => @group_response2['concept_id']
+    }
+
+    permissions_response_items = cmr_client.get_permissions(permissions_options, 'access_token_admin').body.fetch('items', [])
+    permissions_response_items.each { |perm_item| cmr_client.delete_permission(perm_item['concept_id'], 'access_token_admin') }
+
+    permissions_response_items2 = cmr_client.get_permissions(permissions_options2, 'access_token_admin').body.fetch('items', [])
+    permissions_response_items2.each { |perm_item| cmr_client.delete_permission(perm_item['concept_id'], 'access_token_admin') }
+
+    # delete the group
+    delete_group(concept_id: @group_response['concept_id'], admin: true)
+    delete_group(concept_id: @group_response2['concept_id'], admin: true)
+  end
+
+  context 'when incorrectly deleting' do
+    before do
+      login_admin
+      visit edit_system_identity_permission_path(@group_response['concept_id'])
+      cmr_client.add_group_permissions(
+        { 'group_permissions' =>
+          [{
+            'group_id' => @group_response['concept_id'],
+            'permissions' => ['create']
+          }],
+          'system_identity' =>
+          {
+            'target' => 'DASHBOARD_ADMIN'
+          } }, 'access_token_admin'
+      )
+      click_on 'Submit'
+    end
+    it 'does not succeed' do
+      expect(page).to have_content("'Dashboard Admin' permissions were unable to be saved because another user made changes to those permissions.")
+    end
+  end
+
+  context 'when incorrectly creating' do
+    before do
+      login_admin
+      response = cmr_client.add_group_permissions(
+        { 'group_permissions' =>
+          [{
+            'group_id' => @group_response['concept_id'],
+            'permissions' => ['create']
+          }],
+          'system_identity' =>
+          {
+            'target' => 'DASHBOARD_ADMIN'
+          } }, 'access_token_admin'
+      )
+      visit edit_system_identity_permission_path(@group_response['concept_id'])
+      cmr_client.delete_permission(response.body['concept_id'], 'access_token_admin')
+      click_on 'Submit'
+    end
+    it 'does not succeed' do
+      expect(page).to have_content("'Dashboard Admin' permissions were unable to be saved because another user made changes to those permissions.")
+    end
+  end
+
+  context 'when incorrectly adding group' do
+    before do
+      login_admin
+
+      response = cmr_client.add_group_permissions(
+        { 'group_permissions' =>
+          [{
+            'group_id' => @group_response2['concept_id'],
+            'permissions' => ['read']
+          }],
+          'system_identity' =>
+          {
+            'target' => 'USER'
+          } }, 'access_token_admin'
+      )
+      visit edit_system_identity_permission_path(@group_response['concept_id'])
+      cmr_client.update_permission(
+        { 'group_permissions' =>
+          [{
+            'group_id' => @group_response2['concept_id'],
+            'permissions' => %w[read update]
+          }],
+          'system_identity' =>
+          {
+            'target' => 'USER'
+          } }, response.body['concept_id'], 'access_token_admin'
+      )
+      check('system_permissions_USER_', option: 'read')
+
+      click_on 'Submit'
+    end
+
+    it 'does not succeed' do
+      expect(page).to have_content("'User' permissions were unable to be saved because another user made changes to those permissions.")
+    end
+  end
+
+  context 'when updating with the wrong revision_id' do
+    before do
+      login_admin
+
+      response = cmr_client.add_group_permissions(
+        { 'group_permissions' =>
+          [{
+            'group_id' => @group_response['concept_id'],
+            'permissions' => ['read']
+          }],
+          'system_identity' =>
+          {
+            'target' => 'USER'
+          } }, 'access_token_admin'
+      )
+      visit edit_system_identity_permission_path(@group_response['concept_id'])
+      cmr_client.update_permission(
+        { 'group_permissions' =>
+          [{
+            'group_id' => @group_response['concept_id'],
+            'permissions' => %w[read update]
+          }],
+          'system_identity' =>
+          {
+            'target' => 'USER'
+          } }, response.body['concept_id'], 'access_token_admin'
+      )
+      check('system_permissions_USER_', option: 'read')
+
+      click_on 'Submit'
+    end
+
+    it 'does not succeed' do
+      expect(page).to have_content("'User' permissions were unable to be saved because another user made changes to those permissions.")
+    end
+  end
+end


### PR DESCRIPTION
In the situation: 
User A opens the page, User B opens the page, makes changes, and then submits the form, then User A submits the form.
the result should be that User A's changes are rejected and User A is informed of the changes that succeed/fail.  
This required passing information about current revision IDs, and verifying that information while preparing the list of ACLs to change.
