### PR TITLE
Changed ref to point to latest cmr_preview_gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'aasm'
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
 # make sure to delete the local config when done making changes to merge into master
 # bundle config --delete local.cmr_metadata_preview
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '1d700ebba34'
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '6768836687f'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: 1d700ebba34be511e75bd81b6baccad6e1a085bd
-  ref: 1d700ebba34
+  revision: 6768836687f75d47658d6fc1a19a67122661581e
+  ref: 6768836687f
   specs:
     cmr_metadata_preview (0.2.1)
       georuby (~> 2.5.2)


### PR DESCRIPTION
Adding ref to cmr_preview_gem containing the fix for related_urls that don't show up in the preview.