### PR TITLE
MMT-1989 Create a delete metadata proposal request

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
-    crass (1.0.4)
+    crass (1.0.5)
     database_cleaner (1.5.1)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
@@ -166,7 +166,7 @@ GEM
       addressable (~> 2.3)
     libv8 (3.16.14.19)
     libxml-ruby (3.0.0)
-    loofah (2.2.3)
+    loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)

--- a/app/assets/stylesheets/components/_metadata-preview.scss
+++ b/app/assets/stylesheets/components/_metadata-preview.scss
@@ -348,3 +348,9 @@ ul.sub-field {
   float:right;
   padding: 5px;
 }
+
+// Overriding eui defaults for these badges only (bold and caps lock default)
+.proposal-status-badge{
+  text-transform: none;
+  font-weight: normal;
+}

--- a/app/assets/stylesheets/components/_metadata-preview.scss
+++ b/app/assets/stylesheets/components/_metadata-preview.scss
@@ -350,7 +350,11 @@ ul.sub-field {
 }
 
 // Overriding eui defaults for these badges only (bold and caps lock default)
-.proposal-status-badge{
+.proposal-status-badge {
   text-transform: none;
   font-weight: normal;
+}
+
+.proposal-status-display-status {
+  text-decoration: underline;
 }

--- a/app/concerns/permission_checking.rb
+++ b/app/concerns/permission_checking.rb
@@ -40,11 +40,11 @@ module PermissionChecking
     is_non_nasa_draft_user?(user: user, token: token) || is_non_nasa_draft_approver?(user: user, token: token)
   end
 
-  def authorize_proposal_all_user_actions(user:, token:)
+  def proposal_mode_all_user_actions_allowed?(user:, token:)
     redirect_to manage_collection_proposals_path unless Rails.configuration.proposal_mode && either_non_nasa_user_or_approver?(user: user, token: token)
   end
 
-  def authorize_public_actions(user:, token:)
+  def multi_mode_actions_allowed?(user:, token:)
     redirect_to manage_collection_proposals_path unless !Rails.configuration.proposal_mode || (Rails.configuration.proposal_mode && either_non_nasa_user_or_approver?(user: user, token: token))
   end
 

--- a/app/concerns/permission_checking.rb
+++ b/app/concerns/permission_checking.rb
@@ -36,6 +36,18 @@ module PermissionChecking
     end
   end
 
+  def either_non_nasa_user_or_approver?(user:, token:)
+    is_non_nasa_draft_user?(user: user, token: token) || is_non_nasa_draft_approver?(user: user, token: token)
+  end
+
+  def authorize_proposal_all_user_actions(user:, token:)
+    redirect_to manage_collection_proposals_path unless Rails.configuration.proposal_mode && either_non_nasa_user_or_approver?(user: user, token: token)
+  end
+
+  def authorize_public_actions(user:, token:)
+    redirect_to manage_collection_proposals_path unless !Rails.configuration.proposal_mode || (Rails.configuration.proposal_mode && either_non_nasa_user_or_approver?(user: user, token: token))
+  end
+
   def user_has_provider_permission_to(user:, action:, target:, token:, specific_provider: nil)
     user_has_permission_to(user: user, action: action, target: target, type: 'provider', token: token, specific_provider: specific_provider)
   end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -3,11 +3,7 @@ class CollectionsController < ManageCollectionsController
   include CMRCollectionsHelper
 
   before_action :set_collection
-  before_action :ensure_correct_collection_provider, only: [:edit, :clone, :revert, :destroy]
-
-  skip_before_action :proposal_mode_enabled?, only: [:show]
-  # the only functionality that should be available in Draft MMT should be
-  # to view the collection preview
+  before_action :ensure_correct_collection_provider, only: %i[edit clone revert destroy]
 
   layout 'collection_preview', only: [:show]
 
@@ -98,6 +94,13 @@ class CollectionsController < ManageCollectionsController
     send_data collection_download, type: content_type, disposition: "attachment; filename=#{concept_id}.#{download_format}"
   end
 
+  def delete_proposal
+    proposal = CollectionDraftProposal.create_request(@collection, current_user, @native_id, 'delete', session[:name])
+    Rails.logger.info("Audit Log: Delete Collection Proposal Request for #{proposal.entry_title} was created by #{current_user.urs_uid}")
+    flash[:success] = I18n.t('controllers.collections.delete_proposal.flash.success')
+    redirect_to collection_draft_proposal_path(proposal)
+  end
+
   private
 
   def ensure_correct_collection_provider
@@ -152,5 +155,18 @@ class CollectionsController < ManageCollectionsController
     @collection = {}
     @collection_format = ''
     @error = 'This collection is not available. It is either being published right now, does not exist, or you have insufficient permissions to view this collection.'
+  end
+
+  def proposal_mode_enabled?
+    # actions available in both dMMT and MMT
+    if %w[show].include?(params['action'])
+      authorize_public_actions(user: current_user, token: token)
+    # actions available in dMMT to users and approvers
+    elsif %w[delete_proposal].include?(params['action'])
+      authorize_proposal_all_user_actions(user: current_user, token: token)
+    # actions available in MMT
+    else
+      super
+    end
   end
 end

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -23,12 +23,12 @@ module Proposal
       if get_resource.submit && get_resource.save
         add_status_history('submitted')
         remove_status_history('rejected')
-        Rails.logger.info("Audit Log: User #{current_user.urs_uid} submitted #{resource_name.titleize} with title: '#{get_resource.entry_title}' and id: #{get_resource.id}")
+        Rails.logger.info("Audit Log: User #{current_user.urs_uid} submitted #{resource_name.titleize} (a #{get_resource.request_type} metadata request) with title: '#{get_resource.entry_title}' and id: #{get_resource.id}")
 
         ProposalMailer.proposal_submitted_notification(get_user_info, get_resource.draft['ShortName'], get_resource.draft['Version'], params['id']).deliver_now
         flash[:success] = I18n.t("controllers.draft.#{plural_resource_name}.submit.flash.success")
       else
-        Rails.logger.info("Audit Log: User #{current_user.urs_uid} unsuccessfully submitted #{resource_name.titleize} with title: '#{get_resource.entry_title}' and id: #{get_resource.id}")
+        Rails.logger.info("Audit Log: User #{current_user.urs_uid} unsuccessfully submitted #{resource_name.titleize} (a #{get_resource.request_type} metadata request) with title: '#{get_resource.entry_title}' and id: #{get_resource.id}")
         flash[:error] = I18n.t("controllers.draft.#{plural_resource_name}.submit.flash.error")
       end
       redirect_to collection_draft_proposal_path(get_resource)
@@ -42,11 +42,11 @@ module Proposal
       if get_resource.request_type == 'delete'
         short_name = get_resource.draft['ShortName']
         if get_resource.rescind && get_resource.destroy
-          Rails.logger.info("Audit Log: #{resource_name.titleize} #{get_resource.entry_title} was rescinded and destroyed by #{current_user.urs_uid}")
+          Rails.logger.info("Audit Log: #{resource_name.titleize} #{get_resource.entry_title} (a #{get_resource.request_type} metadata request) was rescinded and destroyed by #{current_user.urs_uid}")
           flash[:success] = I18n.t("controllers.draft.#{plural_resource_name}.rescind.flash.delete.success", short_name: short_name)
           redirect_to manage_collection_proposals_path and return
         else
-          Rails.logger.info("Audit Log: Attempt to rescind and destroy #{resource_name.titleize} #{get_resource.entry_title} by #{current_user.urs_uid} failed.")
+          Rails.logger.info("Audit Log: Attempt to rescind and destroy #{resource_name.titleize} #{get_resource.entry_title} (a #{get_resource.request_type} metadata request) by #{current_user.urs_uid} failed.")
           flash[:error] = I18n.t("controllers.draft.#{plural_resource_name}.rescind.flash.delete.error", short_name: short_name)
         end
       elsif get_resource.rescind && get_resource.save

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -20,9 +20,10 @@ module Proposal
     def submit
       authorize get_resource
 
+      add_status_history('submitted')
+      remove_status_history('rejected')
+
       if get_resource.submit && get_resource.save
-        add_status_history('submitted')
-        remove_status_history('rejected')
         Rails.logger.info("Audit Log: User #{current_user.urs_uid} submitted #{resource_name.titleize} (a #{get_resource.request_type} metadata request) with title: '#{get_resource.entry_title}' and id: #{get_resource.id}")
 
         ProposalMailer.proposal_submitted_notification(get_user_info, get_resource.draft['ShortName'], get_resource.draft['Version'], params['id']).deliver_now
@@ -37,6 +38,8 @@ module Proposal
     def rescind
       authorize get_resource
 
+      remove_status_history('submitted')
+
       # An in_work delete request does not make sense.  If a delete request is
       # rescinded, delete the request instead.
       if get_resource.request_type == 'delete'
@@ -50,7 +53,6 @@ module Proposal
           flash[:error] = I18n.t("controllers.draft.#{plural_resource_name}.rescind.flash.delete.error", short_name: short_name)
         end
       elsif get_resource.rescind && get_resource.save
-        remove_status_history('submitted')
         flash[:success] = I18n.t("controllers.draft.#{plural_resource_name}.rescind.flash.success")
       else
         Rails.logger.info("Audit Log: User #{current_user.urs_uid} unsuccessfully rescinded #{resource_name.titleize} with title: '#{get_resource.entry_title}' and id: #{get_resource.id}")

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -65,6 +65,6 @@ class SearchController < ManageMetadataController
   end
 
   def proposal_mode_enabled?
-    authorize_public_actions(user: current_user, token: token)
+    multi_mode_actions_allowed?(user: current_user, token: token)
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,8 +2,6 @@
 class SearchController < ManageMetadataController
   include SearchHelper
 
-  skip_before_action :proposal_mode_enabled?
-
   RESULTS_PER_PAGE = 25
 
   def index
@@ -64,5 +62,9 @@ class SearchController < ManageMetadataController
     end
 
     [records, errors, hits]
+  end
+
+  def proposal_mode_enabled?
+    authorize_public_actions(user: current_user, token: token)
   end
 end

--- a/app/helpers/manage_metadata_helper.rb
+++ b/app/helpers/manage_metadata_helper.rb
@@ -26,13 +26,15 @@ module ManageMetadataHelper
 
   def is_collection_draft_proposal_controller?
     controller.lookup_context.prefixes.each do |item|
-      return true if item.start_with?('proposal')
+      return true if item.start_with?('proposal') || (Rails.configuration.proposal_mode && resource_type == 'collections')
     end
     false
   end
 
   def current_manage_title
-    if controller.lookup_context.prefixes.include?('search')
+    if is_collection_draft_proposal_controller?
+      'manage_collection_proposals'
+    elsif controller.lookup_context.prefixes.include?('search')
       "manage_#{resource_type}"
     elsif controller.lookup_context.prefixes.include?('manage_cmr')
       'manage_cmr'
@@ -40,8 +42,6 @@ module ManageMetadataHelper
       'manage_variables'
     elsif is_services_controller?
       'manage_services'
-    elsif is_collection_draft_proposal_controller?
-      'manage_collection_proposals'
     else
       # default, including collection drafts and everything under manage collections
       'manage_collections'

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -72,4 +72,12 @@ module ProposalsHelper
 
     content_tag(:div, nil, class: classes)
   end
+
+  def rescind_button_text
+    get_resource.request_type == 'create' ? 'Cancel Proposal Submission' : "Cancel #{get_resource.request_type.titleize} Request"
+  end
+
+  def status_badge_text
+    get_resource.request_type == 'create' ? 'Draft Proposal Submission:' : "#{get_resource.request_type.titleize} Metadata Request:"
+  end
 end

--- a/app/models/collection_draft_proposal.rb
+++ b/app/models/collection_draft_proposal.rb
@@ -31,6 +31,26 @@ class CollectionDraftProposal < CollectionDraft
     end
   end
 
+  class << self
+    def create_request(collection, user, native_id, type, username = nil)
+      request = self.create
+      request.request_type = type
+      request.draft = collection
+      request.native_id = native_id
+      request.short_name = request.draft['ShortName']
+      request.entry_title = request.draft['EntryTitle']
+      request.set_user_and_provider(user)
+
+      if type == 'delete'
+        request.submit
+        request.status_history = { 'submitted' => { 'username' => username, 'action_date' => Time.new.utc.to_s } }
+      end
+
+      request.save
+      request
+    end
+  end
+
   private
 
   def provider_required?

--- a/app/views/proposal/collection_draft_proposals/progress.html.erb
+++ b/app/views/proposal/collection_draft_proposals/progress.html.erb
@@ -3,7 +3,9 @@
   <section class="action wide-content">
     <div class="wide-content-inside">
       <span>
-        <span id="proposal-status-display-left" class="eui-badge eui-badge--split ">Proposal Status: <span><%= get_resource.proposal_status.titleize %></span></span>
+        <span class="eui-badge eui-badge--split proposal-status-badge"><%= get_resource.request_type == 'create' ? 'Draft Proposal Submission:' : "#{get_resource.request_type.titleize} Metadata Request:" %>
+          <span><%= get_resource.proposal_status.titleize %></span>
+        </span>
         <span class="progress-update"> Last Updated: <%= "#{get_resource.updated_at.to_s(:default_with_time_zone)}" %></span>
       </span><br>
       <span>

--- a/app/views/proposal/collection_draft_proposals/progress.html.erb
+++ b/app/views/proposal/collection_draft_proposals/progress.html.erb
@@ -3,7 +3,7 @@
   <section class="action wide-content">
     <div class="wide-content-inside">
       <span>
-        <span class="eui-badge eui-badge--split proposal-status-badge"><%= get_resource.request_type == 'create' ? 'Draft Proposal Submission:' : "#{get_resource.request_type.titleize} Metadata Request:" %>
+        <span class="eui-badge eui-badge--split proposal-status-badge"><%= status_badge_text %>
           <span><%= get_resource.proposal_status.titleize %></span>
         </span>
         <span class="progress-update"> Last Updated: <%= "#{get_resource.updated_at.to_s(:default_with_time_zone)}" %></span>
@@ -61,10 +61,10 @@
               <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/submit_modal' %>
             <% end %>
           <% elsif get_resource.submitted? %>
-            <%= link_to 'Rescind this Submission', "#rescind-submission-modal", class: 'eui-btn--blue display-modal' %>
+            <%= link_to rescind_button_text, "#rescind-submission-modal", class: 'eui-btn--blue display-modal' %>
             <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/rescind_modal' %>
           <% elsif get_resource.rejected? %>
-            <%= link_to 'Rescind Rejected Proposal', "#rescind-submission-modal", class: 'eui-btn--blue display-modal' %>
+            <%= link_to rescind_button_text, "#rescind-submission-modal", class: 'eui-btn--blue display-modal' %>
             <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/rescind_modal' %>
           <% elsif get_resource.done? %>
           <% end %>

--- a/app/views/proposal/collection_draft_proposals/show.html.erb
+++ b/app/views/proposal/collection_draft_proposals/show.html.erb
@@ -21,13 +21,13 @@
           </div>
         </span>
       <% elsif get_resource.submitted? %>
-        <%= link_to 'Rescind Draft Submission', "#rescind-submission-modal", class: 'eui-btn--blue display-modal' %>
+        <%= link_to rescind_button_text, "#rescind-submission-modal", class: 'eui-btn--blue display-modal' %>
         <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/rescind_modal' %>
       <% end %>
       <span id="proposal-status-display">
         <a href="<%= progress_collection_draft_proposal_path(get_resource) %>">
-          <span class="eui-badge eui-badge--split proposal-status-badge"><%= get_resource.request_type == 'create' ? 'Draft Proposal Submission:' : "#{get_resource.request_type.titleize} Metadata Request:" %> 
-            <span><%= get_resource.proposal_status.titleize %></span>
+          <span class="eui-badge eui-badge--split proposal-status-badge"><%= status_badge_text %>
+            <span class="proposal-status-display-status"><%= get_resource.proposal_status.titleize %></span>
           </span>
         </a>
       </span>

--- a/app/views/proposal/collection_draft_proposals/show.html.erb
+++ b/app/views/proposal/collection_draft_proposals/show.html.erb
@@ -25,7 +25,11 @@
         <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/rescind_modal' %>
       <% end %>
       <span id="proposal-status-display">
-        <a href="<%= progress_collection_draft_proposal_path(get_resource) %>"><span class="eui-badge eui-badge--split ">Proposal Status: <span><%= get_resource.proposal_status.titleize %></span></span></a>
+        <a href="<%= progress_collection_draft_proposal_path(get_resource) %>">
+          <span class="eui-badge eui-badge--split proposal-status-badge"><%= get_resource.request_type == 'create' ? 'Draft Proposal Submission:' : "#{get_resource.request_type} Metadata Request:" %> 
+            <span><%= get_resource.proposal_status.titleize %></span>
+          </span>
+        </a>
       </span>
     </div>
   </section>

--- a/app/views/proposal/collection_draft_proposals/show.html.erb
+++ b/app/views/proposal/collection_draft_proposals/show.html.erb
@@ -26,7 +26,7 @@
       <% end %>
       <span id="proposal-status-display">
         <a href="<%= progress_collection_draft_proposal_path(get_resource) %>">
-          <span class="eui-badge eui-badge--split proposal-status-badge"><%= get_resource.request_type == 'create' ? 'Draft Proposal Submission:' : "#{get_resource.request_type} Metadata Request:" %> 
+          <span class="eui-badge eui-badge--split proposal-status-badge"><%= get_resource.request_type == 'create' ? 'Draft Proposal Submission:' : "#{get_resource.request_type.titleize} Metadata Request:" %> 
             <span><%= get_resource.proposal_status.titleize %></span>
           </span>
         </a>

--- a/app/views/proposal/collections/show.html.erb
+++ b/app/views/proposal/collections/show.html.erb
@@ -16,9 +16,21 @@
   <% else %>
     <section class="action wide-content">
       <div class="wide-content-inside">
-        <!-- TODO: may need p tags for action buttons/links to display properly -->
+        <span>
+          <%= link_to 'Request this Collection Record be Deleted', '#delete-request-modal', class: 'display-modal eui-btn--link' %>
+        </span>
       </div>
     </section>
+
+
+    <div id="delete-request-modal" class="eui-modal-content">
+      <a href="javascript:void(0);" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
+      <p>Are you sure you want to request this record be deleted?</p>
+      <p>
+        <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
+        <%= link_to 'Yes', delete_proposal_collection_path(revision_id: @revision_id), class: 'eui-btn--blue spinner' %>
+      </p>
+    </div>
 
     <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @collection, is_mmt: true, editable: false, edsc_url: nil, concept_id: nil, additional_information: nil } %>
   <% end %>

--- a/app/views/proposal/collections/show.html.erb
+++ b/app/views/proposal/collections/show.html.erb
@@ -17,7 +17,7 @@
     <section class="action wide-content">
       <div class="wide-content-inside">
         <span>
-          <%= link_to 'Request this Collection Record be Deleted', '#delete-request-modal', class: 'display-modal eui-btn--link' %>
+          <%= link_to 'Submit Delete Request', '#delete-request-modal', class: 'display-modal eui-btn--link' %>
         </span>
       </div>
     </section>
@@ -28,7 +28,7 @@
       <p>Are you sure you want to request this record be deleted?</p>
       <p>
         <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
-        <%= link_to 'Yes', delete_proposal_collection_path(revision_id: @revision_id), class: 'eui-btn--blue spinner' %>
+        <%= link_to 'Yes', create_delete_proposal_collection_path(revision_id: @revision_id), class: 'eui-btn--blue spinner' %>
       </p>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,11 +88,11 @@ en:
             error: 'Collection Draft Proposal was not submitted successfully'
         rescind:
           flash:
-            success: 'Collection Draft Proposal Rescinded Successfully'
-            error: 'Collection Draft Proposal was not rescinded successfully'
+            success: 'Collection Draft Proposal Canceled Successfully'
+            error: 'Collection Draft Proposal was not canceled successfully'
             delete:
-              success: 'The request to delete the collection [Short Name: %{short_name}] has been successfully rescinded.'
-              error: 'The request to delete the collection [Short Name: %{short_name}] could not be successfully rescinded.'
+              success: 'The request to delete the collection [Short Name: %{short_name}] has been successfully canceled.'
+              error: 'The request to delete the collection [Short Name: %{short_name}] could not be successfully canceled.'
       collection_templates:
         create:
           flash:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,9 @@ en:
           flash:
             success: 'Collection Draft Proposal Rescinded Successfully'
             error: 'Collection Draft Proposal was not rescinded successfully'
+            delete:
+              success: 'The request to delete the collection [Short Name: %{short_name}] has been successfully rescinded.'
+              error: 'The request to delete the collection [Short Name: %{short_name}] could not be successfully rescinded.'
       collection_templates:
         create:
           flash:
@@ -115,6 +118,9 @@ en:
       clone:
         flash:
           notice: 'Records must have a unique Short Name. Click here to enter a new Short Name.'
+      delete_proposal:
+        flash:
+          success: 'Delete Collection Metadata Request Created Successfully!'
     variables:
       create:
         flash:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
   get '/collections/:id/revert/:revision_id' => 'collections#revert', as: 'revert_collection'
   get '/collections/:id/clone' => 'collections#clone', as: 'clone_collection'
   get '/collections/:id/download_xml/:format(/:revision_id)' => 'collections#download_xml', as: 'download_collection_xml'
-  get '/collections/:id/delete_proposal' => 'collections#delete_proposal', as: 'delete_proposal_collection'
+  get '/collections/:id/create_delete_proposal' => 'collections#create_delete_proposal', as: 'create_delete_proposal_collection'
 
   resource :variable_generation_processes_search, only: [:new]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
   get '/collections/:id/revert/:revision_id' => 'collections#revert', as: 'revert_collection'
   get '/collections/:id/clone' => 'collections#clone', as: 'clone_collection'
   get '/collections/:id/download_xml/:format(/:revision_id)' => 'collections#download_xml', as: 'download_collection_xml'
+  get '/collections/:id/delete_proposal' => 'collections#delete_proposal', as: 'delete_proposal_collection'
 
   resource :variable_generation_processes_search, only: [:new]
 

--- a/spec/factories/invalid_collection_draft_proposal_factories.rb
+++ b/spec/factories/invalid_collection_draft_proposal_factories.rb
@@ -1,5 +1,10 @@
 FactoryGirl.define do
   factory :empty_collection_draft_proposal, class: CollectionDraftProposal do
+    transient do
+      draft_request_type 'create'
+    end
+
     draft_type 'CollectionDraftProposal'
+    request_type { draft_request_type }
   end
 end

--- a/spec/factories/valid_collection_draft_proposal_factories.rb
+++ b/spec/factories/valid_collection_draft_proposal_factories.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
       draft_entry_title 'Entry Title'
       version '001'
       collection_data_type 'SCIENCE_QUALITY'
+      draft_request_type 'create'
     end
 
     native_id 'full_collection_draft_proposal_id'
@@ -14,6 +15,7 @@ FactoryGirl.define do
     draft_type 'CollectionDraftProposal'
     entry_title { draft_entry_title }
     short_name { draft_short_name }
+    request_type { draft_request_type }
 
     trait :with_valid_dates do
       draft {{

--- a/spec/features/proposal/access_permissions/no_permissions_for_draft_mmt_spec.rb
+++ b/spec/features/proposal/access_permissions/no_permissions_for_draft_mmt_spec.rb
@@ -1,4 +1,8 @@
 describe 'No Permissions for Non-NASA Draft MMT', reset_provider: true do
+  before :all do
+    @ingest_response, @concept_response = publish_collection_draft
+  end
+
   before do
     set_as_proposal_mode_mmt
   end
@@ -15,6 +19,50 @@ describe 'No Permissions for Non-NASA Draft MMT', reset_provider: true do
       before do
         # the real login method goes to URS, and then by default will redirect
         # to the manage collection proposals page
+        real_login(method: 'urs')
+      end
+
+      it 'diplays the landing page with the appropriate error message' do
+        expect(page).to have_content('ABOUT THE METADATA MANAGEMENT TOOL FOR NON-NASA USERS')
+        within 'header.mmt-header' do
+          expect(page).to have_content('NON-NASA USERS')
+          expect(page).to have_link('Login with Earthdata Login', href: login_path(login_method: 'urs'))
+
+          expect(page).to have_no_link('Login with Launchpad')
+        end
+
+        within '.eui-banner--danger' do
+          expect(page).to have_content('It appears you are not provisioned with the proper permissions to access the MMT for Non-NASA Users. Please try again or contact Earthdata Support.')
+          expect(page).to have_link('Earthdata Support', href: 'mailto:support@earthdata.nasa.gov')
+        end
+      end
+    end
+
+    context 'when visiting the Search page' do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:internal_landing_page).and_return(search_path)
+        real_login(method: 'urs')
+      end
+
+      it 'diplays the landing page with the appropriate error message' do
+        expect(page).to have_content('ABOUT THE METADATA MANAGEMENT TOOL FOR NON-NASA USERS')
+        within 'header.mmt-header' do
+          expect(page).to have_content('NON-NASA USERS')
+          expect(page).to have_link('Login with Earthdata Login', href: login_path(login_method: 'urs'))
+
+          expect(page).to have_no_link('Login with Launchpad')
+        end
+
+        within '.eui-banner--danger' do
+          expect(page).to have_content('It appears you are not provisioned with the proper permissions to access the MMT for Non-NASA Users. Please try again or contact Earthdata Support.')
+          expect(page).to have_link('Earthdata Support', href: 'mailto:support@earthdata.nasa.gov')
+        end
+      end
+    end
+
+    context 'when visiting a Collection Show page' do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:internal_landing_page).and_return(collection_path(@ingest_response['concept-id']))
         real_login(method: 'urs')
       end
 

--- a/spec/features/proposal/access_permissions/permissions_for_non_nasa_draft_approver_spec.rb
+++ b/spec/features/proposal/access_permissions/permissions_for_non_nasa_draft_approver_spec.rb
@@ -56,7 +56,7 @@ describe 'Non-NASA Draft Approver Permissions for Draft MMT', reset_provider: tr
 
           expect(page).to have_link('Submit for Review')
           expect(page).to have_link('Delete Collection Draft Proposal')
-          expect(page).to have_content('Proposal Status: In Work')
+          expect(page).to have_content('In Work')
 
           expect(page).to have_content('Metadata Fields')
         end

--- a/spec/features/proposal/access_permissions/permissions_for_non_nasa_draft_approver_spec.rb
+++ b/spec/features/proposal/access_permissions/permissions_for_non_nasa_draft_approver_spec.rb
@@ -56,8 +56,9 @@ describe 'Non-NASA Draft Approver Permissions for Draft MMT', reset_provider: tr
 
           expect(page).to have_link('Submit for Review')
           expect(page).to have_link('Delete Collection Draft Proposal')
-          expect(page).to have_content('In Work')
-
+          within '#proposal-status-display' do
+            expect(page).to have_content('In Work')
+          end
           expect(page).to have_content('Metadata Fields')
         end
       end

--- a/spec/features/proposal/access_permissions/permissions_for_non_nasa_draft_user_spec.rb
+++ b/spec/features/proposal/access_permissions/permissions_for_non_nasa_draft_user_spec.rb
@@ -56,7 +56,7 @@ describe 'Non-NASA Draft User Permissions for Draft MMT', reset_provider: true d
 
           expect(page).to have_link('Submit for Review')
           expect(page).to have_link('Delete Collection Draft Proposal')
-          expect(page).to have_content('Proposal Status: In Work')
+          expect(page).to have_content('In Work')
 
           expect(page).to have_content('Metadata Fields')
         end

--- a/spec/features/proposal/access_permissions/permissions_for_non_nasa_draft_user_spec.rb
+++ b/spec/features/proposal/access_permissions/permissions_for_non_nasa_draft_user_spec.rb
@@ -56,8 +56,9 @@ describe 'Non-NASA Draft User Permissions for Draft MMT', reset_provider: true d
 
           expect(page).to have_link('Submit for Review')
           expect(page).to have_link('Delete Collection Draft Proposal')
-          expect(page).to have_content('In Work')
-
+          within '#proposal-status-display' do
+            expect(page).to have_content('In Work')
+          end
           expect(page).to have_content('Metadata Fields')
         end
       end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_creation_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_creation_spec.rb
@@ -76,4 +76,20 @@ describe 'Collection Draft Proposal creation', js: true do
       end
     end
   end
+
+  context 'when viewing a collection' do
+    before do
+      @ingest_response, _concept_response = publish_collection_draft
+      set_as_proposal_mode_mmt(with_required_acl: true)
+      visit collection_path(@ingest_response['concept-id'])
+    end
+
+    it 'a delete metadata proposal can be created' do
+      click_on 'Request this Collection Record be Deleted'
+      click_on 'Yes'
+
+      expect(page).to have_content('Delete Collection Metadata Request Created Successfully!')
+      expect(page).to have_content('Submitted')
+    end
+  end
 end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_creation_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_creation_spec.rb
@@ -84,12 +84,16 @@ describe 'Collection Draft Proposal creation', js: true do
       visit collection_path(@ingest_response['concept-id'])
     end
 
-    it 'a delete metadata proposal can be created' do
-      click_on 'Request this Collection Record be Deleted'
-      click_on 'Yes'
+    context 'when creating a delete metadata proposal' do
+      before do
+        click_on 'Submit Delete Request'
+        click_on 'Yes'
+      end
 
-      expect(page).to have_content('Delete Collection Metadata Request Created Successfully!')
-      expect(page).to have_content('Submitted')
+      it 'a delete metadata proposal can be created' do
+        expect(page).to have_content('Delete Collection Metadata Request Created Successfully!')
+        expect(page).to have_content('Submitted')
+      end
     end
   end
 end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
@@ -96,7 +96,7 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
         within '#proposal-status-display' do
           expect(page).to have_content('Done')
         end
-        expect(page).to have_content 'Collection Draft Proposal was not rescinded successfully'
+        expect(page).to have_content 'Collection Draft Proposal was not canceled successfully'
       end
     end
   end
@@ -117,7 +117,7 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
       end
 
       it 'can be rescinded and deleted' do
-        expect(page).to have_content "The request to delete the collection [Short Name: #{@short_name}] has been successfully rescinded."
+        expect(page).to have_content "The request to delete the collection [Short Name: #{@short_name}] has been successfully canceled."
         within '.open-drafts' do
           expect(page).to have_no_content @short_name
         end
@@ -132,7 +132,7 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
       end
 
       it 'generates the correct error message' do
-        expect(page).to have_content "The request to delete the collection [Short Name: #{@short_name}] could not be successfully rescinded."
+        expect(page).to have_content "The request to delete the collection [Short Name: #{@short_name}] could not be successfully canceled."
         expect(page).to have_content 'Done'
       end
     end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
@@ -67,7 +67,7 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
     end
 
     it 'has a rescind button and cannot be deleted' do
-      expect(page).to have_link('Rescind Draft Submission')
+      expect(page).to have_link('Cancel Proposal Submission')
       expect(page).to have_no_link('Delete Collection Draft Proposal')
       within '#proposal-status-display' do
         expect(page).to have_content('Submitted')
@@ -75,7 +75,7 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
     end
 
     it 'can be rescinded' do
-      click_on 'Rescind Draft Submission'
+      click_on 'Cancel Proposal Submission'
       click_on 'Yes'
       expect(page).to have_link('Submit for Review')
       within '#proposal-status-display' do
@@ -88,7 +88,7 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
         # After loading the page, manipulate the state of the proposal so that
         # rescind will fail in order to execute the else code.
         mock_publish(@collection_draft_proposal)
-        click_on 'Rescind Draft Submission'
+        click_on 'Cancel Proposal Submission'
         click_on 'Yes'
       end
 
@@ -107,27 +107,34 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
       @collection_draft_proposal = create(:full_collection_draft_proposal, draft_request_type: 'delete')
       mock_submit(@collection_draft_proposal)
       visit collection_draft_proposal_path(@collection_draft_proposal)
+      @short_name = @collection_draft_proposal['short_name']
     end
 
-    it 'can be rescinded and deleted' do
-      short_name = @collection_draft_proposal['short_name']
-      click_on 'Rescind Draft Submission'
-      click_on 'Yes'
+    context 'when rescinding a delete metadata request' do
+      before do
+        click_on 'Cancel Delete Request'
+        click_on 'Yes'
+      end
 
-      expect(page).to have_content "The request to delete the collection [Short Name: #{short_name}] has been successfully rescinded."
-      within '.open-drafts' do
-        expect(page).to have_no_content short_name
+      it 'can be rescinded and deleted' do
+        expect(page).to have_content "The request to delete the collection [Short Name: #{@short_name}] has been successfully rescinded."
+        within '.open-drafts' do
+          expect(page).to have_no_content @short_name
+        end
       end
     end
 
-    it 'generates the correct error message when failing to delete a metadata request' do
-      short_name = @collection_draft_proposal['short_name']
-      mock_publish(@collection_draft_proposal)
-      click_on 'Rescind Draft Submission'
-      click_on 'Yes'
+    context 'when failing to delete a metadata request' do
+      before do
+        mock_publish(@collection_draft_proposal)
+        click_on 'Cancel Delete Request'
+        click_on 'Yes'
+      end
 
-      expect(page).to have_content "The request to delete the collection [Short Name: #{short_name}] could not be successfully rescinded."
-      expect(page).to have_content 'Done'
+      it 'generates the correct error message' do
+        expect(page).to have_content "The request to delete the collection [Short Name: #{@short_name}] could not be successfully rescinded."
+        expect(page).to have_content 'Done'
+      end
     end
   end
 end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_update_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_update_spec.rb
@@ -36,7 +36,7 @@ describe 'Collection Draft Proposal Update', js: true do
 
       it 'cannot be edited' do
         expect(page).to have_content('Only proposals in an "In Work" status can be edited.')
-        expect(page).to have_link('Rescind Draft Submission')
+        expect(page).to have_link('Cancel Proposal Submission')
       end
     end
   end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_view_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_view_spec.rb
@@ -16,10 +16,14 @@ describe 'Viewing Unsubmitted Collection Draft Proposals', js: true do
       end
     end
 
-    it 'has a submit button' do
-      expect(page).to have_link('Submit for Review')
-      click_on('Submit for Review')
-      expect(page).to have_content('Are you sure you want to submit this proposal for review? Upon approval, your collection record will be published to the CMR.')
+    context 'when clicking the submit button' do
+      before do
+        click_on 'Submit for Review'
+      end
+
+      it 'has the correct modal text' do
+        expect(page).to have_content('Are you sure you want to submit this proposal for review? Upon approval, your collection record will be published to the CMR.')
+      end
     end
 
     it 'has a delete link' do
@@ -33,9 +37,14 @@ describe 'Viewing Unsubmitted Collection Draft Proposals', js: true do
       visit collection_draft_proposal_path(draft)
     end
 
-    it 'cannot be submitted yet' do
-      click_on('Submit for Review')
-      expect(page).to have_content('This proposal is not ready to be submitted. Please use the progress indicators on the proposal preview page to address incomplete or invalid fields.')
+    context 'when trying to submit it' do
+      before do
+        click_on('Submit for Review')
+      end
+
+      it 'cannot be submitted yet' do
+        expect(page).to have_content('This proposal is not ready to be submitted. Please use the progress indicators on the proposal preview page to address incomplete or invalid fields.')
+      end
     end
   end
 end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_view_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_view_spec.rb
@@ -12,8 +12,7 @@ describe 'Viewing Unsubmitted Collection Draft Proposals', js: true do
 
     it 'displays the current proposal status' do
       within '#proposal-status-display' do
-        expect(page).to have_content('PROPOSAL STATUS:')
-        expect(page).to have_content('IN WORK')
+        expect(page).to have_content('In Work')
       end
     end
 

--- a/spec/features/proposal/proposal_progress_spec.rb
+++ b/spec/features/proposal/proposal_progress_spec.rb
@@ -33,9 +33,14 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
       end
     end
 
-    it 'cannot be submitted' do
-      click_on 'Submit for Review'
-      expect(page).to have_content('This proposal is not ready to be submitted. Please use the progress indicators on the proposal preview page to address incomplete or invalid fields.')
+    context 'when trying to submit an incomplete proposal' do
+      before do
+        click_on 'Submit for Review'
+      end
+
+      it 'cannot be submitted' do
+        expect(page).to have_content('This proposal is not ready to be submitted. Please use the progress indicators on the proposal preview page to address incomplete or invalid fields.')
+      end
     end
   end
 
@@ -63,7 +68,7 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
     it 'displays the correct actions' do
       within '.progress-actions' do
         expect(page).to have_content('You may rescind this proposal to make additional changes.')
-        expect(page).to have_link('Rescind this Submission')
+        expect(page).to have_link('Cancel Proposal Submission')
       end
     end
   end
@@ -167,7 +172,7 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
       it 'displays the correct actions' do
         within '.progress-actions' do
           expect(page).to have_content('You may rescind this proposal to make additional changes.')
-          expect(page).to have_link('Rescind Rejected Proposal')
+          expect(page).to have_link('Cancel Proposal Submission')
         end
       end
     end


### PR DESCRIPTION
Added the ability to create and rescind a delete metadata proposal request.  Updated the look of the badges per PO feedback (to include the request type).  Updated permissions for search/collections pages in dMMT.