### PR TITLE
MMT-1876: Link SKW, Data Centers, instruments, and platforms in a collection's preview to Earthdata Search collections with the same keywords

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem 'browser'
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
 # make sure to delete the local config when done making changes to merge into master
 # bundle config --delete local.cmr_metadata_preview
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: 'b6272dc6113', branch: 'MMT-1876'
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '5e8de59f4f7'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem 'browser'
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
 # make sure to delete the local config when done making changes to merge into master
 # bundle config --delete local.cmr_metadata_preview
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '1f6ffd54d65'
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: 'b6272dc6113', branch: 'MMT-1876'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,7 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: b6272dc611327974979a2a67d457859d04f9a7fc
-  ref: b6272dc6113
-  branch: MMT-1876
+  revision: 5e8de59f4f75e89515ecd1ce988b16a7a0ced757
+  ref: 5e8de59f4f7
   specs:
     cmr_metadata_preview (0.2.3)
       georuby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: 1f6ffd54d6570f9f920078a84fd51750db3c21ab
-  ref: 1f6ffd54d65
+  revision: b6272dc611327974979a2a67d457859d04f9a7fc
+  ref: b6272dc6113
+  branch: MMT-1876
   specs:
     cmr_metadata_preview (0.2.3)
       georuby

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -41,4 +41,14 @@ module CollectionsHelper
       content_tag(:span, 'NRT', class: 'eui-badge nrt')
     end
   end
+
+  def edsc_url
+    if Rails.env.production?
+      'https://search.earthdata.nasa.gov/search'
+    elsif Rails.env.sit?
+      'https://search.sit.earthdata.nasa.gov/search'
+    elsif Rails.env.uat?
+      'https://search.uat.earthdata.nasa.gov/search'
+    end
+  end
 end

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -48,8 +48,9 @@ module CollectionsHelper
       config_services.dig('earthdata', 'ops', 'edsc_root')
     elsif Rails.env.sit? || Rails.env.development? || Rails.env.test?
       # by directing development and test evironments to the edsc sit environment, there
-      # are occasionally situations where the keywords aren't congruent with those in sit
-      # and so no matches may be found in edsc
+      # are often situations where the keywords in dev or test aren't congruent with those in sit
+      # and so no matches may be found in edsc. For instance, if this was directed to prod
+      # instead, all keywords would be found
       config_services.dig('earthdata', 'sit', 'edsc_root')
     elsif Rails.env.uat?
       config_services.dig('earthdata', 'uat', 'edsc_root')

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -43,12 +43,16 @@ module CollectionsHelper
   end
 
   def edsc_url
+    config_services = Rails.configuration.services
     if Rails.env.production?
-      'https://search.earthdata.nasa.gov/search'
-    elsif Rails.env.sit?
-      'https://search.sit.earthdata.nasa.gov/search'
+      config_services.dig('earthdata', 'ops', 'edsc_root')
+    elsif Rails.env.sit? || Rails.env.development? || Rails.env.test?
+      # by directing development and test evironments to the edsc sit environment, there
+      # are occasionally situations where the keywords aren't congruent with those in sit
+      # and so no matches may be found in edsc
+      config_services.dig('earthdata', 'sit', 'edsc_root')
     elsif Rails.env.uat?
-      'https://search.uat.earthdata.nasa.gov/search'
+      config_services.dig('earthdata', 'uat', 'edsc_root')
     end
   end
 end

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -116,8 +116,8 @@
           <a href="#granules-modal" id="display-granules-modal" class="display-modal is-invisible"></a>
           <div id="granules-modal" class="eui-modal-content">
             <a href=<%=current_provider?(@provider_id) ? "javascript:void(0);" : collection_path %> class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-            <p>This collection has <%= @num_granules %> associated <%= 'granule'.pluralize(@num_granules) %>.</p> 
-            <p id="danger-warning">Deleting this collection will delete all associated granules.</p> 
+            <p>This collection has <%= @num_granules %> associated <%= 'granule'.pluralize(@num_granules) %>.</p>
+            <p id="danger-warning">Deleting this collection will delete all associated granules.</p>
             <p>Please confirm that you wish to continue by entering '<%= CollectionsHelper::DELETE_CONFIRMATION_TEXT %>' below.</p>
             <%= form_tag(collection_path, method: :delete, class: 'granules-confirmation-form') do %>
               <%= text_field_tag('confirmation-text', nil, class: 'full-width') %>
@@ -135,8 +135,7 @@
           <!-- end hidden content for action buttons -->
         </div>
       </section>
-
-      <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @collection, is_mmt: true, editable: false, edsc_url: nil, concept_id: nil, additional_information: nil } %>
+      <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @collection, is_mmt: true, editable: false, edsc_url: edsc_url, concept_id: nil, additional_information: nil } %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
- added an `edsc_url` method to read the current MMT environment (sit,prod,uat,etc) and return the proper edsc url for passage to the preview gem