### PR TITLE
MMT-2045 updating preview gem commit ref

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'aasm'
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
 # make sure to delete the local config when done making changes to merge into master
 # bundle config --delete local.cmr_metadata_preview
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '457a6d8bd74'
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '9b5c23e5510'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: 457a6d8bd741e6b6eaf012e4653f8cdc81cc0c8f
-  ref: 457a6d8bd74
+  revision: 9b5c23e5510237605e4a1ad6ac8376480da88419
+  ref: 9b5c23e5510
   specs:
     cmr_metadata_preview (0.2.1)
       georuby (~> 2.5.2)


### PR DESCRIPTION
Relates to additional attributes changes in preview gem display. They should now display without needing an ancillary keyword or isotopic category and should display their table only when applicable.