### PR TITLE
MMT-2009 Disabled variable name field when provider_id + native_id is found in CMR.  Updated flash for name uniqueness

### DIFF
--- a/app/controllers/base_published_record_controller.rb
+++ b/app/controllers/base_published_record_controller.rb
@@ -63,11 +63,6 @@ class BasePublishedRecordController < ManageMetadataController
       Rails.logger.info("User #{current_user.urs_uid} attempted to ingest #{resource_name} draft #{draft.entry_title} in provider #{current_user.provider_id} but encountered an error.")
 
       @ingest_errors = generate_ingest_errors(ingested_response)
-      # Per CMR's documentation, 422 is the error code when the records fails
-      # non-structural validation e.g. the name of a variable does not match
-      # or a controlled keyword doesn't exist
-      # From observations: 400 is returned when it is structurally invalid
-      # e.g. missing a required field or formatted incorrectly
       flash[:error] = ingested_response.error_message(i18n: I18n.t("controllers.#{plural_resource_name}.create.flash.error"), force_i18n_preface: true)
       redirect_to send("#{resource_name}_draft_path", draft)
     end

--- a/app/controllers/base_published_record_controller.rb
+++ b/app/controllers/base_published_record_controller.rb
@@ -68,11 +68,7 @@ class BasePublishedRecordController < ManageMetadataController
       # or a controlled keyword doesn't exist
       # From observations: 400 is returned when it is structurally invalid
       # e.g. missing a required field or formatted incorrectly
-      flash[:error] = if ingested_response.status == 422
-                        ingested_response.error_message(i18n: I18n.t("controllers.#{plural_resource_name}.create.flash.error"), force_i18n_preface: true)
-                      else
-                        I18n.t("controllers.#{plural_resource_name}.create.flash.error")
-                      end
+      flash[:error] = ingested_response.error_message(i18n: I18n.t("controllers.#{plural_resource_name}.create.flash.error"), force_i18n_preface: true)
       redirect_to send("#{resource_name}_draft_path", draft)
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,6 +147,7 @@ en:
         flash:
           success: 'Variable Draft Published Successfully!'
           error: 'Variable Draft was not published successfully'
+          name_error: 'Variable Draft was not published successfully. CMR does not allow changing the variable name of existing variables.'
       destroy:
         flash:
           success: 'Variable Deleted Successfully!'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,7 +147,6 @@ en:
         flash:
           success: 'Variable Draft Published Successfully!'
           error: 'Variable Draft was not published successfully'
-          name_error: 'Variable Draft was not published successfully. CMR does not allow changing the variable name of existing variables.'
       destroy:
         flash:
           success: 'Variable Deleted Successfully!'

--- a/lib/assets/schemas/variables/umm-var-form.json
+++ b/lib/assets/schemas/variables/umm-var-form.json
@@ -16,7 +16,7 @@
                 {
                   "type": "section",
                   "htmlClass": "col-5",
-                  "items": [{"key": "Name", "field": true}]
+                  "items": [{"key": "Name", "field": true, "readonly": "existing_variable"}]
                 },
                 {
                   "type": "section",

--- a/lib/cmr/response.rb
+++ b/lib/cmr/response.rb
@@ -67,10 +67,12 @@ module Cmr
       end
     end
 
-    def error_message(i18n: nil)
+    def error_message(i18n: nil, force_i18n_preface: nil)
       message = error_messages(i18n: i18n).first
       if message.is_a?(Hash)
         message.fetch('errors', []).first
+      elsif force_i18n_preface && i18n && !message.include?(i18n)
+        "#{i18n}. #{message}"
       else
         message
       end

--- a/lib/cmr/response.rb
+++ b/lib/cmr/response.rb
@@ -71,10 +71,12 @@ module Cmr
       message = error_messages(i18n: i18n).first
       if message.is_a?(Hash)
         message.fetch('errors', []).first
-      elsif force_i18n_preface && i18n && !message.include?(i18n)
-        "#{i18n}. #{message}"
       else
         message
+      end
+
+      if force_i18n_preface && i18n && !message.include?(i18n)
+        "#{i18n}. #{message}"
       end
     end
 

--- a/lib/cmr/response.rb
+++ b/lib/cmr/response.rb
@@ -77,6 +77,8 @@ module Cmr
 
       if force_i18n_preface && i18n && !message.include?(i18n)
         "#{i18n}. #{message}"
+      else
+        message
       end
     end
 

--- a/lib/json_schema_form/umm_form.rb
+++ b/lib/json_schema_form/umm_form.rb
@@ -430,7 +430,7 @@ class UmmFormElement < UmmForm
   end
 
   def element_properties(element)
-    readonly = parsed_json['readonly'].nil? ? {} : { readonly: true }
+    readonly = check_readonly
     autocomplete = parsed_json['autocomplete'].nil? ? {} : { autocomplete: "off" }
     {
       class: element_classes(element),
@@ -439,6 +439,19 @@ class UmmFormElement < UmmForm
       .deep_merge(autocomplete)
       .deep_merge(readonly)
       .deep_merge(validation_properties(element))
+  end
+
+  # Allows selective field disabling based on circumstance
+  # Current use case: variable names should not be changable when the variable already exists in CMR
+  # Needs to return a hash to get merged in element_properties
+  def check_readonly
+    return {} if parsed_json['readonly'].nil?
+
+    return { readonly: true } if parsed_json['readonly'] == true
+
+    # The value in the form JSON for readonly needs to match the value being passed
+    # in the options to create the form
+    { readonly: @options[parsed_json['readonly']] }
   end
 
   # Locates the fragment of the schema that the provided key represents

--- a/spec/factories/variable_draft_factories.rb
+++ b/spec/factories/variable_draft_factories.rb
@@ -10,8 +10,8 @@ FactoryBot.define do
   end
 
   factory :invalid_variable_draft, class: VariableDraft do
-    provider_id {'MMT_2'}
-    draft_type {'VariableDraft'}
+    provider_id { 'MMT_2' }
+    draft_type { 'VariableDraft' }
 
     draft {{
       'Scale': 'string',

--- a/spec/features/variable_drafts/create_variable_draft_from_variable_spec.rb
+++ b/spec/features/variable_drafts/create_variable_draft_from_variable_spec.rb
@@ -44,7 +44,7 @@ describe 'Create new draft from variable', reset_provider: true do
       end
 
       it 'does not succeed' do
-        expect(page).to have_content('Variable Draft was not published successfully. CMR does not allow changing the variable name of existing variables.')
+        expect(page).to have_content('Variable Draft was not published successfully. Variable name [An Incompatible Name] does not match the existing variable name [Test Edit Variable Name 2]')
       end
     end
   end

--- a/spec/features/variable_drafts/create_variable_draft_from_variable_spec.rb
+++ b/spec/features/variable_drafts/create_variable_draft_from_variable_spec.rb
@@ -1,5 +1,5 @@
 describe 'Create new draft from variable', reset_provider: true do
-  context 'when making a draft of a published variable' do
+  context 'when making a draft from a published variable' do
     before do
       login
 

--- a/spec/features/variable_drafts/create_variable_draft_from_variable_spec.rb
+++ b/spec/features/variable_drafts/create_variable_draft_from_variable_spec.rb
@@ -1,5 +1,5 @@
 describe 'Create new draft from variable', reset_provider: true do
-  context 'when editing a published variable' do
+  context 'when making a draft of a published variable' do
     before do
       login
 
@@ -15,6 +15,37 @@ describe 'Create new draft from variable', reset_provider: true do
 
       expect(page).to have_link('Publish Variable Draft')
       expect(page).to have_content('Test Edit Variable Name')
+    end
+  end
+
+  context 'when working with the draft of a published variable' do
+    before do
+      login
+      @native_id = 'TestVariableNativeId'
+      ingest_response, _concept_response = publish_variable_draft(name: 'Test Edit Variable Name 2', native_id: @native_id)
+    end
+
+    context 'when trying to edit the draft name' do
+      before do
+        @variable_draft = create(:full_variable_draft, native_id: @native_id)
+        visit edit_variable_draft_path(@variable_draft)
+      end
+
+      it 'cannot edit the name' do
+        expect(page).to have_field('variable_draft[draft][name]', readonly: true)
+      end
+    end
+
+    context 'when trying to publish/update a variable draft with a different name' do
+      before do
+        @variable_draft = create(:full_variable_draft, native_id: @native_id, draft_short_name: 'An Incompatible Name')
+        visit variable_draft_path(@variable_draft)
+        click_on 'Publish Variable Draft'
+      end
+
+      it 'does not succeed' do
+        expect(page).to have_content('Variable Draft was not published successfully. CMR does not allow changing the variable name of existing variables.')
+      end
     end
   end
 end


### PR DESCRIPTION
Updated the flash message when a variable fails to ingest because we submitted a record which changed the name (not allowed per CMR). 
Added comments to make finding the conversion of variable/service_drafts to published variables/services more apparent for unknowing developers.  Collection drafts publish; Variable and Service drafts create new variables/services.  I feel that these should have been implemented the same way.
Added logic when making the forms for variables/services that allows for marking some fields as readonly based on the conditions at the time of rendering the forms (previously the schema was static)
Disabled the name field when querying the CMR finds a provider+native id to match the current record.
