### PR TITLE
Hotfix/MMT-2231-1 Updating revisions helpers to sort by revision date

### DIFF
--- a/app/concerns/cmr_collections_helper.rb
+++ b/app/concerns/cmr_collections_helper.rb
@@ -6,7 +6,7 @@ module CMRCollectionsHelper
     # try again because CMR might be a little slow to index if it is a newly published revision
     attempts = 0
     while attempts < 20
-      revisions_response = cmr_client.get_collections({ concept_id: concept_id, all_revisions: true, include_granule_counts: true }, token)
+      revisions_response = cmr_client.get_collections({ concept_id: concept_id, all_revisions: true, include_granule_counts: true, sort_key: '-revision_date' }, token)
       revisions = if revisions_response.success?
                     revisions_response.body.fetch('items', [])
                   else

--- a/app/controllers/manage_metadata_controller.rb
+++ b/app/controllers/manage_metadata_controller.rb
@@ -110,7 +110,7 @@ class ManageMetadataController < ApplicationController
     # if the variable is not found, try again because CMR might be a little slow to index if it is a newly published record
     attempts = 0
     while attempts < 20
-      variables_search_response = cmr_client.get_variables(concept_id: @concept_id, all_revisions: true)
+      variables_search_response = cmr_client.get_variables(concept_id: @concept_id, all_revisions: true, sort_key: '-revision_date')
 
       variable_data = if variables_search_response.success?
                         variables_search_response.body.fetch('items', [])
@@ -163,7 +163,7 @@ class ManageMetadataController < ApplicationController
     # if the service is not found, try again because CMR might be a little slow to index if it is a newly published record
     attempts = 0
     while attempts < 20
-      services_search_response = cmr_client.get_services(concept_id: @concept_id, all_revisions: true)
+      services_search_response = cmr_client.get_services(concept_id: @concept_id, all_revisions: true, sort_key: '-revision_date')
 
       service_data = if services_search_response.success?
                        services_search_response.body.fetch('items', [])
@@ -218,7 +218,7 @@ class ManageMetadataController < ApplicationController
     # if the tool is not found, try again because CMR might be a little slow to index if it is a newly published record
     attempts = 0
     while attempts < 20
-      tools_search_response = cmr_client.get_tools(concept_id: @concept_id, all_revisions: true)
+      tools_search_response = cmr_client.get_tools(concept_id: @concept_id, all_revisions: true, sort_key: '-revision_date')
 
       tool_data = if tools_search_response.success?
                     tools_search_response.body.fetch('items', [])

--- a/spec/features/collections/revision_list_spec.rb
+++ b/spec/features/collections/revision_list_spec.rb
@@ -1,15 +1,19 @@
 describe 'Revision list', js: true do
   context 'when viewing a published collection' do
+    before :all do
+      native_id = 'collection_revision_native_id'
+      _ingest_response, _concept_response = publish_collection_draft(native_id: native_id, revision_count: 10, short_name: 'b_test_01')
+      @ingest_response, @concept_response = publish_collection_draft(native_id: native_id, short_name: 'c_test_01')
+    end
+
     before do
       login
 
-      ingest_response, @concept_response = publish_collection_draft(revision_count: 2)
-
-      visit collection_path(ingest_response['concept-id'])
+      visit collection_path(@ingest_response['concept-id'])
     end
 
     it 'displays the number of revisions' do
-      expect(page).to have_content('Revisions (2)')
+      expect(page).to have_content('Revisions (10)')
     end
 
     context 'when clicking on the revision link' do
@@ -27,15 +31,15 @@ describe 'Revision list', js: true do
       end
 
       it 'displays when the revision was made' do
-        expect(page).to have_content(today_string, count: 2)
+        expect(page).to have_content(today_string, count: 10)
       end
 
       it 'displays what user made the revision' do
-        expect(page).to have_content('typical', count: 2)
+        expect(page).to have_content('typical', count: 10)
       end
 
       it 'displays the correct phrasing for reverting records' do
-        expect(page).to have_content('Revert to this Revision', count: 1)
+        expect(page).to have_content('Revert to this Revision', count: 9)
       end
 
       context 'when viewing an old revision' do

--- a/spec/features/services/revision_list_spec.rb
+++ b/spec/features/services/revision_list_spec.rb
@@ -1,15 +1,22 @@
 describe 'Service revision list', reset_provider: true, js: true do
   context 'when viewing a published service' do
+    before :all do
+      # CMR does not return revisions sorted by revision_id. It sorts
+      # by name first (and maybe other things). If the sort_key is working
+      # correctly, the last revision (c_test_01), should be visible on the page
+      native_id = 'service_revision_native_id'
+      _ingest_response, _concept_response, @native_id = publish_service_draft(native_id: native_id, revision_count: 10, name: 'b_test_01')
+      @ingest_response, @concept_response, _native_id = publish_service_draft(native_id: native_id, name: 'c_test_01')
+    end
+
     before do
       login
 
-      ingest_response, @concept_response = publish_service_draft(revision_count: 2)
-
-      visit service_path(ingest_response['concept-id'])
+      visit service_path(@ingest_response['concept-id'])
     end
 
     it 'displays the number of revisions' do
-      expect(page).to have_content('Revisions (2)')
+      expect(page).to have_content('Revisions (10)')
     end
 
     context 'when clicking on the revision link' do
@@ -27,15 +34,19 @@ describe 'Service revision list', reset_provider: true, js: true do
       end
 
       it 'displays when the revision was made' do
-        expect(page).to have_content(today_string, count: 2)
+        expect(page).to have_content(today_string, count: 10)
       end
 
       it 'displays what user made the revision' do
-        expect(page).to have_content('typical', count: 2)
+        expect(page).to have_content('typical', count: 10)
+      end
+
+      it 'displays the most recent revisions' do
+        expect(page).to have_content('11 - Published')
       end
 
       it 'displays the correct phrasing for reverting records' do
-        expect(page).to have_content('Revert to this Revision', count: 1)
+        expect(page).to have_content('Revert to this Revision', count: 9)
       end
 
       context 'when viewing an old revision' do

--- a/spec/features/services/revision_list_spec.rb
+++ b/spec/features/services/revision_list_spec.rb
@@ -5,8 +5,8 @@ describe 'Service revision list', reset_provider: true, js: true do
       # by name first (and maybe other things). If the sort_key is working
       # correctly, the last revision (c_test_01), should be visible on the page
       native_id = 'service_revision_native_id'
-      _ingest_response, _concept_response, @native_id = publish_service_draft(native_id: native_id, revision_count: 10, name: 'b_test_01')
-      @ingest_response, @concept_response, _native_id = publish_service_draft(native_id: native_id, name: 'c_test_01')
+      _ingest_response, _concept_response = publish_service_draft(native_id: native_id, revision_count: 10, name: 'b_test_01')
+      @ingest_response, @concept_response = publish_service_draft(native_id: native_id, name: 'c_test_01')
     end
 
     before do

--- a/spec/features/tools/revision_list_spec.rb
+++ b/spec/features/tools/revision_list_spec.rb
@@ -1,7 +1,11 @@
 describe 'Tool revision list', reset_provider: true, js: true do
   context 'when viewing a published tool' do
     before :all do
-      @ingest_response, @concept_response, @native_id = publish_tool_draft(revision_count: 2)
+      # CMR does not return revisions sorted by revision_id. It sorts
+      # by name first (and maybe other things). If the sort_key is working
+      # correctly, the last revision (c_test_01), should be visible on the page
+      _ingest_response, _concept_response, @native_id = publish_tool_draft(revision_count: 10, name: 'b_test_01')
+      @ingest_response, @concept_response, _native_id = publish_tool_draft(native_id: @native_id, name: 'c_test_01')
     end
 
     # TODO: remove after CMR-6332
@@ -18,7 +22,7 @@ describe 'Tool revision list', reset_provider: true, js: true do
     end
 
     it 'displays the number of revisions' do
-      expect(page).to have_content('Revisions (2)')
+      expect(page).to have_content('Revisions (10)')
     end
 
     context 'when clicking on the revision link' do
@@ -36,11 +40,15 @@ describe 'Tool revision list', reset_provider: true, js: true do
       end
 
       it 'displays when the revision was made' do
-        expect(page).to have_content(today_string, count: 2)
+        expect(page).to have_content(today_string, count: 10)
       end
 
       it 'displays what user made the revision' do
-        expect(page).to have_content('typical', count: 2)
+        expect(page).to have_content('typical', count: 10)
+      end
+
+      it 'displays the most recent revisions' do
+        expect(page).to have_content('11 - Published')
       end
 
 #      TODO: Uncomment in MMT-2233


### PR DESCRIPTION
CMR does not sort by revision date first by default.  In order to ensure the behavior we expect, we need to tell it to sort by revision date.