### PR TITLE
MMT-2125 Mitigating jquery not defined problems in bamboo

### DIFF
--- a/spec/support/ajax_helpers.rb
+++ b/spec/support/ajax_helpers.rb
@@ -29,8 +29,9 @@ module Helpers
     end
 
     def finished_all_jQuery_requests?
+      puts "I am looping"
       # puts "checking jQuery requests. no active calls? #{page.evaluate_script('jQuery.active').zero?}"
-      page.evaluate_script('jQuery.active').zero?
+      page.execute_script('return !!window.jQuery && jQuery.active === 0')
     end
   end
 end

--- a/spec/support/ajax_helpers.rb
+++ b/spec/support/ajax_helpers.rb
@@ -29,7 +29,6 @@ module Helpers
     end
 
     def finished_all_jQuery_requests?
-      puts "I am looping"
       # puts "checking jQuery requests. no active calls? #{page.evaluate_script('jQuery.active').zero?}"
       page.execute_script('return !!window.jQuery && jQuery.active === 0')
     end


### PR DESCRIPTION
When I looked at where this error was occurring, I noticed that it seemed to be related to provider context switching.  One of the things that happens in that context is page loading while under the loop in wait_for_jquery.  
My hypothesis is that jQuery.active was being called after a page load was triggered and before jQuery had been loaded, so it was not defined.  
If the problem rested with some greater jQuery being undefined issue, I would expect the loop in wait_for_jquery to never end.  I think that my hypothesis is supported by this change being tested in bamboo 8 times and not hanging infinitely.  If the observed rate of success before the change was roughly 1 in 3, 8 successes in a row is something like 1 in 6500.  