### PR TITLE
MMT-2067 Updating schema to include a column for submitter

### DIFF
--- a/app/concerns/proposal_index.rb
+++ b/app/concerns/proposal_index.rb
@@ -15,7 +15,7 @@ module ProposalIndex
     end
   end
 
-  def sort_by_submitter(proposals)
+  def sort_by_submitter(proposals, user_hash = {})
     @query = {}
     @query['sort_key'] = params['sort_key'] unless params['sort_key'].blank?
 
@@ -23,8 +23,8 @@ module ProposalIndex
                          # Making these arrays allows empty submitter_ids to sort last/first for ASC/DESC
                          # Using 0 for 'has submitter id' and 1 for 'does not have submitted id'
                          # allows these to naturally sort last in ASC order, and first in DESC order
-                         a_name = @urs_user_hash[a.submitter_id] ? [0, @urs_user_hash[a.submitter_id]] : [1, @urs_user_hash[a.submitter_id]]
-                         b_name = @urs_user_hash[b.submitter_id] ? [0, @urs_user_hash[b.submitter_id]] : [1, @urs_user_hash[b.submitter_id]]
+                         a_name = user_hash[a.submitter_id] ? [0, user_hash[a.submitter_id]] : [1, user_hash[a.submitter_id]]
+                         b_name = user_hash[b.submitter_id] ? [0, user_hash[b.submitter_id]] : [1, user_hash[b.submitter_id]]
                          if params['sort_key'] == 'submitter_id'
                            a_name <=> b_name
                          else

--- a/app/concerns/proposal_index.rb
+++ b/app/concerns/proposal_index.rb
@@ -1,7 +1,11 @@
+# Helper methods used in both dMMT and MMT to help display proposal lists
+
 module ProposalIndex
   extend ActiveSupport::Concern
   include GroupEndpoints
 
+  # Pass in an array of proposals to extract and query URS for user names
+  # set a variable for use in other functions/views
   def set_urs_user_hash(proposals)
     submitters = proposals.map { |proposal| proposal['submitter_id'] }.uniq
     urs_users = retrieve_urs_users(submitters)
@@ -16,6 +20,7 @@ module ProposalIndex
     @query['sort_key'] = params['sort_key'] unless params['sort_key'].blank?
 
     sorted_proposals = proposals.all.sort do |a, b|
+                         # Making these arrays allows empty submitter_ids to sort last/first for ASC/DESC
                          a_name = @urs_user_hash[a.submitter_id] ? [0, @urs_user_hash[a.submitter_id]] : [1, @urs_user_hash[a.submitter_id]]
                          b_name = @urs_user_hash[b.submitter_id] ? [0, @urs_user_hash[b.submitter_id]] : [1, @urs_user_hash[b.submitter_id]]
                          if params['sort_key'] == 'submitter_id'

--- a/app/concerns/proposal_index.rb
+++ b/app/concerns/proposal_index.rb
@@ -21,6 +21,8 @@ module ProposalIndex
 
     sorted_proposals = proposals.all.sort do |a, b|
                          # Making these arrays allows empty submitter_ids to sort last/first for ASC/DESC
+                         # Using 0 for 'has submitter id' and 1 for 'does not have submitted id'
+                         # allows these to naturally sort last in ASC order, and first in DESC order
                          a_name = @urs_user_hash[a.submitter_id] ? [0, @urs_user_hash[a.submitter_id]] : [1, @urs_user_hash[a.submitter_id]]
                          b_name = @urs_user_hash[b.submitter_id] ? [0, @urs_user_hash[b.submitter_id]] : [1, @urs_user_hash[b.submitter_id]]
                          if params['sort_key'] == 'submitter_id'

--- a/app/controllers/manage_proposal_controller.rb
+++ b/app/controllers/manage_proposal_controller.rb
@@ -32,7 +32,7 @@ class ManageProposalController < ManageMetadataController
 
       set_urs_user_hash(dmmt_response.body['proposals'])
       proposals = if sort_key == 'submitter_id'
-                    sort_by_submitter(dmmt_response.body['proposals'])
+                    sort_by_submitter(dmmt_response.body['proposals'], @urs_user_hash)
                   else
                     if sort_dir == 'ASC'
                       dmmt_response.body['proposals'].sort { |a, b| a[sort_key] <=> b[sort_key] }

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -11,14 +11,8 @@ module Proposal
     def index
       working_proposals = resource_class.all
       set_urs_user_hash(working_proposals)
-      if params['sort_key']&.include?('submitter_id')
-        resources = sort_by_submitter(working_proposals)
-        instance_variable_set("@#{plural_resource_name}", Kaminari.paginate_array(resources, total_count: resources.count).page(params.fetch('page', 1)).per(RESULTS_PER_PAGE))
-      else
-        resources = working_proposals.order(index_sort_order)
-                                  .page(params[:page]).per(RESULTS_PER_PAGE)
-        instance_variable_set("@#{plural_resource_name}", resources)
-      end
+      sort_for_index(working_proposals)
+
       @category_of_displayed_proposal = 'Collection'
       @specified_url = '/collection_draft_proposals'
     end
@@ -26,14 +20,8 @@ module Proposal
     def queued_index
       working_proposals = resource_class.where('proposal_status != ?', 'in_work')
       set_urs_user_hash(working_proposals)
-      if params['sort_key']&.include?('submitter_id')
-        resources = sort_by_submitter(working_proposals)
-        instance_variable_set("@#{plural_resource_name}", Kaminari.paginate_array(resources, total_count: resources.count).page(params.fetch('page', 1)).per(RESULTS_PER_PAGE))
-      else
-        resources = working_proposals.order(index_sort_order)
-                                     .page(params[:page]).per(RESULTS_PER_PAGE)
-        instance_variable_set("@#{plural_resource_name}", resources)
-      end
+      sort_for_index(working_proposals)
+
       @category_of_displayed_proposal = 'Queued'
       @specified_url = '/collection_draft_proposals/queued_index'
       render :index
@@ -42,14 +30,8 @@ module Proposal
     def in_work_index
       working_proposals = resource_class.where('proposal_status = ?', 'in_work')
       set_urs_user_hash(working_proposals)
-      if params['sort_key']&.include?('submitter_id')
-        resources = sort_by_submitter(working_proposals)
-        instance_variable_set("@#{plural_resource_name}", Kaminari.paginate_array(resources, total_count: resources.count).page(params.fetch('page', 1)).per(RESULTS_PER_PAGE))
-      else
-        resources = working_proposals.order(index_sort_order)
-                                     .page(params[:page]).per(RESULTS_PER_PAGE)
-        instance_variable_set("@#{plural_resource_name}", resources)
-      end
+      sort_for_index(working_proposals)
+
       @category_of_displayed_proposal = 'In Work'
       @specified_url = '/collection_draft_proposals/in_work_index'
       render :index
@@ -253,6 +235,17 @@ module Proposal
         "#{@query['sort_key']} ASC"
       else
         'updated_at DESC'
+      end
+    end
+
+    def sort_for_index(working_proposals)
+      if params['sort_key']&.include?('submitter_id')
+        resources = sort_by_submitter(working_proposals)
+        instance_variable_set("@#{plural_resource_name}", Kaminari.paginate_array(resources, total_count: resources.count).page(params.fetch('page', 1)).per(RESULTS_PER_PAGE))
+      else
+        resources = working_proposals.order(index_sort_order)
+                                     .page(params[:page]).per(RESULTS_PER_PAGE)
+        instance_variable_set("@#{plural_resource_name}", resources)
       end
     end
   end

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -240,7 +240,7 @@ module Proposal
 
     def sort_for_index(working_proposals)
       if params['sort_key']&.include?('submitter_id')
-        resources = sort_by_submitter(working_proposals)
+        resources = sort_by_submitter(working_proposals, @urs_user_hash)
         instance_variable_set("@#{plural_resource_name}", Kaminari.paginate_array(resources, total_count: resources.count).page(params.fetch('page', 1)).per(RESULTS_PER_PAGE))
       else
         resources = working_proposals.order(index_sort_order)

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -127,4 +127,8 @@ module ProposalsHelper
       'No actions are possible.'
     end
   end
+
+  def display_submitter_name(submitter_id)
+    @urs_user_hash[submitter_id] || 'Pending'
+  end
 end

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -128,7 +128,7 @@ module ProposalsHelper
     end
   end
 
-  def display_submitter_name(submitter_id)
-    @urs_user_hash[submitter_id] || 'Pending'
+  def display_submitter_name(submitter_id, user_hash = {})
+    user_hash[submitter_id] || 'Pending'
   end
 end

--- a/app/models/collection_draft_proposal.rb
+++ b/app/models/collection_draft_proposal.rb
@@ -31,9 +31,10 @@ class CollectionDraftProposal < CollectionDraft
 
       if request_type == 'delete'
         request.submit
+        request.submitter_id = user.urs_uid
         request.status_history =
           { 'submitted' =>
-            { 'username' => (username || user.urs_uid), 'action_date' => Time.new } }
+            { 'username' => username, 'action_date' => Time.new } }
       end
 
       request.save

--- a/app/views/manage_proposal/show.html.erb
+++ b/app/views/manage_proposal/show.html.erb
@@ -30,7 +30,7 @@
           <th><%= sort_by_link('Entry Title', 'entry_title', @query, nil, @specified_url) %></th>
           <th><%= sort_by_link('Proposal Status', 'proposal_status', @query, nil, @specified_url) %></th>
           <th><%= sort_by_link('Request Type', 'request_type', @query, nil, @specified_url) %></th>
-          <th><%= sort_by_link('User Name', 'user_name', @query, nil, @specified_url) %></th>
+          <th><%= sort_by_link('Submitter', 'user_name', @query, nil, @specified_url) %></th>
           <th><%= sort_by_link('Last Modified', 'updated_at', @query, nil, @specified_url) %></th>
           <th>Action</th>
         </tr>
@@ -59,7 +59,7 @@
               <%= proposal['request_type'].titleize %>
             </td>
             <td>
-              <%= proposal['status_history'].fetch('submitted', { 'username' => 'Not Provided' })['username'].titleize %>
+              <%= @urs_user_hash[proposal['submitter_id']] || 'Pending' %>
             </td>
             <td>
               <%= DateTime.parse(proposal['updated_at']).to_s(:date) %>

--- a/app/views/manage_proposal/show.html.erb
+++ b/app/views/manage_proposal/show.html.erb
@@ -59,7 +59,7 @@
               <%= proposal['request_type'].titleize %>
             </td>
             <td>
-              <%= @urs_user_hash[proposal['submitter_id']] || 'Pending' %>
+              <%= display_submitter_name(proposal['submitter_id']) %>
             </td>
             <td>
               <%= DateTime.parse(proposal['updated_at']).to_s(:date) %>

--- a/app/views/manage_proposal/show.html.erb
+++ b/app/views/manage_proposal/show.html.erb
@@ -59,7 +59,7 @@
               <%= proposal['request_type'].titleize %>
             </td>
             <td>
-              <%= display_submitter_name(proposal['submitter_id']) %>
+              <%= display_submitter_name(proposal['submitter_id'], @urs_user_hash) %>
             </td>
             <td>
               <%= DateTime.parse(proposal['updated_at']).to_s(:date) %>

--- a/app/views/proposal/collection_draft_proposals/index.html.erb
+++ b/app/views/proposal/collection_draft_proposals/index.html.erb
@@ -15,7 +15,7 @@
           <th><%= sort_by_link(entry_title_header(resource_name), 'entry_title', @query, nil, @specified_url) %></th>
           <th><%= sort_by_link('Proposal Status', 'proposal_status', @query, nil, @specified_url) %></th>
           <th><%= sort_by_link('Request Type', 'request_type', @query, nil, @specified_url) %></th>
-          <th>Submitter</th>
+          <th><%= sort_by_link('Submitter', 'submitter_id', @query, nil, @specified_url) %></th>
           <th><%= sort_by_link('Last Modified', 'updated_at', @query, nil, @specified_url) %></th>
         </tr>
       </thead>
@@ -43,7 +43,7 @@
               <%= "#{proposal.request_type.titleize}" %>
             </td>
             <td>
-              <%= proposal['status_history'].fetch('submitted', proposal.in_work? ? { 'username' => 'Pending' } : { 'username' => 'Not Provided' })['username'].titleize %>
+              <%= @urs_user_hash[proposal.submitter_id] || 'Pending' %>
             </td>
             <td>
               <%= proposal.updated_at.to_s(:date) %>

--- a/app/views/proposal/collection_draft_proposals/index.html.erb
+++ b/app/views/proposal/collection_draft_proposals/index.html.erb
@@ -43,7 +43,7 @@
               <%= "#{proposal.request_type.titleize}" %>
             </td>
             <td>
-              <%= @urs_user_hash[proposal.submitter_id] || 'Pending' %>
+              <%= display_submitter_name(proposal.submitter_id) %>
             </td>
             <td>
               <%= proposal.updated_at.to_s(:date) %>

--- a/app/views/proposal/collection_draft_proposals/index.html.erb
+++ b/app/views/proposal/collection_draft_proposals/index.html.erb
@@ -43,7 +43,7 @@
               <%= "#{proposal.request_type.titleize}" %>
             </td>
             <td>
-              <%= display_submitter_name(proposal.submitter_id) %>
+              <%= display_submitter_name(proposal.submitter_id, @urs_user_hash) %>
             </td>
             <td>
               <%= proposal.updated_at.to_s(:date) %>

--- a/db/migrate/20200107163307_add_submitter_column.rb
+++ b/db/migrate/20200107163307_add_submitter_column.rb
@@ -1,0 +1,10 @@
+class AddSubmitterColumn < ActiveRecord::Migration
+  def change
+    add_column 'draft_proposals', :submitter_id, :string
+
+    submitted_proposals = CollectionDraftProposal.where.not(proposal_status: 'in_work')
+    submitted_proposals.each do |proposal|
+      proposal.update_column('submitter_id', User.find(proposal.user_id).urs_uid) if proposal.submitter_id.blank?
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191120153904) do
+ActiveRecord::Schema.define(version: 20200107163307) do
 
   create_table "draft_proposals", force: :cascade do |t|
     t.integer  "user_id"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20191120153904) do
     t.datetime "updated_at",        null: false
     t.text     "status_history"
     t.string   "request_type",      null: false
+    t.string   "submitter_id"
   end
 
   create_table "drafts", force: :cascade do |t|

--- a/spec/features/manage_proposals/approver_workflow_spec.rb
+++ b/spec/features/manage_proposals/approver_workflow_spec.rb
@@ -3,6 +3,7 @@
 describe 'When going through the whole collection proposal approver workflow', js: true do
   before do
     login(real_login: true)
+    mock_urs_get_users
     allow_any_instance_of(PermissionChecking).to receive(:is_non_nasa_draft_approver?).and_return(true)
   end
 

--- a/spec/features/manage_proposals/manage_proposal_publish_spec.rb
+++ b/spec/features/manage_proposals/manage_proposal_publish_spec.rb
@@ -1,6 +1,7 @@
 describe 'When publishing collection draft proposals', js: true do
   before do
     login(real_login: true)
+    mock_urs_get_users
     allow_any_instance_of(PermissionChecking).to receive(:is_non_nasa_draft_approver?).and_return(true)
   end
 

--- a/spec/features/manage_proposals/manage_proposal_view_spec.rb
+++ b/spec/features/manage_proposals/manage_proposal_view_spec.rb
@@ -2,6 +2,7 @@ describe 'Proposals listed on the Manage Proposals (MMT) page', js: true do
   context 'when logging in with URS' do
     before do
       login(real_login: true)
+      mock_urs_get_users
       allow_any_instance_of(PermissionChecking).to receive(:is_non_nasa_draft_approver?).and_return(true)
     end
 
@@ -64,7 +65,7 @@ describe 'Proposals listed on the Manage Proposals (MMT) page', js: true do
       end
 
       it 'displays user names' do
-        expect(page).to have_content('Test User1')
+        expect(page).to have_content('Test User')
       end
 
       it 'has the correct header' do

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_create_from_collection_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_create_from_collection_spec.rb
@@ -25,6 +25,10 @@ describe 'Collection Draft Proposal creation from collection', js: true do
         expect(page).to have_content('Collection Metadata Delete Request Created Successfully!')
         expect(page).to have_content('Submitted')
       end
+
+      it 'has a submitter_id' do
+        expect(CollectionDraftProposal.last.submitter_id).to eq('testuser')
+      end
     end
 
     context 'when creating an update metadata proposal' do

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_list_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_list_spec.rb
@@ -2,6 +2,7 @@ describe 'Viewing Collection Draft Proposals Index Pages', js: true do
   context 'when logged in as a user' do
     before do
       login
+      mock_urs_get_users
       set_as_proposal_mode_mmt(with_draft_user_acl: true)
       create(:full_collection_draft_proposal, proposal_short_name: 'M Example Proposal', version: '5', proposal_entry_title: 'M Example Title')
       create(:full_collection_draft_proposal, proposal_short_name: 'N Example Proposal', version: '5', proposal_entry_title: 'N Example Title')
@@ -36,7 +37,7 @@ describe 'Viewing Collection Draft Proposals Index Pages', js: true do
       end
 
       it 'displays submitters' do
-        expect(page).to have_content('Test User1')
+        expect(page).to have_content('Test User')
         expect(page).to have_content('Pending')
       end
 
@@ -136,6 +137,30 @@ describe 'Viewing Collection Draft Proposals Index Pages', js: true do
         end
       end
 
+      context 'when sorting submitter asc' do
+        before do
+          click_on 'Sort by Submitter Asc'
+        end
+
+        it 'sorts in ascending order' do
+          within '.open-draft-proposals tbody tr:nth-child(1)' do
+            expect(page).to have_content('Z Example Title')
+          end
+        end
+
+        context 'when sorting submitter desc' do
+          before do
+            click_on 'Sort by Submitter Desc'
+          end
+
+          it 'sorts in descending order' do
+            within '.open-draft-proposals tbody tr:nth-child(6)' do
+              expect(page).to have_content('Z Example Title')
+            end
+          end
+        end
+      end
+
       context 'when sorting updated at' do
         before do
           click_on 'Sort by Last Modified Asc'
@@ -165,6 +190,7 @@ describe 'Viewing Collection Draft Proposals Index Pages', js: true do
   context 'when logged in as an approver' do
     before do
       login
+      mock_urs_get_users
       set_as_proposal_mode_mmt(with_draft_approver_acl: true)
       4.times { create(:full_collection_draft_proposal) }
       create(:full_collection_draft_proposal, proposal_short_name: 'An Example Proposal', version: '5', proposal_entry_title: 'An Example Title')

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
@@ -10,20 +10,35 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
       visit collection_draft_proposal_path(@collection_draft_proposal)
     end
 
-    context 'when the proposal is submitted' do
+    context 'when clicking the button to submit a proposal' do
       before do
         click_on 'Submit for Review'
       end
 
-      it 'submits a proposal' do
-        click_on 'Yes'
-        expect(page).to have_content('Collection Draft Proposal Submitted for Review Successfully')
-        expect(page).to have_no_link('Temporal Information')
+      context 'when clicking yes to submit a proposal' do
+        before do
+          click_on 'Yes'
+        end
+
+        it 'submits a proposal' do
+          expect(page).to have_content('Collection Draft Proposal Submitted for Review Successfully')
+          expect(page).to have_no_link('Temporal Information')
+          expect(CollectionDraftProposal.last.proposal_status).to eq('submitted')
+        end
+
+        it 'populates the submitter_id' do
+          expect(CollectionDraftProposal.last.submitter_id).to eq('testuser')
+        end
       end
 
-      it 'does not navigate away when cancelling' do
-        click_on 'No'
-        expect(page).to have_link('Temporal Information')
+      context 'when clicking no to submit a proposal' do
+        before do
+          click_on 'No'
+        end
+
+        it 'does not navigate away when cancelling' do
+          expect(page).to have_link('Temporal Information')
+        end
       end
     end
 

--- a/spec/features/proposal/manage_collection_proposals/open_proposals_spec.rb
+++ b/spec/features/proposal/manage_collection_proposals/open_proposals_spec.rb
@@ -46,6 +46,7 @@ describe 'Proposals listed on the Manage Collection Proposals page', js: true do
 
       context 'when visiting the index page' do
         before do
+          mock_urs_get_users
           visit collection_draft_proposals_path
         end
 

--- a/spec/support/approved_proposals_helpers.rb
+++ b/spec/support/approved_proposals_helpers.rb
@@ -69,7 +69,7 @@ module Helpers
 
     # Fake getting user names from URS for updating proposal status in dMMT
     def mock_urs_get_users
-      urs_response_body = { 'users' => [{ 'first_name' => 'Test', 'last_name' => 'User' }] }
+      urs_response_body = { 'users' => [{ 'first_name' => 'Test', 'last_name' => 'User', 'uid': 'testuser' }] }
       urs_response = cmr_success_response(urs_response_body.to_json)
       allow_any_instance_of(Cmr::UrsClient).to receive(:get_urs_users).and_return(urs_response)
     end

--- a/spec/support/proposal_status_helper.rb
+++ b/spec/support/proposal_status_helper.rb
@@ -11,7 +11,7 @@ module Helpers
       record.proposal_status = 'submitted'
       record.status_history = { 'submitted' => { 'username' => 'TestUser1', 'action_date' => '2019-10-11 01:00' } }
       record.approver_feedback = {}
-      record.submitter_id = 'TestUser1'
+      record.submitter_id = 'testuser'
       record.save
     end
 
@@ -23,7 +23,7 @@ module Helpers
           'approved' =>
             { 'username' => 'TestUser2', 'action_date' => '2019-10-11 02:00' } }
       record.approver_feedback = {}
-      record.submitter_id = 'TestUser1'
+      record.submitter_id = 'testuser'
       record.save
     end
 
@@ -37,7 +37,7 @@ module Helpers
       record.approver_feedback =
         { 'reasons' => ['Misspellings/Grammar', 'Other'],
           'note' => 'Test Reason for rejecting a proposal' }
-      record.submitter_id = 'TestUser1'
+      record.submitter_id = 'testuser'
       record.save
     end
 
@@ -55,7 +55,7 @@ module Helpers
       record.proposal_status = 'done'
       record.status_history = { 'submitted' => { 'username' => 'TestUser1', 'action_date' => '2019-10-11 01:00' }, 'approved' => { 'username' => 'TestUser2', 'action_date' => '2019-10-11 02:00' }, 'done' => { 'username' => 'TestUser4', 'action_date' => '2019-10-11 04:00' } }
       record.approver_feedback = {}
-      record.submitter_id = 'TestUser1'
+      record.submitter_id = 'testuser'
       record.save
     end
   end

--- a/spec/support/proposal_status_helper.rb
+++ b/spec/support/proposal_status_helper.rb
@@ -11,6 +11,7 @@ module Helpers
       record.proposal_status = 'submitted'
       record.status_history = { 'submitted' => { 'username' => 'TestUser1', 'action_date' => '2019-10-11 01:00' } }
       record.approver_feedback = {}
+      record.submitter_id = 'TestUser1'
       record.save
     end
 
@@ -22,6 +23,7 @@ module Helpers
           'approved' =>
             { 'username' => 'TestUser2', 'action_date' => '2019-10-11 02:00' } }
       record.approver_feedback = {}
+      record.submitter_id = 'TestUser1'
       record.save
     end
 
@@ -35,6 +37,7 @@ module Helpers
       record.approver_feedback =
         { 'reasons' => ['Misspellings/Grammar', 'Other'],
           'note' => 'Test Reason for rejecting a proposal' }
+      record.submitter_id = 'TestUser1'
       record.save
     end
 
@@ -44,6 +47,7 @@ module Helpers
       record.approver_feedback =
         { 'reasons' => ['Misspellings/Grammar', 'Other'],
           'note' => 'Test Reason for rejecting a proposal' }
+      record.submitter_id = nil
       record.save
     end
 
@@ -51,6 +55,7 @@ module Helpers
       record.proposal_status = 'done'
       record.status_history = { 'submitted' => { 'username' => 'TestUser1', 'action_date' => '2019-10-11 01:00' }, 'approved' => { 'username' => 'TestUser2', 'action_date' => '2019-10-11 02:00' }, 'done' => { 'username' => 'TestUser4', 'action_date' => '2019-10-11 04:00' } }
       record.approver_feedback = {}
+      record.submitter_id = 'TestUser1'
       record.save
     end
   end


### PR DESCRIPTION
And updating sorting on the various index/manage proposal pages to enable sorting by submitter.
Migration to add the user_id of the person who created the record if there is no submitter_id.  This decision was made because it simplified the migration and did not add urs_uid's to our repo.