### PR TITLE
MMT-1726 fixing broken tests in UMM-Cv1.15 update by updating validation, form clearing, and required icons

### DIFF
--- a/app/assets/javascripts/draft_form_selectors.coffee
+++ b/app/assets/javascripts/draft_form_selectors.coffee
@@ -20,7 +20,7 @@ $(document).ready ->
     else
       # clear and hide fields
       $fields.hide()
-      $.each $fields.find('input'), (index, field) ->
+      $.each $fields.find('input').not("input[type='radio']"), (index, field) ->
         $(field).val ''
       $.each $fields.find("input[type='radio']"), (index, field) ->
         $(field).prop 'checked', false
@@ -33,15 +33,18 @@ $(document).ready ->
         $(coordinateSystemType).siblings('.horizontal-data-resolution-fields').show()
         $(coordinateSystemType).siblings('.local-coordinate-system-fields').hide()
       when 'local'
-        $(coordinateSystemType).siblings('.horizontal-data-resolutions-fields').hide()
+        $(coordinateSystemType).siblings('.horizontal-data-resolution-fields').hide()
         $(coordinateSystemType).siblings('.local-coordinate-system-fields').show()
 
-    $allSiblings = $(coordinateSystemType).siblings('.horizontal-data-resolutions-fields, .local-coordinate-system-fields')
+    $allSiblings = $(coordinateSystemType).siblings('.horizontal-data-resolution-fields, .local-coordinate-system-fields')
 
     # Clear all fields (except for radio buttons)
     $allSiblings.find('input, select, textarea').not("input[type='radio']").val ''
     # Uncheck all radio buttons
     $allSiblings.find("input[type='radio']").prop 'checked', false
+    # Close the forms tied to checkboxes
+    $(this).parents('.resolution-and-coordinate-system').find("input[type='checkbox']").prop 'checked', false
+    $(this).parents('.resolution-and-coordinate-system').find("input[type='checkbox']").change()
 
     # Toggle checkboxes
     $(this).siblings('.coordinate-system-picker').prop 'checked', false

--- a/app/assets/javascripts/required_fields.coffee
+++ b/app/assets/javascripts/required_fields.coffee
@@ -84,7 +84,7 @@ $(document).ready ->
       # If the current data-level is the same as the topRequiredDataLevel (this appears to be critical to how variable/service drafts get required icons)
       # or if the current data-level is a top level required field
       # or if any of the fields have values
-      if currentDataLevel == topRequiredDataLevel or requiredFieldDataLevels.indexOf(topDataLevel) != -1 or fieldsWithValues.length > 0
+      if currentDataLevel == topRequiredDataLevel or requiredFieldDataLevels.indexOf(currentDataLevel) != -1 or fieldsWithValues.length > 0
         isRequired = true
         # add required icon to required fields at this data-level
         # addRequiredFields($fields) # TODO is this necessary? it will be removed then re-added lines 120 - 128

--- a/app/assets/javascripts/required_fields.coffee
+++ b/app/assets/javascripts/required_fields.coffee
@@ -69,7 +69,6 @@ $(document).ready ->
 
     isRequired = false
     currentDataLevel = dataLevels.join('_') # this is the current data-level
-    # topDataLevel = dataLevels.join('_') # this is the current data-level
     console.log "currentDataLevel, topDataLevel: #{currentDataLevel}"
 
     # fields at the current data-level (`currentDataLevel`)
@@ -82,10 +81,10 @@ $(document).ready ->
         else
           this.value
 
-      # If the current data-level is the same as the topRequiredDataLevel (is this necessary?)
+      # If the current data-level is the same as the topRequiredDataLevel (this appears to be critical to how variable/service drafts get required icons)
       # or if the current data-level is a top level required field
       # or if any of the fields have values
-      if requiredFieldDataLevels.indexOf(currentDataLevel) != -1 or fieldsWithValues.length > 0
+      if currentDataLevel == topRequiredDataLevel or requiredFieldDataLevels.indexOf(topDataLevel) != -1 or fieldsWithValues.length > 0
         isRequired = true
         # add required icon to required fields at this data-level
         # addRequiredFields($fields) # TODO is this necessary? it will be removed then re-added lines 120 - 128

--- a/app/assets/javascripts/validation.coffee
+++ b/app/assets/javascripts/validation.coffee
@@ -443,6 +443,7 @@ $(document).ready ->
               keyword: keyword,
               dataPath: "/AdditionalAttributes/#{index}/ParameterRangeEnd"
               params: {}
+              schemaPath: "" # these errors need this to not throw errors in getErrorDetails
             errors.push newError
 
   validatePicklistValues = (errors) ->
@@ -525,6 +526,7 @@ $(document).ready ->
       error.message = "value [#{$(this).val()}] does not match a valid selection option"
       error.params = {}
       error.dataPath = dataPath
+      error.schemaPath = "" # these errors need this to not throw errors in getErrorDetails
       errors.push error
 
     # combine TemporalKeywords invalidPicklist errors if more than one exist
@@ -548,6 +550,7 @@ $(document).ready ->
       newError.message = "values [#{values.join(', ')}] do not match a valid selection option"
       newError.params = {}
       newError.dataPath = '/TemporalKeywords'
+      newError.schemaPath = "" # these errors need this to not throw errors in getErrorDetails
       errors.push newError
 
     errors
@@ -656,10 +659,21 @@ $(document).ready ->
     if $('#draft_template_name').length > 0
       error = null
       if $('#draft_template_name').val().length == 0
-        error = { "id": 'draft_template_name', "title": 'Draft Template Name', "params": {}, 'dataPath': '/TemplateName', 'keyword': 'must_exist'}
+       error = 
+          id: 'draft_template_name'
+          title: 'Draft Template Name'
+          params: {}
+          dataPath: '/TemplateName'
+          keyword: 'must_exist'
+          schemaPath: "" # these errors need this to not throw errors in getErrorDetails
       else if globalTemplateNames.indexOf($('#draft_template_name').val()) isnt -1
-        error = { "id": 'draft_template_name', "title": 'Draft Template Name', "params": {}, 'dataPath': '/TemplateName', 'keyword': 'not_unique'}
-
+        error = 
+          id: 'draft_template_name'
+          title: 'Draft Template Name'
+          params: {}
+          dataPath: '/TemplateName'
+          keyword: 'not_unique'
+          schemaPath: "" # these errors need this to not throw errors in getErrorDetails
       if error
         errors.push(error)
         return true

--- a/app/views/collection_drafts/forms/fields/_horizontal_data_resolution_fields.html.erb
+++ b/app/views/collection_drafts/forms/fields/_horizontal_data_resolution_fields.html.erb
@@ -100,7 +100,7 @@
       <div class="checkbox-group">
         <%= check_box_tag(name_to_param("#{name_prefix}|non_gridded_range_resolutions|_checkbox"), nil, non_gridded_range_resolutions_checked, class: 'horizontal-data-resolution-picker non-gridded-range-resolutions', name: nil) %>
         <%= mmt_label(
-          name: 'non_gridded_range_resolution_checkbox',
+          name: 'non_gridded_range_resolutions_checkbox',
           title: 'Non Gridded Range Resolutions',
           prefix: name_prefix
         ) %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_06_201605) do
+ActiveRecord::Schema.define(version: 2020_02_06_201539) do
 
   create_table "draft_proposals", force: :cascade do |t|
     t.integer "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_07_163307) do
+ActiveRecord::Schema.define(version: 2020_02_06_201605) do
 
   create_table "draft_proposals", force: :cascade do |t|
     t.integer "user_id"

--- a/spec/factories/collection_factory_data.rb
+++ b/spec/factories/collection_factory_data.rb
@@ -736,36 +736,36 @@ def collection_one
               'HorizontalResolutionProcessingLevelEnum': 'Point'
             },
             'NonGriddedResolutions': [{
-              'XDimension': 10,
-              'YDimension': 10,
+              'XDimension': 1,
+              'YDimension': 2,
               'Unit': 'Meters',
               'ViewingAngleType': 'At Nadir',
               'ScanDirection': 'Cross Track'
             }],
             'NonGriddedRangeResolutions': [{
-              'MinimumXDimension': 10,
-              'MinimumYDimension': 10,
-              'MaximumXDimension': 20,
-              'MaximumYDimension': 20,
+              'MinimumXDimension': 3,
+              'MinimumYDimension': 4,
+              'MaximumXDimension': 5,
+              'MaximumYDimension': 6,
               'Unit': 'Meters',
               'ViewingAngleType': 'At Nadir',
               'ScanDirection': 'Cross Track'
             }],
             'GriddedResolutions': [{
-              'XDimension': 10,
-              'YDimension': 10,
+              'XDimension': 7,
+              'YDimension': 8,
               'Unit': 'Meters'
             }],
             'GriddedRangeResolutions': [{
-              'MinimumXDimension': 10,
+              'MinimumXDimension': 9,
               'MinimumYDimension': 10,
-              'MaximumXDimension': 20,
-              'MaximumYDimension': 20,
+              'MaximumXDimension': 11,
+              'MaximumYDimension': 12,
               'Unit': 'Meters'
             }],
             'GenericResolutions': [{
-              'XDimension': 10,
-              'YDimension': 10,
+              'XDimension': 13,
+              'YDimension': 14,
               'Unit': 'Meters'
             }]
           },

--- a/spec/features/collection_drafts/forms/radio_button_selectors_spec.rb
+++ b/spec/features/collection_drafts/forms/radio_button_selectors_spec.rb
@@ -79,11 +79,11 @@ describe 'Radio button form selectors', js: true do
 
     context 'when selecting horizontal data resolutions' do
       before do
-        choose 'Horizontal Data Resolutions'
+        choose 'Horizontal Data Resolution'
       end
 
       it 'displays the geographic coordinate system fields' do
-        expect(page).to have_css('.horizontal-data-resolutions-fields')
+        expect(page).to have_css('.horizontal-data-resolution-fields')
       end
 
       it 'does not display the other form fields' do
@@ -101,26 +101,26 @@ describe 'Radio button form selectors', js: true do
       end
 
       it 'does not display the other form fields' do
-        expect(page).to have_no_css('.horizontal-data-resolutions-fields')
+        expect(page).to have_no_css('.horizontal-data-resolution-fields')
       end
     end
 
     context 'when switching between options after filling in form data' do
       before do
-        choose 'Horizontal Data Resolutions'
-        choose 'Gridded'
+        choose 'Horizontal Data Resolution'
+        check 'Gridded Resolutions'
         select 'Meters', from: 'Unit'
         fill_in 'X Dimension', with: '42.0'
         fill_in 'Y Dimension', with: '43.0'
 
         choose 'Local'
-        choose 'Horizontal Data Resolutions'
+        choose 'Horizontal Data Resolution'
       end
 
       it 'clears the form data' do
-        expect(page).to have_no_checked_field('Gridded')
+        expect(page).to have_no_checked_field('Gridded Resolutions')
 
-        choose 'Gridded'
+        check 'Gridded Resolutions'
 
         expect(page).to have_field('Unit', with: '')
         expect(page).to have_field('X Dimension', with: '')

--- a/spec/features/collection_drafts/forms/spatial_information_form_spec.rb
+++ b/spec/features/collection_drafts/forms/spatial_information_form_spec.rb
@@ -32,41 +32,43 @@ describe 'Spatial information form', js: true do
           fill_in 'Ellipsoid Name', with: 'Ellipsoid name'
           fill_in 'Semi Major Axis', with: '3.0'
           fill_in 'Denominator Of Flattening Ratio', with: '4.0'
-          choose 'Horizontal Data Resolutions'
-          within '.horizontal-data-resolutions-fields' do
-            within '.multiple-item-0' do
-              choose 'Gridded'
+          choose 'Horizontal Data Resolution'
+          within '.horizontal-data-resolution-fields' do
+            check 'Point Resolution'
+            within '.horizontal-data-resolution-fields.point-resolution' do
+              choose 'Point'
+            end
+
+            check 'Varies Resolution'
+            choose 'Varies'
+
+            check 'Gridded Resolutions'
+            within '.horizontal-data-resolution-fields.gridded-resolutions' do
               fill_in 'X Dimension', with: '1'
               fill_in 'Y Dimension', with: '2'
               select 'Meters', from: 'Unit'
             end
-          end
-          click_on 'Add another Horizontal Data Resolution'
-          within '.horizontal-data-resolutions-fields' do
-            within '.multiple-item-1' do
-              choose 'Gridded Range'
+
+            check 'Gridded Range Resolutions'
+            within '.horizontal-data-resolution-fields.gridded-range-resolutions' do
               fill_in 'Minimum X Dimension', with: '3'
               fill_in 'Maximum X Dimension', with: '4'
               fill_in 'Minimum Y Dimension', with: '5'
               fill_in 'Maximum Y Dimension', with: '6'
               select 'Meters', from: 'Unit'
             end
-          end
-          click_on 'Add another Horizontal Data Resolution'
-          within '.horizontal-data-resolutions-fields' do
-            within '.multiple-item-2' do
-              choose 'Non Gridded'
+
+            check 'Non Gridded Resolutions'
+            within '.horizontal-data-resolution-fields.non-gridded-resolutions' do
               fill_in 'X Dimension', with: '7'
               fill_in 'Y Dimension', with: '8'
               select 'At Nadir', from: 'Viewing Angle Type'
               select 'Along Track', from: 'Scan Direction'
               select 'Meters', from: 'Unit'
             end
-          end
-          click_on 'Add another Horizontal Data Resolution'
-          within '.horizontal-data-resolutions-fields' do
-            within '.multiple-item-3' do
-              choose 'Non Gridded Range'
+
+            check 'Non Gridded Range Resolutions'
+            within '.horizontal-data-resolution-fields.non-gridded-range-resolutions' do
               fill_in 'Minimum X Dimension', with: '9'
               fill_in 'Maximum X Dimension', with: '10'
               fill_in 'Minimum Y Dimension', with: '11'
@@ -75,23 +77,12 @@ describe 'Spatial information form', js: true do
               select 'Along Track', from: 'Scan Direction'
               select 'Meters', from: 'Unit'
             end
-          end
-          click_on 'Add another Horizontal Data Resolution'
-          within '.horizontal-data-resolutions-fields' do
-            within '.multiple-item-4' do
-              choose 'Point'
-            end
-          end
-          click_on 'Add another Horizontal Data Resolution'
-          within '.horizontal-data-resolutions-fields' do
-            within '.multiple-item-5' do
-              choose 'Varies'
-            end
-          end
-          click_on 'Add another Horizontal Data Resolution'
-          within '.horizontal-data-resolutions-fields' do
-            within '.multiple-item-6' do
-              choose 'Not provided'
+
+            check 'Generic Resolutions'
+            within '.horizontal-data-resolution-fields.generic-resolutions' do
+              fill_in 'X Dimension', with: '13'
+              fill_in 'Y Dimension', with: '14'
+              select 'Meters', from: 'Unit'
             end
           end
         end
@@ -131,9 +122,6 @@ describe 'Spatial information form', js: true do
           click_on 'Save'
         end
 
-        # TODO: MMT-1726: This should be removed from the final push of the branch because the data should be valid
-        click_on 'Yes'
-
         # output_schema_validation Draft.first.draft
         click_on 'Expand All'
       end
@@ -166,49 +154,47 @@ describe 'Spatial information form', js: true do
             expect(page).to have_field('Ellipsoid Name', with: 'Ellipsoid name')
             expect(page).to have_field('Semi Major Axis', with: '3.0')
             expect(page).to have_field('Denominator Of Flattening Ratio', with: '4.0')
-            expect(page).to have_checked_field('Horizontal Data Resolutions')
+            expect(page).to have_checked_field('Horizontal Data Resolution')
 
-            within '.horizontal-data-resolutions-fields' do
-              within '.multiple-item-0' do
-                expect(page).to have_checked_field('Gridded')
-                expect(page).to have_field('X Dimension', with: '1')
-                expect(page).to have_field('Y Dimension', with: '2')
+            within '.horizontal-data-resolution' do
+              expect(page).to have_checked_field('Point Resolution')
+              expect(page).to have_checked_field('Point')
+
+              expect(page).to have_checked_field('Varies Resolution')
+              expect(page).to have_checked_field('Varies')
+
+              within '.horizontal-data-resolution-fields.gridded-resolutions' do
+                expect(page).to have_field('X Dimension', with: '1.0')
+                expect(page).to have_field('Y Dimension', with: '2.0')
                 expect(page).to have_field('Unit', with: 'Meters')
               end
-              within '.multiple-item-1' do
-                expect(page).to have_checked_field('Gridded Range')
-                expect(page).to have_field('Minimum X Dimension', with: '3')
-                expect(page).to have_field('Maximum X Dimension', with: '4')
-                expect(page).to have_field('Minimum Y Dimension', with: '5')
-                expect(page).to have_field('Maximum Y Dimension', with: '6')
+              within '.horizontal-data-resolution-fields.gridded-range-resolutions' do
+                expect(page).to have_field('Minimum X Dimension', with: '3.0')
+                expect(page).to have_field('Maximum X Dimension', with: '4.0')
+                expect(page).to have_field('Minimum Y Dimension', with: '5.0')
+                expect(page).to have_field('Maximum Y Dimension', with: '6.0')
                 expect(page).to have_field('Unit', with: 'Meters')
               end
-              within '.multiple-item-2' do
-                expect(page).to have_checked_field('Non Gridded')
-                expect(page).to have_field('X Dimension', with: '7')
-                expect(page).to have_field('Y Dimension', with: '8')
-                expect(page).to have_field('Unit', with: 'Meters')
-                expect(page).to have_field('Viewing Angle Type', with: 'At Nadir')
-                expect(page).to have_field('Scan Direction', with: 'Along Track')
-              end
-              within '.multiple-item-3' do
-                expect(page).to have_checked_field('Non Gridded Range')
-                expect(page).to have_field('Minimum X Dimension', with: '9')
-                expect(page).to have_field('Maximum X Dimension', with: '10')
-                expect(page).to have_field('Minimum Y Dimension', with: '11')
-                expect(page).to have_field('Maximum Y Dimension', with: '12')
+              within '.horizontal-data-resolution-fields.non-gridded-resolutions' do
+                expect(page).to have_field('X Dimension', with: '7.0')
+                expect(page).to have_field('Y Dimension', with: '8.0')
                 expect(page).to have_field('Unit', with: 'Meters')
                 expect(page).to have_field('Viewing Angle Type', with: 'At Nadir')
                 expect(page).to have_field('Scan Direction', with: 'Along Track')
               end
-              within '.multiple-item-4' do
-                expect(page).to have_checked_field('Point')
+              within '.horizontal-data-resolution-fields.non-gridded-range-resolutions' do
+                expect(page).to have_field('Minimum X Dimension', with: '9.0')
+                expect(page).to have_field('Maximum X Dimension', with: '10.0')
+                expect(page).to have_field('Minimum Y Dimension', with: '11.0')
+                expect(page).to have_field('Maximum Y Dimension', with: '12.0')
+                expect(page).to have_field('Unit', with: 'Meters')
+                expect(page).to have_field('Viewing Angle Type', with: 'At Nadir')
+                expect(page).to have_field('Scan Direction', with: 'Along Track')
               end
-              within '.multiple-item-5' do
-                expect(page).to have_checked_field('Varies')
-              end
-              within '.multiple-item-6' do
-                expect(page).to have_checked_field('Not provided')
+              within '.horizontal-data-resolution-fields.generic-resolutions' do
+                expect(page).to have_field('X Dimension', with: '13.0')
+                expect(page).to have_field('Y Dimension', with: '14.0')
+                expect(page).to have_field('Unit', with: 'Meters')
               end
             end
           end

--- a/spec/features/collection_drafts/forms/validation_spec.rb
+++ b/spec/features/collection_drafts/forms/validation_spec.rb
@@ -283,7 +283,7 @@ describe 'Data validation for a collection draft form', js: true do
       click_on 'No'
 
       expect(page).to have_selector(validation_error)
-      expect(page).to have_content('TemporalExtents should have one type completed')
+      expect(page).to have_content('TemporalExtents should have one option completed')
       choose 'draft_temporal_extents_0_temporal_range_type_SingleDateTime'
 
       within '.single-date-times' do
@@ -321,12 +321,12 @@ describe 'Data validation for a collection draft form', js: true do
 
     it 'validation of anyOf does work' do
       within '.summary-errors' do
-        expect(page).to have_content('At least one Geometry Type is required')
+        expect(page).to have_content('Geometry should have one schema option completed')
       end
 
       within '.horizontal-spatial-domain' do
         expect(page).to have_selector(validation_error)
-        expect(page).to have_content('At least one Geometry Type is required')
+        expect(page).to have_content('Geometry should have one schema option completed')
       end
     end
 

--- a/spec/features/collection_previews/spatial_information_preview_spec.rb
+++ b/spec/features/collection_previews/spatial_information_preview_spec.rb
@@ -31,7 +31,8 @@ describe 'Spatial information preview' do
         end
 
         within '.resolution_and_coordinate_system' do
-          expect(page).to have_content('Description: ResolutionAndCoordinateSystem Description')
+          expect(page).to have_content('Description:')
+          expect(page).to have_content('ResolutionAndCoordinateSystem Description')
 
           within '.geodetic_model_table' do
             within all('tr')[0] do
@@ -42,66 +43,63 @@ describe 'Spatial information preview' do
             end
           end
 
-          within '.horizontal_data_resolution_0' do
-            expect(page).to have_content('Horizontal Resolution Processing Level: Non Gridded Range')
-            within '.horizontal-x-dimension-range' do
-              within '.two-column-fields-left' do
-                expect(page).to have_content('X Dimension Minimum: 1 Meters')
-              end
+          within '.point_resolution' do
+            expect(page).to have_content('Point Resolution')
+            expect(page).to have_content('Horizontal Resolution Processing Level Enum')
+            expect(page).to have_content('Point')
+          end
 
-              within '.two-column-fields-right' do
-                expect(page).to have_content('X Dimension Maximum: 2 Meters')
-              end
+          within '.varies_resolution' do
+            expect(page).to have_content('Varies Resolution')
+            expect(page).to have_content('Horizontal Resolution Processing Level Enum')
+            expect(page).to have_content('Varies')
+          end
+
+          within '.non_gridded_resolutions' do
+            expect(page).to have_content('Non Gridded Resolutions')
+            within '.non_gridded_resolution_0' do
+              expect(page).to have_content('1 Meters')
+              expect(page).to have_content('2 Meters')
+              expect(page).to have_content('At Nadir')
+              expect(page).to have_content('Cross Track')
             end
+          end
 
-            within '.horizontal-y-dimension-range' do
-              within '.two-column-fields-left' do
-                expect(page).to have_content('Y Dimension Minimum: 3 Meters')
-              end
-
-              within '.two-column-fields-right' do
-                expect(page).to have_content('Y Dimension Maximum: 4 Meters')
-              end
+          within '.non_gridded_range_resolutions' do
+            expect(page).to have_content('Non Gridded Range Resolutions')
+            within '.non_gridded_range_resolution_0' do
+              expect(page).to have_content('3 Meters')
+              expect(page).to have_content('4 Meters')
+              expect(page).to have_content('5 Meters')
+              expect(page).to have_content('6 Meters')
+              expect(page).to have_content('At Nadir')
+              expect(page).to have_content('Cross Track')
             end
-            expect(page).to have_content('Viewing Angle: At Nadir')
-            expect(page).to have_content('Scan Direction: Along Track')
           end
 
-          within '.horizontal_data_resolution_1' do
-            expect(page).to have_content('Horizontal Resolution Processing Level: Gridded')
-            expect(page).to have_content('X Dimension: 1 Meters')
-            expect(page).to have_content('Y Dimension: 2 Meters')
+          within '.gridded_resolutions' do
+            expect(page).to have_content('Gridded Resolutions')
+            within '.gridded_resolution_0' do
+              expect(page).to have_content('7 Meters')
+              expect(page).to have_content('8 Meters')
+            end
           end
 
-          within '.horizontal_data_resolution_2' do
-            expect(page).to have_content('Horizontal Resolution Processing Level: Non Gridded')
-            expect(page).to have_content('X Dimension: 3 Statute Miles')
-            expect(page).to have_content('Y Dimension: 4 Statute Miles')
-            expect(page).to have_content('Viewing Angle: At Nadir')
-            expect(page).to have_content('Scan Direction: Cross Track')
+          within '.gridded_range_resolutions' do
+            expect(page).to have_content('Gridded Range Resolutions')
+            within '.gridded_range_resolution_0' do
+              expect(page).to have_content('9 Meters')
+              expect(page).to have_content('10 Meters')
+              expect(page).to have_content('11 Meters')
+              expect(page).to have_content('12 Meters')
+            end
           end
 
-          within '.horizontal_data_resolution_3' do
-            expect(page).to have_content('Horizontal Resolution Processing Level: Varies')
-          end
-
-          within '.horizontal_data_resolution_4' do
-            expect(page).to have_content('Horizontal Resolution Processing Level: Non Gridded')
-            expect(page).to have_content('X Dimension: 5 Statute Miles')
-            expect(page).to have_content('Viewing Angle: At Nadir')
-            expect(page).to have_content('Scan Direction: Cross Track')
-          end
-
-          within '.horizontal_data_resolution_5' do
-            expect(page).to have_content('Horizontal Resolution Processing Level: Gridded Range')
-            within '.horizontal-y-dimension-range' do
-              within '.two-column-fields-left' do
-                expect(page).to have_content('Y Dimension Minimum: 6 Meters')
-              end
-
-              within '.two-column-fields-right' do
-                expect(page).to have_content('Y Dimension Maximum: 7 Meters')
-              end
+          within '.generic_resolutions' do
+            expect(page).to have_content('Generic Resolutions')
+            within '.generic_resolution_0' do
+              expect(page).to have_content('13 Meters')
+              expect(page).to have_content('14 Meters')
             end
           end
         end

--- a/spec/features/collection_templates/template_creation_spec.rb
+++ b/spec/features/collection_templates/template_creation_spec.rb
@@ -197,7 +197,7 @@ describe 'When trying to save a template with a non-unique name', js: true do
       fill_in 'Template Name', with: 'Unique Name2'
       fill_in 'Short Name', with: 'Different text'
 
-      expect(page).to have_content('Template Name must be unique within a provider context') # Verify that name list is updating on failure
+      expect(page).to have_content('Collection Template was not saved because of the following errors: template name') # Verify that name list is updating on failure
 
       fill_in 'Template Name', with: 'Unique Name3'
       fill_in 'Short Name', with: 'Different text'


### PR DESCRIPTION
Updated JS for draft forms to clear checkboxes and to prevent checkboxes from clearing radio button values
Reverting required fields JS to check the top required data level (seems to be important to variable/service draft required fields)
Adding schema path to a variety of errors so that they can be properly processed (threw errors without it)
Updating tests/field names to help get tests to pass