### PR TITLE
MMT-2186 Displaying spatial extents if they are present

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'aasm'
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
 # make sure to delete the local config when done making changes to merge into master
 # bundle config --delete local.cmr_metadata_preview
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '1d700ebba34'
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '19a7d2ee4ab'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: 1d700ebba34be511e75bd81b6baccad6e1a085bd
-  ref: 1d700ebba34
+  revision: 19a7d2ee4ab92825aa22ece39e868cdff7f750e6
+  ref: 19a7d2ee4ab
   specs:
     cmr_metadata_preview (0.2.1)
       georuby (~> 2.5.2)

--- a/app/assets/javascripts/draft_form_selectors.coffee
+++ b/app/assets/javascripts/draft_form_selectors.coffee
@@ -72,35 +72,44 @@ $(document).ready ->
       when 'PeriodicDateTime'
         $parent.siblings('.temporal-range-type.periodic-date-time').show()
 
+  clearFieldsInClass = (fieldsToBeCleared) ->
+    fieldsToBeCleared.find('input, select').not('input[type="radio"]').val ''
+    fieldsToBeCleared.find('input[type="radio"]').prop 'checked', false 
+    fieldsToBeCleared.find("input[type='checkbox']").prop 'checked', false
+    fieldsToBeCleared.find("input[type='checkbox']").change()
+
   # Handle SpatialCoverageType selector
   $('.spatial-coverage-type-select').change ->
     $parent = $(this).parents('.spatial-coverage-type-group')
 
     $parent.siblings('.spatial-coverage-type').hide()
 
-    # Clear all fields except radio buttons
-    $parent.siblings('.spatial-coverage-type').find('input, select').not('input[type="radio"]').val ''
-    # Uncheck radio buttons
-    $parent.siblings('.spatial-coverage-type').find('input[type="radio"]').prop 'checked', false
-
-    # Hide geographic and local coordinate system fields
-    $parent.siblings().find('.horizontal-data-resolution-fields').hide()
-    $parent.siblings().find('.local-coordinate-system-fields').hide()
+    unless $(this).val().indexOf('HORIZONTAL') > -1
+      $parent.siblings().find('.horizontal-data-resolution-fields').hide()
+      $parent.siblings().find('.local-coordinate-system-fields').hide()
 
     switch $(this).val()
+      when ''
+        clearFieldsInClass($parent.siblings('.spatial-coverage-type'))
       when 'HORIZONTAL'
+        clearFieldsInClass($parent.siblings('.spatial-coverage-type').not('.horizontal'))
         $parent.siblings('.spatial-coverage-type.horizontal').show()
       when 'VERTICAL'
+        clearFieldsInClass($parent.siblings('.spatial-coverage-type').not('.vertical'))
         $parent.siblings('.spatial-coverage-type.vertical').show()
       when 'ORBITAL'
+        clearFieldsInClass($parent.siblings('.spatial-coverage-type').not('.orbit'))
         $parent.siblings('.spatial-coverage-type.orbit').show()
       when 'HORIZONTAL_VERTICAL'
+        clearFieldsInClass($parent.siblings('.spatial-coverage-type').not('.horizontal, .vertical'))
         $parent.siblings('.spatial-coverage-type.horizontal').show()
         $parent.siblings('.spatial-coverage-type.vertical').show()
       when 'ORBITAL_VERTICAL'
+        clearFieldsInClass($parent.siblings('.spatial-coverage-type').not('.orbit, .vertical'))
         $parent.siblings('.spatial-coverage-type.orbit').show()
         $parent.siblings('.spatial-coverage-type.vertical').show()
       when 'HORIZONTAL_ORBITAL'
+        clearFieldsInClass($parent.siblings('.spatial-coverage-type').not('.horizontal, .orbit'))
         $parent.siblings('.spatial-coverage-type.horizontal').show()
         $parent.siblings('.spatial-coverage-type.orbit').show()
       when 'HORIZONTAL_VERTICAL_ORBITAL'

--- a/app/views/collection_drafts/forms/fields/_horizontal_data_resolution_fields.html.erb
+++ b/app/views/collection_drafts/forms/fields/_horizontal_data_resolution_fields.html.erb
@@ -156,7 +156,7 @@
         ) %>
 
         <!-- GriddedRangeResolutions -->
-        <div class="horizontal-data-resolution-fields gridded-range-resolutions" style="<%= 'display: none;' unless gridded_range_resolutions_checked %>">
+        <div class="row sub-fields horizontal-data-resolution-fields gridded-range-resolutions" style="<%= 'display: none;' unless gridded_range_resolutions_checked %>">
           <%= mmt_label(
             name: 'gridded_range_resolutions',
             title: 'Gridded Range Resolutions',

--- a/app/views/collection_drafts/forms/fields/_spatial_extent_fields.html.erb
+++ b/app/views/collection_drafts/forms/fields/_spatial_extent_fields.html.erb
@@ -15,7 +15,7 @@
 
 
   <!-- HorizontalSpatialDomain -->
-  <div class="spatial-coverage-type horizontal" style="<%= 'display: none;' unless spatial_coverage_type.to_s.include? 'HORIZONTAL' %>">
+  <div class="spatial-coverage-type horizontal" style="<%= 'display: none;' unless spatial_coverage_type&.include?('HORIZONTAL') || spatial_extent.fetch('HorizontalSpatialDomain', nil) %>">
     <%= mmt_label(
       name: 'horizontal_spatial_domain',
       title: 'Horizontal Spatial Domain',
@@ -35,7 +35,7 @@
 
 
   <!-- OrbitParameters -->
-  <div class="spatial-coverage-type orbit" style="<%= 'display: none;' unless spatial_coverage_type.to_s.include? 'ORBITAL' %>">
+  <div class="spatial-coverage-type orbit" style="<%= 'display: none;' unless spatial_coverage_type&.include?('ORBITAL') || spatial_extent.fetch('OrbitParameters', nil) %>">
     <%= mmt_label(
       name: 'orbit_parameters',
       title: 'Orbit Parameters',
@@ -55,7 +55,7 @@
 
 
   <!-- VerticalSpatialDomains -->
-  <div class="spatial-coverage-type vertical" style="<%= 'display: none;' unless spatial_coverage_type.to_s.include? 'VERTICAL' %>">
+  <div class="spatial-coverage-type vertical" style="<%= 'display: none;' unless spatial_coverage_type&.include?('VERTICAL') || spatial_extent.fetch('VerticalSpatialDomains', nil) %>">
     <%= render partial: 'collection_drafts/forms/type', locals: {
         type: 'vertical_spatial_domain',
         values: spatial_extent['VerticalSpatialDomains'] || [{}],


### PR DESCRIPTION
Updated views such that when the page loads, they display if either the spatial_coverage_type dictates they should or if there is already data in the fields.
Updated JS to not clear fieldsets if the displayed fields are a subset of the new spatial_coverage_type