### PR TITLE
MMT-1719 Approver E-mails when a Proposal is Submitted

### DIFF
--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -104,7 +104,7 @@ module Proposal
         Rails.logger.info("Audit Log: User #{current_user.urs_uid} successfully submitted #{resource_name.titleize} with title: '#{get_resource.entry_title}' and id: #{get_resource.id} (a #{get_resource.request_type} metadata request).")
 
         ProposalMailer.proposal_submitted_notification(get_user_info, get_resource.draft['ShortName'], get_resource.draft['Version'], params['id'], get_resource.request_type).deliver_now
-        approver_users = get_approver_emails(ENV['approvers_urs'].split(','))
+        approver_users = get_approver_emails
         approver_users.each do |approver|
           ProposalMailer.proposal_submitted_approvers_notification(approver, get_resource, get_user_info).deliver_now
         end
@@ -230,8 +230,10 @@ module Proposal
       { name: "#{proposal_urs_user['first_name']} #{proposal_urs_user['last_name']}", email: proposal_urs_user['email_address'] } unless proposal_urs_user.blank?
     end
 
-    def get_approver_emails(approvers_urs)
-      approver_urs_users = retrieve_urs_users(approvers_urs)
+    # Get urs users and get emails from urs for approvers
+    # Returns array of hashes for each user
+    def get_approver_emails
+      approver_urs_users = retrieve_urs_users(ENV['approvers_urs'].split(','))
       approver_emails = []
       approver_urs_users.each do |approver|
         approver_emails.push(name: "#{approver['first_name']} #{approver['last_name']}", email: approver['email_address'])

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -104,6 +104,10 @@ module Proposal
         Rails.logger.info("Audit Log: User #{current_user.urs_uid} successfully submitted #{resource_name.titleize} with title: '#{get_resource.entry_title}' and id: #{get_resource.id} (a #{get_resource.request_type} metadata request).")
 
         ProposalMailer.proposal_submitted_notification(get_user_info, get_resource.draft['ShortName'], get_resource.draft['Version'], params['id'], get_resource.request_type).deliver_now
+        approver_users = get_approver_emails(ENV['approvers_urs'].split(','))
+        approver_users.each do |approver|
+          ProposalMailer.proposal_submitted_approvers_notification(approver, get_resource, get_user_info).deliver_now
+        end
 
         flash[:success] = I18n.t("controllers.draft.#{plural_resource_name}.submit.flash.success")
       else
@@ -224,6 +228,15 @@ module Proposal
     def submitter_from_resource
       proposal_urs_user = retrieve_urs_users([get_resource.submitter_id])[0]
       { name: "#{proposal_urs_user['first_name']} #{proposal_urs_user['last_name']}", email: proposal_urs_user['email_address'] } unless proposal_urs_user.blank?
+    end
+
+    def get_approver_emails(approvers_urs)
+      approver_urs_users = retrieve_urs_users(approvers_urs)
+      approver_emails = []
+      approver_urs_users.each do |approver|
+        approver_emails.push(name: "#{approver['first_name']} #{approver['last_name']}", email: approver['email_address'])
+      end
+      approver_emails
     end
 
     # TODO: Investigate if this can be used to provide sorting to all drafts.

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -47,4 +47,17 @@ class ProposalMailer < ApplicationMailer
 
     mail(to: "#{@user[:name]} <#{@user[:email]}>", subject: email_subject)
   end
+
+  def proposal_submitted_approvers_notification(approver, proposal, user)
+    @approver = approver
+    @user = user
+    @short_name = proposal.draft['ShortName']
+    @version = proposal.draft['Version']
+    @id = proposal.id
+    @request_type = proposal.request_type
+
+    email_subject = "New #{@request_type.titleize} Collection Proposal Submitted in Metadata Management Tool"
+
+    mail(to: "#{@approver[:name]} <#{@approver[:email]}>", subject: email_subject)
+  end
 end

--- a/app/views/proposal_mailer/proposal_submitted_approvers_notification.html.erb
+++ b/app/views/proposal_mailer/proposal_submitted_approvers_notification.html.erb
@@ -1,0 +1,18 @@
+<h1 class="styled-heading"><%= "#{@short_name}_#{@version} Submitted" %></h1>
+
+
+<div class="email-message">
+  <p>
+    <%= @approver[:name] %>,
+  </p>
+  <p>
+    <%= "A collection metadata proposal #{@short_name}_#{@version} has been submitted by #{@user[:name]} for review." %>
+  </p>
+  <div class="center">
+    <%= link_to 'View Collection Metadata Proposal', collection_draft_proposal_url(@id), class: 'btn btn-blue' %>
+  </div>
+</div>
+
+<div class="email-footer">
+  <img src="https://cdn.earthdata.nasa.gov/eui/latest/docs/assets/ed-logos/meatball.png" alt="Meatball" class="image-center" />
+</div>

--- a/app/views/proposal_mailer/proposal_submitted_approvers_notification.text.erb
+++ b/app/views/proposal_mailer/proposal_submitted_approvers_notification.text.erb
@@ -1,0 +1,5 @@
+<%= @approver[:name] %>,
+
+<%= "A collection metadata proposal #{@short_name}_#{@version} has been submitted by #{@user[:name]} for review." %>
+
+View Collection: <%= collection_draft_proposal_url(@id) %>

--- a/spec/features/manage_proposals/approver_workflow_spec.rb
+++ b/spec/features/manage_proposals/approver_workflow_spec.rb
@@ -21,8 +21,6 @@ describe 'When going through the whole collection proposal approver workflow', j
         mock_valid_token_validation
         visit manage_proposals_path
 
-        # Mock URS call to get information to update status history
-        mock_urs_get_users
         within '.open-draft-proposals tbody tr:nth-child(1)' do
           click_on 'Publish'
         end
@@ -84,8 +82,6 @@ describe 'When going through the whole collection proposal approver workflow', j
         mock_valid_token_validation
         visit manage_proposals_path
 
-        # Mock URS call to get information to update status history
-        mock_urs_get_users
         within '.open-draft-proposals tbody tr:nth-child(1)' do
           click_on 'Publish'
         end
@@ -134,8 +130,6 @@ describe 'When going through the whole collection proposal approver workflow', j
         mock_valid_token_validation
         visit manage_proposals_path
 
-        # Mock URS call to get information to update status history
-        mock_urs_get_users
         within '.open-draft-proposals tbody tr:nth-child(1)' do
           click_on 'Delete'
         end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
@@ -12,13 +12,14 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
 
     context 'when the submit proposal button is clicked' do
       before do
-        mock_urs_get_users(count: 2)
-        @email_count = ActionMailer::Base.deliveries.count
         click_on 'Submit for Review'
       end
 
       context 'when clicking yes to submit a proposal' do
         before do
+          mock_get_approver_emails
+          mock_urs_get_users(count: 2)
+          @email_count = ActionMailer::Base.deliveries.count
           click_on 'Yes'
         end
 

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
@@ -10,8 +10,10 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
       visit collection_draft_proposal_path(@collection_draft_proposal)
     end
 
-    context 'when clicking the button to submit a proposal' do
+    context 'when the submit proposal button is clicked' do
       before do
+        mock_urs_get_users(count: 2)
+        @email_count = ActionMailer::Base.deliveries.count
         click_on 'Submit for Review'
       end
 
@@ -29,9 +31,16 @@ describe 'Collection Draft Proposal Submit and Rescind', js: true do
         it 'populates the submitter_id' do
           expect(CollectionDraftProposal.last.submitter_id).to eq('testuser')
         end
+
+        it 'sends emails' do
+          # Expect 3 emails because of the mock call above; 1 to user and 2 to approvers
+          expect(ActionMailer::Base.deliveries.count).to eq(@email_count + 3)
+          expect(ActionMailer::Base.deliveries.last.body.parts[0].body.raw_source).to match(/has been submitted by/)
+          expect(ActionMailer::Base.deliveries.last.body.parts[1].body.raw_source).to match(/has been submitted by/)
+        end
       end
 
-      context 'when clicking no to submit a proposal' do
+      context 'when the no button is clicked' do
         before do
           click_on 'No'
         end

--- a/spec/mailers/previews/proposal_mailer_preview.rb
+++ b/spec/mailers/previews/proposal_mailer_preview.rb
@@ -5,8 +5,9 @@ class ProposalMailerPreview < ActionMailer::Preview
     short_name = 'CIESIN_SEDAC_EPI_2010'
     version = 2010
     id = 1
+    request_type = 'create'
 
-    ProposalMailer.proposal_submitted_notification(user, short_name, version, id)
+    ProposalMailer.proposal_submitted_notification(user, short_name, version, id, request_type)
   end
 
   def new_proposal_submitted_approvers_notification
@@ -25,8 +26,9 @@ class ProposalMailerPreview < ActionMailer::Preview
     short_name = 'CIESIN_SEDAC_EPI_2010'
     version = 2010
     id = 1
+    request_type = 'create'
 
-    ProposalMailer.proposal_approved_notification(user, short_name, version, id)
+    ProposalMailer.proposal_approved_notification(user, short_name, version, id, request_type)
   end
 
   def new_proposal_published_delete_notification

--- a/spec/mailers/previews/proposal_mailer_preview.rb
+++ b/spec/mailers/previews/proposal_mailer_preview.rb
@@ -9,6 +9,17 @@ class ProposalMailerPreview < ActionMailer::Preview
     ProposalMailer.proposal_submitted_notification(user, short_name, version, id)
   end
 
+  def new_proposal_submitted_approvers_notification
+    proposal = CollectionDraftProposal.new
+    proposal.id = 1
+    proposal.draft = { 'ShortName': 'CIESIN_SEDAC_EPI_2010', 'Version': '2010' }
+    proposal.request_type = 'create'
+    user = { name: 'Captain Planet', email: 'supergreen@bluemarble.com' }
+    approver = { name: 'Clark Kent', email: 'supergreen@bluemarble.com' }
+
+    ProposalMailer.proposal_submitted_approvers_notification(approver, proposal, user)
+  end
+
   def new_proposal_approved_notification
     user = { name: 'Captain Planet', email: 'supergreen@bluemarble.com' }
     short_name = 'CIESIN_SEDAC_EPI_2010'

--- a/spec/mailers/proposal_mailer_spec.rb
+++ b/spec/mailers/proposal_mailer_spec.rb
@@ -130,5 +130,39 @@ describe ProposalMailer do
         expect(mail.text_part.body).to have_content(collection_draft_proposal_url(proposal.id))
       end
     end
+
+    context 'when submitting a new record (approvers)' do
+      proposal = CollectionDraftProposal.new
+      proposal.id = 1
+      proposal.draft = { 'ShortName': 'CIESIN_SEDAC_EPI_2010', 'Version': '2010' }
+      proposal.request_type = 'create'
+      user = { name: 'Captain Planet', email: 'supergreen@bluemarble.com' }
+      approver = { name: 'Clark Kent', email: 'supergreen2@bluemarble.com' }
+      let(:mail) { described_class.proposal_submitted_approvers_notification(approver, proposal, user) }
+
+      it 'renders the subject' do
+        expect(mail.subject).to eq('New Create Collection Proposal Submitted in Metadata Management Tool')
+      end
+
+      it 'renders the receiver email' do
+        expect(mail.to).to eq([approver[:email]])
+      end
+
+      it 'renders the sender email' do
+        expect(mail.from).to eq(['no-reply@mmt.earthdata.nasa.gov'])
+      end
+
+      it 'renders the new metadata submitted notice including short name + version' do
+        expect(mail.html_part.body).to have_content("#{proposal.draft['ShortName']}_#{proposal.draft['Version']} Submitted")
+        expect(mail.html_part.body).to have_content("#{approver[:name]}, A collection metadata proposal #{proposal.draft['ShortName']}_#{proposal.draft['Version']} has been submitted by #{user[:name]} for review.", normalize_ws: true)
+        expect(mail.text_part.body).to have_content("#{approver[:name]}, A collection metadata proposal #{proposal.draft['ShortName']}_#{proposal.draft['Version']} has been submitted by #{user[:name]} for review.", normalize_ws: true)
+      end
+
+      it 'renders the link to the collection' do
+        expect(mail.html_part.body).to have_link('View Collection Metadata Proposal', href: collection_draft_proposal_url(proposal.id))
+        # link renders as text in text format email
+        expect(mail.text_part.body).to have_content(collection_draft_proposal_url(proposal.id))
+      end
+    end
   end
 end

--- a/spec/support/approved_proposals_helpers.rb
+++ b/spec/support/approved_proposals_helpers.rb
@@ -78,5 +78,20 @@ module Helpers
       urs_response = cmr_success_response(urs_response_body.to_json)
       allow_any_instance_of(Cmr::UrsClient).to receive(:get_urs_users).and_return(urs_response)
     end
+
+    # Fake getting ACLs from CMR, then getting groups from CMR, then getting group members from CMR
+    def mock_get_approver_emails
+      get_permissions_response_body = { 'items' => [{ 'revision_id' => 1, 'concept_id' => 'ACL1200000353-CMR', 'identity_type' => 'Provider', 'name' => 'Provider - MMT_2 - NON_NASA_DRAFT_APPROVER', 'location' => 'http://localhost:3011/acls/ACL1200000353-CMR' }] }
+      get_permission_response_body = { 'group_permissions' => [{ 'group_id' => 'AG1200000351-MMT_2', 'permissions' => ['create'] }] }
+      group_member_response_body = %w[user1 user2]
+
+      get_permissions_response = cmr_success_response(get_permissions_response_body.to_json)
+      get_permission_response = cmr_success_response(get_permission_response_body.to_json)
+      group_member_response = cmr_success_response(group_member_response_body.to_json)
+
+      allow_any_instance_of(Cmr::CmrClient).to receive(:get_permissions).and_return(get_permissions_response)
+      allow_any_instance_of(Cmr::CmrClient).to receive(:get_permission).and_return(get_permission_response)
+      allow_any_instance_of(Cmr::CmrClient).to receive(:get_group_members).and_return(group_member_response)
+    end
   end
 end


### PR DESCRIPTION
Updated how I was getting the approvers' URS to send the submission e-mails.  This method would tie the e-mails to whomever has the create permissions for approvers in SCIOPS.  