### PR TITLE
MMT-1962 Added the ability for MMT to update proposal statuses in dMMT.

### DIFF
--- a/app/controllers/proposal/approved_proposals_controller.rb
+++ b/app/controllers/proposal/approved_proposals_controller.rb
@@ -6,28 +6,56 @@ module Proposal
 
     skip_before_action :ensure_user_is_logged_in
     skip_before_action :refresh_urs_if_needed, :refresh_launchpad_if_needed, :provider_set?, :proposal_approver_permissions
+    before_action :validate_token_and_user
+
+    PROPOSAL_CLASSES = %w[CollectionDraftProposal].freeze
 
     def approved_proposals
-      passed_token, passed_client_id = request.headers.fetch('Echo-Token', ':').split(':')
-
-      # Navigate a browser elsewhere
-      redirect_to root_path and return if passed_token.blank?
-
-      token_response = cmr_client.validate_token(passed_token, passed_client_id)
-
-      requester_has_approver_permissions = if token_response.success?
-                                             is_non_nasa_draft_approver?(user: User.new(urs_uid: token_response.body['uid']), token: passed_token)
-                                           else
-                                             false
-                                           end
-
-      if requester_has_approver_permissions
+      if @requester_has_approver_permissions
         approved_proposals = CollectionDraftProposal.publish_approved_proposals
 
-        Rails.logger.info("dMMT successfully authenticated and authorized #{token_response.body['uid']} while fetching approved proposals.")
-        render json: { proposals: approved_proposals }, status: :ok
+        # Necessary because the .to_json call clobbers the draft_type field in
+        # each record, but we need that field to identify what kind of proposal
+        # we are processing.
+        proposals_with_draft_types = approved_proposals.as_json
+        proposals_with_draft_types.each_with_index do |record, index|
+          record['draft_type'] = approved_proposals[index]['draft_type']
+        end
+
+        Rails.logger.info("dMMT successfully authenticated and authorized #{@token_response.body['uid']} while fetching approved proposals.")
+        render json: { proposals: proposals_with_draft_types }, status: :ok
       else
-        Rails.logger.info("#{request.uuid}: Attempting to authenticate token resulted in '#{token_response.status}' status. If the status returned ok, then the user's Non-NASA Draft Approver ACL check failed.")
+        Rails.logger.info("#{request.uuid}: Attempting to authenticate token while fetching approved proposals resulted in '#{@token_response.status}' status. If the status returned ok, then the user's Non-NASA Draft Approver ACL check failed.")
+        render json: { body: 'Requesting user could not be authorized', request_id: request.uuid }, status: :unauthorized
+      end
+    end
+
+    # Endpoint for MMT to update dMMT proposal statuses.  Expects to be passed
+    # params: 'draft_type' = table name and 'id' = unique identifier of a
+    # proposal to update that proposal's status to done
+    def update_proposal_status
+      if @requester_has_approver_permissions
+        draft_type = request.params['draft_type']
+        if PROPOSAL_CLASSES.include?(draft_type)
+          # Look for the specified record, if the draft_type is an expected type
+          proposal = draft_type.constantize.find_by(id: request.params['id'])
+          if update_and_save_done_status(proposal, @token_response.body['uid'])
+            # Record was found and altered
+            Rails.logger.info("Proposal of type: #{draft_type} with id: #{request.params['id']} was successfully updated to be 'done'.")
+            render json: { body: nil }, status: :ok
+          else
+            # Record either could not be found or altered.
+            Rails.logger.info("#{request.uuid}: Attempting to update proposal status for proposal of type: #{draft_type} with id: #{request.params['id']} failed because the record could not be #{proposal.blank? ? 'found' : 'altered'}")
+            render json: { body: "Proposal with id: #{request.params['id']} could not be found or altered", request_id: request.uuid }, status: :bad_request
+          end
+        else
+          # This is not a type of proposal that dMMT understands
+          Rails.logger.info("#{request.uuid}: Attempting to update proposal status for proposal of type: #{draft_type} with id: #{request.params['id']} failed because the draft_type is invalid.")
+          render json: { body: "Proposal with id: #{request.params['id']} could not be found or altered", request_id: request.uuid }, status: :bad_request
+        end
+      else
+        # Requester could not be authorized
+        Rails.logger.info("#{request.uuid}: Attempting to authenticate token while updating a proposal's status resulted in '#{@token_response.status}' status. If the status returned ok, then the user's Non-NASA Draft Approver ACL check failed.")
         render json: { body: 'Requesting user could not be authorized', request_id: request.uuid }, status: :unauthorized
       end
     end
@@ -38,6 +66,51 @@ module Proposal
           format.json { render json: { body: nil }, status: :forbidden }
           format.html { redirect_to manage_collections_path }
         end
+      end
+    end
+
+    private
+
+    # Action called before endpoints to validate a token and authorize a user
+    # Expects to be passed an 'Echo-Token' of format 'URS token:URS client id'
+    # in the headers.
+    def validate_token_and_user
+      passed_token, passed_client_id = request.headers.fetch('Echo-Token', ':').split(':')
+
+      # Navigate a browser elsewhere if there is no token
+      redirect_to root_path and return if passed_token.blank?
+
+      @token_response = cmr_client.validate_token(passed_token, passed_client_id)
+
+      @requester_has_approver_permissions = if @token_response.success?
+                                              is_non_nasa_draft_approver?(user: User.new(urs_uid: @token_response.body['uid']), token: passed_token)
+                                            else
+                                              false
+                                            end
+    end
+
+    def update_and_save_done_status(proposal, urs_uid)
+      urs_response = cmr_client.get_urs_users([urs_uid])
+      user = urs_response.body['users'][0]
+      if Rails.env.development? || Rails.env.test?
+        # In the dev and test environments, the server is not in proposal mode,
+        # so it cannot save records or use the existing helper methods
+        # The update_column calls bypass the validations, so the changes can be
+        # made
+        status_change_success = if proposal.proposal_status == 'approved'
+                                  proposal.update_column('proposal_status', 'done')
+                                else
+                                  false
+                                end
+        if status_change_success
+          status_history = proposal.status_history
+          status_history['done'] = { 'username' => "#{user['first_name']} #{user['last_name']}", 'action_date' => Time.now }
+          proposal.update_column('status_history', status_history)
+          proposal.update_column('updated_at', Time.now)
+        end
+        status_change_success
+      else
+        proposal&.change_status_to_done("#{user['first_name']} #{user['last_name']}")
       end
     end
   end

--- a/app/controllers/proposal/approved_proposals_controller.rb
+++ b/app/controllers/proposal/approved_proposals_controller.rb
@@ -41,7 +41,7 @@ module Proposal
           proposal = draft_type.constantize.find_by(id: request.params['id'])
           if update_and_save_done_status(proposal, @token_response.body['uid'])
             # Record was found and altered
-            Rails.logger.info("Proposal of type: #{draft_type} with id: #{request.params['id']} was successfully updated to be 'done'.")
+            Rails.logger.info("Audit Log: Proposal of type: #{draft_type} with id: #{request.params['id']} was successfully updated to be 'done'.")
             render json: { body: nil }, status: :ok
           else
             # Record either could not be found or altered.
@@ -91,6 +91,7 @@ module Proposal
 
     def update_and_save_done_status(proposal, urs_uid)
       urs_response = cmr_client.get_urs_users([urs_uid])
+      return false unless urs_response.success?
       user = urs_response.body['users'][0]
       if Rails.env.development? || Rails.env.test?
         # In the dev and test environments, the server is not in proposal mode,

--- a/app/models/collection_draft_proposal.rb
+++ b/app/models/collection_draft_proposal.rb
@@ -33,7 +33,7 @@ class CollectionDraftProposal < CollectionDraft
         request.submit
         request.status_history =
           { 'submitted' =>
-            { 'username' => (username || user.urs_uid), 'action_date' => Time.new.utc.to_s } }
+            { 'username' => (username || user.urs_uid), 'action_date' => Time.new } }
       end
 
       request.save
@@ -63,6 +63,10 @@ class CollectionDraftProposal < CollectionDraft
 
     event :reject do
       transitions from: :submitted, to: :rejected
+    end
+
+    event :mark_done do
+      transitions from: :approved, to: :done
     end
   end
 
@@ -106,6 +110,11 @@ class CollectionDraftProposal < CollectionDraft
     record_type = draft_type.underscore.split('_').first # we should remove 'draft' and 'proposal' from the native_id
     self.native_id ||= "dmmt_#{record_type}_#{id}"
     save
+  end
+
+  def change_status_to_done(user)
+    self.add_status_history('done', user)
+    self.mark_done!
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,11 +223,11 @@ en:
       search:
         flash:
           error: "Error response returned from CMR: %{error}  <br>"
-    manage_proposals:
-      publish:
+    manage_proposal:
+      publish_proposal:
         flash:
           update_proposal_status:
-            error: "Proposal status was not updated in dMMT successfully."
+            error: "Proposal status was not updated in the Draft Metadata Management Tool successfully."
           delete:
             success: "Collection Metadata Deleted Successfully!"
             error: "Collection metadata was not deleted successfully."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -226,6 +226,8 @@ en:
     manage_proposals:
       publish:
         flash:
+          update_proposal_status:
+            error: "Proposal status was not updated in dMMT successfully."
           delete:
             success: "Collection Metadata Deleted Successfully!"
             error: "Collection metadata was not deleted successfully."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,7 @@ Rails.application.routes.draw do
 
   scope module: :proposal do
     get '/approved_proposals' => 'approved_proposals#approved_proposals', as: 'approved_proposals_approved_proposals'
+    get '/approved_proposals/update_proposal_status' => 'approved_proposals#update_proposal_status', as: 'update_proposal_status_approved_proposals'
     get '/collection_draft_proposals/queued_index' => 'collection_draft_proposals#queued_index', as: 'queued_index_collection_draft_proposals'
     get '/collection_draft_proposals/in_work_index' => 'collection_draft_proposals#in_work_index', as: 'in_work_index_collection_draft_proposals'
     resource :manage_collection_proposals, only: :show

--- a/lib/cmr/dmmt_client.rb
+++ b/lib/cmr/dmmt_client.rb
@@ -1,6 +1,6 @@
 module Cmr
   class DmmtClient < BaseClient
-    def dmmt_get_approved_proposals(token, request)
+    def dmmt_get_approved_proposals(token, request = nil)
       url = if Rails.env.development?
               'http://localhost:3000/approved_proposals'
             elsif Rails.env.test?
@@ -17,7 +17,7 @@ module Cmr
       get(url, nil, headers.merge(token_header(token, true)))
     end
 
-    def dmmt_update_proposal_status(params, token, request)
+    def dmmt_update_proposal_status(params, token, request = nil)
       url = if Rails.env.development?
               'http://localhost:3000/approved_proposals/update_proposal_status'
             elsif Rails.env.test?

--- a/lib/cmr/dmmt_client.rb
+++ b/lib/cmr/dmmt_client.rb
@@ -1,12 +1,29 @@
 module Cmr
   class DmmtClient < BaseClient
-    def dmmt_get_approved_proposals(params, token, request)
+    def dmmt_get_approved_proposals(token, request)
       url = if Rails.env.development?
-              "http://localhost:3000/approved_proposals"
+              'http://localhost:3000/approved_proposals'
             elsif Rails.env.test?
               "http://#{request.ip}:#{request.port}/approved_proposals"
             else
               '/approved_proposals'
+            end
+
+
+      headers = {
+        'Content-Type' => 'application/json'
+      }
+
+      get(url, nil, headers.merge(token_header(token, true)))
+    end
+
+    def dmmt_update_proposal_status(params, token, request)
+      url = if Rails.env.development?
+              'http://localhost:3000/approved_proposals/update_proposal_status'
+            elsif Rails.env.test?
+              "http://#{request.ip}:#{request.port}/approved_proposals/update_proposal_status"
+            else
+              '/approved_proposals/update_proposal_status'
             end
 
 

--- a/lib/tasks/bamboo.rake
+++ b/lib/tasks/bamboo.rake
@@ -1,6 +1,17 @@
 namespace :bamboo do
   desc "Run tests in Bamboo"
-  task :test => ["cmr:start_and_load", :spec] do
+  task :test => [:start_and_load, :spec] do
     # Starts CMR, loads data into CMR, runs 'rake spec'
+  end
+
+  desc "Starts and loads data in local CMR in bamboo"
+  task start_and_load: [:start, "cmr:load"]
+
+  desc 'Start local CMR'
+  task start: ["cmr:stop"] do
+    # Seperate task to let bamboo use redis
+    Process.spawn('cd cmr; nohup java -classpath ./cmr-dev-system-0.1.0-SNAPSHOT-standalone.jar cmr.dev_system.runner > cmr.log 2>&1 &')
+
+    puts 'Cmr is starting up'
   end
 end

--- a/spec/features/manage_proposals/approver_workflow_spec.rb
+++ b/spec/features/manage_proposals/approver_workflow_spec.rb
@@ -4,13 +4,13 @@ describe 'When going through the whole collection proposal approver workflow', j
   before do
     login(real_login: true)
     allow_any_instance_of(PermissionChecking).to receive(:is_non_nasa_draft_approver?).and_return(true)
-    # FactoryGirl respects validations; need to be in proposal mode to create
-    set_as_proposal_mode_mmt(with_draft_approver_acl: true)
   end
 
   context 'when loading the manage proposals page' do
     context 'when publishing a create metadata proposal' do
       before do
+        # FactoryGirl respects validations; need to be in proposal mode to create
+        set_as_proposal_mode_mmt(with_draft_approver_acl: true)
         @native_id = 'dmmt_collection_1'
         @proposal = create(:full_collection_draft_proposal, proposal_short_name: 'Full Workflow Create Test Proposal', proposal_entry_title: 'Test Entry Title', proposal_request_type: 'create', proposal_native_id: @native_id)
         mock_approve(@proposal)
@@ -29,10 +29,6 @@ describe 'When going through the whole collection proposal approver workflow', j
         within '#approver-proposal-modal' do
           click_on 'Publish'
         end
-      end
-
-      after do
-        cmr_client.delete_collection('MMT_2', @native_id, 'ABC-2')
       end
 
       it 'displays expected success messages' do
@@ -65,12 +61,23 @@ describe 'When going through the whole collection proposal approver workflow', j
 
     context 'when publishing an update metadata proposal' do
       before do
-        @update_native_id = "dmmt_collection_#{Faker::Number.number(15)}"
-        @proposal = create(:full_collection_draft_proposal, proposal_short_name: "Full Workflow Update Test Proposal_#{Faker::Number.number(15)}", proposal_entry_title: "Full Workflow Update Test Proposal_#{Faker::Number.number(15)}", proposal_request_type: 'update', proposal_native_id: @update_native_id)
-        mock_approve(@proposal)
+        @ingest_response, _concept_response = publish_collection_draft
+        set_as_proposal_mode_mmt(with_draft_approver_acl: true)
+        visit collection_path(@ingest_response['concept-id'])
+        click_on 'Create Update Proposal'
+        click_on 'Yes'
+        click_on 'Short Name - Required field complete'
+        @short_name = "Full Workflow Update Test Proposal_#{Faker::Number.number(15)}"
+        fill_in 'Short Name', with: @short_name
+        within '.nav-top' do
+          click_on 'Done'
+        end
+        click_on 'Submit for Review'
+        click_on 'Yes'
+        click_on 'Approve Update Request'
+        click_on 'Yes'
         # Workflow is in mmt proper, so switch back
         set_as_mmt_proper
-        @ingest_response, _concept_response = publish_collection_draft(native_id: @update_native_id)
 
         # Mock URS communication because it has no concept of our test users
         mock_valid_token_validation
@@ -86,16 +93,12 @@ describe 'When going through the whole collection proposal approver workflow', j
         end
       end
 
-      after do
-        cmr_client.delete_collection('MMT_2', @update_native_id, 'ABC-2')
-      end
-
       it 'displays expected success messages' do
         expect(page).to have_content('Collection Metadata Successfully Published!')
       end
 
       it 'updated proposal status in dMMT' do
-        proposal = CollectionDraftProposal.find(@proposal.id)
+        proposal = CollectionDraftProposal.where(short_name: @short_name).first
 
         expect(proposal.proposal_status).to eq('done')
         expect(proposal.status_history['done']['username']).to eq('Test User')
@@ -104,23 +107,28 @@ describe 'When going through the whole collection proposal approver workflow', j
 
       context 'when visiting the updated collection' do
         before do
+          wait_for_cmr
           visit collection_path(@ingest_response['concept-id'])
         end
 
         it 'can find the record in CMR' do
           expect(page).to have_content('Full Workflow Update Test Proposal')
+          expect(page).to have_link('Revisions (2)')
         end
       end
     end
 
     context 'when publishing a delete metadata proposal' do
       before do
-        native_id = "dmmt_collection_#{Faker::Number.number(15)}"
-        @proposal = create(:full_collection_draft_proposal, proposal_short_name: 'Full Workflow Delete Test Proposal', proposal_entry_title: 'Full Workflow Create Test Proposal', proposal_request_type: 'delete', proposal_native_id: native_id)
-        mock_approve(@proposal)
+        @ingest_response, @concept_response = publish_collection_draft
+        set_as_proposal_mode_mmt(with_draft_approver_acl: true)
+        visit collection_path(@ingest_response['concept-id'])
+        click_on 'Submit Delete Request'
+        click_on 'Yes'
+        click_on 'Approve Delete Request'
+        click_on 'Yes'
         # Workflow is in mmt proper, so switch back
         set_as_mmt_proper
-        @ingest_response, _concept_response = publish_collection_draft(native_id: native_id)
         # Mock URS communication because it has no concept of our test users
         mock_valid_token_validation
         visit manage_proposals_path
@@ -141,7 +149,7 @@ describe 'When going through the whole collection proposal approver workflow', j
       end
 
       it 'updated proposal status in dMMT' do
-        proposal = CollectionDraftProposal.find(@proposal.id)
+        proposal = CollectionDraftProposal.where(short_name: @concept_response.body['ShortName'], request_type: 'delete').first
 
         expect(proposal.proposal_status).to eq('done')
         expect(proposal.status_history['done']['username']).to eq('Test User')

--- a/spec/features/manage_proposals/approver_workflow_spec.rb
+++ b/spec/features/manage_proposals/approver_workflow_spec.rb
@@ -1,0 +1,162 @@
+# Start to finish test of the approver workflow without mocking the inter-MMT
+# communications.
+describe 'When going through the whole collection proposal approver workflow', js: true do
+  before do
+    login(real_login: true)
+    allow_any_instance_of(PermissionChecking).to receive(:is_non_nasa_draft_approver?).and_return(true)
+    # FactoryGirl respects validations; need to be in proposal mode to create
+    set_as_proposal_mode_mmt(with_draft_approver_acl: true)
+  end
+
+  context 'when loading the manage proposals page' do
+    context 'when publishing a create metadata proposal' do
+      before do
+        @native_id = 'dmmt_collection_1'
+        @proposal = create(:full_collection_draft_proposal, proposal_short_name: 'Full Workflow Create Test Proposal', proposal_entry_title: 'Test Entry Title', proposal_request_type: 'create', proposal_native_id: @native_id)
+        mock_approve(@proposal)
+        # Workflow is in mmt proper, so switch back
+        set_as_mmt_proper
+        # Mock URS communication because it has no concept of our test users
+        mock_valid_token_validation
+        visit manage_proposals_path
+
+        # Mock URS call to get information to update status history
+        mock_urs_get_users
+        within '.open-draft-proposals tbody tr:nth-child(1)' do
+          click_on 'Publish'
+        end
+        select 'MMT_2', from: 'provider-publish-target'
+        within '#approver-proposal-modal' do
+          click_on 'Publish'
+        end
+      end
+
+      after do
+        cmr_client.delete_collection('MMT_2', @native_id, 'ABC-2')
+      end
+
+      it 'displays expected success messages' do
+        expect(page).to have_content('Collection Metadata Successfully Published!')
+      end
+
+      it 'updated proposal status in dMMT' do
+        proposal = CollectionDraftProposal.find(@proposal.id)
+
+        expect(proposal.proposal_status).to eq('done')
+        expect(proposal.status_history['done']['username']).to eq('Test User')
+        expect(Time.parse(proposal.status_history['done']['action_date']).utc).to be_within(1.second).of Time.now
+      end
+
+      context 'when searching for the new collection' do
+        before do
+          # Wait added to improve test consistency; appeared to be searching too
+          # fast to find the added record
+          wait_for_cmr
+          fill_in 'keyword', with: 'MMT_2'
+          click_on 'Search Collections'
+        end
+
+        it 'can find the record in CMR' do
+          expect(page).to have_content('Full Workflow Create Test Proposal')
+          expect(page).to have_content('Test Entry Title')
+        end
+      end
+    end
+
+    context 'when publishing an update metadata proposal' do
+      before do
+        @update_native_id = "dmmt_collection_#{Faker::Number.number(15)}"
+        @proposal = create(:full_collection_draft_proposal, proposal_short_name: "Full Workflow Update Test Proposal_#{Faker::Number.number(15)}", proposal_entry_title: "Full Workflow Update Test Proposal_#{Faker::Number.number(15)}", proposal_request_type: 'update', proposal_native_id: @update_native_id)
+        mock_approve(@proposal)
+        # Workflow is in mmt proper, so switch back
+        set_as_mmt_proper
+        @ingest_response, _concept_response = publish_collection_draft(native_id: @update_native_id)
+
+        # Mock URS communication because it has no concept of our test users
+        mock_valid_token_validation
+        visit manage_proposals_path
+
+        # Mock URS call to get information to update status history
+        mock_urs_get_users
+        within '.open-draft-proposals tbody tr:nth-child(1)' do
+          click_on 'Publish'
+        end
+        within '#approver-proposal-modal' do
+          click_on 'Yes'
+        end
+      end
+
+      after do
+        cmr_client.delete_collection('MMT_2', @update_native_id, 'ABC-2')
+      end
+
+      it 'displays expected success messages' do
+        expect(page).to have_content('Collection Metadata Successfully Published!')
+      end
+
+      it 'updated proposal status in dMMT' do
+        proposal = CollectionDraftProposal.find(@proposal.id)
+
+        expect(proposal.proposal_status).to eq('done')
+        expect(proposal.status_history['done']['username']).to eq('Test User')
+        expect(Time.parse(proposal.status_history['done']['action_date']).utc).to be_within(1.second).of Time.now
+      end
+
+      context 'when visiting the updated collection' do
+        before do
+          visit collection_path(@ingest_response['concept-id'])
+        end
+
+        it 'can find the record in CMR' do
+          expect(page).to have_content('Full Workflow Update Test Proposal')
+        end
+      end
+    end
+
+    context 'when publishing a delete metadata proposal' do
+      before do
+        native_id = "dmmt_collection_#{Faker::Number.number(15)}"
+        @proposal = create(:full_collection_draft_proposal, proposal_short_name: 'Full Workflow Delete Test Proposal', proposal_entry_title: 'Full Workflow Create Test Proposal', proposal_request_type: 'delete', proposal_native_id: native_id)
+        mock_approve(@proposal)
+        # Workflow is in mmt proper, so switch back
+        set_as_mmt_proper
+        @ingest_response, _concept_response = publish_collection_draft(native_id: native_id)
+        # Mock URS communication because it has no concept of our test users
+        mock_valid_token_validation
+        visit manage_proposals_path
+
+        # Mock URS call to get information to update status history
+        mock_urs_get_users
+        within '.open-draft-proposals tbody tr:nth-child(1)' do
+          click_on 'Delete'
+        end
+
+        within '#approver-proposal-modal' do
+          click_on 'Yes'
+        end
+      end
+
+      it 'displays expected success messages' do
+        expect(page).to have_content('Collection Metadata Deleted Successfully!')
+      end
+
+      it 'updated proposal status in dMMT' do
+        proposal = CollectionDraftProposal.find(@proposal.id)
+
+        expect(proposal.proposal_status).to eq('done')
+        expect(proposal.status_history['done']['username']).to eq('Test User')
+        expect(Time.parse(proposal.status_history['done']['action_date']).utc).to be_within(1.second).of Time.now
+      end
+
+      context 'when visiting the deleted collection' do
+        before do
+          visit collection_path(@ingest_response['concept-id'])
+        end
+
+        it 'cannot find the record in CMR' do
+          expect(page).to have_content('This collection is not available. It is either being published right now, does not exist, or you have insufficient permissions to view this collection.')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/manage_proposals/manage_proposal_publish_spec.rb
+++ b/spec/features/manage_proposals/manage_proposal_publish_spec.rb
@@ -29,17 +29,44 @@ describe 'When publishing collection draft proposals', js: true do
         before do
           mock_cmr_get_collections
           click_on 'Delete'
-          click_on 'Yes'
         end
 
-        it 'generates a success message' do
-          expect(page).to have_content('Collection Metadata Deleted Successfully!')
+        context 'when dMMT can update the proposal_status' do
+          before do
+            mock_update_proposal_status
+            click_on 'Yes'
+          end
+
+          it 'generates a success message' do
+            expect(page).to have_content('Collection Metadata Deleted Successfully!')
+          end
+
+          it 'cannot find the record' do
+            visit collection_path(@ingest_response['concept-id'])
+
+            expect(page).to have_content('This collection is not available. It is either being published right now, does not exist, or you have insufficient permissions to view this collection.')
+          end
         end
 
-        it 'cannot find the record' do
-          visit collection_path(@ingest_response['concept-id'])
+        context 'when dMMT cannot update the proposal_status' do
+          before do
+            mock_update_proposal_status(succeed: false)
+            click_on 'Yes'
+          end
 
-          expect(page).to have_content('This collection is not available. It is either being published right now, does not exist, or you have insufficient permissions to view this collection.')
+          it 'generates a success message for the delete action' do
+            expect(page).to have_content('Collection Metadata Deleted Successfully!')
+          end
+
+          it 'generates an error message for the proposal status update' do
+            expect(page).to have_content('Proposal status was not updated in dMMT successfully.')
+          end
+
+          it 'cannot find the record' do
+            visit collection_path(@ingest_response['concept-id'])
+
+            expect(page).to have_content('This collection is not available. It is either being published right now, does not exist, or you have insufficient permissions to view this collection.')
+          end
         end
       end
     end
@@ -50,6 +77,7 @@ describe 'When publishing collection draft proposals', js: true do
         mock_valid_token_validation
         visit manage_proposals_path
         mock_cmr_get_collections(hits: 0)
+        mock_update_proposal_status
         click_on 'Delete'
         click_on 'Yes'
       end
@@ -75,6 +103,7 @@ describe 'When publishing collection draft proposals', js: true do
 
     context 'when creating a new record' do
       before do
+        mock_update_proposal_status
         within '.open-draft-proposals tbody tr:nth-child(1)' do
           click_on 'Publish'
         end
@@ -125,20 +154,47 @@ describe 'When publishing collection draft proposals', js: true do
       cmr_client.delete_collection('MMT_2', @update_native_id, 'ABC-2')
     end
 
-    context 'when there is an existing record with the same native id' do
-      before do
-        @ingest_response, _concept_response = publish_collection_draft(native_id: @update_native_id)
-        click_on 'Publish'
-        click_on 'Yes'
+    context 'when the proposal status update in dMMT succeeds' do
+      context 'when there is an existing record with the same native id' do
+        before do
+          @ingest_response, _concept_response = publish_collection_draft(native_id: @update_native_id)
+          mock_update_proposal_status
+          click_on 'Publish'
+          click_on 'Yes'
+        end
+
+        it 'updates the record' do
+          expect(page).to have_content('Collection Metadata Successfully Published!')
+
+          # CMR needs a moment to update the record
+          wait_for_cmr
+          response = cmr_client.get_collections({ 'native_id': @update_native_id }, 'ABC-2')
+          expect(response.body['items'][0]['meta']['revision-id'].to_i - @ingest_response['revision-id'].to_i).to eq(1)
+        end
       end
+    end
 
-      it 'updates the record' do
-        expect(page).to have_content('Collection Metadata Successfully Published!')
+    context 'when the proposal status update in dMMT fails' do
+      context 'when there is an existing record with the same native id' do
+        before do
+          @ingest_response, _concept_response = publish_collection_draft(native_id: @update_native_id)
+          mock_update_proposal_status(succeed: false)
+          click_on 'Publish'
+          click_on 'Yes'
+        end
 
-        # CMR needs a moment to update the record
-        wait_for_cmr
-        response = cmr_client.get_collections({ 'native_id': @update_native_id }, 'ABC-2')
-        expect(response.body['items'][0]['meta']['revision-id'].to_i - @ingest_response['revision-id'].to_i).to eq(1)
+        it 'updates the record' do
+          expect(page).to have_content('Collection Metadata Successfully Published!')
+
+          # CMR needs a moment to update the record
+          wait_for_cmr
+          response = cmr_client.get_collections({ 'native_id': @update_native_id }, 'ABC-2')
+          expect(response.body['items'][0]['meta']['revision-id'].to_i - @ingest_response['revision-id'].to_i).to eq(1)
+        end
+
+        it 'has an error message for failing to update the proposal status' do
+          expect(page).to have_content('Proposal status was not updated in dMMT successfully.')
+        end
       end
     end
   end

--- a/spec/features/manage_proposals/manage_proposal_publish_spec.rb
+++ b/spec/features/manage_proposals/manage_proposal_publish_spec.rb
@@ -59,7 +59,7 @@ describe 'When publishing collection draft proposals', js: true do
           end
 
           it 'generates an error message for the proposal status update' do
-            expect(page).to have_content('Proposal status was not updated in dMMT successfully.')
+            expect(page).to have_content('Proposal status was not updated in the Draft Metadata Management Tool successfully.')
           end
 
           it 'cannot find the record' do
@@ -193,7 +193,7 @@ describe 'When publishing collection draft proposals', js: true do
         end
 
         it 'has an error message for failing to update the proposal status' do
-          expect(page).to have_content('Proposal status was not updated in dMMT successfully.')
+          expect(page).to have_content('Proposal status was not updated in the Draft Metadata Management Tool successfully.')
         end
       end
     end

--- a/spec/models/collection_draft_proposal_spec.rb
+++ b/spec/models/collection_draft_proposal_spec.rb
@@ -256,9 +256,17 @@ describe CollectionDraftProposal do
 
       expect { CollectionDraftProposal.create! }.to raise_error(ActiveRecord::RecordInvalid)
     end
+
+    it '"change_status_to_done" updates the status history and status of a proposal' do
+      collection_draft_proposal = CollectionDraftProposal.create(request_type: 'create', proposal_status: 'approved')
+      collection_draft_proposal.change_status_to_done('Test User')
+      proposal = CollectionDraftProposal.find(collection_draft_proposal.id)
+
+      expect(proposal.proposal_status).to eq('done')
+      expect(proposal.status_history['done']['username']).to eq('Test User')
+      expect(Time.parse(proposal.status_history['done']['action_date']).utc).to be_within(1.second).of Time.now
+    end
   end
-
-
 
   context 'when running in MMT proper' do
     before do

--- a/spec/support/approved_proposals_helpers.rb
+++ b/spec/support/approved_proposals_helpers.rb
@@ -57,5 +57,21 @@ module Helpers
       dmmt_response = cmr_success_response({ 'proposals' => proposals }.to_json)
       allow_any_instance_of(Cmr::DmmtClient).to receive(:dmmt_get_approved_proposals).and_return(dmmt_response)
     end
+
+    def mock_update_proposal_status(succeed: true)
+      dmmt_response = if succeed
+                        cmr_success_response({'body' => nil}.to_json)
+                      else
+                        cmr_fail_response({ 'body' => nil }.to_json, 400)
+                      end
+      allow_any_instance_of(Cmr::DmmtClient).to receive(:dmmt_update_proposal_status).and_return(dmmt_response)
+    end
+
+    # Fake getting user names from URS for updating proposal status in dMMT
+    def mock_urs_get_users
+      urs_response_body = { 'users' => [{ 'first_name' => 'Test', 'last_name' => 'User' }] }
+      urs_response = cmr_success_response(urs_response_body.to_json)
+      allow_any_instance_of(Cmr::UrsClient).to receive(:get_urs_users).and_return(urs_response)
+    end
   end
 end


### PR DESCRIPTION
Added calls in publish proposal to update proposal status in dMMT.
Added endpoint to dMMT to update proposal status.
Refactored the endpoint in dMMT to get approved proposals to reuse the token validation section
Added AASM transition to 'done'.
Added helpers in tests to mock a call to URS and dMMT.