### PR TITLE
MMT-2331: notify user of associated variable when deleting collection

### DIFF
--- a/app/assets/javascripts/change_current_provider.coffee
+++ b/app/assets/javascripts/change_current_provider.coffee
@@ -104,8 +104,8 @@ $(document).ready ->
 
       success: (data, status, xhr) ->
         # Click the link that the user needs
-        if linkType == 'delete-collection' && $('.collection-granule-count').text() != 'Granules (0)'
-          $('#display-granules-modal').click()
+        if linkType == 'delete-collection' && (numGranules > 0 || numVariables > 0)
+          $('#display-cascade-delete-modal').click()
         else
           $(link)[0].click()
 

--- a/app/assets/javascripts/collections.coffee
+++ b/app/assets/javascripts/collections.coffee
@@ -1,7 +1,6 @@
 $(document).ready ->
   $('.delete-collection-in-current-provider').on 'click', (e) ->
-    count = $('.collection-granule-count').text()
-    if count != 'Granules (0)'
+    if numGranules > 0 || numVariables > 0
       e.stopImmediatePropagation()
 
-      $('#display-granules-modal').click()
+      $('#display-cascade-delete-modal').click()

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -278,7 +278,6 @@ class ApplicationController < ActionController::Base
   end
   helper_method :token
 
-
   def echo_provider_token
     set_provider_context_token if session[:echo_provider_token].nil?
 
@@ -364,6 +363,23 @@ class ApplicationController < ActionController::Base
   end
 
   def set_provider_context_token
+    # If we are in development and the user is not on the VPN, this call will
+    # not be able to connect to legacy services in order to get this token
+    # this will also mean that legacy services actions using the token will fail
+    if Rails.env.development?
+      begin
+        response = echo_client.get_provider_context_token(token, behalfOfProvider: current_user.provider_id).parsed_body
+      rescue => e
+        Rails.logger.info "Preventing get_provider_context_token error in development because of not being on VPN. error: #{e.inspect}"
+
+        session[:echo_provider_token] = ''
+
+        flash[:error] = 'Because you are not on the VPN and in development, the attempt to set an echo_provider_token failed. You will be unable to perform Manage Cmr actions that require the token.<br/>If you need to perform any Manage Cmr actions in development you should log out, get on the VPN, and then log back in'
+
+        return
+      end
+    end
+
     session[:echo_provider_token] = echo_client.get_provider_context_token(token, behalfOfProvider: current_user.provider_id).parsed_body
   end
 
@@ -371,7 +387,7 @@ class ApplicationController < ActionController::Base
   def user_not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore
 
-    flash[:error] =I18n.t("#{policy_name}.#{exception.query}", scope: 'pundit', default: :default)
+    flash[:error] = I18n.t("#{policy_name}.#{exception.query}", scope: 'pundit', default: :default)
     redirect_to(request.referrer || internal_landing_page)
   end
 
@@ -388,16 +404,17 @@ class ApplicationController < ActionController::Base
     # it can be removed once Launchpad has been live and stable in
     # production for a while, with MMT-1615
     return if Rails.env.test? || session[:login_method] == 'urs'
+
     all_session_keys = LAUNCHPAD_SESSION_KEYS | URS_SESSION_KEYS
     # additional token and login keys
     all_session_keys += %i[echo_provider_token login_method]
-      all_session_keys_log = all_session_keys.map do |key|
-        if key == :launchpad_cookie && !session[key].blank?
-          "#{key}: length: #{session[key].length.round(-2)}; snippet: #{session[key].truncate(50)}"
-        else
-          "#{key}: #{session[key]}"
-        end
+    all_session_keys_log = all_session_keys.map do |key|
+      if key == :launchpad_cookie && !session[key].blank?
+        "#{key}: length: #{session[key].length.round(-2)}; snippet: #{session[key].truncate(50)}"
+      else
+        "#{key}: #{session[key]}"
       end
+    end
 
     Rails.logger.debug '>>>>> logging session keys'
     Rails.logger.debug all_session_keys_log.join("\n")
@@ -407,6 +424,7 @@ class ApplicationController < ActionController::Base
     # this is additional logging to diagnose potential issues with refreshing a
     # URS token, it should be removed with MMT-1616
     return if Rails.env.test? || session[:login_method] == 'launchpad'
+
     urs_logging = <<-LOG
       Logging URS keys
       User: #{authenticated_urs_uid}
@@ -447,7 +465,7 @@ class ApplicationController < ActionController::Base
   end
 
   # relatively safe extraction of a hash from the ActionController::Base::Parameters structure.
-  def safe_hash( key)
+  def safe_hash(key)
     params.require(key).permit!.to_h
   end
   helper_method :safe_hash

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -38,7 +38,7 @@ class CollectionsController < ManageCollectionsController
   end
 
   def destroy
-    if @num_granules > 0 && params['confirmation-text'] != DELETE_CONFIRMATION_TEXT
+    if (@num_granules > 0 || @num_variables > 0) && params['confirmation-text'] != DELETE_CONFIRMATION_TEXT
       flash[:error] = 'Collection was not deleted because incorrect confirmation text was provided.'
       render :show and return
     end
@@ -144,6 +144,7 @@ class CollectionsController < ManageCollectionsController
       @native_id = meta['native-id']
       @provider_id = meta['provider-id']
       @num_granules = meta['granule-count']
+      @num_variables = meta.fetch('associations', {}).fetch('variables', []).count
 
       # set up the @download_xml_options so that the Native format is specified and appears first
       @download_xml_options = CollectionsHelper::DOWNLOAD_XML_OPTIONS.deep_dup

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -1,5 +1,5 @@
 module CollectionsHelper
-  DELETE_CONFIRMATION_TEXT = 'I want to delete this collection and all associated granules'.freeze
+  DELETE_CONFIRMATION_TEXT = 'I want to delete this collection and the associated records'.freeze
   DOWNLOAD_XML_OPTIONS = [
     { format: 'atom',     title: 'ATOM' },
     { format: 'dif10',    title: 'DIF 10' },
@@ -90,6 +90,25 @@ module CollectionsHelper
           end)
         end
       end
+    end
+  end
+
+  def display_cascade_delete_modal_text(num_granules, num_variables)
+    if num_granules > 0 && num_variables > 0
+      associated_text = "#{num_granules} associated #{'granule'.pluralize(num_granules)} and #{num_variables} associated #{'variable'.pluralize(num_variables)}"
+      delete_text = 'associated granules and variables'
+    elsif num_granules > 0
+      associated_text = "#{num_granules} associated #{'granule'.pluralize(num_granules)}"
+      delete_text = 'associated granules'
+    elsif num_variables > 0
+      associated_text = "#{num_variables} associated #{'variable'.pluralize(num_variables)}"
+      delete_text = 'associated variables'
+    end
+
+    content_tag(:div) do
+      concat(content_tag(:p, "This collection has #{associated_text}."))
+      concat(content_tag(:p, "Deleting this collection will delete all #{delete_text}."))
+      concat(content_tag(:p, "Please confirm that you wish to continue by entering \"#{CollectionsHelper::DELETE_CONFIRMATION_TEXT}\" below."))
     end
   end
 end

--- a/app/helpers/modals_helper.rb
+++ b/app/helpers/modals_helper.rb
@@ -1,0 +1,28 @@
+module ModalsHelper
+
+  def modal_close_x_link(alternate_link: nil, alternate_link_condition: nil)
+    link = determine_modal_close_href(alternate_link: alternate_link, alternate_link_condition: alternate_link_condition)
+
+    content_tag(:a, '', class: 'modal-close float-r', href: link) do
+      concat(content_tag(:i, '', class: 'fa fa-times') do
+        concat(content_tag(:span, 'Close', class: 'is-invisible'))
+      end)
+    end
+  end
+
+  def modal_close_button(button_text: 'Close', alternate_link: nil, alternate_link_condition: nil)
+    link = determine_modal_close_href(alternate_link: alternate_link, alternate_link_condition: alternate_link_condition)
+
+    content_tag(:a, button_text, class: 'eui-btn modal-close', href: link)
+  end
+
+  def determine_modal_close_href(alternate_link:, alternate_link_condition:)
+    # condition should be passed such that the alternate link will used
+    # when the condition is true
+    if alternate_link_condition
+      alternate_link
+    else
+      'javascript:void(0);'
+    end
+  end
+end

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -99,10 +99,10 @@
 
           <!-- hidden content for action buttons -->
           <div id="delete-record-modal" class="eui-modal-content">
-            <a href="javascript:void(0);" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
+            <%= modal_close_x_link %>
             <p>Are you sure you want to delete this record?</p>
             <p>
-              <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
+              <%= modal_close_button(button_text: 'No') %>
               <%= link_to 'Yes', collection_path, method: :delete, class: 'eui-btn--blue spinner' %>
             </p>
           </div>
@@ -114,28 +114,30 @@
               draft: @draft,
               draft_id: @draft.try(:id) }
             } %>
+
           <!-- Hidden link to allow modal to be shown -->
-          <a href="#granules-modal" id="display-granules-modal" class="display-modal is-invisible"></a>
-          <div id="granules-modal" class="eui-modal-content">
-            <a href=<%=current_provider?(@provider_id) ? "javascript:void(0);" : collection_path %> class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-            <p>This collection has <%= @num_granules %> associated <%= 'granule'.pluralize(@num_granules) %>.</p> 
-            <p id="danger-warning">Deleting this collection will delete all associated granules.</p> 
-            <p>Please confirm that you wish to continue by entering '<%= CollectionsHelper::DELETE_CONFIRMATION_TEXT %>' below.</p>
+          <a href="#cascade-delete-modal" id="display-cascade-delete-modal" class="display-modal is-invisible"></a>
+          <div id="cascade-delete-modal" class="eui-modal-content">
+            <!-- if the user chooses to change providers and then NOT to delete the collection, we should refresh the page so that their provider context displays correctly -->
+            <%= modal_close_x_link(alternate_link: collection_path, alternate_link_condition: !current_provider?(@provider_id)) %>
+
+            <%= display_cascade_delete_modal_text(@num_granules, @num_variables) %>
+
             <%= form_tag(collection_path, method: :delete, class: 'granules-confirmation-form') do %>
               <%= text_field_tag('confirmation-text', nil, class: 'full-width') %>
               <p>
-                <a href=<%=current_provider?(@provider_id) ? "javascript:void(0);" : collection_path %> class="eui-btn modal-close">Cancel</a>
+                <%= modal_close_button(button_text: 'Cancel', alternate_link: collection_path, alternate_link_condition: !current_provider?(@provider_id)) %>
                 <%= submit_tag 'Delete Collection', class: 'eui-btn--red spinner' %>
               </p>
             <% end %>
           </div>
 
           <div id="tags-modal" class="eui-modal-content">
-            <a href="javascript:void(0);" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
+            <%= modal_close_x_link %>
             <span class="tag-keys-display">
               <%= display_collection_tag_info(tags_info: @tags_info, num_tags: @num_tags, tags_error: @tags_error, tag_keys: @tag_keys) %>
             </span>
-            <p><a href="javascript:void(0)" class="eui-btn modal-close">Close</a></p>
+            <p><%= modal_close_button %></p>
           </div>
           <%= render partial: 'shared/download_xml', locals: {
             concept_id: @concept_id,
@@ -145,6 +147,12 @@
           <!-- end hidden content for action buttons -->
         </div>
       </section>
+
+      <script>
+        // number of granules and associated variables for delete action
+        var numGranules = <%= @num_granules %>;
+        var numVariables = <%= @num_variables %>;
+      </script>
 
       <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @collection, is_mmt: true, editable: false, edsc_url: nil, concept_id: nil, additional_information: nil } %>
     <% end %>

--- a/app/views/shared/_not_current_provider_modal.html.erb
+++ b/app/views/shared/_not_current_provider_modal.html.erb
@@ -1,12 +1,12 @@
 <% modal_index = false unless modal_index.present? %>
 
 <div id="not-current-provider-modal<%= "-#{modal_index}" if modal_index %>" class="eui-modal-content">
-  <a href="javascript:void(0);" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
+  <%= modal_close_x_link %>
   <p>
     <span class="record-action"></span> requires you change your provider context to <span class="provider"></span>. Would you like to change your provider context and perform this action?
   </p>
   <p>
-    <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
+    <%= modal_close_button(button_text: 'No') %>
     <%= link_to 'Yes', '#', class: 'eui-btn--blue spinner not-current-provider-link', data: { index: modal_index } %>
 
     <% if options[:revisions] %>

--- a/spec/features/collections/delete_collection_spec.rb
+++ b/spec/features/collections/delete_collection_spec.rb
@@ -1,8 +1,21 @@
-describe 'Delete collection', js: true do
+describe 'Delete Collection', js: true do
   before :all do
-    @ingest_response, _concept_response = publish_collection_draft
+    collection_with_granule_title = SecureRandom.uuid
+    @collection_with_granule_ingest_response, _collection_concept_response = publish_collection_draft(entry_title: collection_with_granule_title)
+    _granule_ingest_response, _granule_concept_response = ingest_granules(collection_entry_title: collection_with_granule_title, count: 1)
+
+    collection_with_granule_and_variable_title = SecureRandom.uuid
+    @collection_with_granule_and_variable_ingest_response, _collection_concept_response = publish_collection_draft(entry_title: collection_with_granule_and_variable_title)
+    _granule_ingest_response, _granule_concept_response = ingest_granules(collection_entry_title: collection_with_granule_and_variable_title, count: 2)
+    _variable_ingest_response, _variable_concept_response = publish_variable_draft(collection_concept_id: @collection_with_granule_and_variable_ingest_response['concept-id'])
+
+    @collection_with_variable_ingest_response, _collection_concept_response = publish_collection_draft
+    _variable_ingest_response, _variable_concept_response = publish_variable_draft(collection_concept_id: @collection_with_variable_ingest_response['concept-id'])
+    _variable_ingest_response, _variable_concept_response = publish_variable_draft(collection_concept_id: @collection_with_variable_ingest_response['concept-id'])
 
     @ingested_collection_for_delete_messages, _concept_response = publish_collection_draft
+
+    wait_for_cmr # improves reliabliity of finding granules for collection
   end
 
   before do
@@ -10,171 +23,354 @@ describe 'Delete collection', js: true do
   end
 
   context 'when viewing a published collection' do
-    before do
-      visit collection_path(@ingest_response['concept-id'])
-    end
-
-    context 'when the collection has no granules' do
-      it 'displays a delete link' do
-        expect(page).to have_content('Delete Collection Record')
-      end
-
-      context 'when clicking the delete link' do
-        before do
-          click_on 'Delete Collection Record'
-
-          within '#delete-record-modal' do
-            click_on 'Yes'
-          end
-        end
-
-        it 'redirects to the revisions page and displays a confirmation message' do
-          expect(page).to have_content('Collection Deleted Successfully!')
-
-          expect(page).to have_content('Revision History')
-          expect(page).to have_selector('tbody > tr', count: 2)
-
-          within first('tbody > tr') do
-            expect(page).to have_content('Deleted')
-          end
-
-          expect(page).to have_content('Reinstate', count: 1)
-        end
-      end
-    end
-  end
-
-  context 'when viewing a published collection with granules' do
-    before do
-      login
-      collection_title = SecureRandom.uuid
-      collection_ingest_response, _collection_concept_response = publish_collection_draft(entry_title: collection_title)
-      _granule_ingest_response, _granule_concept_response = ingest_granules(collection_entry_title: collection_title, count: 1)
-      wait_for_cmr # improves reliabliity of finding granules for collection
-
-      visit collection_path(collection_ingest_response['concept-id'])
-    end
-
-    it 'displays the number of granules' do
-      expect(page).to have_content('Granules (1)')
-    end
-
-    context 'when clicking the delete link' do
+    context 'when the collection is in the current provider context' do
       before do
-        click_on 'Delete Collection Record'
+        ingest_response, _concept_response = publish_collection_draft
+
+        visit collection_path(ingest_response['concept-id'])
       end
 
-      it 'displays the correct warning text and has a confirmation text field' do
-        expect(page).to have_content('This collection has 1 associated granule.')
-        expect(page).to have_content('Deleting this collection will delete all associated granules.')
-        expect(page).to have_content("Please confirm that you wish to continue by entering 'I want to delete this collection and all associated granules' below.")
-        expect(page).to have_field('confirmation-text')
-        within '#granules-modal' do
-          expect(page).to have_link('Cancel', href: 'javascript:void(0);')
-          expect(page).to have_link('Close', href: 'javascript:void(0);')
-        end
-      end
-
-      context 'when the user provides the correct confirmation text' do
-        before do
-          fill_in 'confirmation-text', with: 'I want to delete this collection and all associated granules'
-          click_on 'Delete Collection'
+      context 'when the collection has no granules' do
+        it 'displays a delete link' do
+          expect(page).to have_content('Delete Collection Record')
         end
 
-        it 'deletes the record' do
-          expect(page).to have_content('Collection Deleted Successfully!')
-        end
-      end
-
-      context 'when the user provides the incorrect confirmation text' do
-        before do
-          fill_in 'confirmation-text', with: 'Incorrect confirmation text'
-          click_on 'Delete Collection'
-        end
-
-        it 'does not delete the record' do
-          expect(page).to have_content('Collection was not deleted because incorrect confirmation text was provided.')
-        end
-      end
-    end
-  end
-
-  context 'when switching provider context while deleting' do
-    before do
-      login(provider: 'LARC', providers: %w[MMT_2 LARC])
-      collection_title = SecureRandom.uuid
-      collection_ingest_response, _collection_concept_response = publish_collection_draft(entry_title: collection_title)
-      _granule_ingest_response, _granule_concept_response = ingest_granules(collection_entry_title: collection_title, count: 1)
-      wait_for_cmr # improves reliabliity of finding granules for collection
-
-      visit collection_path(collection_ingest_response['concept-id'])
-    end
-
-    context 'when clicking the delete link' do
-      before do
-        click_on 'Delete Collection Record'
-      end
-
-      it 'displays the provider context switch modal' do
-        expect(page).to have_content('Deleting this collection requires you change your provider context to MMT_2. Would you like to change your provider context and perform this action?')
-      end
-
-      context 'when changing provider context' do
-        before do
-          find('.not-current-provider-link').click
-        end
-
-        it 'displays the correct warning text and has a confirmation text field' do
-          expect(page).to have_content('This collection has 1 associated granule.')
-          expect(page).to have_content('Deleting this collection will delete all associated granules.')
-          expect(page).to have_content("Please confirm that you wish to continue by entering 'I want to delete this collection and all associated granules' below.")
-          expect(page).to have_field('confirmation-text')
-        end
-
-        context 'when the user provides the correct confirmation text' do
+        context 'when clicking the delete link' do
           before do
-            fill_in 'confirmation-text', with: 'I want to delete this collection and all associated granules'
-            click_on 'Delete Collection'
+            click_on 'Delete Collection Record'
+
+            within '#delete-record-modal' do
+              click_on 'Yes'
+            end
           end
 
-          it 'deletes the record' do
+          it 'redirects to the revisions page and displays a confirmation message' do
             expect(page).to have_content('Collection Deleted Successfully!')
+
+            expect(page).to have_content('Revision History')
+            expect(page).to have_selector('tbody > tr', count: 2)
+
+            within first('tbody > tr') do
+              expect(page).to have_content('Deleted')
+            end
+
+            expect(page).to have_content('Reinstate', count: 1)
           end
         end
+      end
+    end
 
-        context 'when the user provides the incorrect confirmation text' do
+    context 'when switching provider context while deleting' do
+      before do
+        ingest_response_2, _concept_response = publish_collection_draft
+        login(provider: 'LARC', providers: %w[MMT_2 LARC])
+        visit collection_path(ingest_response_2['concept-id'])
+      end
+
+      context 'when the collection has no granules or variables' do
+        context 'when clicking the delete link' do
           before do
-            fill_in 'confirmation-text', with: 'Incorrect confirmation text'
-            click_on 'Delete Collection'
+            click_on 'Delete Collection Record'
           end
 
-          it 'does not delete the record' do
-            expect(page).to have_content('Collection was not deleted because incorrect confirmation text was provided.')
+          it 'displays the provider context switch modal' do
+            expect(page).to have_content('Deleting this collection requires you change your provider context to MMT_2. Would you like to change your provider context and perform this action?')
+          end
+
+          context 'when changing provider context' do
+            before do
+              find('.not-current-provider-link').click
+            end
+
+            it 'redirects to the revisions page and displays a confirmation message' do
+              expect(page).to have_content('Collection Deleted Successfully!')
+
+              expect(page).to have_content('Revision History')
+              expect(page).to have_selector('tbody > tr', count: 2)
+
+              within first('tbody > tr') do
+                expect(page).to have_content('Deleted')
+              end
+
+              expect(page).to have_content('Reinstate', count: 1)
+            end
           end
         end
+      end
+    end
+  end
 
-        context 'when the user cancels from the delete confirmation modal' do
+  context 'when viewing a published collection with records that will be cascade deleted' do
+    context 'when the collection is in the current provider context' do
+      context 'when viewing a published collection with granules' do
+        before do
+          visit collection_path(@collection_with_granule_ingest_response['concept-id'])
+        end
+
+        it 'displays the number of granules' do
+          expect(page).to have_content('Granules (1)')
+        end
+
+        context 'when clicking the delete link' do
           before do
-            click_on 'Cancel'
+            click_on 'Delete Collection Record'
           end
 
-          it 'refreshes the page' do
-            within '.eui-badge--sm.daac' do
-              expect(page).to have_content('MMT_2')
+          it 'displays the correct warning text and has a confirmation text field' do
+            expect(page).to have_content('This collection has 1 associated granule.')
+            expect(page).to have_content('Deleting this collection will delete all associated granules.')
+            expect(page).to have_content('Please confirm that you wish to continue by entering "I want to delete this collection and the associated records" below.')
+            expect(page).to have_field('confirmation-text')
+            within '#cascade-delete-modal' do
+              expect(page).to have_link('Cancel', href: 'javascript:void(0);')
+              expect(page).to have_link('Close', href: 'javascript:void(0);')
+            end
+          end
+
+          context 'when the user provides the incorrect confirmation text' do
+            before do
+              fill_in 'confirmation-text', with: 'Incorrect confirmation text'
+              click_on 'Delete Collection'
+            end
+
+            it 'does not delete the record' do
+              expect(page).to have_content('Collection was not deleted because incorrect confirmation text was provided.')
+            end
+          end
+        end
+      end
+
+      context 'when viewing a published collection with granules and variables' do
+        before do
+          visit collection_path(@collection_with_granule_and_variable_ingest_response['concept-id'])
+        end
+
+        it 'displays the number of granules' do
+          expect(page).to have_content('Granules (2)')
+        end
+
+        context 'when clicking the delete link' do
+          before do
+            click_on 'Delete Collection Record'
+          end
+
+          it 'displays the correct warning text and has a confirmation text field' do
+            expect(page).to have_content('This collection has 2 associated granules and 1 associated variable.')
+            expect(page).to have_content('Deleting this collection will delete all associated granules and variables.')
+            expect(page).to have_content('Please confirm that you wish to continue by entering "I want to delete this collection and the associated records" below.')
+            expect(page).to have_field('confirmation-text')
+            within '#cascade-delete-modal' do
+              expect(page).to have_link('Cancel', href: 'javascript:void(0);')
+              expect(page).to have_link('Close', href: 'javascript:void(0);')
+            end
+          end
+
+          context 'when the user provides the incorrect confirmation text' do
+            before do
+              fill_in 'confirmation-text', with: 'Incorrect confirmation text'
+              click_on 'Delete Collection'
+            end
+
+            it 'does not delete the record' do
+              expect(page).to have_content('Collection was not deleted because incorrect confirmation text was provided.')
+            end
+          end
+        end
+      end
+
+      context 'when viewing a published collection with variables' do
+        before do
+          visit collection_path(@collection_with_variable_ingest_response['concept-id'])
+        end
+
+        it 'displays the number of granules' do
+          expect(page).to have_content('Granules (0)')
+        end
+
+        context 'when clicking the delete link' do
+          before do
+            click_on 'Delete Collection Record'
+          end
+
+          it 'displays the correct warning text and has a confirmation text field' do
+            expect(page).to have_content('This collection has 2 associated variables.')
+            expect(page).to have_content('Deleting this collection will delete all associated variables.')
+            expect(page).to have_content('Please confirm that you wish to continue by entering "I want to delete this collection and the associated records" below.')
+            expect(page).to have_field('confirmation-text')
+            within '#cascade-delete-modal' do
+              expect(page).to have_link('Cancel', href: 'javascript:void(0);')
+              expect(page).to have_link('Close', href: 'javascript:void(0);')
+            end
+          end
+
+          context 'when the user provides the incorrect confirmation text' do
+            before do
+              fill_in 'confirmation-text', with: 'Incorrect confirmation text'
+              click_on 'Delete Collection'
+            end
+
+            it 'does not delete the record' do
+              expect(page).to have_content('Collection was not deleted because incorrect confirmation text was provided.')
+            end
+          end
+        end
+      end
+
+      context 'when deleting the collection by providing the correct confirmation text' do
+        context 'when the collection has granules' do
+          before do
+            collection_title = SecureRandom.uuid
+            collection_ingest_response, _collection_concept_response = publish_collection_draft(entry_title: collection_title)
+            _granule_ingest_response, _granule_concept_response = ingest_granules(collection_entry_title: collection_title, count: 1)
+            wait_for_cmr # improves reliabliity of finding granules for collection
+
+            visit collection_path(collection_ingest_response['concept-id'])
+          end
+
+          context 'when the user provides the correct confirmation text' do
+            before do
+              click_on 'Delete Collection Record'
+
+              fill_in 'confirmation-text', with: 'I want to delete this collection and the associated records'
+              click_on 'Delete Collection'
+            end
+
+            it 'deletes the record' do
+              expect(page).to have_content('Collection Deleted Successfully!')
             end
           end
         end
 
-        context 'when the user closes the delete confirmation modal' do
+        context 'when the collection has variables' do
           before do
-            within '#granules-modal' do
-              click_on 'Close'
-            end
+            collection_ingest_response, _collection_concept_response = publish_collection_draft
+            _variable_ingest_response, _variable_concept_response = publish_variable_draft(collection_concept_id: collection_ingest_response['concept-id'])
+
+            visit collection_path(collection_ingest_response['concept-id'])
           end
 
-          it 'refreshes the page' do
-            within '.eui-badge--sm.daac' do
-              expect(page).to have_content('MMT_2')
+          context 'when the user provides the correct confirmation text' do
+            before do
+              click_on 'Delete Collection Record'
+
+              fill_in 'confirmation-text', with: 'I want to delete this collection and the associated records'
+              click_on 'Delete Collection'
+            end
+
+            it 'deletes the record' do
+              expect(page).to have_content('Collection Deleted Successfully!')
+            end
+          end
+        end
+      end
+    end
+
+    context 'when switching provider context while deleting' do
+      before do
+        login(provider: 'LARC', providers: %w[MMT_2 LARC])
+      end
+
+      context 'when viewing a published collection with granules and variables' do
+        before do
+          visit collection_path(@collection_with_granule_and_variable_ingest_response['concept-id'])
+        end
+
+        it 'displays the number of granules' do
+          expect(page).to have_content('Granules (2)')
+        end
+
+        context 'when clicking the delete link' do
+          before do
+            click_on 'Delete Collection Record'
+          end
+
+          it 'displays the provider context switch modal' do
+            expect(page).to have_content('Deleting this collection requires you change your provider context to MMT_2. Would you like to change your provider context and perform this action?')
+          end
+
+          context 'when changing provider context' do
+            before do
+              find('.not-current-provider-link').click
+            end
+
+            it 'displays the correct warning text and has a confirmation text field' do
+              expect(page).to have_content('This collection has 2 associated granules and 1 associated variable.')
+              expect(page).to have_content('Deleting this collection will delete all associated granules and variables.')
+              expect(page).to have_content('Please confirm that you wish to continue by entering "I want to delete this collection and the associated records" below.')
+              expect(page).to have_field('confirmation-text')
+              within '#cascade-delete-modal' do
+                expect(page).to have_link('Cancel', href: collection_path(@collection_with_granule_and_variable_ingest_response['concept-id']))
+                expect(page).to have_link('Close', href: collection_path(@collection_with_granule_and_variable_ingest_response['concept-id']))
+              end
+            end
+
+            context 'when the user provides the incorrect confirmation text' do
+              before do
+                fill_in 'confirmation-text', with: 'Incorrect confirmation text'
+                click_on 'Delete Collection'
+              end
+
+              it 'does not delete the record' do
+                expect(page).to have_content('Collection was not deleted because incorrect confirmation text was provided.')
+              end
+            end
+
+            context 'when the user cancels from the delete confirmation modal' do
+              before do
+                click_on 'Cancel'
+              end
+
+              it 'refreshes the page' do
+                within '.eui-badge--sm.daac' do
+                  expect(page).to have_content('MMT_2')
+                end
+              end
+            end
+
+            context 'when the user closes the delete confirmation modal' do
+              before do
+                within '#cascade-delete-modal' do
+                  click_on 'Close'
+                end
+              end
+
+              it 'refreshes the page' do
+                within '.eui-badge--sm.daac' do
+                  expect(page).to have_content('MMT_2')
+                end
+              end
+            end
+          end
+        end
+      end
+
+      context 'when deleting the collection by providing the correct confirmation text' do
+        before do
+          collection_title = SecureRandom.uuid
+          collection_ingest_response, _collection_concept_response = publish_collection_draft(entry_title: collection_title)
+          _granule_ingest_response, _granule_concept_response = ingest_granules(collection_entry_title: collection_title, count: 1)
+          wait_for_cmr # improves reliabliity of finding granules for collection
+
+          visit collection_path(collection_ingest_response['concept-id'])
+        end
+
+        context 'when clicking the delete link' do
+          before do
+            click_on 'Delete Collection Record'
+          end
+          context 'when changing provider context' do
+            before do
+              find('.not-current-provider-link').click
+            end
+            context 'when the user provides the correct confirmation text' do
+              before do
+                fill_in 'confirmation-text', with: 'I want to delete this collection and the associated records'
+                click_on 'Delete Collection'
+              end
+
+              it 'deletes the record' do
+                expect(page).to have_content('Collection Deleted Successfully!')
+              end
             end
           end
         end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -7,11 +7,12 @@ VCR.configure do |c|
   c.ignore_localhost = true
   c.default_cassette_options = { allow_playback_repeats: true }
   c.after_http_request do |request, response|
-    Rails.logger.info 'VCR logging:'
+    Rails.logger.info 'VCR logging: >>>'
     begin
       Rails.logger.debug("Response #{request.method} #{request.uri} result : Headers: #{response.headers} - Body Size (bytes): #{response.body.to_s.bytesize} Status: #{response.status}")
     rescue => e
       Rails.logger.error "#{self.class} Error: #{e}"
     end
+    Rails.logger.info '<<<'
   end
 end


### PR DESCRIPTION
* add getting variable count on collections show page
* modify modal to display proper messages for granules and/or variables
* ensure workflows for deleting collection with granules or variables all work
* update tests for deleting collection

* add helper methods for modal close links and use on collections show page
* some whitespace changes in application controller to appease rubocop
* add try/catch for echo provider token in development