### PR TITLE
MMT-2137 Adjusting tests for variable uniqueness changes in CMR

### DIFF
--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -103,7 +103,7 @@ Rails.application.configure do
   config.templates_enabled = true
 
   # Feature toggle for approver workflow in MMT.
-  config.mmt_approver_workflow_enabled = false
+  config.mmt_approver_workflow_enabled = true
 
   config.cmr_env = 'uat'
   config.echo_env = 'uat'

--- a/spec/features/variables/create_collection_association_spec.rb
+++ b/spec/features/variables/create_collection_association_spec.rb
@@ -120,6 +120,22 @@ describe 'Creating Variable Collection Associations', js: true, reset_provider: 
           end
         end
 
+        it 'shows a failure message' do
+          expect(page).to have_content('Only one collection allowed in the list because a variable can only be associated with one collection.')
+        end
+      end
+
+      context 'When submitting the form with one AMSR-E record selected' do
+        before do
+          within '#collections-select' do
+            find("input[value='#{@collection_ingest_response1['concept-id']}']").set(true)
+
+            click_button 'Submit'
+
+            wait_for_cmr
+          end
+        end
+
         it 'shows a success message' do
           expect(page).to have_content('Collection Associations Created Successfully!')
         end
@@ -133,15 +149,13 @@ describe 'Creating Variable Collection Associations', js: true, reset_provider: 
 
           it 'shows the associated collections' do
             within '#collection-associations' do
-              expect(page).to have_selector('tbody > tr', count: 2)
+              expect(page).to have_selector('tbody > tr', count: 1)
 
               within 'tbody tr:nth-child(1)' do
-                expect(page).to have_content('MODIS-I Water Skipper')
-              end
-              within 'tbody tr:nth-child(2)' do
                 expect(page).to have_content('MODIS-I Water Traveler')
               end
 
+              expect(page).to have_no_content('MODIS-I Water Skipper')
               expect(page).to have_no_content('AQUA Not MODIS-I')
             end
           end

--- a/spec/features/variables/delete_collection_assocation_spec.rb
+++ b/spec/features/variables/delete_collection_assocation_spec.rb
@@ -6,12 +6,11 @@ describe 'Deleting Variable Collection Associations', js: true, reset_provider: 
 
     @variable_ingest_response, _concept_response = publish_variable_draft
 
-    create_variable_collection_association(@variable_ingest_response['concept-id'], @ingest_response1['concept-id'], @ingest_response2['concept-id'])
+    create_variable_collection_association(@variable_ingest_response['concept-id'], @ingest_response1['concept-id'])
   end
 
   before :all do
     @ingest_response1, _concept_response1 = publish_collection_draft(entry_title: 'MODIS-I Water Traveler')
-    @ingest_response2, _concept_response2 = publish_collection_draft(entry_title: 'MODIS-I Water Skipper')
   end
 
   context 'When viewing the associated collections page' do
@@ -21,12 +20,9 @@ describe 'Deleting Variable Collection Associations', js: true, reset_provider: 
 
     it 'shows the associated collections' do
       within '#collection-associations' do
-        expect(page).to have_selector('tbody > tr', count: 2)
+        expect(page).to have_selector('tbody > tr', count: 1)
 
         within 'tbody tr:nth-child(1)' do
-          expect(page).to have_content('MODIS-I Water Skipper')
-        end
-        within 'tbody tr:nth-child(2)' do
           expect(page).to have_content('MODIS-I Water Traveler')
         end
       end
@@ -59,14 +55,12 @@ describe 'Deleting Variable Collection Associations', js: true, reset_provider: 
             click_link 'refresh the page'
           end
 
-          it 'reloades the page and dislay the correct associations' do
+          it 'reloads the page and displays no associations' do
             within '#collection-associations' do
               expect(page).to have_selector('tbody > tr', count: 1)
+              expect(page).to have_content('No Collection Associations found.')
 
-              within 'tbody tr:nth-child(1)' do
-                expect(page).to have_content('MODIS-I Water Skipper')
-              end
-
+              expect(page).to have_no_content('MODIS-I Water Skipper')
               expect(page).to have_no_content('MODIS-I Water Traveler')
             end
           end

--- a/spec/features/variables/delete_variable_spec.rb
+++ b/spec/features/variables/delete_variable_spec.rb
@@ -5,11 +5,9 @@ describe 'Delete variable', js: true do
     @ingested_variable_with_associations, _concept_response = publish_variable_draft
 
     ingested_collection_1, _concept_response = publish_collection_draft
-    ingested_collection_2, _concept_response = publish_collection_draft
 
     create_variable_collection_association(@ingested_variable_with_associations['concept-id'],
-                                           ingested_collection_1['concept-id'],
-                                           ingested_collection_2['concept-id'])
+                                           ingested_collection_1['concept-id'])
 
     @ingested_variable_without_associations, _concept_response = publish_variable_draft
 
@@ -21,7 +19,7 @@ describe 'Delete variable', js: true do
   end
 
   context 'when viewing a published variable' do
-    context 'when the variable has associated collections' do
+    context 'when the variable has an associated collection' do
       before do
         visit variable_path(@ingested_variable_with_associations['concept-id'])
       end
@@ -41,7 +39,7 @@ describe 'Delete variable', js: true do
 
         it 'informs the user of the number of collection associations that will also be deleted' do
           # 2 associated collections
-          expect(page).to have_content('This variable is associated with 2 collections. Deleting this variable will also delete the collection associations.')
+          expect(page).to have_content('This variable is associated with 1 collections. Deleting this variable will also delete the collection associations.')
         end
 
         context 'when clicking Yes' do

--- a/spec/features/variables/variable_permissions_spec.rb
+++ b/spec/features/variables/variable_permissions_spec.rb
@@ -125,14 +125,12 @@ describe 'Variables permissions', js: true do
             expect(page).to have_no_content('collections. Deleting this variable will also delete the collection associations')
           end
 
-          context 'when the variable has associated collections' do
+          context 'when the variable has an associated collection' do
             before :all do
               ingested_collection_1, concept_response_1 = publish_collection_draft
-              ingested_collection_2, concept_response_2 = publish_collection_draft
 
               create_variable_collection_association(@ingested_variable_for_delete_modal['concept-id'],
-                                                     ingested_collection_1['concept-id'],
-                                                     ingested_collection_2['concept-id'])
+                                                     ingested_collection_1['concept-id'])
             end
 
             before do
@@ -147,7 +145,7 @@ describe 'Variables permissions', js: true do
 
             it 'informs the user of the number of collection associations that will also be deleted' do
               # 2 associations created
-              expect(page).to have_content('This variable is associated with 2 collections. Deleting this variable will also delete the collection associations')
+              expect(page).to have_content('This variable is associated with 1 collections. Deleting this variable will also delete the collection associations')
             end
           end
         end


### PR DESCRIPTION
CMR made a change such that you cannot associate two collections to one variable.  Some of our tests tested for that specifically and needed to be changed as a consequence.  