### PR TITLE
MMT-2000 Odds and ends update based on PO walkthrough

### DIFF
--- a/app/assets/stylesheets/components/_metadata-preview.scss
+++ b/app/assets/stylesheets/components/_metadata-preview.scss
@@ -358,3 +358,7 @@ ul.sub-field {
 .proposal-status-display-status {
   text-decoration: underline;
 }
+
+.proposal-reject-button {
+  margin-right: .625em
+}

--- a/app/assets/stylesheets/components/_timeline.scss
+++ b/app/assets/stylesheets/components/_timeline.scss
@@ -44,7 +44,6 @@
   border: 3px solid $orange;
 }
 
-// TODO: refactor the timeline node classes, esp to incorporate rejected
 .timeline-node-rejected {
   border: 3px solid $red;
 }
@@ -61,7 +60,6 @@
   margin-left: -3px;
 }
 
-// TODO: refactor the timeline line classes, esp to incorporate rejected
 .timeline-line-faded-rejected::after {
   bottom: -123px;
 }

--- a/app/assets/stylesheets/components/_timeline.scss
+++ b/app/assets/stylesheets/components/_timeline.scss
@@ -18,7 +18,7 @@
   max-width: 1200px;
 }
 
-.timeline-node, .timeline-faded-node, .timeline-node-active, .timeline-node-rejected {
+.timeline-node, .timeline-node-faded, .timeline-node-active, .timeline-node-rejected {
   content: '';
   position: absolute;
   width: 22px;
@@ -32,12 +32,12 @@
 
 // Using opacity for the nodes made the line visible, so change the color
 // to generate the faded effect.
-.timeline-faded-node {
+.timeline-node-faded {
   background-color: $pale-blue;
 }
 
 // The settings that need to change to display the active color ring.
-.timeline-node-active {
+.timeline-node-active, .timeline-node-rejected {
   width: 24px;
   height: 24px;
   left: -21px;
@@ -46,14 +46,11 @@
 
 // TODO: refactor the timeline node classes, esp to incorporate rejected
 .timeline-node-rejected {
-  width: 24px;
-  height: 24px;
-  left: -21px;
   border: 3px solid $red;
 }
 
 // The ::after classes control the lines on the timeline
-.timeline-line-active::after, .timeline-faded-line-active::after, .timeline-line::after, .timeline-faded-line::after {
+.timeline-line-active::after, .timeline-line-faded-active::after, .timeline-line::after, .timeline-line-faded::after, .timeline-line-faded-rejected::after {
   content: '';
   position: absolute;
   width: 2px;
@@ -65,23 +62,15 @@
 }
 
 // TODO: refactor the timeline line classes, esp to incorporate rejected
-.timeline-faded-line-rejected::after {
-  content: '';
-  position: absolute;
-  width: 2px;
-  background-color: $dolphin-grey;
-  top: 19px;
+.timeline-line-faded-rejected::after {
   bottom: -123px;
-  left: 53%;
-  margin-left: -3px;
+}
+
+.timeline-line-faded-active::after, .timeline-line-faded::after, .timeline-line-faded-rejected::after {
   opacity: 0.2;
 }
 
-.timeline-faded-line-active::after, .timeline-faded-line::after {
-  opacity: 0.2;
-}
-
-.timeline-line::after, .timeline-faded-line::after {
+.timeline-line::after, .timeline-line-faded::after {
   top: 22px;
   bottom: -92px;
 }

--- a/app/concerns/permission_checking.rb
+++ b/app/concerns/permission_checking.rb
@@ -42,7 +42,7 @@ module PermissionChecking
 
   # shortcut helper methods
   def approver?
-    is_non_nasa_draft_approver?(user: current_user, token: token)
+    @user_has_approver_permissions || is_non_nasa_draft_approver?(user: current_user, token: token)
   end
 
   def non_nasa_user?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -324,11 +324,7 @@ class ApplicationController < ActionController::Base
 
   # Detemine if the user should see the proposal approver tab in MMT
   def proposal_approver_permissions
-    @user_has_approver_permissions = if Rails.configuration.proposal_mode
-                                       false
-                                     else
-                                       is_non_nasa_draft_approver?(user: current_user, token: token)
-                                     end
+    @user_has_approver_permissions = is_non_nasa_draft_approver?(user: current_user, token: token)
   end
 
   def proposal_mode_enabled?

--- a/app/controllers/manage_proposal_controller.rb
+++ b/app/controllers/manage_proposal_controller.rb
@@ -5,6 +5,7 @@ class ManageProposalController < ManageMetadataController
   RESULTS_PER_PAGE = 25
 
   def show
+    @ingest_errors = params['ingest_errors']
     @specified_url = 'manage_proposals'
     @providers = ['Select a provider to publish this record'] + current_user.available_providers
 
@@ -70,7 +71,7 @@ class ManageProposalController < ManageMetadataController
       publish_create_or_update_proposal(proposal, provider)
     end
 
-    redirect_to manage_proposals_path
+    redirect_to manage_proposals_path(ingest_errors: @ingest_errors)
   end
 
   private
@@ -118,6 +119,7 @@ class ManageProposalController < ManageMetadataController
         update_proposal_status_in_dmmt(proposal)
       else
         flash[:error] = I18n.t('controllers.manage_proposal.publish_proposal.flash.delete.error')
+        @ingest_errors = generate_ingest_errors(cmr_response)
         Rails.logger.info("User: #{current_user.urs_uid} could not delete a collection with native_id #{proposal['native_id']} based on proposal with short name: #{proposal['short_name']} and id: #{proposal['id']}")
         Rails.logger.error("Delete collection from proposal error: #{cmr_response.clean_inspect}")
       end
@@ -134,6 +136,7 @@ class ManageProposalController < ManageMetadataController
       update_proposal_status_in_dmmt(proposal)
     else
       flash[:error] = I18n.t('controllers.manage_proposal.publish_proposal.flash.create.error')
+      @ingest_errors = generate_ingest_errors(cmr_response)
       Rails.logger.info("User: #{current_user.urs_uid} could not publish proposal with short name: #{proposal['short_name']} and id: #{proposal['id']} in the CMR.")
       Rails.logger.error("Ingest collection from proposal error: #{cmr_response.clean_inspect}")
     end

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -5,7 +5,6 @@ module Proposal
     skip_before_action :provider_set?
 
     before_action :ensure_non_nasa_draft_permissions
-    before_action :check_approver_status, only: [:show, :progress]
     before_action(only: [:submit, :rescind, :progress, :approve, :reject]) { set_resource }
 
     def index
@@ -216,12 +215,6 @@ module Proposal
     def user_from_resource
       proposal_urs_user = retrieve_urs_users([User.find(get_resource.user_id).urs_uid])[0]
       { name: "#{proposal_urs_user['first_name']} #{proposal_urs_user['last_name']}", email: proposal_urs_user['email_address'] } unless proposal_urs_user.blank?
-    end
-
-    # Used as a before action to manipulate which look of the role based
-    # two-look pages is used.
-    def check_approver_status
-      @non_nasa_approver = approver?
     end
 
     # TODO: Investigate if this can be used to provide sorting to all drafts.

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -18,8 +18,8 @@ module Proposal
 
     def queued_index
       resources = resource_class.where('proposal_status != ?', 'in_work')
-      .order(index_sort_order)
-      .page(params[:page]).per(RESULTS_PER_PAGE)
+                                .order(index_sort_order)
+                                .page(params[:page]).per(RESULTS_PER_PAGE)
       instance_variable_set("@#{plural_resource_name}", resources)
       @category_of_displayed_proposal = 'Queued'
       @specified_url = '/collection_draft_proposals/queued_index'
@@ -28,8 +28,8 @@ module Proposal
 
     def in_work_index
       resources = resource_class.where('proposal_status = ?', 'in_work')
-      .order(index_sort_order)
-      .page(params[:page]).per(RESULTS_PER_PAGE)
+                                .order(index_sort_order)
+                                .page(params[:page]).per(RESULTS_PER_PAGE)
       instance_variable_set("@#{plural_resource_name}", resources)
       @category_of_displayed_proposal = 'In Work'
       @specified_url = '/collection_draft_proposals/in_work_index'

--- a/app/controllers/proposal/manage_collection_proposals_controller.rb
+++ b/app/controllers/proposal/manage_collection_proposals_controller.rb
@@ -10,9 +10,8 @@ module Proposal
       # If you change this number you must also change it in the corresponding test file - features/manage_collections/open_drafts_spec.rb.
       @proposal_display_max_count = 5
       @proposal_type = 'CollectionDraftProposal'
-      @non_nasa_approver = approver?
 
-      if @non_nasa_approver
+      if @user_has_approver_permissions
         @in_work_proposals =
           CollectionDraftProposal.where('proposal_status = ?', 'in_work')
                                  .order('updated_at DESC')

--- a/app/controllers/proposal/manage_collection_proposals_controller.rb
+++ b/app/controllers/proposal/manage_collection_proposals_controller.rb
@@ -10,7 +10,7 @@ module Proposal
       # If you change this number you must also change it in the corresponding test file - features/manage_collections/open_drafts_spec.rb.
       @proposal_display_max_count = 5
       @proposal_type = 'CollectionDraftProposal'
-      @non_nasa_approver = is_non_nasa_draft_approver?(user: current_user, token: token)
+      @non_nasa_approver = approver?
 
       if @non_nasa_approver
         @in_work_proposals =

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -21,7 +21,7 @@ module ProposalsHelper
   def submit_node
     classes = if get_resource.in_work?
                 # If the proposal is in work, this is the current node
-                %w[timeline-node-active timeline-faded-line-active]
+                %w[timeline-node-active timeline-line-faded-active]
               elsif get_resource.submitted?
                 # If the proposal has been submitted, this is the current node
                 # and we want to make the next line active to show it is
@@ -40,7 +40,7 @@ module ProposalsHelper
     classes = if get_resource.rejected?
                 # This node is the active node when a rejected proposal
                 # has not been rescinded
-                %w[timeline-node-rejected timeline-faded-line-rejected]
+                %w[timeline-node-rejected timeline-line-faded-rejected]
               elsif @status_history['approved']
                 # If the proposal has been approved, a later node is active.
                 %w[timeline-node timeline-line]
@@ -48,9 +48,9 @@ module ProposalsHelper
                 # If this proposal has been rejected, but isn't in the rejected
                 # state, this node should be visible, but no progress to the next
                 # state is shown (e.g. a faded line)
-                %w[timeline-faded-node timeline-faded-line-rejected]
+                %w[timeline-node-faded timeline-line-faded-rejected]
               else
-                %w[timeline-faded-node timeline-faded-line]
+                %w[timeline-node-faded timeline-line-faded]
               end
 
     content_tag(:div, nil, class: classes)
@@ -68,7 +68,7 @@ module ProposalsHelper
                 # and the node and line should be displayed
                 %w[timeline-node timeline-line]
               else
-                %w[timeline-faded-node timeline-faded-line]
+                %w[timeline-node-faded timeline-line-faded]
               end
 
     content_tag(:div, nil, class: classes)
@@ -79,7 +79,7 @@ module ProposalsHelper
     classes = if get_resource.done?
                 %w[timeline-node-active]
               else
-                %w[timeline-faded-node]
+                %w[timeline-node-faded]
               end
 
     content_tag(:div, nil, class: classes)
@@ -122,7 +122,7 @@ module ProposalsHelper
         'No actions are possible.'
       end
     elsif get_resource.submitted? || get_resource.rejected?
-      'You may rescind this proposal to make additional changes.'
+      'You may cancel this proposal to make additional changes.'
     else
       'No actions are possible.'
     end

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -115,7 +115,7 @@ module ProposalsHelper
   def get_available_actions_text
     if get_resource.in_work?
       'Make additional changes or submit this proposal for approval.'
-    elsif @non_nasa_approver
+    elsif @user_has_approver_permissions
       if get_resource.approved?
         'Please visit the Metadata Management Tool for NASA users to finish publishing this metadata.'
       elsif get_resource.done?

--- a/app/views/manage_proposal/show.html.erb
+++ b/app/views/manage_proposal/show.html.erb
@@ -1,4 +1,21 @@
 <div class="row row-content manage-proposals-mmt">
+  <% if @ingest_errors && !@ingest_errors.empty? %>
+    <section class="errors">
+      <div class="eui-banner--danger">
+        <div class="eui-banner__message">
+          <h4><i class="fa fa-exclamation-triangle"></i> This proposal has the following errors:</h4>
+          <ul class="no-bullet">
+            <% @ingest_errors.each do |error| %>
+              <li>
+                <%= error[:error] %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </section>
+  <% end %>
+
   <section>
     <h2><%= "Approved Proposals" %></h2>
 
@@ -27,28 +44,28 @@
           </td>
         </tr>
       <% else %>
-        <% @proposals.each do |draft| %>
+        <% @proposals.each do |proposal| %>
           <tr class='<%= cycle("alt", "") %>'>
             <td>
-              <%= draft['short_name'] %>
+              <%= proposal['short_name'] %>
             </td>
             <td>
-              <%= draft['entry_title'] %>
+              <%= proposal['entry_title'] %>
             </td>
             <td>
-              <%= draft['proposal_status'].titleize %>
+              <%= proposal['proposal_status'].titleize %>
             </td>
             <td>
-              <%= draft['request_type'].titleize %>
+              <%= proposal['request_type'].titleize %>
             </td>
             <td>
-              <%= draft['status_history'].fetch('submitted', { 'username' => 'Not Provided' })['username'].titleize %>
+              <%= proposal['status_history'].fetch('submitted', { 'username' => 'Not Provided' })['username'].titleize %>
             </td>
             <td>
-              <%= DateTime.parse(draft['updated_at']).to_s(:date) %>
+              <%= DateTime.parse(proposal['updated_at']).to_s(:date) %>
             </td>
             <td>
-              <%= link_to draft['request_type'] == 'delete' ? 'Delete' : 'Publish' , "#approver-proposal-modal", class: 'eui-btn--link display-modal approver-proposal-modal-link', data: { 'proposal': draft.to_json } %>
+              <%= link_to proposal['request_type'] == 'delete' ? 'Delete' : 'Publish' , "#approver-proposal-modal", class: 'eui-btn--link display-modal approver-proposal-modal-link', data: { 'proposal': proposal.to_json } %>
             </td>
           </tr>
         <% end %>

--- a/app/views/proposal/collection_draft_proposals/index.html.erb
+++ b/app/views/proposal/collection_draft_proposals/index.html.erb
@@ -15,7 +15,7 @@
           <th><%= sort_by_link(entry_title_header(resource_name), 'entry_title', @query, nil, @specified_url) %></th>
           <th><%= sort_by_link('Proposal Status', 'proposal_status', @query, nil, @specified_url) %></th>
           <th><%= sort_by_link('Request Type', 'request_type', @query, nil, @specified_url) %></th>
-          <th><%= sort_by_link('Submitter', 'user_name', @query, nil, @specified_url) %></th>
+          <th>Submitter</th>
           <th><%= sort_by_link('Last Modified', 'updated_at', @query, nil, @specified_url) %></th>
         </tr>
       </thead>
@@ -43,7 +43,7 @@
               <%= "#{proposal.request_type.titleize}" %>
             </td>
             <td>
-              <%= proposal['status_history'].fetch('submitted', proposal.in_work? ? { 'username' => 'Not Submitted' } : { 'username' => 'Not Provided' })['username'].titleize %>
+              <%= proposal['status_history'].fetch('submitted', proposal.in_work? ? { 'username' => 'Pending' } : { 'username' => 'Not Provided' })['username'].titleize %>
             </td>
             <td>
               <%= proposal.updated_at.to_s(:date) %>

--- a/app/views/proposal/collection_draft_proposals/index.html.erb
+++ b/app/views/proposal/collection_draft_proposals/index.html.erb
@@ -15,6 +15,7 @@
           <th><%= sort_by_link(entry_title_header(resource_name), 'entry_title', @query, nil, @specified_url) %></th>
           <th><%= sort_by_link('Proposal Status', 'proposal_status', @query, nil, @specified_url) %></th>
           <th><%= sort_by_link('Request Type', 'request_type', @query, nil, @specified_url) %></th>
+          <th><%= sort_by_link('Submitter', 'user_name', @query, nil, @specified_url) %></th>
           <th><%= sort_by_link('Last Modified', 'updated_at', @query, nil, @specified_url) %></th>
         </tr>
       </thead>
@@ -23,26 +24,29 @@
       <% if get_resources.blank? %>
         <tr>
           <td colspan="6">
-            No <%= current_user.provider_id %> Drafts found
+            No <%= @category_of_displayed_proposal %> Proposals found
           </td>
         </tr>
       <% else %>
-        <% get_resources.each do |draft| %>
+        <% get_resources.each do |proposal| %>
           <tr class='<%= cycle("alt", "") %>'>
             <td>
-              <%= link_to draft.display_short_name, send("#{resource_name}_path", draft) %>
+              <%= link_to proposal.display_short_name, send("#{resource_name}_path", proposal) %>
             </td>
             <td>
-              <%= draft.display_entry_title %>
+              <%= proposal.display_entry_title %>
             </td>
             <td>
-              <%= link_to draft.proposal_status.titleize, send("progress_#{resource_name}_path", draft) %>
+              <%= link_to proposal.proposal_status.titleize, send("progress_#{resource_name}_path", proposal) %>
             </td>
             <td>
-              <%= "#{draft.request_type.titleize}" %>
+              <%= "#{proposal.request_type.titleize}" %>
             </td>
             <td>
-              <%= draft.updated_at.to_s(:date) %>
+              <%= proposal['status_history'].fetch('submitted', proposal.in_work? ? { 'username' => 'Not Submitted' } : { 'username' => 'Not Provided' })['username'].titleize %>
+            </td>
+            <td>
+              <%= proposal.updated_at.to_s(:date) %>
             </td>
           </tr>
         <% end %>

--- a/app/views/proposal/collection_draft_proposals/progress.html.erb
+++ b/app/views/proposal/collection_draft_proposals/progress.html.erb
@@ -63,7 +63,7 @@
             <% end %>
             <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/delete_modal' %>
           <% elsif get_resource.submitted? %>
-            <% if @non_nasa_approver %>
+            <% if @user_has_approver_permissions %>
               <%= link_to state_action_button_text('Approve'), "#approve-submission-modal", class: 'eui-btn--blue display-modal' %>
               <%= link_to state_action_button_text('Reject'), "#reject-submission-modal", class: 'eui-btn--red display-modal' %>
               <p class="progress-actions-links">

--- a/app/views/proposal/collection_draft_proposals/progress.html.erb
+++ b/app/views/proposal/collection_draft_proposals/progress.html.erb
@@ -52,13 +52,16 @@
           <% if get_resource.in_work? %>
             <% if @errors.any? %>
               <%= link_to 'Submit for Review', '#invalid-proposal-modal', class: 'eui-btn--blue display-modal' %>
-              <%= link_to 'Edit Proposal', edit_collection_draft_proposal_path(get_resource) %>
+              <%= link_to 'Edit Proposal', edit_collection_draft_proposal_path(get_resource), class: 'display-modal eui-btn--link bar-after' %>
+              <%= link_to 'Delete Proposal', "#delete-proposal-modal", class: 'display-modal' %>
               <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/invalid_proposal_modal' %>
             <% else %>
               <%= link_to 'Submit for Review', '#submit-proposal-modal', class: 'eui-btn--blue display-modal' %>
-              <%= link_to 'Edit Proposal', edit_collection_draft_proposal_path(get_resource) %>
+              <%= link_to 'Edit Proposal', edit_collection_draft_proposal_path(get_resource), class: 'display-modal eui-btn--link bar-after' %>
+              <%= link_to 'Delete Proposal', "#delete-proposal-modal", class: 'display-modal' %>
               <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/submit_modal' %>
             <% end %>
+            <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/delete_modal' %>
           <% elsif get_resource.submitted? %>
             <% if @non_nasa_approver %>
               <%= link_to state_action_button_text('Approve'), "#approve-submission-modal", class: 'eui-btn--blue display-modal' %>
@@ -76,7 +79,6 @@
           <% elsif get_resource.rejected? %>
             <%= link_to state_action_button_text('Cancel'), "#rescind-submission-modal", class: 'eui-btn--blue display-modal' %>
             <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/rescind_modal' %>
-          <% elsif get_resource.done? %>
           <% end %>
         </p>
       </div>

--- a/app/views/proposal/collection_draft_proposals/proposal_partials/_delete_modal.html.erb
+++ b/app/views/proposal/collection_draft_proposals/proposal_partials/_delete_modal.html.erb
@@ -1,0 +1,8 @@
+<div id="delete-proposal-modal" class="eui-modal-content">
+  <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
+  <p>Are you sure you want to delete this proposal?</p>
+  <p>
+    <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
+    <%= link_to 'Yes', collection_draft_proposal_path(get_resource), method: :delete, class: 'eui-btn--blue spinner' %>
+  </p>
+</div>

--- a/app/views/proposal/collection_draft_proposals/proposal_partials/_rescind_modal.html.erb
+++ b/app/views/proposal/collection_draft_proposals/proposal_partials/_rescind_modal.html.erb
@@ -1,6 +1,6 @@
 <div id="rescind-submission-modal" class="eui-modal-content">
   <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-  <p>Are you sure you want to rescind this proposal submission? The proposal will not be reviewed until it has been resubmitted.</p>
+  <p>Are you sure you want to cancel this proposal submission? The proposal will not be reviewed until it has been resubmitted.</p>
   <p>
     <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
     <%= link_to 'Yes', rescind_collection_draft_proposal_path(get_resource), class: 'eui-btn--blue spinner' %>

--- a/app/views/proposal/collection_draft_proposals/show.html.erb
+++ b/app/views/proposal/collection_draft_proposals/show.html.erb
@@ -14,7 +14,7 @@
           <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/delete_modal' %>
         </span>
       <% elsif get_resource.submitted? %>
-        <% if @non_nasa_approver %>
+        <% if @user_has_approver_permissions %>
           <%= link_to state_action_button_text('Approve'), "#approve-submission-modal", class: 'eui-btn--blue display-modal' %>
           <%= link_to state_action_button_text('Reject'), "#reject-submission-modal", class: 'eui-btn--red display-modal' %>
           <%= link_to state_action_button_text('Cancel'), "#rescind-submission-modal", class: 'eui-btn--link display-modal' %>

--- a/app/views/proposal/collection_draft_proposals/show.html.erb
+++ b/app/views/proposal/collection_draft_proposals/show.html.erb
@@ -16,7 +16,7 @@
       <% elsif get_resource.submitted? %>
         <% if @user_has_approver_permissions %>
           <%= link_to state_action_button_text('Approve'), "#approve-submission-modal", class: 'eui-btn--blue display-modal' %>
-          <%= link_to state_action_button_text('Reject'), "#reject-submission-modal", class: 'eui-btn--red display-modal' %>
+          <%= link_to state_action_button_text('Reject'), "#reject-submission-modal", class: 'eui-btn--red display-modal proposal-reject-button' %>
           <%= link_to state_action_button_text('Cancel'), "#rescind-submission-modal", class: 'eui-btn--link display-modal' %>
           <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/approve_modal' %>
           <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/reject_modal' %>

--- a/app/views/proposal/collection_draft_proposals/show.html.erb
+++ b/app/views/proposal/collection_draft_proposals/show.html.erb
@@ -11,23 +11,18 @@
             <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/submit_modal' %>
           <% end %>
           <%= link_to 'Delete Collection Draft Proposal', "#delete-proposal-modal", class: 'display-modal' %>
-          <div id="delete-proposal-modal" class="eui-modal-content">
-            <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-            <p>Are you sure you want to delete this proposal?</p>
-            <p>
-              <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
-              <%= link_to 'Yes', collection_draft_proposal_path(get_resource), method: :delete, class: 'eui-btn--blue spinner' %>
-            </p>
-          </div>
+          <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/delete_modal' %>
         </span>
       <% elsif get_resource.submitted? %>
         <% if @non_nasa_approver %>
           <%= link_to state_action_button_text('Approve'), "#approve-submission-modal", class: 'eui-btn--blue display-modal' %>
           <%= link_to state_action_button_text('Reject'), "#reject-submission-modal", class: 'eui-btn--red display-modal' %>
+          <%= link_to state_action_button_text('Cancel'), "#rescind-submission-modal", class: 'eui-btn--link display-modal' %>
           <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/approve_modal' %>
           <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/reject_modal' %>
+        <% else %>
+          <%= link_to state_action_button_text('Cancel'), "#rescind-submission-modal", class: 'eui-btn--blue display-modal' %>
         <% end %>
-        <%= link_to state_action_button_text('Cancel'), "#rescind-submission-modal", class: 'eui-btn--blue display-modal' %>
         <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/rescind_modal' %>
       <% elsif get_resource.rejected? %>
         <%= link_to state_action_button_text('Cancel'), "#rescind-submission-modal", class: 'eui-btn--link display-modal' %>

--- a/app/views/proposal/collections/show.html.erb
+++ b/app/views/proposal/collections/show.html.erb
@@ -17,7 +17,7 @@
     <section class="action wide-content">
       <div class="wide-content-inside">
         <span>
-          <%= link_to 'Create Update Proposal', '#update-request-modal', class: 'display-modal eui-btn--link bar-after' %>
+          <%= link_to 'Create Update Request', '#update-request-modal', class: 'display-modal eui-btn--link bar-after' %>
           <%= link_to 'Submit Delete Request', '#delete-request-modal', class: 'display-modal eui-btn--link' %>
         </span>
       </div>
@@ -26,13 +26,13 @@
 
     <div id="update-request-modal" class="eui-modal-content">
       <a href="javascript:void(0);" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-      <p>Are you sure you want to create a proposal to update this record?</p>
+      <p>Are you sure you want to create a request to update this record?</p>
       <p>
         <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
         <%= link_to 'Yes', create_update_proposal_collection_path(revision_id: @revision_id), class: 'eui-btn--blue spinner' %>
       </p>
     </div>
-    
+
     <div id="delete-request-modal" class="eui-modal-content">
       <a href="javascript:void(0);" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
       <p>Are you sure you want to request this record be deleted?</p>

--- a/app/views/proposal/manage_collection_proposals/show.html.erb
+++ b/app/views/proposal/manage_collection_proposals/show.html.erb
@@ -1,6 +1,6 @@
 <main class="dashboard" role="main">
   <article id="metadata" class="row-content flex-row--start" role="article">
-    <% if @non_nasa_approver %>
+    <% if @user_has_approver_permissions %>
       <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/manage_proposals_for_approver' %>
     <% else %>
       <%= render partial: 'proposal/collection_draft_proposals/proposal_partials/manage_proposals_for_user' , locals: {

--- a/app/views/shared/_user_info_dropdown.html.erb
+++ b/app/views/shared/_user_info_dropdown.html.erb
@@ -23,6 +23,10 @@
             <span class="eui-badge--sm daac"><%= current_user.provider_id %></span>
           </div>
         </a>
+      <% elsif Rails.configuration.proposal_mode %>
+        <div class="available-permissions">
+          <span class="eui-badge--sm"><%= @user_has_approver_permissions ? 'Approver' : 'User' %></span>
+        </div>
       <% end %>
       <!-- End provider context badge -->
   </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,8 +84,8 @@ en:
             error: 'Collection Draft Proposal was not deleted successfully'
         submit:
           flash:
-            success: 'Collection Draft Proposal Submitted Successfully'
-            error: 'Collection Draft Proposal was not submitted successfully'
+            success: 'Collection Draft Proposal Submitted for Review Successfully'
+            error: 'Collection Draft Proposal was not submitted for review successfully'
         rescind:
           flash:
             success: 'Collection Draft Proposal Canceled Successfully'
@@ -128,10 +128,10 @@ en:
           notice: 'Records must have a unique Short Name. Click here to enter a new Short Name.'
       delete_proposal:
         flash:
-          success: 'Delete Collection Metadata Request Created Successfully!'
+          success: 'Collection Metadata Delete Request Created Successfully!'
       update_proposal:
         flash:
-          success: 'Update Collection Metadata Request Created Successfully!'
+          success: 'Collection Metadata Update Request Created Successfully!'
     variables:
       create:
         flash:

--- a/spec/features/manage_proposals/approver_workflow_spec.rb
+++ b/spec/features/manage_proposals/approver_workflow_spec.rb
@@ -64,7 +64,7 @@ describe 'When going through the whole collection proposal approver workflow', j
         @ingest_response, _concept_response = publish_collection_draft
         set_as_proposal_mode_mmt(with_draft_approver_acl: true)
         visit collection_path(@ingest_response['concept-id'])
-        click_on 'Create Update Proposal'
+        click_on 'Create Update Request'
         click_on 'Yes'
         click_on 'Short Name - Required field complete'
         @short_name = "Full Workflow Update Test Proposal_#{Faker::Number.number(15)}"

--- a/spec/features/manage_proposals/manage_proposal_publish_spec.rb
+++ b/spec/features/manage_proposals/manage_proposal_publish_spec.rb
@@ -137,6 +137,8 @@ describe 'When publishing collection draft proposals', js: true do
 
         it 'provides an error message' do
           expect(page).to have_content('Collection metadata was not successfully published.')
+          expect(page).to have_content('This proposal has the following errors:')
+          expect(page).to have_content('The Entry Title [Create Request Title] must be unique.')
         end
       end
     end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_create_from_collection_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_create_from_collection_spec.rb
@@ -11,7 +11,7 @@ describe 'Collection Draft Proposal creation from collection', js: true do
     end
 
     it 'displays the proposal actions' do
-      expect(page).to have_link('Create Update Proposal')
+      expect(page).to have_link('Create Update Request')
       expect(page).to have_link('Submit Delete Request')
     end
 
@@ -22,19 +22,19 @@ describe 'Collection Draft Proposal creation from collection', js: true do
       end
 
       it 'a delete metadata proposal can be created' do
-        expect(page).to have_content('Delete Collection Metadata Request Created Successfully!')
+        expect(page).to have_content('Collection Metadata Delete Request Created Successfully!')
         expect(page).to have_content('Submitted')
       end
     end
 
     context 'when creating an update metadata proposal' do
       before do
-        click_on 'Create Update Proposal'
+        click_on 'Create Update Request'
         click_on 'Yes'
       end
 
       it 'an update metadata proposal can be created' do
-        expect(page).to have_content('Update Collection Metadata Request Created Successfully!')
+        expect(page).to have_content('Collection Metadata Update Request Created Successfully!')
         expect(page).to have_content('In Work')
       end
     end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_list_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_list_spec.rb
@@ -37,7 +37,7 @@ describe 'Viewing Collection Draft Proposals Index Pages', js: true do
 
       it 'displays submitters' do
         expect(page).to have_content('Test User1')
-        expect(page).to have_content('Not Submitted')
+        expect(page).to have_content('Pending')
       end
 
       context 'when sorting short name' do

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_list_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_list_spec.rb
@@ -35,6 +35,11 @@ describe 'Viewing Collection Draft Proposals Index Pages', js: true do
         expect(page).to have_content('Delete')
       end
 
+      it 'displays submitters' do
+        expect(page).to have_content('Test User1')
+        expect(page).to have_content('Not Submitted')
+      end
+
       context 'when sorting short name' do
         before do
           click_on 'Sort by Short Name Asc'

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
@@ -17,7 +17,7 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
 
       it 'submits a proposal' do
         click_on 'Yes'
-        expect(page).to have_content('Collection Draft Proposal Submitted Successfully')
+        expect(page).to have_content('Collection Draft Proposal Submitted for Review Successfully')
         expect(page).to have_no_link('Temporal Information')
       end
 
@@ -37,7 +37,7 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
       end
 
       it 'provides an error message' do
-        expect(page).to have_content('Collection Draft Proposal was not submitted successfully')
+        expect(page).to have_content('Collection Draft Proposal was not submitted for review successfully')
         within '#proposal-status-display' do
           expect(page).to have_content('Done')
         end
@@ -175,7 +175,7 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
       end
 
       it 'can go to the progress page' do
-        expect(page).to have_content('You may rescind this proposal to make additional changes.')
+        expect(page).to have_content('You may cancel this proposal to make additional changes.')
         expect(page).to have_content('No Date Provided')
         expect(page).to have_content('No User Provided')
       end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_update_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_update_spec.rb
@@ -67,12 +67,12 @@ describe 'Collection Draft Proposal Update', reset_provider: true, js: true do
 
         context 'when creating an update metadata proposal' do
           before do
-            click_on 'Create Update Proposal'
+            click_on 'Create Update Request'
             click_on 'Yes'
           end
 
           it 'creates the update metadata proposal' do
-            expect(page).to have_content('Update Collection Metadata Request Created Successfully!')
+            expect(page).to have_content('Collection Metadata Update Request Created Successfully!')
             expect(page).to have_content('In Work')
           end
 

--- a/spec/features/proposal/proposal_progress_spec.rb
+++ b/spec/features/proposal/proposal_progress_spec.rb
@@ -15,15 +15,15 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
         within '#timeline-create-submission' do
           expect(page).to have_content('In Work')
           expect(page).to have_css('div.timeline-node-active')
-          expect(page).to have_css('div.timeline-faded-line-active')
+          expect(page).to have_css('div.timeline-line-faded-active')
           expect(page).to have_no_content('Submitted')
           expect(page).to have_no_content('By')
         end
 
         within '#timeline-review-submission' do
           expect(page).to have_css('p.timeline-stage-inactive', text: 'Approval')
-          expect(page).to have_css('div.timeline-faded-node')
-          expect(page).to have_css('div.timeline-faded-line')
+          expect(page).to have_css('div.timeline-node-faded')
+          expect(page).to have_css('div.timeline-line-faded')
         end
       end
 
@@ -32,6 +32,7 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
           expect(page).to have_content('Make additional changes or submit this proposal for approval.')
           expect(page).to have_link('Submit for Review')
           expect(page).to have_link('Edit Proposal')
+          expect(page).to have_link('Delete Proposal')
         end
       end
 
@@ -63,14 +64,14 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
 
         within '#timeline-review-submission' do
           expect(page).to have_css('p.timeline-stage-inactive', text: 'Approval')
-          expect(page).to have_css('div.timeline-faded-node')
-          expect(page).to have_css('div.timeline-faded-line')
+          expect(page).to have_css('div.timeline-node-faded')
+          expect(page).to have_css('div.timeline-line-faded')
         end
       end
 
       it 'displays the correct actions' do
         within '.progress-actions' do
-          expect(page).to have_content('You may rescind this proposal to make additional changes.')
+          expect(page).to have_content('You may cancel this proposal to make additional changes.')
           expect(page).to have_link('Cancel Proposal Submission')
 
           expect(page).to have_no_link('Approve Proposal Submission')
@@ -129,7 +130,7 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
           within '#timeline-create-submission' do
             expect(page).to have_content('In Work')
             expect(page).to have_css('div.timeline-node-active')
-            expect(page).to have_css('div.timeline-faded-line-active')
+            expect(page).to have_css('div.timeline-line-faded-active')
             expect(page).to have_no_content('Submitted')
             expect(page).to have_no_content('By')
           end
@@ -141,8 +142,8 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
             expect(page).to have_content('Reason(s): Misspellings/Grammar and Other')
             expect(page).to have_content('Note: Test Reason for rejecting a proposal')
             expect(page).to have_link('Click for full details')
-            expect(page).to have_css('div.timeline-faded-node')
-            expect(page).to have_css('div.timeline-faded-line-rejected')
+            expect(page).to have_css('div.timeline-node-faded')
+            expect(page).to have_css('div.timeline-line-faded-rejected')
           end
         end
 
@@ -171,8 +172,8 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
 
             within '#timeline-review-submission' do
               expect(page).to have_css('p.timeline-stage-inactive', text: 'Approval')
-              expect(page).to have_css('div.timeline-faded-node')
-              expect(page).to have_css('div.timeline-faded-line')
+              expect(page).to have_css('div.timeline-node-faded')
+              expect(page).to have_css('div.timeline-line-faded')
 
               expect(page).to have_no_content('Rejected')
               expect(page).to have_no_content('Reason(s)')
@@ -183,7 +184,7 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
 
           it 'displays the correct actions' do
             within '.progress-actions' do
-              expect(page).to have_content('You may rescind this proposal to make additional changes.')
+              expect(page).to have_content('You may cancel this proposal to make additional changes.')
               expect(page).to have_link('Cancel Proposal Submission')
 
               expect(page).to have_no_link('Approve Proposal Submission')
@@ -216,13 +217,13 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
             expect(page).to have_content('Note: Test Reason for rejecting a proposal')
             expect(page).to have_link('Click for full details')
             expect(page).to have_css('div.timeline-node-rejected')
-            expect(page).to have_css('div.timeline-faded-line-rejected')
+            expect(page).to have_css('div.timeline-line-faded-rejected')
           end
         end
 
         it 'displays the correct actions' do
           within '.progress-actions' do
-            expect(page).to have_content('You may rescind this proposal to make additional changes.')
+            expect(page).to have_content('You may cancel this proposal to make additional changes.')
             expect(page).to have_link('Cancel Proposal Submission')
           end
         end
@@ -305,15 +306,15 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
         within '#timeline-create-submission' do
           expect(page).to have_content('In Work')
           expect(page).to have_css('div.timeline-node-active')
-          expect(page).to have_css('div.timeline-faded-line-active')
+          expect(page).to have_css('div.timeline-line-faded-active')
           expect(page).to have_no_content('Submitted')
           expect(page).to have_no_content('By')
         end
 
         within '#timeline-review-submission' do
           expect(page).to have_css('p.timeline-stage-inactive', text: 'Approval')
-          expect(page).to have_css('div.timeline-faded-node')
-          expect(page).to have_css('div.timeline-faded-line')
+          expect(page).to have_css('div.timeline-node-faded')
+          expect(page).to have_css('div.timeline-line-faded')
         end
       end
 
@@ -343,14 +344,14 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
           expect(page).to have_content('Submitted: 2019-10-11 01:00')
           expect(page).to have_content('By: TestUser1')
           expect(page).to have_css('div.timeline-node-active')
-          # expect(page).to have_css('div.timeline-faded-line-active')
+          # expect(page).to have_css('div.timeline-line-faded-active')
           expect(page).to have_css('div.timeline-line-active')
         end
 
         within '#timeline-review-submission' do
           expect(page).to have_css('p.timeline-stage-inactive', text: 'Approval')
-          expect(page).to have_css('div.timeline-faded-node')
-          expect(page).to have_css('div.timeline-faded-line')
+          expect(page).to have_css('div.timeline-node-faded')
+          expect(page).to have_css('div.timeline-line-faded')
         end
       end
 
@@ -415,7 +416,7 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
           within '#timeline-create-submission' do
             expect(page).to have_content('In Work')
             expect(page).to have_css('div.timeline-node-active')
-            expect(page).to have_css('div.timeline-faded-line-active')
+            expect(page).to have_css('div.timeline-line-faded-active')
             expect(page).to have_no_content('Submitted')
             expect(page).to have_no_content('By')
           end
@@ -427,8 +428,8 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
             expect(page).to have_content('Reason(s): Misspellings/Grammar and Other')
             expect(page).to have_content('Note: Test Reason for rejecting a proposal')
             expect(page).to have_link('Click for full details')
-            expect(page).to have_css('div.timeline-faded-node')
-            expect(page).to have_css('div.timeline-faded-line-rejected')
+            expect(page).to have_css('div.timeline-node-faded')
+            expect(page).to have_css('div.timeline-line-faded-rejected')
           end
         end
 
@@ -457,8 +458,8 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
 
             within '#timeline-review-submission' do
               expect(page).to have_css('p.timeline-stage-inactive', text: 'Approval')
-              expect(page).to have_css('div.timeline-faded-node')
-              expect(page).to have_css('div.timeline-faded-line')
+              expect(page).to have_css('div.timeline-node-faded')
+              expect(page).to have_css('div.timeline-line-faded')
 
               expect(page).to have_no_content('Rejected')
               expect(page).to have_no_content('Reason(s)')
@@ -502,7 +503,7 @@ describe 'Viewing Progress Page for Collection Metadata Proposals', js: true do
             expect(page).to have_content('Note: Test Reason for rejecting a proposal')
             expect(page).to have_link('Click for full details')
             expect(page).to have_css('div.timeline-node-rejected')
-            expect(page).to have_css('div.timeline-faded-line-rejected')
+            expect(page).to have_css('div.timeline-line-faded-rejected')
           end
         end
 


### PR DESCRIPTION
Did a find and replace for the CSS on the progress page: timeline-faded-node => timeline-node-faded for consistency with other classes.  Similarly for timeline-faded-line => timeline-line-faded.
Changed a before action that was checking approver ACLs to also happen in proposal mode
Made a series of changes to reduce how often we were going to CMR to check approver acls
Added a badge that displays approver/user status in dMMT
Added submitter column to index pages (sorting deferred)
Added ingest error display when publishing a proposal fails
Made a series of changes to maintain output consistency (e.g. cancel, word order)
Updated variable names draft => proposal in proposal files