### PR TITLE
MMT-1966 updating the table to require a proposal_status

### DIFF
--- a/app/models/collection_draft_proposal.rb
+++ b/app/models/collection_draft_proposal.rb
@@ -2,6 +2,7 @@ class CollectionDraftProposal < CollectionDraft
   include AASM
   self.table_name = 'draft_proposals'
   validates :request_type, presence: true
+  validates :proposal_status, presence: true
 
   # after_initialize :exception_unless_draft_only
   # after_find :exception_unless_draft_only

--- a/db/migrate/20191105200412_add_required_to_proposal_status.rb
+++ b/db/migrate/20191105200412_add_required_to_proposal_status.rb
@@ -1,0 +1,10 @@
+class AddRequiredToProposalStatus < ActiveRecord::Migration
+  def up
+    CollectionDraftProposal.where(proposal_status: nil).update_all(proposal_status: 'in_work')
+    change_column 'draft_proposals', :proposal_status, :string, null: false
+  end
+
+  def down
+    change_column 'draft_proposals', :proposal_status, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191101143748) do
+ActiveRecord::Schema.define(version: 20191105200412) do
 
   create_table "draft_proposals", force: :cascade do |t|
     t.integer  "user_id"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20191101143748) do
     t.string   "provider_id"
     t.string   "native_id"
     t.string   "draft_type"
-    t.string   "proposal_status"
+    t.string   "proposal_status",   null: false
     t.text     "approver_feedback"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false

--- a/spec/models/collection_draft_proposal_spec.rb
+++ b/spec/models/collection_draft_proposal_spec.rb
@@ -204,6 +204,17 @@ describe CollectionDraftProposal do
 
       expect { CollectionDraftProposal.create! }.to raise_error(ActiveRecord::RecordInvalid)
     end
+
+    it 'creating a draft proposal without a proposal_status should fail to save' do
+      collection_draft_proposal = CollectionDraftProposal.create(request_type: 'create', proposal_status: nil)
+      # AASM is actually populating the proposal status during the creation.
+      # Set it to nil and try to save, the validation should stop it.
+      collection_draft_proposal.proposal_status = nil
+      expect(collection_draft_proposal.save).to be(false)
+      expect { collection_draft_proposal.save! }.to raise_error(ActiveRecord::RecordInvalid)
+
+      expect { CollectionDraftProposal.create! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
   end
 
 


### PR DESCRIPTION
AASM does an incomplete job of masking nils.  For most cases, it reports nil as 'in work' and can function, but Charles noticed that it does not work with operations that are closer to the database, e.g. where(proposal_status = 'in_work').  This sort of query is used in the approver views.