### PR TITLE
MMT2281

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -11,7 +11,7 @@
 .card {
   border: 1px solid darken($light-blue, 8%);
   border-radius: 4px;
-  width: 350px;
+  width: 375px;
   margin-bottom: 10px;
   flex: 0 1 auto;
 

--- a/lib/json_schema_form/umm_preview_elements/umm_preview_contacts.rb
+++ b/lib/json_schema_form/umm_preview_elements/umm_preview_contacts.rb
@@ -181,13 +181,11 @@ class UmmPreviewContacts < UmmPreviewElement
                      end)
 
               concat(content_tag(:ul, class: 'arrow-tag-group-list') do
-                if ['GET SERVICE', 'GET DATA'].include? related_url['Type']
+                if related_url['Type']
                   concat content_tag(:li, related_url['Type'], class: 'arrow-tag-group-item')
-                  concat content_tag(:li, related_url['Subtype'], class: 'arrow-tag-group-item') if related_url['Subtype']
-                elsif related_url['Subtype']
+                end
+                if related_url['Subtype']
                   concat content_tag(:li, related_url['Subtype'], class: 'arrow-tag-group-item')
-                elsif related_url['Type']
-                  concat content_tag(:li, related_url['Type'], class: 'arrow-tag-group-item')
                 end
               end)
             end)

--- a/lib/json_schema_form/umm_preview_elements/umm_preview_url.rb
+++ b/lib/json_schema_form/umm_preview_elements/umm_preview_url.rb
@@ -33,14 +33,11 @@ class UmmPreviewURL < UmmPreviewElement
         concat content_tag(:p, metadata['Description']) if metadata['Description']
         concat(get_url(metadata))
         concat(content_tag(:ul, class: 'arrow-tag-group-list') do
-          if ['GET SERVICE', 'GET DATA'].include? url_type(metadata)
+          if url_type(metadata)
             concat content_tag(:li, url_type(metadata), class: 'arrow-tag-group-item')
-            concat content_tag(:li, url_subtype(metadata), class: 'arrow-tag-group-item') if url_subtype(metadata)
-          elsif url_subtype(metadata)
-            # TODO this should be modified in MMT-2281 so Type is shown
+          end
+          if url_subtype(metadata)
             concat content_tag(:li, url_subtype(metadata), class: 'arrow-tag-group-item')
-          elsif url_type(metadata)
-            concat content_tag(:li, url_type(metadata), class: 'arrow-tag-group-item')
           end
         end)
       end)

--- a/spec/factories/tool_draft_factories.rb
+++ b/spec/factories/tool_draft_factories.rb
@@ -123,6 +123,7 @@ FactoryBot.define do
           'Description': 'Access the WRS-2 Path/Row to Latitude/Longitude Converter.',
           'URLContentType': 'DistributionURL',
           'Type': 'DOWNLOAD SOFTWARE',
+          'Subtype': 'MOBILE APP', 
           'URLValue': 'http://www.scp.byu.edu/software/slice_response/Xshape_temp.html'
         },
         'RelatedURLs': [

--- a/spec/features/service_drafts/preview/valid/service_contacts_preview_spec.rb
+++ b/spec/features/service_drafts/preview/valid/service_contacts_preview_spec.rb
@@ -88,6 +88,10 @@ describe 'Valid Service Draft Service Contacts Preview' do
               expect(page).to have_css('p', text: related_urls[0]['Description'])
               expect(page).to have_css('p', text: related_urls[0]['Value'])
             end
+            within 'ul.arrow-tag-group-list' do
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'DATA SET LANDING PAGE')
+              expect(page).to have_css('li.arrow-tag-group-item', count: 1)
+            end
           end
 
           # Fifth card; RelatedUrl 2
@@ -96,6 +100,10 @@ describe 'Valid Service Draft Service Contacts Preview' do
               expect(page).to have_css('p', text: related_urls[1]['Description'])
               expect(page).to have_css('p', text: related_urls[1]['Value'])
             end
+            within 'ul.arrow-tag-group-list' do
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'VIEW RELATED INFORMATION')
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'READ-ME')
+            end
           end
 
           # Sixth card; RelatedUrl 3
@@ -103,6 +111,10 @@ describe 'Valid Service Draft Service Contacts Preview' do
             within '.card-body-details-full' do
               expect(page).to have_css('p', text: related_urls[2]['Description'])
               expect(page).to have_css('p', text: related_urls[2]['Value'])
+            end
+            within 'ul.arrow-tag-group-list' do
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'GET RELATED VISUALIZATION')
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'GIOVANNI')
             end
           end
         end
@@ -175,6 +187,10 @@ describe 'Valid Service Draft Service Contacts Preview' do
               expect(page).to have_css('p', text: related_urls[0]['Description'])
               expect(page).to have_css('p', text: related_urls[0]['Value'])
             end
+            within 'ul.arrow-tag-group-list' do
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'DATA SET LANDING PAGE')
+              expect(page).to have_css('li.arrow-tag-group-item', count: 1)
+            end
           end
 
           # Fifth card; RelatedUrl 2
@@ -183,6 +199,10 @@ describe 'Valid Service Draft Service Contacts Preview' do
               expect(page).to have_css('p', text: related_urls[1]['Description'])
               expect(page).to have_css('p', text: related_urls[1]['Value'])
             end
+            within 'ul.arrow-tag-group-list' do
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'VIEW RELATED INFORMATION')
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'READ-ME')
+            end
           end
 
           # Sixth card; RelatedUrl 3
@@ -190,6 +210,10 @@ describe 'Valid Service Draft Service Contacts Preview' do
             within '.card-body-details-full' do
               expect(page).to have_css('p', text: related_urls[2]['Description'])
               expect(page).to have_css('p', text: related_urls[2]['Value'])
+            end
+            within 'ul.arrow-tag-group-list' do
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'GET RELATED VISUALIZATION')
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'GIOVANNI')
             end
           end
         end

--- a/spec/features/tool_drafts/preview/valid/related_urls_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/related_urls_preview_spec.rb
@@ -48,7 +48,7 @@ describe 'Valid Tool Draft Related URL Preview' do
                 within '.card-body' do
                   expect(page).to have_css('p', text: 'Test related url')
                   expect(page).to have_link(nil, href: 'nasa.gov')
-                  # expect(page).to have_css('li', text: 'GET RELATED VISUALIZATION') # Not rendered... see comments in preview class
+                  expect(page).to have_css('li.arrow-tag-group-item', text: 'GET RELATED VISUALIZATION') #type; uncommented by CT
                   expect(page).to have_css('li.arrow-tag-group-item', text: 'MAP')
                 end
               end
@@ -61,7 +61,7 @@ describe 'Valid Tool Draft Related URL Preview' do
                 within '.card-body' do
                   expect(page).to have_css('p', text: 'Test another related url')
                   expect(page).to have_link(nil, href: 'algorithms.org')
-                  # expect(page).to have_css('li', text: 'VIEW RELATED INFORMATION') # Not rendered... see comments in preview class
+                  expect(page).to have_css('li.arrow-tag-group-item', text: 'VIEW RELATED INFORMATION')
                   expect(page).to have_css('li.arrow-tag-group-item', text: 'ALGORITHM DOCUMENTATION')
                 end
               end

--- a/spec/features/tool_drafts/preview/valid/tool_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/tool_information_preview_spec.rb
@@ -114,8 +114,9 @@ describe 'Valid Tool Draft Tool Information Preview' do
             within '.card-body' do
               expect(page).to have_css('p', text: 'Access the WRS-2 Path/Row to Latitude/Longitude Converter.')
               expect(page).to have_link(nil, href: 'http://www.scp.byu.edu/software/slice_response/Xshape_temp.html')
-              expect(page).to have_css('li', text: 'DOWNLOAD SOFTWARE')
-            end
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'DOWNLOAD SOFTWARE')
+              expect(page).to have_css('li.arrow-tag-group-item', text: 'MOBILE APP')
+             end
           end
         end
       end


### PR DESCRIPTION

- Added a subtype to the full tool draft factory for tool information>URLs
- Added tests to files in service_drafts and tool_drafts to confirm any URL/Related URL Types and Subtypes are displayed as arrow tags
- Increased the width of the cards from 350px to 375px to accommodate the longest type/subtype

