### PR TITLE
MMT-2198 Reading Subscriptions from CMR

### DIFF
--- a/app/assets/stylesheets/components/_metadata-preview.scss
+++ b/app/assets/stylesheets/components/_metadata-preview.scss
@@ -363,3 +363,20 @@ ul.sub-field {
 .proposal-reject-button {
   margin-right: .625em
 }
+
+.subscriptions-table{
+  .wrapping-div {
+    word-wrap: break-word;
+    overflow-wrap:break-word;
+  }
+  .wrapping-td {
+    max-width:25em;
+  }
+  
+  width: 100%
+}
+
+.query-wrap {
+  word-wrap: break-word;
+  overflow-wrap:break-word;
+}

--- a/app/assets/stylesheets/components/_metadata-preview.scss
+++ b/app/assets/stylesheets/components/_metadata-preview.scss
@@ -367,10 +367,10 @@ ul.sub-field {
 .subscriptions-table{
   .wrapping-div {
     word-wrap: break-word;
-    overflow-wrap:break-word;
+    overflow-wrap: break-word;
   }
   .wrapping-td {
-    max-width:25em;
+    max-width: 25em;
   }
   
   width: 100%
@@ -378,5 +378,5 @@ ul.sub-field {
 
 .query-wrap {
   word-wrap: break-word;
-  overflow-wrap:break-word;
+  overflow-wrap: break-word;
 }

--- a/app/assets/stylesheets/overrides/_eui.scss
+++ b/app/assets/stylesheets/overrides/_eui.scss
@@ -30,3 +30,7 @@ textarea::-webkit-input-placeholder {
   font-weight: 100; 
 }
 
+// Used on the subscriptions index page
+.link-lift {
+  margin-bottom: .22em
+}

--- a/app/concerns/cmr_subscriptions.rb
+++ b/app/concerns/cmr_subscriptions.rb
@@ -1,0 +1,26 @@
+module CMRSubscriptions
+  extend ActiveSupport::Concern
+
+  def get_latest_revision(concept_id, revision_id)
+    attempts = 0
+    while attempts < 20
+      revisions_response = cmr_client.get_subscriptions({ concept_id: concept_id, all_revisions: true }, token)
+
+      revisions = if revisions_response.success?
+                    revisions_response.body.fetch('items', [])
+                  else
+                    []
+                  end
+      revisions.select! { |revision| revision['meta']['deleted'] == false }
+      revisions.sort! { |a, b| b['meta']['revision-id'] <=> a['meta']['revision-id'] }
+
+      latest = revisions.first
+
+      return latest if latest.present? && latest['meta']['revision-id'].to_s >= revision_id.to_s
+
+      attempts += 1
+      sleep 0.05
+    end
+    nil
+  end
+end

--- a/app/concerns/cmr_subscriptions.rb
+++ b/app/concerns/cmr_subscriptions.rb
@@ -1,6 +1,9 @@
 module CMRSubscriptions
   extend ActiveSupport::Concern
 
+  # This is derived from a similar method found in the cmr_collections_helper
+  # Subscriptions face a similar challenge where without something like this,
+  # MMT can try to load the page without finding the user's new content.
   def get_latest_revision(concept_id, revision_id)
     attempts = 0
     while attempts < 20

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -4,7 +4,7 @@ class SubscriptionsController < ManageCmrController
   RESULTS_PER_PAGE = 25
   before_action :subscriptions_enabled?
   before_action :add_top_level_breadcrumbs
-  before_action :fetch_native_id, only: %i[update destroy]
+  before_action :fetch_subscription, only: %i[show edit update destroy]
 
   def index
     authorize :subscription
@@ -34,36 +34,16 @@ class SubscriptionsController < ManageCmrController
   def show
     authorize :subscription
 
-    concept_id = params.permit(:id)['id']
-    subscription_response = cmr_client.get_concept(concept_id, token, {})
-    if subscription_response.success?
-      @subscription = subscription_response.body
-      @subscription['id'] = concept_id
-      user = get_subscriber(@subscription['SubscriberId']).fetch(0, {})
-      @user = "#{user['first_name']} #{user['last_name']}"
-      add_breadcrumb @subscription['id'].to_s
-    else
-      Rails.logger.info("Could not find subscription: #{subscription_response.clean_inspect}")
-      flash[:error] = subscription_response.error_message
-      redirect_to subscriptions_path
-    end
+    user = get_subscriber(@subscription['SubscriberId']).fetch(0, {})
+    @user = "#{user['first_name']} #{user['last_name']}"
+    add_breadcrumb @concept_id.to_s
   end
 
   def edit
     authorize :subscription
 
-    concept_id = params.permit(:id)['id']
-    subscription_response = cmr_client.get_concept(concept_id, token, {})
-    if subscription_response.success?
-      @subscription = subscription_response.body
-      @subscription['id'] = concept_id
-      set_previously_selected_subscriber(@subscription['SubscriberId'])
-      add_breadcrumb @subscription['id'].to_s, subscription_path(@subscription['id'])
-    else
-      Rails.logger.info("Could not find subscription: #{subscription_response.clean_inspect}")
-      flash[:error] = subscription_response.error_message
-      redirect_to subscription_path(concept_id)
-    end
+    set_previously_selected_subscriber(@subscription['SubscriberId'])
+    add_breadcrumb @concept_id.to_s, subscription_path(@concept_id)
   end
 
   def create
@@ -75,6 +55,10 @@ class SubscriptionsController < ManageCmrController
     subscription_response = cmr_client.ingest_subscription(@subscription.to_json, current_user.provider_id, native_id, token)
     if subscription_response.success?
       flash[:success] = I18n.t('controllers.subscriptions.create.flash.success')
+
+      # Hitting CMR too quickly in dev environment.
+      sleep(1) if Rails.env.development?
+
       redirect_to subscription_path(subscription_response.parsed_body['result']['concept_id'])
     else
       Rails.logger.error("Creating a subscription failed with CMR Response: #{subscription_response.clean_inspect}")
@@ -87,18 +71,22 @@ class SubscriptionsController < ManageCmrController
 
   def update
     authorize :subscription
-    @subscription = subscription_params
-    @subscription['EmailAddress'] = get_subscriber_email(@subscription['SubscriberId'])
+    new_subscription = subscription_params
+    new_subscription['EmailAddress'] = get_subscriber_email(new_subscription['SubscriberId'])
 
-    subscription_response = cmr_client.ingest_subscription(@subscription.to_json, current_user.provider_id, @native_id, token)
+    subscription_response = cmr_client.ingest_subscription(new_subscription.to_json, current_user.provider_id, @native_id, token)
     if subscription_response.success?
       flash[:success] = I18n.t('controllers.subscriptions.update.flash.success')
+
+      # Hitting CMR too quickly in dev environment.
+      sleep(1) if Rails.env.development?
+
       redirect_to subscription_path(@concept_id)
     else
       Rails.logger.error("Updating a subscription failed with CMR Response: #{subscription_response.clean_inspect}")
       flash[:error] = subscription_response.error_message(i18n: I18n.t('controllers.subscriptions.update.flash.success'))
 
-      set_previously_selected_subscriber(@subscription['SubscriberId'])
+      set_previously_selected_subscriber(new_subscription['SubscriberId'])
       redirect_to edit_subscription_path(@concept_id)
     end
   end
@@ -109,6 +97,10 @@ class SubscriptionsController < ManageCmrController
     delete_response = cmr_client.delete_subscription(current_user.provider_id, @native_id, token)
     if delete_response.success?
       flash[:success] = I18n.t('controllers.subscriptions.destroy.flash.success')
+
+      # Hitting CMR too quickly in dev environment.
+      sleep(1) if Rails.env.development?
+
       redirect_to subscriptions_path
     else
       Rails.logger.error("Failed to delete a subscription.  CMR Response: #{delete_response.clean_inspect}")
@@ -152,9 +144,18 @@ class SubscriptionsController < ManageCmrController
     add_breadcrumb 'Subscriptions', subscriptions_path
   end
 
-  def fetch_native_id
+  def fetch_subscription
     @concept_id = params.permit(:id)['id']
-    subscription_search_response = cmr_client.get_subscriptions({ 'ConceptId' => @concept_id }, token)
-    @native_id = subscription_search_response.body['items'].first['native_id'] if subscription_search_response.success?
+    options = { 'ConceptId' => @concept_id }
+    subscription_response = cmr_client.get_subscriptions(options, token)
+    if subscription_response.success? && subscription_response.body['hits'] == 1
+      @subscription = subscription_response.body['items'].first['umm']
+      @native_id = subscription_response.body['items'].first['meta']['native-id']
+    else
+      Rails.logger.info("Could not find subscription: #{subscription_response.clean_inspect}")
+      flash[:error] = subscription_response.error_message
+      redirect_to subscriptions_path
+      return
+    end
   end
 end

--- a/app/views/subscriptions/edit.html.erb
+++ b/app/views/subscriptions/edit.html.erb
@@ -2,7 +2,7 @@
   <section>
     <h2>Edit <span class="provider-context"><%= current_user.provider_id %></span> Subscription</h2>
 
-    <%= form_tag(subscription_path(@subscription['id'], native_id: @subscription['native_id']), method: :put, class: 'subscription-form') do %>
+    <%= form_tag(subscription_path(@concept_id), method: :put, class: 'subscription-form') do %>
       <%= render partial: 'subscriptions/forms/subscription_fields' %>
 
       <fieldset>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -11,7 +11,7 @@
     <% end %>
 
     <p>
-      <em><span class="fa fa-info-circle"></span> Subscription operations may take some time. If you are not seeing what you expect below, please <%= link_to 'refresh the page', 'javascript:history.go(0)', class: 'eui-btn--link link-lift' %>.</em>
+      <em><span class="fa fa-info-circle"></span> Subscription operations run periodically throughout each day. Email notifications are sent if new data matching your query is available.</em>
     </p>
 
     <table class="subscriptions-table">
@@ -38,14 +38,12 @@
                 </div>
               </td>
               <td><%= subscription['CollectionConceptId'] %></td>
-              <!-- TODO: need to put a limit or char cutoff for query? -->
               <td class='wrapping-td'>
                 <div class='wrapping-div'>
                   <%= subscription['Query'].truncate(200) %>
                 </div>
               </td>
               <td><%= subscription['EmailAddress'] %></td>
-              <!-- TODO: Update this path to the correct path -->
               <% if policy(:subscription).edit? %>
                 <td><%= link_to 'Edit', edit_subscription_path(subscription['ConceptId']) %></td>
               <% end %>
@@ -57,7 +55,6 @@
                       <p>Are you sure you want to delete the subscription named '<%= subscription['Name'] %>'?</p>
                     <p>
                       <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
-                      <!-- TODO: Update this path to the correct path -->
                       <%= link_to 'Yes', subscription_path(subscription['ConceptId']), method: :delete, class: 'eui-btn--blue' %>
                     </p>
                   </div>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -28,14 +28,14 @@
           <% @subscriptions.each_with_index do |subscription, index| %>
             <tr>
               <td>
-                <%= subscription['description'] %>
+                <%= link_to subscription['Name'], subscription_path(subscription['ConceptId']) %>
               </td>
               <!-- TODO: need to put a limit or char cutoff for query? -->
-              <td><%= subscription['metadata'] %></td>
-              <td><%= subscription['email_address'] %></td>
+              <td><%= subscription['Query'] %></td>
+              <td><%= subscription['EmailAddress'] %></td>
               <!-- TODO: Update this path to the correct path -->
               <% if policy(:subscription).edit? %>
-                <td><%= link_to 'Edit', subscriptions_path %></td>
+                <td><%= link_to 'Edit', edit_subscription_path(subscription['ConceptId']) %></td>
               <% end %>
               <% if policy(:subscription).destroy? %>
                 <td>
@@ -46,7 +46,7 @@
                     <p>
                       <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
                       <!-- TODO: Update this path to the correct path -->
-                      <%= link_to 'Yes', subscriptions_path, class: 'eui-btn--blue' %>
+                      <%= link_to 'Yes', subscriptions_path(subscription['ConceptId']), method: :delete, class: 'eui-btn--blue' %>
                     </p>
                   </div>
                 </td>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -32,12 +32,18 @@
         <% else %>
           <% @subscriptions.each_with_index do |subscription, index| %>
             <tr>
-              <td>
-                <%= link_to subscription['Name'], subscription_path(subscription['ConceptId']) %>
+              <td class='wrapping-td'>
+                <div class='wrapping-div'>
+                  <%= link_to subscription['Name'], subscription_path(subscription['ConceptId']) %>
+                </div>
               </td>
               <td><%= subscription['CollectionConceptId'] %></td>
               <!-- TODO: need to put a limit or char cutoff for query? -->
-              <td><%= subscription['Query'] %></td>
+              <td class='wrapping-td'>
+                <div class='wrapping-div'>
+                  <%= subscription['Query'].truncate(200) %>
+                </div>
+              </td>
               <td><%= subscription['EmailAddress'] %></td>
               <!-- TODO: Update this path to the correct path -->
               <% if policy(:subscription).edit? %>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -10,6 +10,10 @@
       <p><%= page_entries_info @subscriptions, entry_name: 'Subscription' %></p>
     <% end %>
 
+    <p>
+      <em><span class="fa fa-info-circle"></span> Subscription operations may take some time. If you are not seeing what you expect below, please <%= link_to 'refresh the page', 'javascript:history.go(0)', class: 'eui-btn--link link-lift' %>.</em>
+    </p>
+
     <table class="subscriptions-table">
       <thead>
         <tr>
@@ -42,11 +46,11 @@
                   <%= link_to 'Delete', "#delete-subscription-modal-#{index}", class: 'display-modal' %>
                   <div id="delete-subscription-modal-<%= index %>" class="eui-modal-content">
                     <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-                      <p>Are you sure you want to delete the subscription named '<%= subscription['description'] %>'?</p>
+                      <p>Are you sure you want to delete the subscription named '<%= subscription['Name'] %>'?</p>
                     <p>
                       <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
                       <!-- TODO: Update this path to the correct path -->
-                      <%= link_to 'Yes', subscriptions_path(subscription['ConceptId']), method: :delete, class: 'eui-btn--blue' %>
+                      <%= link_to 'Yes', subscription_path(subscription['ConceptId']), method: :delete, class: 'eui-btn--blue' %>
                     </p>
                   </div>
                 </td>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -17,7 +17,8 @@
     <table class="subscriptions-table">
       <thead>
         <tr>
-          <th>Description</th>
+          <th>Name</th>
+          <th>Collection Concept Id</th>
           <th>Query</th>
           <th>Subscribers</th>
           <th colspan="2">Actions</th>
@@ -34,6 +35,7 @@
               <td>
                 <%= link_to subscription['Name'], subscription_path(subscription['ConceptId']) %>
               </td>
+              <td><%= subscription['CollectionConceptId'] %></td>
               <!-- TODO: need to put a limit or char cutoff for query? -->
               <td><%= subscription['Query'] %></td>
               <td><%= subscription['EmailAddress'] %></td>

--- a/app/views/subscriptions/show.html.erb
+++ b/app/views/subscriptions/show.html.erb
@@ -2,7 +2,7 @@
   <section>
     <h2><%= @subscription.fetch('Name')%></h2>
     <p>Collection Concept ID: <%= @subscription.fetch('CollectionConceptId') %></p>
-    <p>Query: <%= @subscription.fetch('Query') %></p>
+    <p class='query-wrap'>Query: <%= @subscription.fetch('Query') %></p>
 
     <h3>Subscriber</h3>
     <table class="space-top space-bot" id="subscriber">

--- a/app/views/subscriptions/show.html.erb
+++ b/app/views/subscriptions/show.html.erb
@@ -22,7 +22,7 @@
       </tbody>
     </table>
     <% if policy(:subscription).edit? %>
-      <%= link_to 'Edit', edit_subscription_path(@subscription['id'], subscription: @subscription, native_id: @subscription['native_id']), class: 'eui-btn' %>
+      <%= link_to 'Edit', edit_subscription_path(@concept_id), class: 'eui-btn' %>
     <% end %>
     <% if policy(:subscription).destroy? %>
       <%= link_to 'Delete', '#delete-subscription-modal', class: 'display-modal eui-btn eui-btn--red' %>
@@ -31,7 +31,7 @@
         <p>Are you sure you want to delete this subscription?</p>
         <p>
           <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
-          <%= link_to 'Yes', subscription_path(@subscription['id'], subscription: @subscription, native_id: @subscription['native_id']), method: :delete, class: 'eui-btn--blue spinner' %>
+          <%= link_to 'Yes', subscription_path(@concept_id), method: :delete, class: 'eui-btn--blue spinner' %>
         </p>
       </div>
     <% end %>

--- a/lib/cmr/cmr_client.rb
+++ b/lib/cmr/cmr_client.rb
@@ -553,7 +553,7 @@ module Cmr
       url = if Rails.env.development? || Rails.env.test?
               'http://localhost:3003/subscriptions.umm_json'
             else
-              '/search/subscriptions.json'
+              '/search/subscriptions.umm_json'
             end
       get(url, options, token_header(token))
     end

--- a/lib/cmr/cmr_client.rb
+++ b/lib/cmr/cmr_client.rb
@@ -550,7 +550,6 @@ module Cmr
     end
 
     def get_subscriptions(options = {}, token = nil)
-      # search collections via GET
       url = if Rails.env.development? || Rails.env.test?
               'http://localhost:3003/subscriptions.umm_json'
             else

--- a/lib/cmr/cmr_client.rb
+++ b/lib/cmr/cmr_client.rb
@@ -549,21 +549,14 @@ module Cmr
       get(url, options, headers.merge(token_header(token)))
     end
 
-    ### Subscription search
-
     def get_subscriptions(options = {}, token = nil)
-      # TODO: this is a stubbed success response because we do not have the cmr
-      # endpoint available yet. We should update this to be a real cmr call
-      # when the update becomes available
-
-      # the structure of the success and failure responses are unclear at this point
-      # so they will change
-      success_response_body =  '{"items":[{"description":"It is a subscription", "user_id":"fake_user_id", "email_address":"fake@fake.fake", "collection_concept_id":"C1200000000-FAKE", "metadata":"thing=stuff&&stuff_id=stuff&&stuff_color=more_stuff"},{"description":"It is a second subscription", "user_id":"fake_user_id", "email_address":"fake2@fake.fake", "collection_concept_id":"C1200000001-FAKE", "metadata":"thing=stuff&&stuff_id=stuff2&&stuff_color=more_stuff2"}]}'
-      Cmr::Response.new(Faraday::Response.new(status: 200, body: JSON.parse(success_response_body)))
-
-      # This error response is provided for viewing and testing a failure
-      # error_response_body = '{"errors":["some error message"]}'
-      # Cmr::Response.new(Faraday::Response.new(status: 400, body: JSON.parse(error_response_body)))
+      # search collections via GET
+      url = if Rails.env.development? || Rails.env.test?
+              'http://localhost:3003/subscriptions.umm_json'
+            else
+              '/search/subscriptions.json'
+            end
+      get(url, options, token_header(token))
     end
 
     private

--- a/spec/features/manage_cmr/subscriptions/create_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/create_subscriptions_spec.rb
@@ -69,11 +69,9 @@ describe 'Creating Subscriptions' do
           end
 
           after do
-            allow_any_instance_of(SubscriptionPolicy).to receive(:destroy?).and_return(true)
-            visit subscriptions_path
-
-            click_on 'Delete'
-            click_on 'Yes'
+            native_id = cmr_client.get_subscriptions({'Name' => name}, 'token').body['items'].first['meta']['native-id']
+            delete_response = cmr_client.delete_subscription('MMT_2', native_id, 'token')
+            raise unless delete_response.success?
           end
 
           it 'creates the subscription' do
@@ -99,7 +97,8 @@ describe 'Creating Subscriptions' do
 
           # Clean up the one made before the test.
           after do
-            cmr_client.delete_subscription('MMT_2', @native_id_failure, 'token').inspect
+            delete_response = cmr_client.delete_subscription('MMT_2', @native_id_failure, 'token')
+            raise unless delete_response.success?
           end
 
           it 'fails to create the subscription' do

--- a/spec/features/manage_cmr/subscriptions/create_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/create_subscriptions_spec.rb
@@ -68,6 +68,14 @@ describe 'Creating Subscriptions' do
             end
           end
 
+          after do
+            allow_any_instance_of(SubscriptionPolicy).to receive(:destroy?).and_return(true)
+            visit subscriptions_path
+
+            click_on 'Delete'
+            click_on 'Yes'
+          end
+
           it 'creates the subscription' do
             expect(page).to have_content('Subscription Created Successfully!')
           end
@@ -78,7 +86,8 @@ describe 'Creating Subscriptions' do
           # in the CMR.
           let(:name2) { 'Exciting Subscription with Important Data4' }
           before do
-            @ingest_response, _subscription = publish_new_subscription(name: name2, query: query, collection_concept_id: collection_concept_id, native_id: 'test_native_id')
+            @native_id_failure = 'test_native_id'
+            @ingest_response, _search_response, _subscription = publish_new_subscription(name: name2, query: query, collection_concept_id: collection_concept_id, native_id: @native_id_failure)
 
             fill_in 'Subscription Name', with: name2
             VCR.use_cassette('urs/rarxd5taqea', record: :none) do
@@ -90,7 +99,7 @@ describe 'Creating Subscriptions' do
 
           # Clean up the one made before the test.
           after do
-            cmr_client.delete_subscription('MMT_2', 'test_native_id', 'token').inspect
+            cmr_client.delete_subscription('MMT_2', @native_id_failure, 'token').inspect
           end
 
           it 'fails to create the subscription' do

--- a/spec/features/manage_cmr/subscriptions/create_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/create_subscriptions_spec.rb
@@ -68,6 +68,8 @@ describe 'Creating Subscriptions' do
             end
           end
 
+          # TODO: using reset_provider may be cleaner than these after blocks,
+          # but does not currently work. Reinvestigate after CMR-6310
           after do
             native_id = cmr_client.get_subscriptions({'Name' => name}, 'token').body['items'].first['meta']['native-id']
             delete_response = cmr_client.delete_subscription('MMT_2', native_id, 'token')
@@ -95,7 +97,8 @@ describe 'Creating Subscriptions' do
             end
           end
 
-          # Clean up the one made before the test.
+          # TODO: using reset_provider may be cleaner than these after blocks,
+          # but does not currently work. Reinvestigate after CMR-6310
           after do
             delete_response = cmr_client.delete_subscription('MMT_2', @native_id_failure, 'token')
             raise unless delete_response.success?

--- a/spec/features/manage_cmr/subscriptions/delete_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/delete_subscriptions_spec.rb
@@ -31,8 +31,6 @@ describe 'Deleting Subscriptions' do
       context 'when clicking yes' do
         before do
           click_on 'Yes'
-
-          wait_for_cmr
         end
 
         it 'deletes a subscription' do

--- a/spec/features/manage_cmr/subscriptions/delete_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/delete_subscriptions_spec.rb
@@ -10,10 +10,10 @@ describe 'Deleting Subscriptions' do
     before do
       # make a record
       @native_id = 'test_native_id'
-      @ingest_response, @subscription = publish_new_subscription(native_id: @native_id)
+      @ingest_response, _search_response, _subscription = publish_new_subscription(native_id: @native_id)
       # go to show page
       VCR.use_cassette('urs/rarxd5taqea', record: :none) do
-        visit subscription_path(@ingest_response['concept_id'], subscription: @subscription, native_id: @native_id)
+        visit subscription_path(@ingest_response['concept_id'])
       end
     end
 
@@ -31,6 +31,8 @@ describe 'Deleting Subscriptions' do
       context 'when clicking yes' do
         before do
           click_on 'Yes'
+
+          wait_for_cmr
         end
 
         it 'deletes a subscription' do

--- a/spec/features/manage_cmr/subscriptions/edit_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/edit_subscriptions_spec.rb
@@ -9,10 +9,16 @@ describe 'Edit/Updating Subscriptions' do
     @ingest_response, _search_response, @subscription = publish_new_subscription(native_id: @native_id)
   end
 
+  after do
+    delete_response = cmr_client.delete_subscription('MMT_2', @native_id, 'token')
+
+    raise unless delete_response.success?
+  end
+
   context 'when visiting the show page and clicking the edit button' do
     before do
       VCR.use_cassette('urs/rarxd5taqea', record: :none) do
-        visit subscription_path(@ingest_response['concept_id'], subscription: @subscription, native_id: @native_id)
+        visit subscription_path(@ingest_response['concept_id'])
         click_on 'Edit'
       end
     end
@@ -77,9 +83,9 @@ describe 'Edit/Updating Subscriptions' do
       end
 
       after do
-        cmr_client.delete_subscription('MMT_2', @second_native_id, 'token')
-        
-        wait_for_cmr
+        delete_response = cmr_client.delete_subscription('MMT_2', @second_native_id, 'token')
+
+        raise unless delete_response.success?
       end
 
       it 'fails and repopulates the form' do

--- a/spec/features/manage_cmr/subscriptions/edit_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/edit_subscriptions_spec.rb
@@ -5,8 +5,8 @@ describe 'Edit/Updating Subscriptions' do
     allow_any_instance_of(SubscriptionPolicy).to receive(:show?).and_return(true)
     allow_any_instance_of(SubscriptionPolicy).to receive(:update?).and_return(true)
     # make a record
-    @native_id = 'test_native_id'
-    @ingest_response, _search_response, @subscription = publish_new_subscription(native_id: @native_id)
+    @ingest_response, search_response, @subscription = publish_new_subscription
+    @native_id = search_response.body['items'].first['meta']['native-id']
   end
 
   after do

--- a/spec/features/manage_cmr/subscriptions/edit_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/edit_subscriptions_spec.rb
@@ -9,6 +9,8 @@ describe 'Edit/Updating Subscriptions' do
     @native_id = search_response.body['items'].first['meta']['native-id']
   end
 
+  # TODO: using reset_provider may be cleaner than these after blocks,
+  # but does not currently work. Reinvestigate after CMR-6310
   after do
     delete_response = cmr_client.delete_subscription('MMT_2', @native_id, 'token')
 
@@ -82,6 +84,8 @@ describe 'Edit/Updating Subscriptions' do
         end
       end
 
+      # TODO: using reset_provider may be cleaner than these after blocks,
+      # but does not currently work. Reinvestigate after CMR-6310
       after do
         delete_response = cmr_client.delete_subscription('MMT_2', @second_native_id, 'token')
 

--- a/spec/features/manage_cmr/subscriptions/edit_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/edit_subscriptions_spec.rb
@@ -3,11 +3,10 @@ describe 'Edit/Updating Subscriptions' do
     login
     allow_any_instance_of(SubscriptionPolicy).to receive(:create?).and_return(true)
     allow_any_instance_of(SubscriptionPolicy).to receive(:show?).and_return(true)
-    allow_any_instance_of(SubscriptionPolicy).to receive(:destroy?).and_return(true)
     allow_any_instance_of(SubscriptionPolicy).to receive(:update?).and_return(true)
     # make a record
     @native_id = 'test_native_id'
-    @ingest_response, @subscription = publish_new_subscription(native_id: @native_id)
+    @ingest_response, _search_response, @subscription = publish_new_subscription(native_id: @native_id)
   end
 
   context 'when visiting the show page and clicking the edit button' do
@@ -31,7 +30,7 @@ describe 'Edit/Updating Subscriptions' do
     before do
       # go to show page
       VCR.use_cassette('urs/rarxd5taqea', record: :none) do
-        visit edit_subscription_path(@ingest_response['concept_id'], subscription: @subscription, native_id: @native_id)
+        visit edit_subscription_path(@ingest_response['concept_id'])
       end
     end
 
@@ -70,11 +69,17 @@ describe 'Edit/Updating Subscriptions' do
         fill_in 'Subscription Name', with: @new_name
         @second_native_id = 'test_edit_id_2'
 
-        @ingest_response, @subscription = publish_new_subscription(name: @new_name, native_id: @second_native_id)
+        _ingest_response, _search_response, _subscription = publish_new_subscription(name: @new_name, native_id: @second_native_id)
 
         VCR.use_cassette('urs/rarxd5taqea', record: :none) do
           click_on 'Submit'
         end
+      end
+
+      after do
+        cmr_client.delete_subscription('MMT_2', @second_native_id, 'token')
+        
+        wait_for_cmr
       end
 
       it 'fails and repopulates the form' do

--- a/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
@@ -8,6 +8,8 @@ describe 'Viewing a list of subscriptions' do
     _ingest_response2, @search_response2, @subscription2 = publish_new_subscription
   end
 
+  # TODO: using reset_provider may be cleaner than these after blocks,
+  # but does not currently work. Reinvestigate after CMR-6310
   after(:all) do
     delete_response1 = cmr_client.delete_subscription('MMT_2', @search_response.body['items'].first['meta']['native-id'], 'token')
     delete_response2 = cmr_client.delete_subscription('MMT_2', @search_response2.body['items'].first['meta']['native-id'], 'token')
@@ -125,6 +127,8 @@ describe 'Viewing a list of subscriptions' do
       visit subscriptions_path
     end
 
+    # TODO: using reset_provider may be cleaner than these after blocks,
+    # but does not currently work. Reinvestigate after CMR-6310
     after do
       delete_response1 = cmr_client.delete_subscription('MMT_2', @search_response.body['items'].first['meta']['native-id'], 'token')
       delete_response2 = cmr_client.delete_subscription('MMT_1', @search_response2.body['items'].first['meta']['native-id'], 'token')

--- a/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
@@ -6,8 +6,6 @@ describe 'Viewing a list of subscriptions' do
   before(:all) do
     _ingest_response, @search_response, @subscription = publish_new_subscription
     _ingest_response2, @search_response2, @subscription2 = publish_new_subscription
-
-    wait_for_cmr
   end
 
   after(:all) do
@@ -123,7 +121,6 @@ describe 'Viewing a list of subscriptions' do
       _ingest_response, @search_response, @subscription = publish_new_subscription
       _ingest_response2, @search_response2, @subscription2 = publish_new_subscription(provider: 'MMT_1', email_address: 'fake@fake.fake')
 
-      wait_for_cmr
       allow_any_instance_of(SubscriptionPolicy).to receive(:index?).and_return(true)
       visit subscriptions_path
     end

--- a/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
@@ -45,7 +45,7 @@ describe 'Viewing a list of subscriptions' do
       # only 2 subscriptions on them, but if the subscription tests are run
       # together, CMR does not always finish deleting subscriptions from other
       # tests before starting this one, so it fails at the commented out line.
-      it 'displays expected subscriptions without edit or delete' do
+      it 'displays expected subscriptions without edit or delete links' do
         expect(page).to have_no_link('Create a Subscription')
         # expect(page).to have_content('Showing all 2 Subscriptions')
 

--- a/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
@@ -1,3 +1,7 @@
+# TODO: When CMR-6310 has been finished, we should add a test for viewing the 
+# subscription page with no subscriptions. Until we have the provider reset,
+# that test would be flaky and fail intermittently because of CMR's update time.
+
 describe 'Viewing a list of subscriptions' do
   before do
     login
@@ -41,7 +45,7 @@ describe 'Viewing a list of subscriptions' do
       # only 2 subscriptions on them, but if the subscription tests are run
       # together, CMR does not always finish deleting subscriptions from other
       # tests before starting this one, so it fails at the commented out line.
-      it 'displays sample subscriptions' do
+      it 'displays expected subscriptions without edit or delete' do
         expect(page).to have_no_link('Create a Subscription')
         # expect(page).to have_content('Showing all 2 Subscriptions')
 
@@ -77,7 +81,7 @@ describe 'Viewing a list of subscriptions' do
       # only 2 subscriptions on them, but if the subscription tests are run
       # together, CMR does not always finish deleting subscriptions from other
       # tests before starting this one, so it fails at the commented out line.
-      it 'displays sample subscriptions and links' do
+      it 'displays expected subscriptions and edit and delete links' do
         expect(page).to have_link('Create a Subscription')
         # expect(page).to have_content('Showing all 2 Subscriptions')
 

--- a/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
@@ -3,6 +3,19 @@ describe 'Viewing a list of subscriptions' do
     login
   end
 
+  before(:all) do
+    _ingest_response, @search_response, @subscription = publish_new_subscription
+    _ingest_response2, @search_response2, @subscription2 = publish_new_subscription
+    
+    wait_for_cmr
+  end
+
+  after(:all) do
+    delete_response1 = cmr_client.delete_subscription('MMT_2', @search_response.body['items'].first['meta']['native-id'], 'token')
+    delete_response2 = cmr_client.delete_subscription('MMT_2', @search_response2.body['items'].first['meta']['native-id'], 'token')
+    raise unless delete_response1.success? && delete_response2.success?
+  end
+
   context 'when the user has read access' do
     before do
       allow_any_instance_of(SubscriptionPolicy).to receive(:index?).and_return(true)
@@ -17,54 +30,65 @@ describe 'Viewing a list of subscriptions' do
         expect(page).to have_css('h2.current', text: 'Manage CMR')
         expect(page).to have_content('View Subscriptions')
       end
+    end
 
-      # The two tests in this context need to be revised when we have real endpoints
-      context 'when viewing the index page' do
-        before do
-          visit subscriptions_path
-        end
-
-        it 'displays the dummy subscription' do
-          expect(page).to have_no_link('Create a Subscription')
-          expect(page).to have_content('Showing all 2 Subscriptions')
-
-          within '.subscriptions-table' do
-            expect(page).to have_content('Description')
-            expect(page).to have_content('Query')
-            expect(page).to have_content('Subscribers')
-            expect(page).to have_content('Actions')
-            expect(page).to have_content('It is a subscription')
-            expect(page).to have_content('thing=stuff&&stuff_id=stuff&&stuff_color=more_stuff')
-            expect(page).to have_content('fake@fake.fake')
-            expect(page).to have_no_link('Edit')
-            expect(page).to have_no_link('Delete')
-          end
-        end
+    context 'when viewing the index page' do
+      before do
+        visit subscriptions_path
       end
 
-      context 'when viewing the index page with full permissions' do
-        before do
-          allow_any_instance_of(SubscriptionPolicy).to receive(:edit?).and_return(true)
-          allow_any_instance_of(SubscriptionPolicy).to receive(:destroy?).and_return(true)
-          allow_any_instance_of(SubscriptionPolicy).to receive(:create?).and_return(true)
-          visit subscriptions_path
+      it 'displays sample subscriptions' do
+        expect(page).to have_no_link('Create a Subscription')
+        expect(page).to have_content('Showing all 2 Subscriptions')
+
+        within '.subscriptions-table' do
+          expect(page).to have_content('Name')
+          expect(page).to have_content('Query')
+          expect(page).to have_content('Collection Concept Id')
+          expect(page).to have_content('Subscribers')
+          expect(page).to have_content('Actions')
+          expect(page).to have_content(@subscription['Name'])
+          expect(page).to have_content(@subscription['Query'])
+          expect(page).to have_content(@subscription['EmailAddress'])
+          expect(page).to have_content(@subscription['CollectionConceptId'])
+          expect(page).to have_content(@subscription2['CollectionConceptId'])
+          expect(page).to have_content(@subscription2['EmailAddress'])
+          expect(page).to have_content(@subscription2['Name'])
+          expect(page).to have_content(@subscription2['Query'])
+          expect(page).to have_no_link('Edit')
+          expect(page).to have_no_link('Delete')
         end
+      end
+    end
 
-        it 'displays the dummy subscription and links' do
-          expect(page).to have_link('Create a Subscription')
-          expect(page).to have_content('Showing all 2 Subscriptions')
+    context 'when viewing the index page with full permissions' do
+      before do
+        allow_any_instance_of(SubscriptionPolicy).to receive(:edit?).and_return(true)
+        allow_any_instance_of(SubscriptionPolicy).to receive(:destroy?).and_return(true)
+        allow_any_instance_of(SubscriptionPolicy).to receive(:create?).and_return(true)
+        visit subscriptions_path
+      end
 
-          within '.subscriptions-table' do
-            expect(page).to have_content('Description')
-            expect(page).to have_content('Query')
-            expect(page).to have_content('Subscribers')
-            expect(page).to have_content('Actions')
-            expect(page).to have_content('It is a subscription')
-            expect(page).to have_content('thing=stuff&&stuff_id=stuff&&stuff_color=more_stuff')
-            expect(page).to have_content('fake@fake.fake')
-            expect(page).to have_link('Edit')
-            expect(page).to have_link('Delete')
-          end
+      it 'displays sample subscriptions and links' do
+        expect(page).to have_link('Create a Subscription')
+        expect(page).to have_content('Showing all 2 Subscriptions')
+
+        within '.subscriptions-table' do
+          expect(page).to have_content('Name')
+          expect(page).to have_content('Query')
+          expect(page).to have_content('Collection Concept Id')
+          expect(page).to have_content('Subscribers')
+          expect(page).to have_content('Actions')
+          expect(page).to have_content(@subscription['Name'])
+          expect(page).to have_content(@subscription['Query'])
+          expect(page).to have_content(@subscription['EmailAddress'])
+          expect(page).to have_content(@subscription['CollectionConceptId'])
+          expect(page).to have_content(@subscription2['CollectionConceptId'])
+          expect(page).to have_content(@subscription2['EmailAddress'])
+          expect(page).to have_content(@subscription2['Name'])
+          expect(page).to have_content(@subscription2['Query'])
+          expect(page).to have_link('Edit')
+          expect(page).to have_link('Delete')
         end
       end
     end

--- a/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
@@ -9,10 +9,10 @@ describe 'When Viewing Subscription Show Page' do
     before do
       # make a record
       native_id = 'test_native_id'
-      @ingest_response, @subscription = publish_new_subscription(native_id: native_id)
+      @ingest_response, _concept_response, @subscription = publish_new_subscription(native_id: native_id)
       # go to show page
       VCR.use_cassette('urs/rarxd5taqea', record: :none) do
-        visit subscription_path(@ingest_response['concept_id'], subscription: @subscription, native_id: native_id)
+        visit subscription_path(@ingest_response['concept_id'])
       end
     end
 
@@ -39,10 +39,10 @@ describe 'When Viewing Subscription Show Page' do
       allow_any_instance_of(SubscriptionPolicy).to receive(:destroy?).and_return(true)
       # make a record
       native_id = 'test_native_id'
-      @ingest_response, @subscription = publish_new_subscription(native_id: native_id)
+      @ingest_response, _concept_response, @subscription = publish_new_subscription(native_id: native_id)
       # go to show page
       VCR.use_cassette('urs/rarxd5taqea', record: :none) do
-        visit subscription_path(@ingest_response['concept_id'], subscription: @subscription, native_id: native_id)
+        visit subscription_path(@ingest_response['concept_id'])
       end
     end
 

--- a/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
@@ -5,15 +5,11 @@ describe 'When Viewing Subscription Show Page' do
     allow_any_instance_of(SubscriptionPolicy).to receive(:show?).and_return(true)
   end
 
-  context 'when visiting the show page with read access' do
+  context 'when visiting the show page' do
     before do
       # make a record
-      @native_id = 'test_native_id'
-      @ingest_response, _concept_response, @subscription = publish_new_subscription(native_id: @native_id)
-      # go to show page
-      VCR.use_cassette('urs/rarxd5taqea', record: :none) do
-        visit subscription_path(@ingest_response['concept_id'])
-      end
+      @ingest_response, search_response, @subscription = publish_new_subscription(native_id: @native_id)
+      @native_id = search_response.body['items'].first['meta']['native-id']
     end
 
     after do
@@ -22,50 +18,56 @@ describe 'When Viewing Subscription Show Page' do
       raise unless delete_response.success?
     end
 
-    it 'has the correct information' do
-      expect(page).to have_content(@subscription['Name'])
-      expect(page).to have_content(@subscription['Query'])
-      expect(page).to have_content(@subscription['CollectionConceptId'])
-      within '#subscriber' do
-        expect(page).to have_content(@subscription['SubscriberId'])
-        expect(page).to have_content(@subscription['EmailAddress'])
-        expect(page).to have_content('Rvrhzxhtra Vetxvbpmxf')
+    context 'when the user has read access only' do
+      before do
+        # go to show page
+        VCR.use_cassette('urs/rarxd5taqea', record: :none) do
+          visit subscription_path(@ingest_response['concept_id'])
+        end
+      end
+
+      it 'has the correct information' do
+        expect(page).to have_content(@subscription['Name'])
+        expect(page).to have_content(@subscription['Query'])
+        expect(page).to have_content(@subscription['CollectionConceptId'])
+        within '#subscriber' do
+          expect(page).to have_content(@subscription['SubscriberId'])
+          expect(page).to have_content(@subscription['EmailAddress'])
+          expect(page).to have_content('Rvrhzxhtra Vetxvbpmxf')
+        end
+      end
+
+      it 'has the correct buttons' do
+        expect(page).to have_no_link('Edit')
+        expect(page).to have_no_link('Delete')
       end
     end
 
-    it 'has the correct buttons' do
-      expect(page).to have_no_link('Edit')
-      expect(page).to have_no_link('Delete')
-    end
-  end
-
-  context 'when visiting the show page with update/delete access' do
-    before do
-      allow_any_instance_of(SubscriptionPolicy).to receive(:edit?).and_return(true)
-      allow_any_instance_of(SubscriptionPolicy).to receive(:destroy?).and_return(true)
-      # make a record
-      native_id = 'test_native_id'
-      @ingest_response, _concept_response, @subscription = publish_new_subscription(native_id: native_id)
-      # go to show page
-      VCR.use_cassette('urs/rarxd5taqea', record: :none) do
-        visit subscription_path(@ingest_response['concept_id'])
+    context 'when visiting the show page with update/delete access' do
+      before do
+        allow_any_instance_of(SubscriptionPolicy).to receive(:edit?).and_return(true)
+        allow_any_instance_of(SubscriptionPolicy).to receive(:destroy?).and_return(true)
+        # go to show page
+        VCR.use_cassette('urs/rarxd5taqea', record: :none) do
+          visit subscription_path(@ingest_response['concept_id'])
+        end
       end
-    end
 
-    it 'has the correct information' do
-      expect(page).to have_content(@subscription['Name'])
-      expect(page).to have_content(@subscription['Query'])
-      expect(page).to have_content(@subscription['CollectionConceptId'])
-      within '#subscriber' do
-        expect(page).to have_content(@subscription['SubscriberId'])
-        expect(page).to have_content(@subscription['EmailAddress'])
-        expect(page).to have_content('Rvrhzxhtra Vetxvbpmxf')
+      it 'has the correct information' do
+        expect(page).to have_content(@subscription['Name'])
+        expect(page).to have_content(@subscription['Query'])
+        expect(page).to have_content(@subscription['CollectionConceptId'])
+        within '#subscriber' do
+          expect(page).to have_content(@subscription['SubscriberId'])
+          expect(page).to have_content(@subscription['EmailAddress'])
+          expect(page).to have_content('Rvrhzxhtra Vetxvbpmxf')
+        end
       end
-    end
 
-    it 'has the correct buttons' do
-      expect(page).to have_link('Edit')
-      expect(page).to have_link('Delete')
+      it 'has the correct buttons' do
+        expect(page).to have_link('Edit')
+        expect(page).to have_link('Delete')
+      end
     end
   end
 end

--- a/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
@@ -12,6 +12,8 @@ describe 'When Viewing Subscription Show Page' do
       @native_id = search_response.body['items'].first['meta']['native-id']
     end
 
+    # TODO: using reset_provider may be cleaner than these after blocks,
+    # but does not currently work. Reinvestigate after CMR-6310
     after do
       delete_response = cmr_client.delete_subscription('MMT_2', @native_id, 'token')
 

--- a/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
@@ -8,12 +8,18 @@ describe 'When Viewing Subscription Show Page' do
   context 'when visiting the show page with read access' do
     before do
       # make a record
-      native_id = 'test_native_id'
-      @ingest_response, _concept_response, @subscription = publish_new_subscription(native_id: native_id)
+      @native_id = 'test_native_id'
+      @ingest_response, _concept_response, @subscription = publish_new_subscription(native_id: @native_id)
       # go to show page
       VCR.use_cassette('urs/rarxd5taqea', record: :none) do
         visit subscription_path(@ingest_response['concept_id'])
       end
+    end
+
+    after do
+      delete_response = cmr_client.delete_subscription('MMT_2', @native_id, 'token')
+
+      raise unless delete_response.success?
     end
 
     it 'has the correct information' do

--- a/spec/support/subscriptions_helpers.rb
+++ b/spec/support/subscriptions_helpers.rb
@@ -4,8 +4,8 @@ module Helpers
       random = SecureRandom.uuid
       subscription = {
         'Name' => name || "Test_Subscription_#{random}",
-        'CollectionConceptId' => collection_concept_id || 'C0000-TEST',
-        'Query' => query || 'field=Test_Query',
+        'CollectionConceptId' => collection_concept_id || "C#{Faker::Number.number(digits: 6)}-TEST",
+        'Query' => query || "field=Test_Query&field2=#{Faker::Number.number(digits: 6)}_#{Faker::Superhero.name}",
         'SubscriberId' => subscriber_id || 'rarxd5taqea',
         'EmailAddress' => email_address || 'uozydogeyyyujukey@tjbh.eyyy'
       }
@@ -16,10 +16,11 @@ module Helpers
 
       wait_for_cmr
 
-      # TODO: Add the concept response like the draft helpers have when we have
-      # a read endpoint.
+      search_response = cmr_client.get_subscriptions({ 'ConceptId' => ingest_response.parsed_body['result']['concept_id'] }, 'token')
 
-      [ingest_response.parsed_body['result'], subscription]
+      raise Array.wrap(search_response.body['errors']).join(' /// ') unless search_response.success?
+
+      [ingest_response.parsed_body['result'], search_response, subscription]
     end
   end
 end


### PR DESCRIPTION
Updated Index controller and view actions to read from CMR
Updated Show/Edit/Update/Destroy to only require a (concept_)id to be passed
Created a before action for Show/Edit/Update/Destroy to find the rest of the information they need from CMR
Updated Edit/Delete buttons where necessary
Updated get_subscriptions
Updated tests - note: the after block deletes could be removed if we could correctly use reset_provider, but it does not work correctly because there is a bug in CMR (ticket written).