### PR TITLE
MMT-2195 Perform validation before publish and submit

### DIFF
--- a/app/controllers/collection_drafts_controller.rb
+++ b/app/controllers/collection_drafts_controller.rb
@@ -496,6 +496,7 @@ class CollectionDraftsController < BaseDraftsController
 
   def generate_model_error
     return unless get_resource.errors.any?
+
     get_resource.errors.full_messages.reject(&:blank?).map(&:downcase).join(', ')
   end
 
@@ -503,7 +504,7 @@ class CollectionDraftsController < BaseDraftsController
     return if validate_metadata.blank?
 
     action = resource_name == 'collection_draft_proposal' ? 'submitted for review' : 'published'
-    flash[:error] = "This collection can't be #{action}."
+    flash[:error] = "This collection can not be #{action}."
     redirect_to send("#{resource_name}_path", get_resource) and return
   end
 end

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -80,7 +80,7 @@ module Proposal
         @first_stage = 'In Work'
 
         # This applies the same validation as is applied on the preview/show page
-        show_view_setup
+        collection_validation_setup
         load_umm_c_schema
         @errors = validate_metadata
       else

--- a/app/controllers/proposal/collection_draft_proposals_controller.rb
+++ b/app/controllers/proposal/collection_draft_proposals_controller.rb
@@ -7,6 +7,11 @@ module Proposal
 
     before_action :ensure_non_nasa_draft_permissions
     before_action(only: [:submit, :rescind, :progress, :approve, :reject]) { set_resource }
+    before_action(only: [:submit]) do
+      load_umm_c_schema
+      collection_validation_setup
+      verify_valid_metadata
+    end
 
     def index
       working_proposals = current_user.send(plural_resource_name)

--- a/spec/features/manage_cmr/subscriptions/subscription_form_validation_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/subscription_form_validation_spec.rb
@@ -57,7 +57,7 @@ describe 'Subscription Form Validation', js: true do
           end
         end
 
-        it 'displays the proper validation errors withing the form' do
+        it 'displays the proper validation errors within the form' do
           expect(page).to have_content('Query must be a valid CMR granule search query.')
           expect(page).to have_content('Subscriber is required.')
 
@@ -81,7 +81,7 @@ describe 'Subscription Form Validation', js: true do
           end
         end
 
-        it 'displays the proper validation errors withing the form' do
+        it 'displays the proper validation errors within the form' do
           expect(page).to have_content('Query must be a valid CMR granule search query.')
           expect(page).to have_content('Subscriber is required.')
 
@@ -105,7 +105,7 @@ describe 'Subscription Form Validation', js: true do
           end
         end
 
-        it 'displays the proper validation errors withing the form' do
+        it 'displays the proper validation errors within the form' do
           expect(page).to have_content('Query must be a valid CMR granule search query.')
           expect(page).to have_content('Subscriber is required.')
 
@@ -131,7 +131,7 @@ describe 'Subscription Form Validation', js: true do
           end
         end
 
-        it 'displays the proper validation errors withing the form' do
+        it 'displays the proper validation errors within the form' do
           expect(page).to have_content('Subscriber is required.')
 
           expect(page).to have_no_content('Query must be a valid CMR granule search query.')

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_submit_spec.rb
@@ -116,6 +116,20 @@ describe 'Collection Draft Proposal Submit and Rescind', reset_provider: true, j
       end
     end
 
+    context 'when the collection is valid on page load, but not when the user tries to submit it' do
+      before do
+        @collection_draft_proposal.draft['Version'] = ''
+        @collection_draft_proposal.save
+
+        click_on 'Submit'
+        click_on 'Yes'
+      end
+
+      it 'displays an error message' do
+        expect(page).to have_content('This collection can not be submitted for review')
+      end
+    end
+
     context 'when the submission fails' do
       before do
         # After loading the page, manipulate the state of the proposal so that


### PR DESCRIPTION
Renamed show_view_setup to collection_validation_setup because it needs to be run in all of the places we run validate_metadata.
Added verify_valid_metadata as a before action for publish action to repeat the validation that was run when the show page was loaded.
Added before actions for the submit action (proposals) to load the schema, run collection_validation_setup, and run the validation