### PR TITLE
MMT-1980 MMT-1981 Adding submit button and rescind buttons to dMMT workflow.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,7 +10,7 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
 
- *= require eui-1.0.9/eui
+ *= require eui-1.1.7/eui
  *= require dropzone-4.0.1/dropzone
  *= require select2-4.0.1/select2.min
  *= require bootstrap-datepicker-1.6.0/bootstrap-datepicker.standalone.min

--- a/app/assets/stylesheets/components/_metadata-preview.scss
+++ b/app/assets/stylesheets/components/_metadata-preview.scss
@@ -346,7 +346,5 @@ ul.sub-field {
 
 #proposal-status-display{
   float:right;
-// As an alternate placement location idea
-//  padding:7px 20px 7px 0px;
-  padding: 7px;
+  padding: 5px;
 }

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -27,7 +27,7 @@ module Proposal
         Rails.logger.info("Audit Log: User #{current_user.urs_uid} unsuccessfully submitted #{resource_name.titleize} with title: '#{get_resource.entry_title}' and id: #{get_resource.id}")
         flash[:error] = I18n.t("controllers.draft.#{plural_resource_name}.submit.flash.error")
       end
-      redirect_to collection_draft_proposal_path(get_resource) and return
+      redirect_to collection_draft_proposal_path(get_resource)
     end
 
     def rescind
@@ -39,7 +39,7 @@ module Proposal
         Rails.logger.info("Audit Log: User #{current_user.urs_uid} unsuccessfully rescinded #{resource_name.titleize} with title: '#{get_resource.entry_title}' and id: #{get_resource.id}")
         flash[:error] = I18n.t("controllers.draft.#{plural_resource_name}.rescind.flash.error")
       end
-      redirect_to collection_draft_proposal_path(get_resource) and return
+      redirect_to collection_draft_proposal_path(get_resource)
     end
 
     def publish

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -8,11 +8,12 @@ module Proposal
     before_action(only: %I[submit rescind]) { set_resource }
 
     def edit
-      unless get_resource&.in_work?
+      if get_resource&.in_work?
+        super
+      else
         flash[:error] = 'Only proposals in an "In Work" status can be edited.'
-        redirect_to collection_draft_proposal_path(get_resource) and return
+        redirect_to collection_draft_proposal_path(get_resource)
       end
-      super
     end
 
     def submit
@@ -53,11 +54,12 @@ module Proposal
       # According to the documentation, only "In Work" proposals should be deletable
       # "Rejected" and "Submitted" can be rescinded to "In Work" to be deleted.
       # "Approved" and "Done" can be neither rescinded nor deleted.
-      unless get_resource&.in_work?
+      if get_resource&.in_work?
+        super
+      else
         flash[:error] = I18n.t("controllers.draft.#{plural_resource_name}.destroy.flash.error") + '. Only proposals in an "In Work" status can be deleted.'
-        redirect_to collection_draft_proposal_path(get_resource) and return
+        redirect_to collection_draft_proposal_path(get_resource)
       end
-      super
     end
 
     private

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -1,0 +1,12 @@
+class ProposalMailer < ApplicationMailer
+  def proposal_submitted_notification(user, short_name, version, id)
+    @user = user
+    @short_name = short_name
+    @version = version
+    @id = id
+
+    email_subject = 'New Create Collection Proposal Submitted in Metadata Management Tool'
+
+    mail(to: "#{@user[:name]} <#{@user[:email]}>", subject: email_subject)
+  end
+end

--- a/app/models/collection_draft_proposal.rb
+++ b/app/models/collection_draft_proposal.rb
@@ -13,8 +13,15 @@ class CollectionDraftProposal < CollectionDraft
 
   aasm column: 'proposal_status', whiny_transitions: false do
     state :in_work, initial: true
-    # When this state is enabled, uncomment a test in spec/features/proposal/collection_draft_proposals/collection_draft_proposals_destroy_spec.rb
-    # state :submitted
+    state :submitted
+
+    event :submit do
+      transitions from: :in_work, to: :submitted
+    end
+
+    event :rescind do
+      transitions from: :submitted, to: :in_work
+    end
   end
 
   private

--- a/app/policies/collection_draft_proposal_policy.rb
+++ b/app/policies/collection_draft_proposal_policy.rb
@@ -1,5 +1,4 @@
 class CollectionDraftProposalPolicy < ApplicationPolicy
-  
   def publish?
     false
   end
@@ -26,6 +25,14 @@ class CollectionDraftProposalPolicy < ApplicationPolicy
 
   def destroy?
     verify_mode_and_non_nasa_draft_user
+  end
+
+  def submit?
+    update?
+  end
+
+  def rescind?
+    update?
   end
 
   private

--- a/app/views/proposal/collection_draft_proposals/show.html.erb
+++ b/app/views/proposal/collection_draft_proposals/show.html.erb
@@ -15,7 +15,7 @@
             <%= link_to 'Submit for Review', "#submit-proposal-modal", class: 'eui-btn--blue display-modal' %>
             <div id="submit-proposal-modal" class="eui-modal-content">
               <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-              <p>Are you sure you want to submit this proposal?</p>
+              <p>Are you sure you want to submit this proposal for review? Upon approval, your collection record will be published to the CMR.</p>
               <p>
                 <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
                 <%= link_to 'Yes', submit_collection_draft_proposal_path(get_resource), class: 'eui-btn--blue spinner' %>
@@ -33,9 +33,19 @@
           </div>
         </span>
       <% elsif get_resource.submitted? %>
-        <%= link_to 'Rescind Draft Submission', rescind_collection_draft_proposal_path(get_resource), class: 'eui-btn--blue display-modal' %>
+        <%= link_to 'Rescind Draft Submission', "#rescind-submission-modal", class: 'eui-btn--blue display-modal' %>
+        <div id="rescind-submission-modal" class="eui-modal-content">
+          <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
+          <p>Are you sure you want to rescind this proposal submission? The proposal will not be reviewed until it has been resubmitted.</p>
+          <p>
+            <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
+            <%= link_to 'Yes', rescind_collection_draft_proposal_path(get_resource), class: 'eui-btn--blue spinner' %>
+          </p>
+        </div>
       <% end %>
-      <span id="proposal-status-display">Proposal Status: <%= get_resource.proposal_status.titleize %></span>
+      <span id="proposal-status-display">
+        <span class="eui-badge eui-badge--split ">Proposal Status: <span><%= get_resource.proposal_status.titleize %></span></span>
+      </span>
     </div>
   </section>
 

--- a/app/views/proposal/collection_draft_proposals/show.html.erb
+++ b/app/views/proposal/collection_draft_proposals/show.html.erb
@@ -18,8 +18,7 @@
               <p>Are you sure you want to submit this proposal?</p>
               <p>
                 <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
-                <!-- TODO: Update this to a valid link when submission is supported. -->
-                <a href="javascript:void(0)" class="eui-btn modal-close">Yes</a>
+                <%= link_to 'Yes', submit_collection_draft_proposal_path(get_resource), class: 'eui-btn--blue spinner' %>
               </p>
             </div>
           <% end %>
@@ -33,12 +32,14 @@
             </p>
           </div>
         </span>
+      <% elsif get_resource.submitted? %>
+        <%= link_to 'Rescind Draft Submission', rescind_collection_draft_proposal_path(get_resource), class: 'eui-btn--blue display-modal' %>
       <% end %>
       <span id="proposal-status-display">Proposal Status: <%= get_resource.proposal_status.titleize %></span>
     </div>
   </section>
 
-  <%= render partial: 'collection_drafts/progress/preview_progress', locals: { unpublished_resource: get_resource, metadata_errors: @errors || @ingest_errors } %>
+  <%= render partial: 'collection_drafts/progress/preview_progress', locals: { unpublished_resource: get_resource, metadata_errors: @errors || @ingest_errors } if get_resource.in_work? %>
 
   <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: get_resource.draft, is_mmt: true, editable: true, edsc_url: nil, concept_id: nil, additional_information: nil} %>
 </div>

--- a/app/views/proposal_mailer/proposal_submitted_notification.html.erb
+++ b/app/views/proposal_mailer/proposal_submitted_notification.html.erb
@@ -1,0 +1,18 @@
+<h1 class="styled-heading"><%= "#{@short_name}_#{@version} Submitted" %></h1>
+
+
+<div class="email-message">
+  <p>
+    <%= @user[:name] %>,
+  </p>
+  <p>
+    <%= "Your collection metadata proposal #{@short_name}_#{@version} has been successfully submitted for review." %>
+  </p>
+  <div class="center">
+    <%= link_to 'View Collection Metadata Proposal', collection_draft_proposal_url(@id), class: 'btn btn-blue' %>
+  </div>
+</div>
+
+<div class="email-footer">
+  <img src="https://cdn.earthdata.nasa.gov/eui/latest/docs/assets/ed-logos/meatball.png" alt="Meatball" class="image-center" />
+</div>

--- a/app/views/proposal_mailer/proposal_submitted_notification.text.erb
+++ b/app/views/proposal_mailer/proposal_submitted_notification.text.erb
@@ -1,0 +1,5 @@
+<%= @user[:name] %>,
+
+<%= "Your collection metadata proposal #{@short_name}_#{@version} has been successfully submitted for review." %>
+
+View Collection: <%= collection_draft_proposal_url(@id) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,14 @@ en:
           flash:
             success: 'Collection Draft Proposal Deleted Successfully!'
             error: 'Collection Draft Proposal was not deleted successfully'
+        submit:
+          flash:
+            success: 'Collection Draft Proposal Submitted Successfully'
+            error: 'Collection Draft Proposal was not submitted successfully'
+        rescind:
+          flash:
+            success: 'Collection Draft Proposal Rescinded Successfully'
+            error: 'Collection Draft Proposal was not rescinded successfully'
       collection_templates:
         create:
           flash:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,6 +124,8 @@ Rails.application.routes.draw do
     resources :collection_draft_proposals, controller: 'collection_draft_proposals', draft_type: 'CollectionDraftProposal', as: 'collection_draft_proposals' do
       member do
         get 'edit', path: 'edit(/:form)'
+        get 'submit'
+        get 'rescind'
       end
     end
     get 'proposal/subregion_options' => 'collection_draft_proposals#subregion_options'

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_destroy_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_destroy_spec.rb
@@ -30,19 +30,17 @@ describe 'Collection Draft Proposal destruction', js: true do
     end
   end
 
-  # This test should be uncommented when the submitted state is added.  It works
-  # without modification, locally, at the time of writing.
-  # context 'when deleting a "Submitted" proposal' do
-  #   before do
-  #     draft = create(:full_collection_draft_proposal, draft_short_name: 'A Deletable Example')
-  #     proposal = CollectionDraftProposal.first
-  #     proposal.proposal_status = 'submitted'
-  #     proposal.save
-  #     visit collection_draft_proposal_path(draft)
-  #   end
+  context 'when deleting a "Submitted" proposal' do
+    before do
+      draft = create(:full_collection_draft_proposal, draft_short_name: 'A Deletable Example')
+      proposal = CollectionDraftProposal.first
+      proposal.proposal_status = 'submitted'
+      proposal.save
+      visit collection_draft_proposal_path(draft)
+    end
 
-  #   it 'does not have a delete link' do
-  #     expect(page).to have_no_link('Delete Collection Draft Proposal')
-  #   end
-  # end
+    it 'does not have a delete link' do
+      expect(page).to have_no_link('Delete Collection Draft Proposal')
+    end
+  end
 end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_destroy_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_destroy_spec.rb
@@ -30,7 +30,7 @@ describe 'Collection Draft Proposal destruction', js: true do
     end
   end
 
-  context 'when deleting a "Submitted" proposal' do
+  context 'when attempting to delete a "Submitted" proposal' do
     before do
       draft = create(:full_collection_draft_proposal, draft_short_name: 'A Deletable Example')
       proposal = CollectionDraftProposal.first

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
@@ -71,13 +71,20 @@ describe 'Collection Draft Proposal Submit', js: true do
     it 'has a rescind button and cannot be deleted' do
       expect(page).to have_link('Rescind Draft Submission')
       expect(page).to have_no_link('Delete Collection Draft Proposal')
-      expect(page).to have_content('Proposal Status: Submitted')
+      within '#proposal-status-display' do
+        expect(page).to have_content('PROPOSAL STATUS:')
+        expect(page).to have_content('SUBMITTED')
+      end
     end
 
     it 'can be rescinded' do
       click_on 'Rescind Draft Submission'
+      click_on 'Yes'
       expect(page).to have_link('Submit for Review')
-      expect(page).to have_content('Proposal Status: In Work')
+      within '#proposal-status-display' do
+        expect(page).to have_content('PROPOSAL STATUS:')
+        expect(page).to have_content('IN WORK')
+      end
     end
 
     context 'when rescinding fails' do
@@ -88,6 +95,7 @@ describe 'Collection Draft Proposal Submit', js: true do
         proposal.proposal_status = 'in_work'
         proposal.save
         click_on 'Rescind Draft Submission'
+        click_on 'Yes'
       end
 
       it 'provides the correct error message' do

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
@@ -1,0 +1,99 @@
+describe 'Collection Draft Proposal Submit', js: true do
+  before do
+    login
+  end
+
+  context 'when submitting a validated proposal' do
+    before do
+      set_as_proposal_mode_mmt(with_required_acl: true)
+      @collection_draft_proposal = create(:full_collection_draft_proposal)
+      visit collection_draft_proposal_path(@collection_draft_proposal)
+    end
+
+    context 'when the proposal is submitted' do
+      before do
+        click_on 'Submit for Review'
+      end
+
+      it 'submits a proposal' do
+        click_on 'Yes'
+        expect(page).to have_content('Collection Draft Proposal Submitted Successfully')
+        expect(page).to have_no_link('Temporal Information')
+      end
+
+      it 'does not navigate away when cancelling' do
+        click_on 'No'
+        expect(page).to have_link('Temporal Information')
+      end
+    end
+
+    context 'when the submission fails' do
+      before do
+        # After loading the page, manipulate the state of the proposal so that
+        # submit will fail in order to execute the else code in the controller.
+        proposal = CollectionDraftProposal.first
+        proposal.proposal_status = 'submitted'
+        proposal.save
+        click_on 'Submit for Review'
+        click_on 'Yes'
+      end
+
+      it 'provides an error message' do
+        expect(page).to have_content('Collection Draft Proposal was not submitted successfully')
+        expect(page).to have_link('Rescind Draft Submission')
+      end
+    end
+  end
+
+  context 'when submitting an incomplete proposal' do
+    before do
+      set_as_proposal_mode_mmt(with_required_acl: true)
+      @collection_draft_proposal = create(:empty_collection_draft_proposal)
+      visit collection_draft_proposal_path(@collection_draft_proposal)
+      click_on 'Submit for Review'
+    end
+
+    it 'cannot be submitted' do
+      expect(page).to have_text('This proposal is not ready to be submitted. Please use the progress indicators on the proposal preview page to address incomplete or invalid fields.')
+    end
+  end
+
+  context 'when viewing a submitted proposal as a user' do
+    before do
+      set_as_proposal_mode_mmt(with_required_acl: true)
+      @collection_draft_proposal = create(:full_collection_draft_proposal)
+      proposal = CollectionDraftProposal.first
+      proposal.proposal_status = 'submitted'
+      proposal.save
+      visit collection_draft_proposal_path(@collection_draft_proposal)
+    end
+
+    it 'has a rescind button and cannot be deleted' do
+      expect(page).to have_link('Rescind Draft Submission')
+      expect(page).to have_no_link('Delete Collection Draft Proposal')
+      expect(page).to have_content('Proposal Status: Submitted')
+    end
+
+    it 'can be rescinded' do
+      click_on 'Rescind Draft Submission'
+      expect(page).to have_link('Submit for Review')
+      expect(page).to have_content('Proposal Status: In Work')
+    end
+
+    context 'when rescinding fails' do
+      before do
+        # After loading the page, manipulate the state of the proposal so that
+        # rescind will fail in order to execute the else code.
+        proposal = CollectionDraftProposal.first
+        proposal.proposal_status = 'in_work'
+        proposal.save
+        click_on 'Rescind Draft Submission'
+      end
+
+      it 'provides the correct error message' do
+        expect(page).to have_link 'Submit for Review'
+        expect(page).to have_content 'Collection Draft Proposal was not rescinded successfully'
+      end
+    end
+  end
+end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_update_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_update_spec.rb
@@ -2,15 +2,16 @@ describe 'Collection Draft Proposal Update', js: true do
   before do
     login
   end
+
   context 'when updating an existing collection draft proposal' do
     before do
       set_as_proposal_mode_mmt(with_required_acl: true)
       @collection_draft_proposal = create(:full_collection_draft_proposal)
-      visit edit_collection_draft_proposal_path(@collection_draft_proposal)
     end
 
     context 'when updating data' do
       before do
+        visit edit_collection_draft_proposal_path(@collection_draft_proposal)
         fill_in 'Short Name', with: 'A Special Short Name'
         fill_in 'Abstract', with: 'collection abstract'
         within '.nav-top' do
@@ -22,6 +23,20 @@ describe 'Collection Draft Proposal Update', js: true do
         expect(page).to have_content('Collection Draft Proposal Updated Successfully!')
         expect(page).to have_content('A Special Short Name')
         expect(page).to have_content('collection abstract')
+      end
+    end
+
+    context 'when a proposal is not "in work"' do
+      before do
+        proposal = CollectionDraftProposal.first
+        proposal.proposal_status = 'submitted'
+        proposal.save
+        visit edit_collection_draft_proposal_path(@collection_draft_proposal)
+      end
+
+      it 'cannot be edited' do
+        expect(page).to have_content('Only proposals in an "In Work" status can be edited.')
+        expect(page).to have_link('Rescind Draft Submission')
       end
     end
   end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_view_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_view_spec.rb
@@ -11,13 +11,16 @@ describe 'Viewing Unsubmitted Collection Draft Proposals', js: true do
     end
 
     it 'displays the current proposal status' do
-      expect(page).to have_content('Proposal Status: In Work')
+      within '#proposal-status-display' do
+        expect(page).to have_content('PROPOSAL STATUS:')
+        expect(page).to have_content('IN WORK')
+      end
     end
 
     it 'has a submit button' do
       expect(page).to have_link('Submit for Review')
       click_on('Submit for Review')
-      expect(page).to have_content('Are you sure you want to submit this proposal?')
+      expect(page).to have_content('Are you sure you want to submit this proposal for review? Upon approval, your collection record will be published to the CMR.')
     end
 
     it 'has a delete link' do

--- a/spec/mailers/draft_mailer_spec.rb
+++ b/spec/mailers/draft_mailer_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe DraftMailer do
   context 'draft_published_notification' do
     user = { name: 'Captain Planet', email: 'supergreen@bluemarble.com' }

--- a/spec/mailers/group_mailer_spec.rb
+++ b/spec/mailers/group_mailer_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe GroupMailer do
   context 'invite_user' do
     let(:invite) { create(:user_invite) }

--- a/spec/mailers/previews/proposal_mailer_preview.rb
+++ b/spec/mailers/previews/proposal_mailer_preview.rb
@@ -1,0 +1,11 @@
+# Preview emails at http://localhost:3000/rails/mailers/proposal_mailer
+class ProposalMailerPreview < ActionMailer::Preview
+  def new_proposal_submitted_notification
+    user = { name: 'Captain Planet', email: 'supergreen@bluemarble.com' }
+    short_name = 'CIESIN_SEDAC_EPI_2010'
+    version = 2010
+    id = 1
+
+    ProposalMailer.proposal_submitted_notification(user, short_name, version, id)
+  end
+end

--- a/spec/mailers/proposal_mailer_spec.rb
+++ b/spec/mailers/proposal_mailer_spec.rb
@@ -1,0 +1,36 @@
+describe ProposalMailer do
+  context 'proposal submission notification' do
+    user = { name: 'Captain Planet', email: 'supergreen@bluemarble.com' }
+
+    context 'when publishing a new record' do
+      id = 1
+      short_name = 'CIESIN_SEDAC_EPI_2010'
+      version = 2010
+      let(:mail) { described_class.proposal_submitted_notification(user, short_name, version, id) }
+
+      it 'renders the subject' do
+        expect(mail.subject).to eq('New Create Collection Proposal Submitted in Metadata Management Tool')
+      end
+
+      it 'renders the receiver email' do
+        expect(mail.to).to eq([user[:email]])
+      end
+
+      it 'renders the sender email' do
+        expect(mail.from).to eq(['no-reply@mmt.earthdata.nasa.gov'])
+      end
+
+      it 'renders the new record published notice including short name + version' do
+        expect(mail.html_part.body).to have_content("#{short_name}_#{version} Submitted")
+        expect(mail.html_part.body).to have_content("#{user[:name]}, Your collection metadata proposal #{short_name}_#{version} has been successfully submitted for review.", normalize_ws: true)
+        expect(mail.text_part.body).to have_content("#{user[:name]}, Your collection metadata proposal #{short_name}_#{version} has been successfully submitted for review.", normalize_ws: true)
+      end
+
+      it 'renders the link to the collection' do
+        expect(mail.html_part.body).to have_link('View Collection', href: collection_draft_proposal_url(id))
+        # link renders as text in text format email
+        expect(mail.text_part.body).to have_content(collection_draft_proposal_url(id))
+      end
+    end
+  end
+end

--- a/spec/mailers/proposal_mailer_spec.rb
+++ b/spec/mailers/proposal_mailer_spec.rb
@@ -20,7 +20,7 @@ describe ProposalMailer do
         expect(mail.from).to eq(['no-reply@mmt.earthdata.nasa.gov'])
       end
 
-      it 'renders the new record published notice including short name + version' do
+      it 'renders the new metadata submitted notice including short name + version' do
         expect(mail.html_part.body).to have_content("#{short_name}_#{version} Submitted")
         expect(mail.html_part.body).to have_content("#{user[:name]}, Your collection metadata proposal #{short_name}_#{version} has been successfully submitted for review.", normalize_ws: true)
         expect(mail.text_part.body).to have_content("#{user[:name]}, Your collection metadata proposal #{short_name}_#{version} has been successfully submitted for review.", normalize_ws: true)

--- a/vendor/assets/stylesheets/eui-1.1.7/eui.css
+++ b/vendor/assets/stylesheets/eui-1.1.7/eui.css
@@ -1,6 +1,6 @@
 @font-face {
   font-family: "eui-icon-library";
-  src: url("data:application/x-font-woff;charset=utf-8;base64,d09GRgABAAAAAB3QAA4AAAAANCAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAABRAAAABoAAAAccn4jLkdERUYAAAFgAAAAHQAAACAAYQAET1MvMgAAAYAAAABKAAAAYEE7XpljbWFwAAABzAAAAEIAAAFCAA/03WN2dCAAAAIQAAAABAAAAAQAEQFEZ2FzcAAAAhQAAAAIAAAACP//AANnbHlmAAACHAAAGOcAACvMRMhriWhlYWQAABsEAAAALgAAADYHc8DbaGhlYQAAGzQAAAAcAAAAJAPxAcVobXR4AAAbUAAAADsAAABwCuMDy2xvY2EAABuMAAAAagAAAGoB5PpObWF4cAAAG/gAAAAfAAAAIACuAoRuYW1lAAAcGAAAAOsAAAIQLaotqXBvc3QAAB0EAAAAyQAAAhKxwPdSeJxjYGBgZACCM7aLzoPoywoO+jAaAEGVBUAAAHicY2BkYGDgA2IJBhBgYmAEQmMgZgHzGAAGewBmAAAAeJxjYGFiYPzCwMrAwOjDmMbAwOAOpb8ySDK0MDAwMbBxMsCBAILJEJDmmsJw4CPTRyPGA/8PMOgxHmRwAAozIilRYGAEADt8DGoAAHicY2BgYGaAYBkGRgYQsAHyGMF8FgYFIM0ChED+R6P//4Ek0////IxQlQyMbAwwJgMjE5BgYkAFjAzDHgAActoG3gAAABEBRAAAAAH//wACeJy1Wn2MJEd176ruruqPmememZ7unZndmZ3p3em93fPefLfvbu/O2NhofTaBdWwT7vjyB3ec8QFxgg8IymERwA7ExoAxuXz8QRDgSCZYYBMpUSwRKcKKooiPRHwlMigiCWCEkogIor38XnXv192Z/JW7ne7qV6/ee/Xq1av3XrfGtbKmaZ9gt2q6JrXVzzPtwNpT0tB+PPy8ML+z9pTO0dQ+rxPYJPBTUrD/WXuKEXxUHpWTUTkuf+D+N76R3br5p2U2AjVDYxef5Rr7K83VIi3WVjQtnbZZ6DFxgPXSxbxxjE0jvdsbT4dhLRBSVLoiCIfT8R/o+mt1Pdb11+g6K+r6Z/HAOa53nfnYY1977OQ1/fnPnDv3mXPfVBgxYfObMzRd/4yub14A1mNnbnioGbC/PUeokIlrmpLpWa2kLWgay1jGxH40DOV0DIG6HkvoIgIIOzzG2I8CMBufIWK/eyNjMTPYe69mOu9y/hq0Y7bQH9/w0Gzw2NcfO3E6g6MfcJ29FjdN8V28+C/s2+wCtDunaZVhGAgwjbq9CXGO0l7cFbUgHA3TRHzq6fPnnz7/07lOd7Zatsut1bVJv1OWPrtwnnr+sNNqdWRsTfsrE6sroGdNszGnC5qntbUD2jFNW8S04k63d4SBemcYJpc8p/9HP9dcubkgXVey70j3LB4eVQ9npbvuWJvr6uEZy7nXtTafUQ/rlnvNIrXocmq79cYFy3GsBUu1XNeix736aJNdLOR6n4x7K6wr5rYXgGMB+DQose4qGx9lw5B9xGyYnjklUu4UrYZpnmqYvtk4dfOhu8/dfYguX/IEwNOHSYqHp6bZEJ55GpDG6fUc49Chy2RYVMzT3AR4zpzR82h4lO2W4dFLyZrbDNe3hXjyMgHNXPTbdoS4XA98y/Ri0kMQHmYyN8S9evjoHra7BbppRw+7ue5R2C/RQy4D3zL/GskwnB5hkVLH3rW4ZGbbPHbW4s8v11Eu7G4ZPK1y8Vn2AvYl+R8Xz1X4jCYkirWRlmqHYdW/ot2nadFoEtMv2XWvXnJPts0oE303fnpJX1rOLH9SHk8Pw/5wGYZzbLTTwm7Z2Ljr5Mm7tq5fPXny7MmT39nYwPUuYVQM08RFfFUBzm5s2OpRdZwNvc2zXhh6C81qpdo8q64LXtjc2NionDx5srKx+Z2N83SpnLywQYTo8h+Ab2yk28/h5keIBrsXA6vN7b8Q+4hpz2ir7ATb0Ip4wFy6sN4xlgmrc8LxxHnTPC88h11zUZMumiVAXDXuUxi3no1bCGBxmQqGbcbW1RAa/DcKXTI1dpedBNo89kt6BW+5xzyKD5hmC9bwqlfh0jLNB0Tp69t2cfMDAM4JcfvtQsyh+YD44hVtchevbYZX4LW0h5QA8S9tsxpcIgR6//7FeWVbfouNvJzXTzP6u4T/yQ6rjPzuae9m9eI63Npt0SXzetu2yNs037LN7V07s82lef8V51XX9m35t64U25Mibjhw9uwB8v7k3x4smKa97/FMoZ/YZ1q64a73u5svdPv9Lqt0+888iI1csPZ9IuP9+D6TmX+0090nG9viTyctTnewWWGTURqrzTXpKQ8X10a1OOfNHqTh04P2taVqXOkkqwcPPq4IXsg4P3Htsu+v8dV9g2ufyNjQWaJv83HZN3hAp2try11PI0ytf5RNppjmNAKPoyyddHtJX467IgHKZJUl/VXeLbHBMhcD0Y2nSS+e9pLRGD2rpCsKEuAFZQkPYdQH6ViKXoL/kn5D/MZTcMApEYcpGExbbBROk6FCEVG/BBaYrQTVaUayxaNQAl4ToYQMYQJdADmd1lZZLOQwHU5H0ygNI4yvAYUnWDgZjsIgTEM5jkICMomAAdESZEsFQJh2hD+QFAPcgxYkSXqY4KTf4gPR4qMWi4chcGot1uYtZWzwb1GYdlscsGg6AanpREAjbA2ub0qjE0jWF4PuAJM8qtM8SpzmD7qw0QTzHU7D6aQf9wbhFLT6vTRMlShwryBOXHpHOPCnaZ+0kwxTKH4wxdAR2BGFcDqeHGWDdBoTAHo6xEaQXU5T6KOXjFd5jB/MRyBM6tG6QQpW602TcYl3BdrxuDehGUFNIqL1+uvtrfATk3HGTcO1TcGYZIgnmW4wrnNEb/jHOScEhGuGoXMdLUMw7gFkWISvEDAEQC45cywbANDACDyZjEgJXHWDCJtcN/GjPks3JbeABo4GRy+nIQ7nwiSCGFIsgorJbOqHUgE1DG7yfQ3iqOu8IEgqEoAbhuEA1yA4CaV+uJo0EdA10DAgCM3EIDyL6xDGsLiDWRN56EA3bGKtK65EwaDZMUMnKEY6HGSUKkgv+CuAJidMuaUjPdMGWBFLoZTHsyuh2oQmQMQEURIV+hHm9PA+NEygmRkJIi+oXycuNGcjWwyhekgyg13Y9nSvZqauq3WApgVhGEouHYhKIK7okFikePrppA9adrDkQnFkwpBYOQxlhplZgkmal2pqkmeqAZYhsVxkIywjzPLhjFlKNVxBDZiHDjFMnWcQ0GXREt2hHGaZBAANy3aZUWTMJUuAxXCyCdCH2pkoYAa07jAKCGdhmg4ZF1cLxG30GaaeqwWolmErExX0hDvYkFHoABhKRl4wuWPmylSaoGWClWSPhu5iaQDEXE21eMJQCiMFZ+tIWyOTTs9M/KKzXxlHtjcyy1Uikg6V7iEgMdBLMC9Jm8fiXDO3/XKkLWq3aK/T3oJTCP64u8rhOTjSnn5LJArAVBrUYscQ9pZYlghhD0e0s2tBS0cEjjGr+viojmMsoUhuEtfo7BhddnqVO1EhrBW9aKYg9ILuGFLntarvh06l7EVOu37TzP65xSYitMJwplh2y2HoluNW1S37BbuIv9I9CwtV/N27+7y7K6wJt1osVrHhbayTJa2Pl6OZtleuN+YPVyq9mWbMbFnwdM+qe4WgYOtI3SqlmVKxWCi4xVqxHJXOVxYXK6tP7jkmkb+1Ln6VfY89qQ20G7S7tLciT8aUawF5NRxVlCKm5Agn45RSVXo8ypAXxHDkSF9LPIGjnU7IScIVCtJXlOkLBxinQ2gAr10CxRZPcdrWoLvJaDL6QaXRqJSCV1zVe4nv1sPFl9u2KIqVQ7VKuDZ/bmmxFpYcJygtu5H07Eq7UohkSRQqdd9vN3zEpUL4nDuOaXut+cgP5hd+fuRIa22t9ZwTVKOFqD4Td2aalSBKSpFZqBScEktXov1+pVqvLDVqHccpVyq25c+VewuRa5fniq25yPu55TUqsuTAjxfhQSUzXL9RDtq+/Yv2sWPto3TeRxf/kf0b+yys6rj2NtgUxVA4luiswTmWGRRNO4EuEOiMKG9JMiREWjksJQSyRGV4dExFU4Mi4ZhiaOg6yVoUTY8QFyMKkJFqsaesw1ahYJGvhs/wXUPC3rGNbOuQVXCtZesrW40XQ2TazPJMN44Oz9Tr9W48c3jmkueNAobanNyLJaECDMcJwGxQPWzJZesb+d19EbwL18/smwHZbgyCuO99RGx4FnvzUVWPiCjn66mqS4r5I3DqKQVQDrG+sraysvYb9mmzElTM0/at77z1hwRZWW8H33Xw77tB+8itt4JeBTb8AmxYap0dehR9QYdqy2PHD2l1ZITU5PibbrrpTf8Uep57x+jY0vHp/Pz0+CtxW7jD/TPqOo6syb1jIYfitnRsdIdLMeVZjeR+MMtb1MZX6Q5WBVHrTpazmWUwSH9ozMWfsUe1Czu5Di0rOQv26FZOREnOh7fzJaWfn+V8mpeOml7CdzcNd7cQOwTv3BFnV1y+gsxWWS/t3tw8kx0jlTvmG6nr3irEvWI0EqIupGWOx/BHaF4OObt9hP72L0PLIe+9cq7S166B6gWiMSGzQlVEYSFu3QS+OsL6Jgh56QY5yUUnV0gqsPFlJSg36zFffEloN4rebM3CoSdaQXeflMvD+auX5kqscutut8sqUndDx6jGdUQundmS3ylLVuvg6KxEDdYMulf1Z0y9cONen8q0tmaz59n98KkkOWLkkp6Jl8Kl0m2VHYFulVfF9s/rcDTDKXseyfX+I7cNXn6NU7hm1OrbDnbx/HIQVsNCfOdBfZosNduzbqvJjs9WDWvxxpdO2st8aWGWG2LUYW5hX9SorYx01+1N54TfqehZzev/z6ZYXgO8H/OmOoBU+65GCVdW1cuKGSnNkap7hm6Z9w26XyGdfaU7uE/ld+zE5nOIHsR9fQI/R5f+fYKboO1q+y8+y77OntVszYPHWNGOaCe0O7V3aw9iX31OVRyh3gnRx/EyHi7ihMbpfJjjBlkmECKGvSgzhnmQuyaESZaATmIl8RGqu6g+qs9kyelkCnPq4hHORGVg3YScO1aNUokhJTwhG0kwJX8+amPSRCqhWWfTTdGXQ0aZCOmEHXKlENJ9Q6Ox+aPWr7XmNup1WwpW50ax6L+Tm55XqNeLJc/kb2ggDCuOLLdaLSCSCwKE00/OzPydZdT9ydcnfkO30CyPs+bm9+fiWaPkWK3g3RbOQdfCwMCxXt/wSiVdbyBQkvZrjlTFbTIoFoOVRuOTH3ozonz79FtLwi03DwaW7x/9y5LvyxnD052gPhc5nudEA7pZCPaqa0GwFnz52q4fcSF45Heuu65Tztrlebbv12++ubY0Wz8OhbmlkhsNs/G/55Ud6b31TYgoC/fuyplLWqgNNa0KRUHJMg8wenmB2hynsdypTauzNZHZwmxWEViblaLn36wK1myOLfJio7HYadSLgR9WrWp7MagxvaqbgWWUa36l9riqYMcNz68udVq9il2tOPNuubofNnY1znMXMv0m7gcRB31Q+4L2Ne1b2vPav2ovaP+l/QKhp4XjKWSzbIEtsz5LsYWvY+vsFex29jp2N7uX3cfewc6z97OH2cfZH7NPs8+xp9lfsC+z59jX2LfY99kP2X+ynyOQtXmF7+MH+ITfwDdgvZR1wn5EhNCpRdkt9iWl42ReLV5iB5C7HjXJ5BBv6TIdDvphrb9mUow1GEE7MKx4lY8CEURoIRuGIcObjJN4pFLhw2yZD5Atx6LFBjFS3ck0HclRImSMrHucZFjRCFjTscJKFRY45mjJBKbfE2FENi8DJOA1OC4sRCZoEnTHo2Et2nMj4CUPkh5CBRvmVwUahgO5gz3d/bSFUctAO3Sydk5tFA5S+IAt7sNaSkCoaTehdIfQaJoLFm4LkOb3aBednX41eLj7AZwTD5s6HR1gORjPUe0YO8DzodQfUX82eKub6dljTY6iSRonrITAWcbyqDE6ylNTINJLI+Gx6TGmTOMAyw0hSWlfqMMirLF6ylh3fnmwb94s2RVulqVueMJsVjqeu7R4Q9kQulOv/3T1uJ1W9zcWy3MvKcp6577T97f7c3VdD0wxaxZtyixDKe5Agsy6vGyoHLRWQnYcIv8Kkf+ZtlFBWmg/Lswu93OEoslDyqRDKhkwWy8TxqyhO9Wq6XK9KLhTtmxdVmTVDX3LrbwUqZuLQLGB3G1Z133caoYxgxtSPcAFpbYx55LulG8bRoD0LzIM0wCGXgbmEQAqLEv6bkI71vXX6TpG8BL9KAct0fBFuqg0tkEwYunrKttHak1Zp2RCMEwBbLL2p01VUkGLfrdRkp513GWaOm4S2e9VZrAQXl253jyxxpg/n1RXmHPjkas2HynbhlsYlYrMDT6ZrUmjd32u/g+eeezMm25af/Mbov290YH24sp1bq0Q6mYRi1W0rU7n4HyjXH5lYoVzZauw3K7rFeFDdd6B0G8tH4w6lVcvY7pIdyyk1YZk9ToSvdBjVlmYQhcDJlsVA+n7AQeht4lzhSofbrmIsIpVkZkbq1gOJOkSuTE8JjMDvdiQwisji/ZDEwk+GoYMkTfrbkPggPA+igERcu8FbvAZtG20Z9D2aOmpgEI/qjLNqAoAtPtu9eLR4BXcJe4+fg510ohZNIoAlHH3CVAAFmHeQFhZbo+Mn7qXiBugLgGqQPFzLgnVUaRaB7EKBJktFBNfoLpJ3tHnpr7dsfl9HdFE1sG65U4cJsX9+uGUVdqt0pxcXV3+sI1e81XFgiyUk2x5gsor8pV4/fEzZ44fP3PPjTgbTGQVG+yf2arKV5a1l2jr8NoICVaotHvJ20tzQqEG9iwFGHCtYRvul6KDyTQPLwAnhxumKkgZTVghZPWC+HbB2jyjErbHrMLmD2a5U5hdmGXMLs29p80cUZgpFlsz5ZZjO1w+cmqh9aNqdZGtfoGG0OXT70s60Uw4eN9Stx7Wx3whMJlVrziu/jsTpG6N0/X6vbvP3obWpQzAyEKacaqK1EOVioYBFTIlz1+GS0wjGh1lFF71VJY/x2J21auXlo745bLfbi0tod1q5w/FR06deuTU83wJC9P0TWEJP9TZarPsH9mLmD+wd5yiEcuLYVwN2Aqr+pZ47d73tJG2n96X747BdkIwqYr5OKPi7N1ZSpKy58pb/JSQefN9wvSbkkG2VTg3X7DapRiqefN+FlTjcPFdrxWWXyVZxK536BSDtnHOP0PaU98OBFuqWshDF2pTFkqHSW/Sl2MczyLp9mJBxfheskap1pAOz3E3CcIadF7rJmP49t5klarVIwxb46PueIJDbJr0E6pwTxOBcBTpzXDUj6bJmCIBKvLH/RiwMKLYaAJq096oj9O/G/fSQ1SVxmmB4yoKBmE6TrG6MY0KRE0kQyxzH/CIFn5MS3+M9dLhlOToI5BQp3tYi4dhHB1ig+lgqFROA3CEErNREAfdvhj0JL0k6NfEYJjieB2Fst8dYGIeQ2eNqvbdIAYwGg7EgBZyICLiLFStpJ8ss4mYiHAgkjHmA731476Ih8AFYxWnD2UQz7JafzQGXxUD0XNEsuPYFnKNTQc9etdCeuyHgyE25Bgih2LUH6d9QpxQSM5OqIjxfU+cO/fEuc3/fvstt7z9lntuGA5vGN6ZVZ/pTCIvR35TVV+pHKoqj7oq7lLhWs8q1Fm9m5qup6qqW5VYU9U8VcVcDdtynVkFN6sX66rUmRHWjRwrK72rOrSR134Vxq6bOhyzovBWSZxKotngLZxcgByfkevP/xl5gV1xoT4e0yMi+qx8TWA1XzN782A0VdzMls6Rxg7eQgp7ZEgKk6rqq7Sjpq5o66pcrLRDZ8SW1rhSiaFkydgSjmfnDb49060b32kaap5biEqJ+Uz17PVE1pFVnPN12Xm7om9pZUsfeRk5u2aoqmSdjdimzS2Rr2bOmvrpLUvZUFhkINzMpcyZcF3VVPf6inte3E9Eq/ogTSgblTghslYio5qQSdaSEULBIJJZE6dFGka1rBWlOFPSKGthaILYPY2uZN3/zs2iNWvOOU1pd8WsO2t2HNF0m+bsrNltct7sUgsAaXfMWXfO7Nqy6cwRsNNkrNm5ggVcxXVp+rY/3/MtNl+1y/Nt367Oc+n35gEu24Fv2qZXtX08dZd8i7fR7nSA1OaWv9T1qafqG45BHta8RGfXaad/idYGozEOU1W4p2MgQaJOvrRHx0Ob6lfqPSN9XVVLCVOVrcfTiUJEPhkRSo1Q4KXi8IpKO/iBxZIjaStgbW1XurZT5K5624agojjzRLGk3rEwu2YrE/IYWzCvoKmHuVnzzYJr2BY3LMuS0ofqmFFgdtHjiOu4hQDSEc6s4+ueaRZ0ejdlmsIQxaJwGL2CQajnSj+8XE9txCMvqqdp/hyt6QPYh6xdaZ6/Gnpe6D109fW1lSsI73jU/VtGsVm++vpwpalpl8rQ1hLt6OUyUEG8lqUrKrDo7ZyMWJAuvRqgl7l6jKXYI9Y36Q1HweIWlHpASfj2fsdmRbuI2FLqesEuMnuPpHfqJcMQliUMo2jw31dyf6gblUtVb8aV0p3xqp4fXUl3t18ut8jl3JI3yiqkPfVhT/65CTLhOYbzTpVJQ6r6ROEozepLEY6qIxixZ07fW261lluWms2PWRDAUXQ4nw9gNsE81+dhRQqIBkHhkwKCdfieec63iMz9an63M96cBaLbBbJDexiRNO+6eJptwjs5XTqTED7OuqDbddgl3wF6OzNfCLJoJZd486ET50+cOJ9xvkDNE9ru7ynkzsh8RIZK9Be2cao73xmakxU+xw/zyZ88/Z73PH2enah8u1r9diX/oHC9Wl2oVnfFpTL7EmyLRzxGlI0fVeEOs1qc3YcTfRs2nORyPGo3nRO23Wza9nl7wZk6+Mtksx+17VX7BH42W6Wmvffbjbo20A7CQFTFkr466GYVvMMsq4wgQaaeRH2UkfdQoJztMtLEPwh7P6z22fdbLlI19srHDh6+1mCfEvay5TLxxpdZDoFPrd9ofXkQx4O4JhzrA89ixH5bmMZ1hw59bMMSgL3sbslca9k2hb2+fsouxISdfTua11g9bZx/s7hdqKQv42oUsZP/m8+kRIhJ9RsKkuejbBbsLPTg2LZpCOPRCxR8mK3gmovaNUHbMOj8U89s6/mLoXFSCNN92kU6fnLlas+biaq1WR2bcLZWPeB5gBzYDYCI/wurpb/uAHicY2BkYGAA4qz5AQHx/DZfGeSZGEDgsoKDPoL+f4CJgfEAkMvBAJYGAPmmCLwAAHicY2BkYGA8+P8Agx4TAwgASUYGVMACAFCzArp4nGNiYBBkAAImCGYEUqpgDIFCDNsZlsJ5MCjHIM6QB5TLA0OQiDyQZmDQAbMVMdSDoAqYZAAAwFMItQAAAAAqACoAKgB0ALAA3gE4AXoBvAH+AkAC3AL4AxIDSAN+A7QD6gQqBF4HKge+CFYI+AkgCVQJbgmICbYKCgpoCrIK4AsQC/gMQg9QD7YQDBBSEmgTAhOWE9gUNBS0FNIU5BUCFTwVkhXmAAB4nGNgZGBgMGEKZrBgAAEmIGZkAIk5MOiBBAAV8gE1AHicnY/BagIxFEVvnFEodOGiC5ePrs2QyYCgH2BXbqW4UxkkIBOIuuiP9Ev6Q/2T3oxvU0EEA493eLk39wXAK75hkI/BGO/KA85XygWm+FEuMTaF8pA8Ux6RA5WmfOFEelfmASZolAt8YqNcUvOrPISYN+UR+QMtLgiwrD0iOtKRvEPClvUFtJdgwz529hh2aZs4uSv9L1v2onPfEw5MEnhUcOwL1qPkq8pjzpuG5emsMePDsTsvYzq04isnC7ndkCM/t431rqb6iQ+uaUo4UZYNwtycXPU9b491m04hduJcXTnn5JmUP+BEWGoAeJxdzck2AwEURdE6pYle9KIL0ff1XgUxRORfTDLzf/4MKzkm7uSsdSe7KIvRvr+K1m8o/q87ektKJphkimkazDDLHPMssMgSyzRZYZU11tlgky22abHDLnvsc0CbQ47ocMwJp5xxzgWXXHHNDbfccU9FkI3P4ccgqr/Wtmsf7KN9sj37bF/sq32zfftuB+NGZcPqh37oh37oh37oh37oh37oh37oh37qp37qp37qp37qp37qp37qp37qp37qp36tX+vX+QPLeXNpAAAA") format("woff");
+  src: url("data:application/x-font-woff;charset=utf-8;base64,d09GRgABAAAAAB9gAA4AAAAANtAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAABRAAAABoAAAAcfDojXkdERUYAAAFgAAAAHQAAACAAYwAET1MvMgAAAYAAAABKAAAAYEE7XptjbWFwAAABzAAAAEIAAAFCAA/032N2dCAAAAIQAAAABAAAAAQAEQFEZ2FzcAAAAhQAAAAIAAAACP//AANnbHlmAAACHAAAGXkAAC0Y8bo+AmhlYWQAABuYAAAALgAAADYRL8ELaGhlYQAAG8gAAAAcAAAAJAPxAcVobXR4AAAb5AAAADwAAAB0CwgD8GxvY2EAABwgAAAAbgAAAG4YcRB4bWF4cAAAHJAAAAAfAAAAIACwAoRuYW1lAAAcsAAAAOsAAAIT5jdimnBvc3QAAB2cAAABxAAAA2rqf+JseJxjYGBgZACCM7aLzoPo6/8c3GE0AE7pBzQAAHicY2BkYGDgA2IJBhBgYmAEQlMgZgHzGAAGkQBoAAAAeJxjYGFiYPzCwMrAwOjDmMbAwOAOpb8ySDK0MDAwMbBxMsCBAILJEJDmmsJw4CPTRxPGA/8PMOgxHmRwAAozIilRYGAEADu2DGwAAHicY2BgYGaAYBkGRgYQsAHyGMF8FgYFIM0ChED+R5P//4Ek0////IxQlQyMbAwwJgMjE5BgYkAFjAzDHgAAdQgG4AAAABEBRAAAAAH//wACeJy1WnuMJMdZ76rururHzHTPTE/3zszuzM707vTe7nlvnt2+u907x44Prc+GZI3jkLskxHZylws+Aob4eERcIkji8IhzgHE4Hn9AlGCkQKxggwTCUpBQLIRQEkDgAAoR4hWCIkCggPb4fdW9r7tz+Iu7ne7qr76q76uvvvpe3RrXqpqmfYw9pOma1NY/zbRjG89LQ/uX8aeF+aWN53WOpvZpncAmgZ+Xgv3PxvOM4JPqpJpMqnH1Q0++4x3soZ1fr7IJZjM0duMlrrHf11wt0mJtTdOytMtCj4ljbJAtF43TLI30/mCajsNGIKSo9UUQjtPpL+j6W3Q91vU36zor6/qv4YFzXB+79LPPfOGZ83cNFz955conr/yFwogJmz+Qo+n6J3V95zqwnrl05sPtgP3RFUIFT1zTFE8vaRVtSdNYTjIm8pNxKNMpGOp7LKGLCMDs+DRjXw1AbHqJJvvx+xiLmcF+9E6m8z7nb0Y7ZkvD6ZkPzwfPfPGZcxdzOPoB19lbcNMU3eUbf8deYdch3QVNq43DQIBo1B/MiHKUDeK+aAThZJwl4uMvXL36wtWvL/T68/WqXe2sb8yGvar02fWr1POLvU6nJ2MrHa7NrL6AnDXNxpqua57W1Y5ppzVtGcuKe/3BJsPsvXGY3PSc/R/9XHPlzpJ0Xcm+JN3LeLimHi5Ld8uxdrbUw4uW87hr7byoHrYs965latHlwl7rHUuW41hLlmq5rkWPh+XRJb1YKuQ+mw7WWF8s7G0AxwbwNKiw/jqbnmLjkP202TI9M6Wp3BStlmleaJm+2brwwIm3X3n7Cbr8ticATj9CXHwkNc2W8MyLgLQubhUYJ07cwsOyIp4VKsAL4oyeJ+NT7CAP126e1twjuLXHxKduYdAsWH/DPhO3yoHvql5McgjCk0wWinhYDj9ziOxBhu7fl8NBqocE9k3kUPDAd9W/QTyM000WKXEc3oubVrZHY38vfudWGRXMHuTB02o3XmJfw7kk++PiuQ6b0QZHsTbRMu0ktPrbtCc0LZrMYvolB+71m+7JnhrlrB/Ez27qy6q55s+q0/Qk9A+XcbjAJvstnJbt7cfOn39s9/r58+cvnz//pe1tXB8TRs0wTVzE5xXg8va2rR5Vx+XQ27nshaG31K7X6u3L6rrkhe3t7e3a+fPna9s7X9q+Spfa+evbNBFd/g3w7e1s7znc+Wmagz2OgfX23l+Ic8S0F7V1do5ta2U8YC19aO8U24TdOed44qppXhWew+66oUkXzQogrhr3cYzbysctBdC4XATjLmNbaggN/kOFLpkae0BPAm0R5yW7jbU8pB7l95tmB9rwxjfi0jHN94vKF/f04oH3A7ggxMMPC7GA5vvFb91WJw/Q2iN4G1orh6YSmPy390iNbmICvX/y6rTyI79LRt5K6+v5/AeY/9d9Uvn0B5d9kNSry3D3tEU3ret79ljem/O796j90P5qC24+eNt1NbUju/atL8XeoogaHM6hM0DWn+zbUyXTtI88mwv0Y0dMSzfcrWF/52v94bDPav3hi0/hIJesIx/LaT97xGTmL+13D0nHdumTp4V3B5k1NptksTpcs4GycHFj0ogL2uwpGp4et++u1ONaL1k/fvxZNeH1nPJzd6/6/gZfPzK6+7mcDPkSfY+Oy/6UB+RdO7vmOo2wtOEpNkuxzDQCjVMsm/UHyVBO+yIBymydJcN13q+w0SoXI9GP02QQp4NkMkXPOsmKggRYQVnBQxgNMXUsxSDBf0m/MX7TFBTgJeIwA4G0wyZhmowVioiGFZDAaiVmTfMpOzwKJeANEUrwECaQBZCztLHOYiHH2TidpFEWRhjfAApPsHEynIRBmIVyGoUEZBIBA6Il8JYJgLDsCH+YUoxwDzrgJBlggbNhh49Eh086LB6HwGl0WJd3lLLBvkVh1u9wwKJ0hqnSmYBE2AZMX0qjE3A2FKP+CIs8pdM6KpzWj3mhownWO07DdDaMB6MwxVzDQRZmihWYV0xOVAabHPhpNiTpJOMMgh+lGDoBOZohTKezU2yUpTEBIKcTbALeZZpBHoNkus5j/KA+AmHSgPYNXLDGIE2mFd4XaMfTwYxWBDGJiPbrD/aOwr+ajDNuGq5tCsYkQzzJdINxnSN6wz/OOSEgXDMMnetoGYJxDyDDInyFgCEAcsmZY9kAYA6MwJPJaCqBq27QxCbXTfyoz9JNyS2ggaLB0ctpiMO5MGlCDCmXMYvJbOqHUAE1DG7yIy2iqOu8JIgrYoAbhuEA1yA4MaV+uJq0EMxroGGAEVqJQXgW18GMYXEHq6bpIQPdsIm0rqjSDAatjhk6QTHS4ZhGiYLkgr8S5uSEKXdlpOfSACkiKZTweH4lVJvQBCYxMSmxCvkIMz15BA0TaGY+BU0vqF8nKrRmI98MoXqIM4Nd37N0b2Kmrqt9gKQFYRiKLx2IiiGu5iG2SPD000ketO0gyYWiyIQhsXMYygwz1wSTJC/V0iTPRQMsQ2K7SEdYPjErhjNmKdFwBTWgHjrYMHWeQzAvi1boDuEwyyQA5rBslxllxlzSBGgMJ53A/BA7EyWsgPYdSgHmLCzTIeXiaoO4jT7D1AuxANUybKWigp5wBxlSCh0AQ/HISyZ3zEKYShK0TdCS/NHQXWwNgFirqTZPGEpgJOB8H+lo5NzpuYrfcI4q5cjPRq65ikWSoZI9GCQCegXqJenwWJxr5p5djrRl7UHtrdp3wwvBHvfXOSwHR9oz7IhEAZhKgzrsNMLeCssTIZzhiE52I+joiMAxZl2fntLhxhKK5GZxg3zH5BbvVe1FpbBR9qK5ktBLumNInTfqvh86taoXOd3m/XNHF5bbiNBK47ly1a2GoVuNO3W36pfsMv4q71paquPv8YP+7rGwIdx6uVzHgbexT5a0fq4azXW9arO1eLJWG8y1Y2bLkqd7VtMrBSVbR+pWq8xVyuVSyS03ytWocrW2vFxb/9QhN4n8rXPj8+xv2ae0kXZGe0x7N/JkLLkRkFWDq6IUMSNDOJtmlKrS4ymGvCCGIUf6WuEJDG06IyMJUyhIXlEuLzgwTk5oBKtdwYwdnsHbNiC72WQ2+ftaq1WrBK+7Y/Aa322Gy99q26Is1k40auHG4pWV5UZYcZygsupG0rNr3VopkhVRqjV9v9vyEZcK4XPuOKbtdRYjP1hc+sbmZmdjo/OyE9Sjpag5F/fm2rUgSiqRWaqVnArL1qKjfq3erK20Gj3HqdZqtuUvVAdLkWtXF8qdhcj7huW1arLiwI6XYUElM1y/VQ26vv3f3dOnu6fI30c3/pz9I/s1aNVZ7XugUxRDwS2Rr4EfyxWKlp1AFgh0JpS3JDkSIq0ClhECaaJSPHJTUWpQJBxTDA1ZJ3mLoukJ4mJEATJSLfa8ddIqlSyy1bAZvmtI6DuOkW2dsEqutWp9brfxaohMm1ud68fRyblms9mP507O3fS8XcJQm5N5sSREgOHwAMzGrCctuWr9aXF3XwXv+r1zR+YwbT/GhLgffkRseBln85qqR0SU8w1U1SXD+hE4DZQAKIfYWttYW9v4PvuiWQtq5kX7oR986J8JsrbVDf7Kwb+/CrqbDz2E+WrQ4a9Bh6XW25+Poi/IUB15nPgx7Y6MkJqcfef997/zr0PPcx+ZnF45my4upmdfj9vSI+5vUtdZZE3uI0sFFLeV05NHXIopL2vE91N53qIOvkp3sCuIWveznJ08g0H6Q2Nu/Ce7pl3fz3VoW8lYsGu7ORElOR/dy5eUfP6zoNO+eVR6E92Dc7gHmdif8NF9dg7E5WvIbJX20ukt1DPZV1K5r76Ruh6uQjwuJhMhmkJa5nQKe4TmrZDLey70R74ZWgH50dvnKkPtLoheIBoTMi9URRQW4tZPYKsj7G+CkJdu4JNMdHKbpAIHX9aCarsZ8+XXhHar7M03LDg90Qn6R6RcHS/eubJQYbWHDppdVpO6GzpGPW4icunNV/xeVbJGD66zFrVYO+jfMZwz9dJ9h20q07qazb7MnoRNJc4RI1f0nL0MJpVu62wTslVWFce/qMPRClP2ZSTXRzffMPrWu5zSXZPO0HZwihdXg7AeluJHj+tpstLuzrudNjs7Xzes5fteO+uu8pWleW6ISY+5pSNRq7E20V13kC4Iv1fT85rX/59OsaIG+CTWTXUAqc5dgxKuvKqXFzMyWiNV9wzdMp8Y9T9HMvtcf/SEyu/YuZ2XET2IJ4YEfpkuwycENzG3qx298RL7IntJszUPFmNN29TOaY9q79Wewrn6DVVxhHhnND/cy3S8DA8N73yS4wZeZmAihr4oNYZ6kLkmhFmegM5ixfEm1V1UH9Vn8uR0lkKd+niEMVEZWD8h445do1RiTAlPyCYSRMmeT7pYNE2V0Krz5WboKyCTnIVsxk64Ugjpvq3V2vlq5zs6C9vNpi0Fa3KjXPZ/kJueV2o2yxXP5G9rIQwrTyy3Xi8hkgsChNOfmpv7Y8to+rMvzvyWbqFZnebNna8sxPNGxbE6wXst+EHXwsDAsb6z5VUqut5CoCTtN2/WxRtkUC4Ha63Wr/zkdyHKty++uyLcavt4YPn+qd+r+L6cMzzdCZoLkeN5TjSim4Vgr74RBBvBZ+/u+xEXgkd+7557etW8XV1kR773gQcaK/PNsxCYW6m40Tgf/1Ne1ZHeu9+JiLL0+IGcuaKF2ljT6hAUhCyLAGNQFKjNaRbL/dq08q2JzDdmp47A2qyVPf8BVbBmC2yZl1ut5V6rWQ78sG7Vu8tBg+l13Qwso9rwa41nVQU7bnl+faXXGdTses1ZdKv1o9CxO+HPXfD0/bgfRxz0E9pntC9of6l9WfsH7Wvaf2j/jdDTgnsK2TxbYqtsyDIc4XvYFnsde5i9lb2dPc6eYD/ArrIPso+wn2O/zD7BfoO9wH6XfZa9zL7A/pJ9hf0z+3f2DQSyNq/xI/wYn/EzfBvaS1kn9EdECJ06lN3iXFI6TurV4RV2DLnrKZNUDvGWLrPxaBg2hhsmxVijCaQDxYrX+SQQQYQWsmEoMqzJNIknKhU+yVb5CNlyLDpsFCPVnaXZRE4SIWNk3dMkx4omwEqnCitTWKBYoCUzqP5AhBHpvAyQgDdguLAROaNJ0J9Oxo3o0I2ANz1IeggVbFxcFWgcjuQ+dnrwaRejkYP258nbxWyTcJTBBuxSHzcyAkJMByfK9ieapAVj4R4DWXGPDsyz368Gjw8+gHLi4VBnk2OsAOM5apxmx3gxlPoj6s8H73YzPX9syEk0y+KEVRA4y1ieMianeGYKRHpZJDyWnmZKNY6xQhGSjM6FchZhgzUzxvqLq6Mji2bFrnGzKnXDE2a71vPcleUzVUPoTrP59fWzdlY/2lquLrymLJu9Jy4+2R0uNHU9MMW8WbYpswyleAQJMuvzqqFy0EYF2XGI/CtE/mfaRg1pof2sMPvcLxDKJg8pkw6pZMBsvUoY84bu1Oumy/Wy4E7VsnVZk3U39C239lqkbi4CxRZyt1Vd93FrGMYcbkj1ABeU2sacS7pTvm0YAdK/yDBMAxh6FZibANRYnvTdj3as62/VdYzgFfpRDlqh4ct0UWlsi2BE0tdVto/UmrJOyYRgWALI5O1PmKqkghb93kBJet7xmGnquElkv3eYwVJ4Z+1e89wGY/5iUl9jzn2bd+w8XbUNtzSplJkb/Eq+J63BvYX4f+LSM5feef/Wd70tOjqYHOsur93jNkqhbpaxWWXb6vWOL7aq1dcnVrhQtUqr3aZeEz5E5x0L/c7q8ahXe9Mqlot0x0JabUjWbCLRCz1mVYUpdDFislMzkL4fcxB6m/ArVPlwq2WEVayOzNxYx3YgSZfIjWExmRno5ZYUXhVZtB+aSPDRMGSIvFl3WwIOwvsZDIiQey9xg8+hbaM9h7ZHW08FFPpRlWlOVQAg3feqF48Gr+Eucffxc6iTRsyjUQagirtPgBKwCPMMYeW5PTJ+6l4haoC6BKgDxS+oJFRHkWofxDoQZL5RTHyG6iZFx5Cb+l7Hzld0RBN5B+tXe3GYlI/qJzNW63YqC3J9ffWjNnrNN5ZLslRN8u0Jaq8rduI7z166dPbspXfdB99gIqvYZn/D1lW+sqq9RtuC1UZIsEal3ZveXpozCjVwZinAgGkNuzC/FB3M0iK8AJwMbpipIGUyY6WQNUvilZK1c0klbM9YpZ2/n+dOaX5pnjG7svC+LnNEaa5c7sxVO47tcPn0haXOV+v1Zbb+GRpCl098IOlFc+HoAyv9Ztic8qXAZFaz5rj6j82QurUuNpuPH/S9La1PGYCRhzTTTBWpxyoVDQMqZEpevAyXWEY0OcUovBqoLH+BxeyON62sbPrVqt/trKyg3ekWD+WnL1x4+sKX+Qo2pu2bwhJ+qLP1dtXfPIxYPLAfuEAjVpfDuB6wNVb3LfGWw+9pI+0ovS8/GIPth2BSFfPho+L83VlGnLKXq7v0FJNF8wPC9NuSgbd1GDdfsMbNGKr5wFEW1ONw+YfeIiy/TryIA+/QKQbtws+/SNJT3w4Eu6JaKkIXalMWSs5kMBvKKdyzSPqDWFAxfpBsUKo1Juc57SdB2IDMG/1kCts+mK1TtXqCYRt80p/O4MTSZJhQhTtNBMJRpDfjyTBKkylFAlTkj4cxYGFEsdEMs6WDyRDevx8PshNUlYa3gLuKglGYTTPsbkyjAtEQyRjbPAQ8oo2f0tafZoNsnBIfQwQSyruHjXgcxtEJNkpHYyVyGgAXSsQmQRz0h2I0kPSSYNgQo3EG9zoJ5bA/wsI8hs4GVe37QQxgNB6JEW3kSEREWahayTBZZTMxE+FIJFOsB3IbxkMRj4ELwipOH8sgnmeN4WQKuioGoueIeIfbFnKDpaMBvWshOQ7D0RgHcgqWQzEZTrMhIc4oJGfnVMT4geeuXHnuys5/vefBB9/z4LvOjMdnxo/m1WfySWTlyG6q6iuVQ1XlUVfFXSpc63mFOq93U9P1VFV1txJrqpqnqpirYbumM6/g5vViXZU684l1o8DKS++qDm0UtV+FceCmnGNeFN4tiVNJNB+8i1MwUOAzMv3FP6MosCsq1MdjekREn5evCazWa+ZvHoy2ipvZyhWS2PEHSWBPj0lgUlV9lXTU0tXcuioXK+mQj9iVGlciMRQvOVnC8eyiwfdWunvj+01DrXMXUQmxWKmev57IO/KKc7Ev+29X9F2p7MqjKCPn1xxVlazzEXtzc0sUu1mQpn56y1I1FBYpCDcLLgsiXFc11cO24l2vbieidX2UJZSNSniIvJXIqCFkkrdkhFAwiGTehLfIwqiRt6IMPiWL8haGJojds+h22v1P3Cxb8+aC05Z2X8y782bPEW23bc7Pm/025+0+tQCQds+cdxfMvi3bzgIBe23G2r3baMAdXJemb/uLA99ii3W7utj17foil/5gEeCqHfimbXp128dTf8W3eBftXg9IXW75K32feuq+4RhkYc2bZHaPdvGbSG00mcKZqsI9uYEEiTrZ0gG5hy7Vr9R7Rvq6qpERpipbT9OZQkQ+GRFKg1BgpeLwtkI7/qHliiPpKGBvbVe6tlPmrnrbhqCiPPdcuaLesTC7YSsV8hhbMm8jqY9ws+GbJdewLW5YliWlD9Exo8TssscR13ELAaQjnHnH1z3TLOn0bso0hSHKZeEwegWDUM+VfnirnLqIR15VTmnxHG3oI+iHbNxund8eel7offjOextrt2He8aj7h41yu3rnveFaW9Nu5qGrJdqpW3mggngjT1dUYDHY94zYkD69GqCXuXqMrTjE1l/QG46SxS0I9Zji8D3Dns3KdhmxpdT1kl1m9iFOH9UrhiEsSxhG2eA/r/j+yX5UrdS9OVdKd86re350O9k9fCvfouBzl98or5AO1Ic9xecmyIQXGPydKpOGVPWJwkmW15ciuKpNjDi0pr9d7XRWO5Zazb+wIICh6HG+GEBtgkWuL0KLFBANgsImBQTr8UPrXOzQNE+q9T3MeHseiG4fyA6dYUTSvO/iab4N6+T0ySchfJx3MW/fYTd9B+jtr3wpyKOVguOdD5+7eu7c1ZzydWqe0w5+TyH3RxYjclSaf2kPp77/naE5W+ML/CSf/eoL73vfC1fZudor9forteKDwq16falePxCXyvxLsF0a8RRRNn5UhTvJGnF+H8/0Pdh4VvBxzW4752y73bbtq/aSkzr4y3mzr9n2un0OP5utU9M+/O1GUxtpx6EgqmJJXx308wreSZZXRpAgU0+iPsooeihQzk8ZSeLPhH0UWvvSBy0XqRp7/TPHT95tsI8Le9VymXjHt1gOgS9s3Wd9dhTHo7ghHOtDL2HEUVuYxj0nTvzstiUA+5a3S+Zaq7Yp7K2tC3YpJuz829Gixupp0+Kbxb1CJX0Z16CInezfYs4lQkyq31CQvBjlq2CXIQfHtk1DGNeuU/BhdoK7bmh3BV3DIP+nntnu82+FxnkhTPcFF+n4+bU7PW8uqjfmdRzC+Ub9mOcBcuwgoJCpZkOmTxbfg97yNejs/3hmrzjWzmX6cJNdo+vt2/ufe/548WknWnuwQ3vraSe0M3tfIO1/ezddZ7H6ICmvAquaCr3QZLsYyrmYB196LAsjpY/rcNlaPNY8s2TKAb3M9hynUglLlVpH9ZVs26na8vG9tx9ZRl/T0eUPmmvRphDz3KhLScOE1au71Cson6+UG7W9tyD/C7BT7LYAAAB4nGNgZGBgAOKbJw2S4/ltvjLIMzGAwPV/Du4I+v8BJgbGA0AuBwNYGgBDNgs8AAB4nGNgZGBgPPj/AIMeEwMIAElGBlTAAgBQswK6eJxjYmAQZAACJghmBFKqYAyBQgzbGZbCeTAoxyDOkAeUywNDkIg8kGZg0AGzFTHUg6AKmASbDADjuwj/AAAAKgAqACoAdACwAN4BOAF6AbwB/gJAAtwC+AMSA0gDfgO0A+oEKgReByoHvghWCPgJIAlUCW4JiAm2CgoKaAqyCuALEAv4DEIPUA+2EAwQUhJoEwITlhPYFDQUtBTSFOQVAhU8FZIV5hYqFowAAHicY2BkYGAwYwpmsGAAASYgZmQAiTkw6IEEABYoATcAeJydjzFqAzEQRb/s9YIhhbukHNJrGe02sQ/gIpDWRTrbLEawrEC2i1wkR/GJfBB/yWoSCAFrkeYxvNkvAXjCNwzSMljgtfCE/Y/CU1hcCldYmLrwjLwsXJMHmqaasyN5KvEEL+gKT/HJ784VnWvhGcQ8F67J7+hxhmeqxx4BI2kg7xCx5f4C+rO3fh9GO/hd3EZ2/lR/aussnXKNODBJ0KKBsq64/0u+Wx19C5fPlqfDG38dxtM6xEMvbaOykt93ZKtT69S26qg/8MYNhyKO1NKAMDhFN7mmB2DTx6MPo6i6RlXlkZQbx9RY0QB4nG2SiXLaMBCG+cnBkQBNQpKm932r9/R9hLzYGmTJ6Ajl7fpmreQxpoVqxqP9P++udlfqdDv1+v2rcxM3dHbXj5p20cUBDnGEY/TQxwBDnOAUI4wxwR2c4RwXmOISV7jGXdzgHu7jAR7iER7jCZ7iGZ7jBV7iFV7jDd7iHd7jAxg+4hM+4wu+4hu+90RBYsHMUb0PhVGKhJdGj+accSVzzRTN/TQpa82KCWmFIpaZld6DyfNyF1qZF/58l4bqJCLBFemM21FtW/J1inGr6tirJAu6tUb/ffp/cAq+3sd1luk+D1Vypp+erOaKKakXzC1DPDmVO+eCZsZsUD+iXJkZpQZzY/KYoFLBNb/H/9JelClfaqzkVfzsguwgKkfciiI174z1jDtxurEzcqLXiEncvSzJNcWeJb2SPtbanDjckpQt6BRGWQq8lRmZOMKSLE9uaxN8mFEvt1wHRYeaO36grR9aWgZpKWOmvzEvXMZmPMuJcV8aVxVkacuEXTds0rIilFy7UasV19m4VUYQ11vpjOJ1vc0dmEFrp8pLqcOm5TRSqeemkcdRWucm237ipPk6DWzGrUtXtgzk0tttIv4AigAP/A==") format("woff");
   font-weight: normal;
   font-style: normal; }
 .eui-icon {
@@ -34,6 +34,9 @@
 
 .eui-fa-arrow-circle-up:before {
   content: "\f109"; }
+
+.eui-fa-bars:before {
+  content: "\f133"; }
 
 .eui-fa-calendar:before {
   content: "\f10a"; }
@@ -88,6 +91,9 @@
 
 .eui-fa-minus-circle:before {
   content: "\f12f"; }
+
+.eui-fa-question-circle:before {
+  content: "\f134"; }
 
 .eui-fa-rss:before {
   content: "\f131"; }
@@ -644,49 +650,6 @@ table {
     padding: 0;
     display: block; }
 
-table[data-sortable] {
-  border-collapse: collapse;
-  border-spacing: 0; }
-  table[data-sortable] th:after {
-    content: "";
-    display: inline-block;
-    vertical-align: inherit;
-    height: 0;
-    width: 0;
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent;
-    margin-right: 1px;
-    margin-left: 10px;
-    float: right; }
-  table[data-sortable] th:not([data-sorted="true"]):after {
-    font-family: 'EUI-Icon-Library';
-    content: "\f11b";
-    position: relative;
-    right: 3px;
-    bottom: 3px;
-    color: #989898;
-    font-size: 0.8em; }
-  table[data-sortable] th:not([data-sortable="false"]) {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
-    -webkit-touch-callout: none;
-    cursor: pointer; }
-    table[data-sortable] th:not([data-sortable="false"]):hover {
-      background-color: #c6c6c6; }
-  table[data-sortable] th[data-sorted="true"]:after {
-    visibility: visible;
-    content: ""; }
-  table[data-sortable] th[data-sorted-direction="descending"]:after {
-    border-top-color: inherit;
-    margin-top: 8px; }
-  table[data-sortable] th[data-sorted-direction="ascending"]:after {
-    border-bottom-color: inherit;
-    margin-top: 3px; }
-
 h1 {
   font-size: 2.2em; }
 
@@ -730,6 +693,9 @@ p.highlight {
 
 /* List Styles
 ===========================================*/
+ul, ol {
+  padding-left: 1.4em; }
+
 /* Display list items without a bullet */
 .no-bullet {
   list-style: none; }
@@ -739,13 +705,6 @@ p.highlight {
   padding-left: 0; }
   .inline li {
     display: inline; }
-
-pre {
-  border: 1px solid #cbd7e3;
-  background-color: #ecf1f5;
-  padding: 1em;
-  border-radius: 5px;
-  line-height: 1.4em; }
 
 a:link,
 a:visited {
@@ -1050,6 +1009,8 @@ footer {
 .eui-banner--danger, .eui-banner--info, .eui-banner--success, .eui-banner--warn {
   padding: 0.75em 1em;
   text-align: center; }
+  .eui-banner--danger a, .eui-banner--info a, .eui-banner--success a, .eui-banner--warn a {
+    text-decoration: underline; }
 
 .eui-banner__message {
   margin: 0; }
@@ -1121,22 +1082,26 @@ footer {
   color: white;
   line-height: 0.8;
   text-transform: uppercase;
-  font-weight: normal;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
+  font-weight: bold;
   -webkit-font-smoothing: antialiased;
   -webkit-transition: background 0.2s linear;
   -moz-transition: background 0.2s linear;
   transition: background 0.2s linear; }
 
-.eui-badge:hover {
-  color: white;
-  background: #1a5981; }
 .eui-badge--sm {
-  font-size: 0.6em;
-  font-weight: bold; }
+  font-size: 0.6em; }
 .eui-badge--md {
   font-size: 0.8em; }
 .eui-badge--lg {
   font-size: 1em; }
+.eui-badge--split {
+  padding-right: 0; }
+  .eui-badge--split span {
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    background: rgba(0, 0, 0, 0.4);
+    padding: 0.2em 0.7em 0.2em 0.7em; }
 
 .eui-breadcrumbs {
   margin: 0 0 2em 0; }
@@ -1157,15 +1122,16 @@ footer {
       .eui-breadcrumbs__item:last-child:after {
         content: ""; }
 
-.eui-btn, .eui-btn--green, .eui-btn--blue {
+.eui-btn, .eui-btn--green, .eui-btn--blue, .eui-btn--red, .eui-btn--link {
   display: inline-block;
   padding: 0.5em 1em;
   text-align: center;
   vertical-align: middle;
   border: 1px solid rgba(50, 50, 50, 0.2);
   color: white;
-  transition: background 0.15s ease-in-out; }
-  .eui-btn:link, .eui-btn--green:link, .eui-btn--blue:link, .eui-btn:visited, .eui-btn--green:visited, .eui-btn--blue:visited {
+  transition: background 0.15s ease-in-out;
+  outline: none; }
+  .eui-btn:link, .eui-btn--green:link, .eui-btn--blue:link, .eui-btn--red:link, .eui-btn--link:link, .eui-btn:visited, .eui-btn--green:visited, .eui-btn--blue:visited, .eui-btn--red:visited, .eui-btn--link:visited {
     color: white; }
 
 .eui-btn {
@@ -1184,6 +1150,10 @@ footer {
     background-color: #2276ac; }
     .eui-btn--blue:hover {
       background-color: #1a5981; }
+  .eui-btn--red {
+    background-color: #e74c3c; }
+    .eui-btn--red:hover {
+      background-color: #d62c1a; }
   .eui-btn--sm {
     font-size: 0.8em;
     padding: 0.2em 0.7em; }
@@ -1194,6 +1164,51 @@ footer {
     border-radius: 4px; }
   .eui-btn--disabled {
     opacity: 0.65; }
+  .eui-btn--pill span {
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 15px;
+    padding: 3px 10px;
+    font-size: 0.8em;
+    color: #fff;
+    margin-left: 5px; }
+  .eui-btn--link {
+    border: none; }
+    .eui-btn--link:link, .eui-btn--link:visited {
+      color: #2276ac; }
+  .eui-btn--group-main {
+    padding-right: 0.5em;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0; }
+  .eui-btn--group-secondary {
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+    border-left: none;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0; }
+    .eui-btn--group-secondary i {
+      display: inline-block;
+      vertical-align: top;
+      padding-top: 2px; }
+
+.button-group {
+  display: inline-block; }
+  .button-group--dropdown {
+    background: white;
+    list-style-type: none;
+    margin: 5px 0 0 0;
+    padding: 0;
+    display: none;
+    position: absolute;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+    border-radius: 5px;
+    border: 1px solid #d2d2d2;
+    font-size: 0.9em; }
+  .button-group--dropdown li {
+    padding: 10px 20px 0 20px;
+    margin: 0;
+    display: block; }
+  .button-group--dropdown li:last-child {
+    padding-bottom: 10px; }
 
 input.eui-btn:focus {
   border: 3px solid #c8e3f4;
@@ -1204,7 +1219,8 @@ input.eui-btn:focus {
   float: left;
   margin: 0.5em 1em;
   padding: 1em;
-  background: rgba(235, 235, 235, 0.9); }
+  background: rgba(235, 235, 235, 0.9);
+  word-wrap: break-word; }
 
 .eui-callout-box__title {
   position: relative;
@@ -1220,7 +1236,10 @@ input.eui-btn:focus {
   padding: 0; }
   .eui-callout-box__list li {
     padding: 0.5em 0;
-    list-style: none; }
+    list-style: none;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap; }
     .eui-callout-box__list li a, .eui-callout-box__list li a:visited {
       color: #323232; }
     .eui-callout-box__list li a:hover {
@@ -1311,103 +1330,75 @@ input.eui-btn:focus {
       margin: 0.5em 0; }
 
 .eui-feature-grid-row {
-  display: table;
-  width: 100%; }
-  .eui-feature-grid-row__title {
-    margin: 0;
-    padding: 1.2em 1.8em 0;
-    font-size: 0.9em;
-    min-height: 100px;
-    font-weight: bold;
-    position: absolute;
+  text-align: center;
+  display: inline-block;
+  max-width: 1200px; }
+  .eui-feature-grid-row__content {
     width: 100%;
-    z-index: 200;
-    bottom: 0;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.91) 0%, rgba(0, 0, 0, 0.91) 18%, rgba(0, 0, 0, 0.51) 32%, transparent 50%);
+    transition: 0.5s;
+    padding: 1em; }
+    .eui-feature-grid-row__content:hover {
+      background-color: rgba(0, 0, 0, 0.6);
+      transition: background-color 0.5s; }
+      .eui-feature-grid-row__content:hover .eui-feature-grid-row__description {
+        opacity: 1;
+        transition: 0.5s; }
+  .eui-feature-grid-row__title {
+    font-size: 0.9em;
+    font-weight: bold;
     color: white;
-    -webkit-transition: min-height 0.7s ease;
-    -moz-transition: min-height 0.7s ease;
-    transition: min-height 0.7s ease; }
-    .eui-feature-grid-row__title .eui-icon {
-      width: 38px;
-      height: 38px;
-      display: table;
-      vertical-align: middle;
-      margin: -35px auto 10px;
-      border-radius: 50%;
-      padding: 0;
-      background-color: #2276ac;
-      text-align: center;
-      font-size: 2.4em;
-      box-shadow: 0 0 15px rgba(50, 50, 50, 0.2);
-      line-height: 1.1; }
+    text-align: left; }
   .eui-feature-grid-row__description {
-    position: relative;
-    z-index: 300;
-    margin: 115px 0 0 0;
-    padding: 0 1.8em 1.2em;
-    font-size: 0.8em;
-    line-height: 1.6;
-    visibility: hidden;
     opacity: 0;
-    -webkit-transition: all 1s ease;
-    -moz-transition: all 1s ease;
-    transition: all 1s ease; }
+    transition: opacity 0.5s;
+    text-align: left;
+    color: rgba(255, 255, 255, 0.9);
+    font-weight: 100;
+    text-shadow: 2px 0px 18px rgba(0, 0, 0, 0.9);
+    overflow-y: auto;
+    margin-top: 0.3em; }
+  .eui-feature-grid-row__event-date {
+    font-size: 1em;
+    text-align: left;
+    color: rgba(255, 255, 255, 0.7);
+    font-weight: 100;
+    margin-left: 0.1em;
+    margin-bottom: 0.3em;
+    margin-top: 0; }
   .eui-feature-grid-row__image {
     text-align: center;
-    position: relative;
-    display: table-cell;
-    width: 33.33333%; }
-    .eui-feature-grid-row__image, .eui-feature-grid-row__image:visited {
-      height: 250px;
-      color: white;
-      vertical-align: top;
-      background-size: cover;
-      background-position: center; }
-    .eui-feature-grid-row__image:hover * {
-      color: white; }
-    .eui-feature-grid-row__image:hover .eui-feature-grid-row__title {
-      min-height: 220px;
-      background: none; }
-    .eui-feature-grid-row__image:hover .eui-feature-grid-row__description {
-      visibility: visible;
-      opacity: 1; }
-    .eui-feature-grid-row__image:hover:after {
-      height: 250px; }
-    .eui-feature-grid-row__image:after {
-      content: "";
-      height: 100px;
-      position: absolute;
-      left: 0;
-      bottom: 0;
-      right: 0;
-      background: #323232;
-      opacity: 0.8;
-      -webkit-transition: all 0.5s ease-in-out;
-      -moz-transition: all 0.5s ease-in-out;
-      transition: all 0.5s ease-in-out; }
-  @media screen and (max-width: 800px) {
-    .eui-feature-grid-row .eui-feature-grid-row__image {
-      display: block;
-      width: 100%; }
-      .eui-feature-grid-row .eui-feature-grid-row__image:after {
-        height: 250px;
-        opacity: 0.6; }
-      .eui-feature-grid-row .eui-feature-grid-row__image .eui-feature-grid-row__title {
-        position: inherit;
-        background: none; }
-        .eui-feature-grid-row .eui-feature-grid-row__image .eui-feature-grid-row__title .eui-icon {
-          margin: 10px auto; }
-      .eui-feature-grid-row .eui-feature-grid-row__image .eui-feature-grid-row__description {
-        -webkit-transition: none;
-        -moz-transition: none;
-        transition: none;
-        visibility: visible;
-        opacity: 1;
-        margin-top: 10px; }
-      .eui-feature-grid-row .eui-feature-grid-row__image:hover .eui-feature-grid-row__title {
-        min-height: 100px;
-        background: none; } }
+    display: inline-flex;
+    width: 270px;
+    height: 320px;
+    margin: 0.8em;
+    box-shadow: 0 0 10px #b1bdbd;
+    background-size: cover !important;
+    background-repeat: no-repeat !important;
+    background-position: center center !important; }
 
+/* -----------------------------------------
+Custom breakpoints:
+These have been created to make granular adjustments so that the flex
+container will always display only 4 or 2 item in each "row". These are not
+the standard breakpoints from _breakpoints.css
+--------------------------------------------*/
+@media screen and (max-width: 1220px) {
+  a.eui-feature-grid-row__image {
+    margin: 0.1em; } }
+@media screen and (max-width: 1125px) {
+  a.eui-feature-grid-row__image {
+    width: 200px;
+    height: 237px;
+    margin: 0.8em; } }
+@media screen and (max-width: 950px) {
+  a.eui-feature-grid-row__image {
+    margin: 0.1em; } }
+@media screen and (max-width: 845px) {
+  a.eui-feature-grid-row__image {
+    width: 270px;
+    height: 320px;
+    margin: 0.2em; } }
 .eui-flyout {
   position: absolute;
   top: 100px;
@@ -1442,7 +1433,6 @@ input.eui-btn:focus {
       padding: 15px;
       vertical-align: middle; }
     .eui-flyout__info-box {
-      display: -webkit-box;
       display: -webkit-flex;
       display: -ms-flexbox;
       display: flex;
@@ -1482,6 +1472,24 @@ input.eui-btn:focus {
 
 .eui-icon.eui-icon--lg {
   font-size: 2em; }
+
+.eui-info-box {
+  border: 1px solid #cbd7e3;
+  background-color: #ecf1f5;
+  border-radius: 5px;
+  line-height: 1.4em;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  overflow: auto;
+  padding: 1em;
+  list-style-position: inside; }
+  .eui-info-box pre {
+    margin: 0;
+    padding: 0; }
+  .eui-info-box p:first-child {
+    margin-top: 0; }
+  .eui-info-box p:last-child {
+    margin-bottom: 0; }
 
 .eui-masthead-logo {
   padding: 0.5em 0; }
@@ -1566,7 +1574,6 @@ input.eui-btn:focus {
     margin: 0;
     list-style: none;
     width: 400px;
-    display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
@@ -1939,17 +1946,63 @@ ul.eui-select-bar {
       list-style: none;
       padding: 1em 0em; }
 
-#nav-content {
-  background-color: rgba(50, 50, 50, 0.85);
-  height: 3.4em; }
-
-/* top-of-page nav bar */
-.eui-supermenu {
+.eui-menu, .eui-supermenu {
   margin: 0;
   padding: 0;
   color: white;
   font-size: 1em;
-  font-weight: 300;
+  font-weight: 300; }
+
+.eui-menu {
+  display: inline-block; }
+  .eui-menu a:link, .eui-menu a:visited {
+    color: white; }
+  .eui-menu ul, .eui-menu li {
+    margin: 0;
+    padding: 0; }
+  .eui-menu ul {
+    list-style-type: none; }
+    .eui-menu ul > li {
+      display: inline-block; }
+      .eui-menu ul > li > a {
+        padding: 15px;
+        display: block; }
+        .eui-menu ul > li > a:hover {
+          background: #333333; }
+    .eui-menu ul > li:hover .eui-sub-menu {
+      display: block; }
+  .eui-menu .eui-sub-menu {
+    position: absolute;
+    background: #333333;
+    z-index: 100;
+    display: none;
+    box-shadow: 0px 2px 2px 0px rgba(50, 50, 50, 0.25); }
+    .eui-menu .eui-sub-menu li {
+      display: block; }
+      .eui-menu .eui-sub-menu li a {
+        padding: 10px 20px; }
+        .eui-menu .eui-sub-menu li a:hover {
+          background: #1a1a1a; }
+      .eui-menu .eui-sub-menu li i {
+        opacity: 0.4;
+        margin-left: 5px; }
+      .eui-menu .eui-sub-menu li.has-children:hover .eui-third-menu {
+        display: block; }
+  .eui-menu .eui-third-menu {
+    background: #4d4d4d;
+    font-size: 0.8em; }
+    .eui-menu .eui-third-menu a {
+      padding: 0; }
+
+@media screen and (max-width: 650px) {
+  .eui-menu ul > li {
+    display: block; }
+
+  .eui-menu .eui-sub-menu {
+    position: inherit;
+    display: block; } }
+/* top-of-page nav bar */
+.eui-supermenu {
   float: right;
   position: relative;
   /* all nav links are white, all the time */
@@ -1994,9 +2047,9 @@ ul.eui-select-bar {
       .eui-supermenu > ul > li > ul ul ul > li {
         font-size: 0.8em;
         margin: 0; }
-    .eui-supermenu > ul > li:hover {
+    .eui-supermenu > ul > li:hover, .eui-supermenu > ul > li.eui-supermenu-open {
       background: rgba(0, 0, 0, 0.9); }
-      .eui-supermenu > ul > li:hover > ul {
+      .eui-supermenu > ul > li:hover > ul, .eui-supermenu > ul > li.eui-supermenu-open > ul {
         display: block; }
 
 .eui-layout .container {
@@ -2238,6 +2291,10 @@ ul.eui-select-bar {
       font-size: 0;
       background: #d8e5ee; }
 
+.eui-bg--red {
+  background: #b3241c; }
+.eui-bg--light-red {
+  background: #f2dede; }
 .eui-bg--bright-red {
   background: #e74c3c; }
 .eui-bg--dark-green {
@@ -2250,8 +2307,12 @@ ul.eui-select-bar {
   background: #c8e3f4; }
 .eui-bg--light-green {
   background: #20ce6f; }
+.eui-bg--mint-green {
+  background: #dff0d9; }
 .eui-bg--light-grey {
   background: #ebebeb; }
+.eui-bg--light-yellow {
+  background: #fff6c7; }
 .eui-bg--medium-blue {
   background: #b5cede; }
 .eui-bg--midnight-blue {


### PR DESCRIPTION
Making the rescind button was much faster than making new records to test submit and its side effects.  The rescind button is the work for MMT-1981, so this PR satisfies both tickets.

- Added a guard in proposal's edit such that only proposals 'in work' can be edited.  
- Added submit and rescind actions to controller.
- Added mailer for submitting a proposal
- Added submitted state, submit and rescind events in model
- Added submit and rescind policies (same as update)
- Updated submit button to correct link and added rescind button in 'Submitted' state
- Updated show view to not display progress when draft is submitted
- Tests
- Routes
