### PR TITLE
MMT-2325 updating data migration to account for improperly formatted existing variables

### DIFF
--- a/db/migrate/20200903193441_umm_v_1_7_data_migration.rb
+++ b/db/migrate/20200903193441_umm_v_1_7_data_migration.rb
@@ -36,8 +36,11 @@ class UmmV17DataMigration < ActiveRecord::Migration[5.2]
     characteristics = draft['Characteristics']
     return draft unless characteristics.is_a?(Hash) && characteristics['GroupPath']
 
+    # There may be cases where an existing group_path contains the name already
+    # If there is no name or if the name is already within the group_path,
+    # save that as new name.
     group_path = characteristics['GroupPath']
-    if group_path && !draft['Name']
+    if group_path && !draft['Name'] || draft['Name'] && group_path.end_with?(draft['Name'])
       draft['Name'] = group_path
       return draft
     end

--- a/db/migrate/20200903193441_umm_v_1_7_data_migration.rb
+++ b/db/migrate/20200903193441_umm_v_1_7_data_migration.rb
@@ -31,23 +31,34 @@ class UmmV17DataMigration < ActiveRecord::Migration[5.2]
   ############################# To 1.7 ########################################
   # Merge the name and GroupPath fields with only one slash between them
   def merge_group_path_and_name_for_1_7(draft)
-    return draft unless draft.dig('Characteristics', 'GroupPath')
-    return draft['Name'] = "#{draft.dig('Characteristics', 'GroupPath')}" if draft.dig('Characteristics', 'GroupPath') && !draft['Name']
+    return draft unless draft['Characteristics']
 
-    draft['Name'] = if draft['Name'].start_with?('/') && draft.dig('Characteristics', 'GroupPath').end_with?('/')
-                      "#{draft.dig('Characteristics', 'GroupPath').chop}#{draft['Name']}"
-                    elsif draft['Name'].start_with?('/') || draft.dig('Characteristics', 'GroupPath').end_with?('/')
-                      "#{draft.dig('Characteristics', 'GroupPath')}#{draft['Name']}"
+    characteristics = draft['Characteristics']
+    return draft unless characteristics.is_a?(Hash) && characteristics['GroupPath']
+
+    group_path = characteristics['GroupPath']
+    if group_path && !draft['Name']
+      draft['Name'] = group_path
+      return draft
+    end
+
+    draft['Name'] = if draft['Name'].start_with?('/') && group_path.end_with?('/')
+                      "#{group_path.chop}#{draft['Name']}"
+                    elsif draft['Name'].start_with?('/') || group_path.end_with?('/')
+                      "#{group_path}#{draft['Name']}"
                     else
-                      "#{draft.dig('Characteristics', 'GroupPath')}/#{draft['Name']}"
+                      "#{group_path}/#{draft['Name']}"
                     end
     draft
   end
 
   def pull_indexes_to_top_for_1_7(draft)
-    return draft unless draft.dig('Characteristics', 'IndexRanges')
+    return draft unless draft['Characteristics']
 
-    draft['IndexRanges'] = draft.delete('Characteristics')['IndexRanges']
+    characteristics = draft.delete('Characteristics')
+    return draft unless characteristics.is_a?(Hash) && characteristics['IndexRanges']
+
+    draft['IndexRanges'] = characteristics['IndexRanges']
     draft
   end
 

--- a/spec/migrations/umm_v_1_7_spec.rb
+++ b/spec/migrations/umm_v_1_7_spec.rb
@@ -16,6 +16,7 @@ describe 'Migration tests for UMM-V 1.7' do
       @name_slash_draft = create(:full_variable_draft_1_6, draft_name: name_slash, draft_group_path: group_path_no_slash)
       @group_path_slash_draft = create(:full_variable_draft_1_6, draft_name: name_no_slash, draft_group_path: group_path_slash)
       @two_slash_draft = create(:full_variable_draft_1_6, draft_name: name_slash, draft_group_path: group_path_slash)
+      @name_in_group_path_draft = create(:full_variable_draft_1_6, draft_name: name_slash, draft_group_path: "#{group_path_no_slash}#{name_slash}")
       @no_name_draft = create(:full_variable_draft_1_6, draft_group_path: group_path_slash)
       @no_name_draft.draft['Name'] = nil
       @no_name_draft.save
@@ -27,7 +28,7 @@ describe 'Migration tests for UMM-V 1.7' do
     end
 
     after :all do
-      VariableDraft.delete([@draft.id, @empty_draft.id, @no_slash_draft.id, @name_slash_draft.id, @group_path_slash_draft.id, @two_slash_draft.id, @no_name_draft, @invalid_draft])
+      VariableDraft.delete([@draft.id, @empty_draft.id, @no_slash_draft.id, @name_slash_draft.id, @group_path_slash_draft.id, @two_slash_draft.id, @no_name_draft.id, @invalid_draft.id, @name_in_group_path_draft.id])
     end
 
     it 'the migration only removed the fields removed from the schema' do
@@ -41,6 +42,7 @@ describe 'Migration tests for UMM-V 1.7' do
       expect(VariableDraft.find(@group_path_slash_draft.id).draft['Name']).to eq("#{group_path_slash}#{name_no_slash}")
       expect(VariableDraft.find(@two_slash_draft.id).draft['Name']).to eq("#{group_path_slash.chop}#{name_slash}")
       expect(VariableDraft.find(@no_name_draft.id).draft['Name']).to eq("#{group_path_slash}")
+      expect(VariableDraft.find(@name_in_group_path_draft.id).draft['Name']).to eq("#{group_path_no_slash}#{name_slash}")
     end
 
     it 'the index ranges are migrated correctly' do

--- a/spec/migrations/umm_v_1_7_spec.rb
+++ b/spec/migrations/umm_v_1_7_spec.rb
@@ -27,7 +27,7 @@ describe 'Migration tests for UMM-V 1.7' do
     end
 
     after :all do
-      VariableDraft.delete([@draft.id, @empty_draft.id, @no_slash_draft.id, @name_slash_draft.id, @group_path_slash_draft.id, @two_slash_draft.id])
+      VariableDraft.delete([@draft.id, @empty_draft.id, @no_slash_draft.id, @name_slash_draft.id, @group_path_slash_draft.id, @two_slash_draft.id, @no_name_draft, @invalid_draft])
     end
 
     it 'the migration only removed the fields removed from the schema' do


### PR DESCRIPTION
Data migration failed because there were existing drafts which had a string for characteristics and strings do not respond to dig.