### PR TITLE
MMT-2031 Removing Database Cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ gem 'bootstrap3-datetimepicker-rails'
 gem 'breadcrumbs_on_rails'
 gem 'builder'
 gem 'carmen', '~>1.0.2'  # countries and subdivisions
-gem 'database_cleaner' # added to provide a solution to Capybara's problems with js=>true
 gem 'factory_girl_rails', :require => true
 gem 'faker'
 gem 'figaro'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,8 +115,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
+    connection_pool (2.2.2)
     crass (1.0.5)
-    database_cleaner (1.7.0)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.3.2)
@@ -360,7 +360,7 @@ DEPENDENCIES
   carmen (~> 1.0.2)
   cmr_metadata_preview!
   coffee-rails (~> 4.2.0)
-  database_cleaner
+  connection_pool
   factory_girl_rails
   faker
   faraday

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,6 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
-    connection_pool (2.2.2)
     crass (1.0.5)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
@@ -360,7 +359,6 @@ DEPENDENCIES
   carmen (~> 1.0.2)
   cmr_metadata_preview!
   coffee-rails (~> 4.2.0)
-  connection_pool
   factory_girl_rails
   faker
   faraday

--- a/spec/features/collection_templates/template_index_spec.rb
+++ b/spec/features/collection_templates/template_index_spec.rb
@@ -29,7 +29,7 @@ describe 'When visiting the template index page', js:true do
       expect(page).to have_content('An Example Template') # in the breadcrumbs
       expect(page).to have_content('Metadata Preview')
     end
-    
+
     context 'when there are multiple records' do
       before do
         create(:full_collection_template, collection_template_name: 'An Example Template2')

--- a/spec/features/collection_templates/template_index_spec.rb
+++ b/spec/features/collection_templates/template_index_spec.rb
@@ -4,15 +4,15 @@ describe 'When visiting the template index page', js:true do
   context 'when there is one record' do
     before do
       login
-      create(:full_collection_template, collection_template_name: 'An Example Template')
+      @template = create(:full_collection_template, collection_template_name: 'An Example Template')
       visit collection_templates_path
     end
 
     it 'has expected links for one record' do
       # Create button is actually a link
       expect(page).to have_link('Create a Collection Template', href: '/collection_templates/new')
-      expect(page).to have_link('An Example Template', href: '/collection_templates/1')
-      expect(page).to have_link('Edit', href: '/collection_templates/1/edit')
+      expect(page).to have_link('An Example Template', href: collection_template_path(@template['id']))
+      expect(page).to have_link('Edit', href: edit_collection_template_path(@template['id']))
       expect(page).to have_link('Delete', href: '#delete-template-modal-0')
     end
 
@@ -32,17 +32,17 @@ describe 'When visiting the template index page', js:true do
 
     context 'when there are multiple records' do
       before do
-        create(:full_collection_template, collection_template_name: 'An Example Template2')
+        @template2 = create(:full_collection_template, collection_template_name: 'An Example Template2')
         visit collection_templates_path
       end
 
       it 'has expected links for both records' do
-        expect(page).to have_link('An Example Template', href: '/collection_templates/1')
-        expect(page).to have_link('Edit', href: '/collection_templates/1/edit')
+        expect(page).to have_link('An Example Template', href: collection_template_path(@template['id']))
+        expect(page).to have_link('Edit', href: edit_collection_template_path(@template['id']))
         expect(page).to have_link('Delete', href: '#delete-template-modal-0')
 
-        expect(page).to have_link('An Example Template', href: '/collection_templates/2')
-        expect(page).to have_link('Edit', href: '/collection_templates/2/edit')
+        expect(page).to have_link('An Example Template2', href: collection_template_path(@template2['id']))
+        expect(page).to have_link('Edit', href: edit_collection_template_path(@template2['id']))
         expect(page).to have_link('Delete', href: '#delete-template-modal-1')
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,6 @@ require 'rspec/rails'
 require 'selenium/webdriver'
 require 'rack_session_access/capybara'
 require 'capybara-screenshot/rspec'
-require 'database_cleaner'
 
 require 'rake'
 require 'rails/tasks'
@@ -104,30 +103,31 @@ RSpec.configure do |config|
 
   Capybara.default_max_wait_time = (ENV['CAPYBARA_WAIT_TIME'] || 15).to_i
 
+  config.use_transactional_fixtures = true
+  # This was necessary pre Rails 5, but Rails 5 may support transactional fixtures for Capybara.
   # Lines below taken from http://stackoverflow.com/questions/8178120/capybara-with-js-true-causes-test-to-fail
-  config.use_transactional_fixtures = false
   # https://github.com/rails/rails/pull/19282
   # config.use_transactional_tests = false
-  config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
-  end
+  # config.before(:suite) do
+  #   DatabaseCleaner.clean_with(:truncation)
+  # end
 
-  config.before(:each) do
-    # set the default
-    DatabaseCleaner.strategy = :transaction
-  end
+  # config.before(:each) do
+  #   # set the default
+  #   DatabaseCleaner.strategy = :transaction
+  # end
 
-  config.before(:each, type: :feature) do
-    DatabaseCleaner.strategy = :truncation
-  end
+  # config.before(:each, type: :feature) do
+  #   DatabaseCleaner.strategy = :truncation
+  # end
 
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
+  # config.before(:each) do
+  #   DatabaseCleaner.start
+  # end
 
-  config.append_after(:each) do
-    DatabaseCleaner.clean
-  end
+  # config.append_after(:each) do
+  #   DatabaseCleaner.clean
+  # end
   # End of lines from http://stackoverflow.com/questions/8178120/capybara-with-js-true-causes-test-to-fail
 
   # Catch all requests, specific examples are still caught using their specific cassettes

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -104,31 +104,9 @@ RSpec.configure do |config|
   Capybara.default_max_wait_time = (ENV['CAPYBARA_WAIT_TIME'] || 15).to_i
 
   config.use_transactional_fixtures = true
-  # This was necessary pre Rails 5, but Rails 5 may support transactional fixtures for Capybara.
-  # Lines below taken from http://stackoverflow.com/questions/8178120/capybara-with-js-true-causes-test-to-fail
+  # Rails 5 appears to support transactional fixtures for Capybara.
+  # If this regresses, the old solution was taken from: http://stackoverflow.com/questions/8178120/capybara-with-js-true-causes-test-to-fail
   # https://github.com/rails/rails/pull/19282
-  # config.use_transactional_tests = false
-  # config.before(:suite) do
-  #   DatabaseCleaner.clean_with(:truncation)
-  # end
-
-  # config.before(:each) do
-  #   # set the default
-  #   DatabaseCleaner.strategy = :transaction
-  # end
-
-  # config.before(:each, type: :feature) do
-  #   DatabaseCleaner.strategy = :truncation
-  # end
-
-  # config.before(:each) do
-  #   DatabaseCleaner.start
-  # end
-
-  # config.append_after(:each) do
-  #   DatabaseCleaner.clean
-  # end
-  # End of lines from http://stackoverflow.com/questions/8178120/capybara-with-js-true-causes-test-to-fail
 
   # Catch all requests, specific examples are still caught using their specific cassettes
   config.around(:each) do |spec|


### PR DESCRIPTION
Rails 5 added the necessary support to remove database cleaner.  Needed to lightly rewrite a pair of template tests to get them to pass due to the change.  Using database cleaner caused the ids to reset for each test (e.g. the first one always had an id of 1), but transactional fixtures still allows the record id to increment (e.g. each id is random based on the order the tests are run).  The tests were updated to be agnostic to this (like the rest of the tests of this nature in our codebase).  