### PR TITLE
MMT-2126 Stop displaying/logging tokens returned by CMR in error messages

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -68,7 +68,7 @@ class CollectionsController < ManageCollectionsController
       Rails.logger.info("Audit Log: Collection Revision for record #{@concept_id} with native_id: #{@native_id} for provider: #{@provider_id} by user #{session[:urs_uid]} has been successfully revised")
       redirect_to collection_revisions_path(revision_id: latest_revision_id.to_i + 1)
     else
-      Rails.logger.error("Ingest (Revert) Collection Error: #{ingested_response.inspect}")
+      Rails.logger.error("Ingest (Revert) Collection Error: #{ingested_response.clean_inspect}")
       Rails.logger.info("User #{current_user.urs_uid} attempted to revert Collection #{@concept_id} by ingesting a previous revision in provider #{current_user.provider_id} but encountered an error.")
 
       @errors = generate_ingest_errors(ingested_response)

--- a/lib/cmr/base_client.rb
+++ b/lib/cmr/base_client.rb
@@ -90,7 +90,15 @@ module Cmr
           client_response_headers_for_logs['set-cookie'] = "length: #{set_cookie_to_log.length.round(-2)}; snippet: #{set_cookie_to_log.truncate(60)}"
         end
 
-        Rails.logger.error "#{self.class} Response Error: #{client_response.body.inspect}" if client_response.error?
+        if client_response.error?
+          error_string = if self.class == Cmr::CmrClient
+                           client_response.clean_inspect(body_only: true)
+                         else
+                           client_response.body.inspect
+                         end
+
+          Rails.logger.error "#{self.class} Response Error: #{error_string}"
+        end
 
         Rails.logger.info "#{self.class} Response #{method} #{url} result : Headers: #{client_response_headers_for_logs} - Body Size (bytes): #{client_response.body.to_s.bytesize} - Body md5: #{Digest::MD5.hexdigest(client_response.body.to_s)} - Status: #{client_response.status} - Time: #{Time.now.to_s(:log_time)}"
       rescue => e

--- a/spec/cmr/response_spec.rb
+++ b/spec/cmr/response_spec.rb
@@ -1,0 +1,13 @@
+describe 'CMR Response' do
+  context 'when trying to remove tokens from error messages' do
+    it 'removes tokens' do
+      cmr_response = cmr_fail_response('errors' => ['Token [definitelyafaketoken] is not a valid launchpad token.'])
+      expect(cmr_response.clean_inspect).to include({ 'errors' => ['Token beginning with defini is not a valid launchpad token.'] }.to_s)
+    end
+
+    it 'does not alter errors with no tokens' do
+      cmr_response = cmr_fail_response('errors' => ['Only one collection allowed in the list because a variable can only be associated with one collection.'])
+      expect(cmr_response.clean_inspect).to include({ 'errors' => ['Only one collection allowed in the list because a variable can only be associated with one collection.'] }.to_s)
+    end
+  end
+end

--- a/spec/cmr/response_spec.rb
+++ b/spec/cmr/response_spec.rb
@@ -1,13 +1,23 @@
 describe 'CMR Response' do
   context 'when trying to remove tokens from error messages' do
-    it 'removes tokens' do
+    it 'removes tokens in hash responses' do
       cmr_response = cmr_fail_response('errors' => ['Token [definitelyafaketoken] is not a valid launchpad token.'])
       expect(cmr_response.clean_inspect).to include({ 'errors' => ['Token beginning with defini is not a valid launchpad token.'] }.to_s)
     end
 
-    it 'does not alter errors with no tokens' do
+    it 'removes tokens in string responses' do
+      cmr_response = cmr_fail_response('Token [definitelyafaketoken] is not a valid launchpad token.')
+      expect(cmr_response.clean_inspect).to include('Token beginning with defini is not a valid launchpad token.')
+    end
+
+    it 'does not alter errors in hash responses with no tokens' do
       cmr_response = cmr_fail_response('errors' => ['Only one collection allowed in the list because a variable can only be associated with one collection.'])
       expect(cmr_response.clean_inspect).to include({ 'errors' => ['Only one collection allowed in the list because a variable can only be associated with one collection.'] }.to_s)
+    end
+
+    it 'does not alter errors in string responses with no tokens' do
+      cmr_response = cmr_fail_response('Only one collection allowed in the list because a variable can only be associated with one collection.')
+      expect(cmr_response.clean_inspect).to include('Only one collection allowed in the list because a variable can only be associated with one collection.')
     end
   end
 end

--- a/spec/features/users/user_login_spec.rb
+++ b/spec/features/users/user_login_spec.rb
@@ -121,7 +121,7 @@ describe 'User login' do
 
         context 'when the user successfully logs in with launchpad' do
           before do
-            no_linked_account_response = Cmr::Response.new(Faraday::Response.new(status: 404, body: '{"error": "NAMS auid testuser is not associated with a EDL profile"}'))
+            no_linked_account_response = cmr_fail_response('{"error": "NAMS auid testuser is not associated with a EDL profile"}', 404)
             allow_any_instance_of(Cmr::UrsClient).to receive(:get_urs_uid_from_nams_auid).and_return(no_linked_account_response)
 
             real_login(method: 'launchpad', associated: false)


### PR DESCRIPTION
Added a helper method to replace the token in an error message with "Token beginning with <first 6 characters>...".
Applied helper method whenever the errors are being checked/set.
Made sure that clean inspect checks/sets the errors before returning a string containing them
Checked where we were using inspect vs clean_inspect and changed to clean_inspect when possible