### PR TITLE
MMT-1993 Formatting the timestamp on retrieval, not writing to allow proper retrieval

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
-    crass (1.0.4)
+    crass (1.0.5)
     database_cleaner (1.5.1)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
@@ -166,7 +166,7 @@ GEM
       addressable (~> 2.3)
     libv8 (3.16.14.19)
     libxml-ruby (3.0.0)
-    loofah (2.2.3)
+    loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -125,7 +125,7 @@ module Proposal
 
     def add_status_history(target)
       get_resource.status_history ||= {}
-      get_resource.status_history[target] = { 'username' => session[:name], 'action_date' => Time.new.in_time_zone('UTC').to_s(:default_with_time_zone) }
+      get_resource.status_history[target] = { 'username' => session[:name], 'action_date' => Time.new }
     end
 
     def remove_status_history(target)
@@ -133,7 +133,7 @@ module Proposal
     end
 
     def get_progress_message(action)
-      "#{action == 'done' ? 'Published' : action.titleize}: #{@status_history[action]['action_date']} By: #{@status_history[action]['username']}"
+      "#{action == 'done' ? 'Published' : action.titleize}: #{@status_history.fetch(action, {})['action_date'].in_time_zone('UTC').to_s(:default_with_time_zone)} By: #{@status_history.fetch(action, {})['username']}"
     end
   end
 end

--- a/spec/features/proposal/proposal_progress_spec.rb
+++ b/spec/features/proposal/proposal_progress_spec.rb
@@ -214,4 +214,23 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
       end
     end
   end
+
+  context 'when viewing a complete draft' do
+    before do
+      @collection_draft_proposal = create(:full_collection_draft_proposal)
+      visit progress_collection_draft_proposal_path(@collection_draft_proposal)
+    end
+
+    # Verifies that the Time is formatted correctly in the status_history
+    it 'can submit a proposal' do
+      click_on 'Submit for Review'
+      click_on 'Yes'
+
+      visit progress_collection_draft_proposal_path(@collection_draft_proposal)
+
+      within '.progress-actions' do
+        expect(page).to have_link('Rescind this Submission')
+      end
+    end
+  end
 end

--- a/spec/features/proposal/proposal_progress_spec.rb
+++ b/spec/features/proposal/proposal_progress_spec.rb
@@ -221,7 +221,9 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
       visit progress_collection_draft_proposal_path(@collection_draft_proposal)
     end
 
-    # Verifies that the Time is formatted correctly in the status_history
+    # This works through enough of the workflow to verify that the helpers in
+    # the controller are storing the time in a way that is retrievable (which
+    # caused the original ticket to bounce back).
     it 'can submit a proposal' do
       click_on 'Submit for Review'
       click_on 'Yes'


### PR DESCRIPTION
Writing the default_with_time_zone was causing it to throw an error while parsing it on retrieval.  The test case provided here actually invokes the add_status_history call rather than using the helper methods, so automated testing should catch this mistake from here on.