### PR TITLE
Hotfix/MMT-2301-1 Moving delete modal to separate partial

### DIFF
--- a/app/views/base_published_record/_delete_link.html.erb
+++ b/app/views/base_published_record/_delete_link.html.erb
@@ -1,0 +1,5 @@
+<% if current_provider?(@provider_id) %>
+  <%= link_to "Delete #{@published_resource_name.capitalize} Record", "#delete-record-modal", class: "display-modal delete-#{@published_resource_name} eui-btn--link bar-before" %>
+<% elsif available_provider?(@provider_id) %>
+  <%= link_to "Delete #{@published_resource_name.capitalize} Record", '#not-current-provider-modal', class: 'display-modal not-current-provider eui-btn--link bar-before', data: { 'provider': @provider_id, record_action: "delete-#{@published_resource_name}", num_associated_collections: "#{@num_associated_collections}" } %>
+<% end %>

--- a/app/views/base_published_record/_delete_modal.html.erb
+++ b/app/views/base_published_record/_delete_modal.html.erb
@@ -1,9 +1,3 @@
-<% if current_provider?(@provider_id) %>
-  <%= link_to "Delete #{@published_resource_name.capitalize} Record", "#delete-record-modal", class: "display-modal delete-#{@published_resource_name} eui-btn--link bar-before" %>
-<% elsif available_provider?(@provider_id) %>
-  <%= link_to "Delete #{@published_resource_name.capitalize} Record", '#not-current-provider-modal', class: 'display-modal not-current-provider eui-btn--link bar-before', data: { 'provider': @provider_id, record_action: "delete-#{@published_resource_name}", num_associated_collections: "#{@num_associated_collections}" } %>
-<% end %>
-
 <div id="delete-record-modal" class="eui-modal-content">
   <a href="javascript:void(0);" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
   <p>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -19,9 +19,10 @@
 
         <%= link_to 'Download JSON', send("download_json_#{@published_resource_name}_path", @concept_id, revision_id: @revision_id), class: 'eui-btn--link', target: '_blank' %>
 
-        <%= render partial: 'base_published_record/delete_link_with_modal' %>
+        <%= render partial: 'base_published_record/delete_link' %>
         <%= render partial: 'base_published_record/manage_collection_associations' %>
 
+        <%= render partial: 'base_published_record/delete_modal' %>
         <%= render partial: 'shared/not_current_provider_modal', locals: {
           options: {
             @published_resource_name.to_sym => get_resource,

--- a/app/views/tools/show.html.erb
+++ b/app/views/tools/show.html.erb
@@ -19,8 +19,9 @@
 
         <%= link_to 'Download JSON', send("download_json_#{@published_resource_name}_path", @concept_id, revision_id: @revision_id), class: 'eui-btn--link', target: '_blank' %>
 
-        <%= render partial: 'base_published_record/delete_link_with_modal' %>
-
+        <%= render partial: 'base_published_record/delete_link' %>
+        
+        <%= render partial: 'base_published_record/delete_modal' %>
         <%= render partial: 'shared/not_current_provider_modal', locals: {
           options: {
             @published_resource_name.to_sym => get_resource,

--- a/app/views/variables/show.html.erb
+++ b/app/views/variables/show.html.erb
@@ -19,9 +19,10 @@
 
         <%= link_to 'Download JSON', send("download_json_#{@published_resource_name}_path", @concept_id, revision_id: @revision_id), class: 'eui-btn--link', target: '_blank' %>
 
-        <%= render partial: 'base_published_record/delete_link_with_modal' %>
+        <%= render partial: 'base_published_record/delete_link' %>
         <%= render partial: 'base_published_record/manage_collection_associations' if ['variable', 'service'].include? @published_resource_name %>
 
+        <%= render partial: 'base_published_record/delete_modal' %>
         <%= render partial: 'shared/not_current_provider_modal', locals: {
           options: {
             @published_resource_name.to_sym => get_resource,

--- a/spec/features/provider_context/provider_context_spec.rb
+++ b/spec/features/provider_context/provider_context_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe 'Provider context', reset_provider: true, js: true do
   let(:order_guid) { 'FF330AD3-1A89-871C-AC94-B689A5C95723' }
 

--- a/spec/features/provider_context/provider_context_spec.rb
+++ b/spec/features/provider_context/provider_context_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 describe 'Provider context', reset_provider: true, js: true do
   let(:order_guid) { 'FF330AD3-1A89-871C-AC94-B689A5C95723' }
 


### PR DESCRIPTION
Having the modal in the same partial as the link causes a line break.  Separated them so that the display remains the same as before.