### PR TITLE
MMT-2367 Update Variable Collection Association

### DIFF
--- a/app/controllers/base_published_record_controller.rb
+++ b/app/controllers/base_published_record_controller.rb
@@ -98,8 +98,10 @@ class BasePublishedRecordController < ManageMetadataController
   def revert
     latest_revision_id = @revisions.dig(0, 'meta', 'revision-id')
 
-    # grab the concept_id of the associated collection of the correct revision
-    associated_concept_id = @revisions.dig(@revision_id.to_i, 'associations', 'collections', 0, 'concept-id')
+    # grab the collection concept_id for the most recent revision;
+    # we have decided to revert the metadata and leave the association alone
+    # if users want or expect another behavior, we can respond to that feedback
+    associated_concept_id = first_non_deleted_revision.dig('associations', 'collections', 0, 'concept-id')
 
     # Ingest revision
     ingested_response = cmr_client.send("ingest_#{resource_name}", metadata: get_resource.to_json, provider_id: @provider_id, collection_concept_id: associated_concept_id, native_id: @native_id, token: token)
@@ -231,5 +233,9 @@ class BasePublishedRecordController < ManageMetadataController
   # @return [String]
   def capitalized_resource_name
     resource_name.capitalize
+  end
+
+  def first_non_deleted_revision
+    @revisions.reject { |revision| revision.dig('meta', 'deleted') }[0]
   end
 end

--- a/app/controllers/base_published_record_controller.rb
+++ b/app/controllers/base_published_record_controller.rb
@@ -236,6 +236,6 @@ class BasePublishedRecordController < ManageMetadataController
   end
 
   def first_non_deleted_revision
-    @revisions.reject { |revision| revision.dig('meta', 'deleted') }[0]
+    @revisions.reject { |revision| revision.dig('meta', 'deleted') }.first
   end
 end

--- a/app/controllers/cmr_search_controller.rb
+++ b/app/controllers/cmr_search_controller.rb
@@ -3,6 +3,16 @@ class CmrSearchController < ManageMetadataController
   RESULTS_PER_PAGE = 500
 
   def new
+    fetch_collections
+  end
+
+  def edit
+    fetch_collections
+  end
+
+  private
+
+  def fetch_collections
     permitted = params.to_unsafe_h unless params.nil? # need to understand what this is doing more, think related to nested parameters not permitted.
 
     cmr_params = {
@@ -58,8 +68,6 @@ class CmrSearchController < ManageMetadataController
 
     @collections = Kaminari.paginate_array(collection_results, total_count: collection_count).page(permitted['page']).per(RESULTS_PER_PAGE)
   end
-
-  private
 
   # CMR requires some additional data in the payload when particular
   # keys are provided so we need to compensate for that here

--- a/app/controllers/collection_associations_controller.rb
+++ b/app/controllers/collection_associations_controller.rb
@@ -201,7 +201,7 @@ class CollectionAssociationsController < CmrSearchController
   def variable_id
     return params[:variable_id] if params[:variable_id]
 
-    params[:id] if params[:id].split('-').first.starts_with?(/V\d/)
+    params[:id] if params[:id]&.split('-').first.starts_with?(/V\d/)
   end
 
   def add_high_level_breadcrumbs

--- a/app/controllers/collection_associations_controller.rb
+++ b/app/controllers/collection_associations_controller.rb
@@ -200,8 +200,9 @@ class CollectionAssociationsController < CmrSearchController
 
   def variable_id
     return params[:variable_id] if params[:variable_id]
+    return nil unless params[:id]
 
-    params[:id] if params[:id]&.split('-').first.starts_with?(/V\d/)
+    params[:id] if params[:id].split('-').first.starts_with?(/V\d/)
   end
 
   def add_high_level_breadcrumbs

--- a/app/controllers/collection_associations_controller.rb
+++ b/app/controllers/collection_associations_controller.rb
@@ -97,13 +97,11 @@ class CollectionAssociationsController < CmrSearchController
     ingest_response = cmr_client.ingest_variable(metadata: metadata.to_json, provider_id: @provider_id, native_id: @native_id, collection_concept_id: params['selected_collection'], token: token, headers_override: { 'Content-Type' => format })
 
     if ingest_response.success?
-      # get information for publication email notification before draft is deleted
       var_concept_id = ingest_response.body['concept-id']
       col_concept_id = ingest_response.body['associated-item']['concept-id']
       Rails.logger.info("Audit Log: Variable with concept_id: #{var_concept_id} republished with a new collection association. The new associated collection has a concept_id of: #{col_concept_id} in provider: #{@provider_id}")
       redirect_to send("#{lower_resource_name}_collection_associations_path", var_concept_id), flash: { success: I18n.t("controllers.collection_associations.#{resource_name.downcase.pluralize}.update.flash.success") }
     else
-      # Log error message
       Rails.logger.error("Ingest #{resource_name} Metadata Error: #{ingest_response.clean_inspect}")
       Rails.logger.info("User #{current_user.urs_uid} attempted to ingest #{resource_name} from the manage collection associations page in provider #{current_user.provider_id} but encountered an error.")
 

--- a/app/controllers/collection_associations_controller.rb
+++ b/app/controllers/collection_associations_controller.rb
@@ -84,7 +84,7 @@ class CollectionAssociationsController < CmrSearchController
     # Get metadata in its native format so that we can reingest it.
     search_response = cmr_client.get_concept(params[:variable_id], token, {})
     if search_response.success?
-      format = search_response.headers['content_type']
+      format = search_response.headers['content-type']
       metadata = search_response.body
     else
       Rails.logger.error("Search #{resource_name} Metadata Error: #{search_response.clean_inspect}")

--- a/app/controllers/manage_metadata_controller.rb
+++ b/app/controllers/manage_metadata_controller.rb
@@ -127,7 +127,7 @@ class ManageMetadataController < ApplicationController
   end
 
   def set_metadata_information
-    # this process was suggested/requested by the CMR team: 
+    # this process was suggested/requested by the CMR team:
     # search for metadata record by concept id to get the native_id and provider_id
     # if the metadata record is not found, try again because CMR might be a little slow to index if it is a newly published record
     attempts = 0

--- a/app/controllers/variable_drafts_collection_searches_controller.rb
+++ b/app/controllers/variable_drafts_collection_searches_controller.rb
@@ -1,25 +1,22 @@
 class VariableDraftsCollectionSearchesController < CmrSearchController
 
   before_action :set_resource
-  before_action :ensure_not_editing
 
   def new
     add_top_level_breadcrumbs
 
-    unless @draft.collection_concept_id.blank?
-      current_collection_response = cmr_client.get_collections_by_post(
-        { concept_id: @draft.collection_concept_id }, token
-      )
-      if current_collection_response.success?
-        if current_collection_response.body['hits'] > 0
-          @current_collection_info = current_collection_response.body.dig('items', 0)
-        else
-          @current_collection_error = "There was an error retrieving Collection #{@draft.collection_concept_id} because the collection does not exist."
-        end
+    current_collection_response = cmr_client.get_collections_by_post(
+      { concept_id: @draft.collection_concept_id }, token
+    )
+    if current_collection_response.success?
+      if current_collection_response.body['hits'] > 0
+        @current_collection_info = current_collection_response.body.dig('items', 0)
       else
-        Rails.logger.info("Error retrieving Collection #{@draft.collection_concept_id} that is intended to be associated with Variable Draft #{@draft.id}: #{current_collection_response.clean_inspect}")
-        @current_collection_error = "There was an error retrieving Collection #{@draft.collection_concept_id} that is currently selected as the Collection to be associated with this Variable Draft."
+        @current_collection_error = "There was an error retrieving Collection #{@draft.collection_concept_id} because the collection does not exist."
       end
+    else
+      Rails.logger.info("Error retrieving Collection #{@draft.collection_concept_id} that is intended to be associated with Variable Draft #{@draft.id}: #{current_collection_response.clean_inspect}")
+      @current_collection_error = "There was an error retrieving Collection #{@draft.collection_concept_id} that is currently selected as the Collection to be associated with this Variable Draft."
     end
 
     add_breadcrumb 'Collection Association Search', :collection_search_variable_draft_path
@@ -36,23 +33,5 @@ class VariableDraftsCollectionSearchesController < CmrSearchController
 
   def set_resource
     @draft = VariableDraft.find(params[:id])
-  end
-
-  def ensure_not_editing
-    # temporarily we are blocking the changing of a collection association for
-    # published variables. so if we are editing a published variable they should
-    # not be able to access this page and clear the existing association
-
-    # search for a variable by native id
-    variable_params = { native_id: @draft.native_id, provider: @draft.provider_id }
-    variable_search_response = cmr_client.get_variables(variable_params, token)
-    editing = if variable_search_response.success?
-                variable_search_response.body['hits'].to_i > 0 ? true : false
-              else
-                Rails.logger.error("Error searching for published Variable before VariableDraftsCollectionSearchesController#new: #{variable_search_response.clean_inspect}")
-                true
-              end
-
-    redirect_to variable_draft_path(@draft) if editing
   end
 end

--- a/app/controllers/variable_drafts_controller.rb
+++ b/app/controllers/variable_drafts_controller.rb
@@ -16,23 +16,6 @@ class VariableDraftsController < BaseDraftsController
     set_measurement_names if @current_form == 'measurement_identifiers'
   end
 
-  def show
-    # search for a variable by native id
-    variable_params = { native_id: get_resource.native_id, provider: get_resource.provider_id }
-    variable_search_response = cmr_client.get_variables(variable_params, token)
-    # temporarily we are blocking the changing of a collection association for
-    # published variables. so if we are editing a published variable they should
-    # not be able to access the collection association form to change it
-    @editing = if variable_search_response.success?
-                 variable_search_response.body['hits'].to_i > 0 ? true : false
-               else
-                 Rails.logger.error("Error searching for published Variable in VariableDraftsController#show: #{variable_search_response.clean_inspect}")
-                 true
-               end
-
-    super
-  end
-
   def update_associated_collection
     authorize get_resource
 

--- a/app/helpers/manage_metadata_helper.rb
+++ b/app/helpers/manage_metadata_helper.rb
@@ -24,7 +24,14 @@ module ManageMetadataHelper
   ]
 
   def is_variable_controller?
-    (VARIABLES_CONTROLLERS & controller.lookup_context.prefixes).any? || (controller.lookup_context.prefixes.include?('collection_associations') && params[:variable_id])
+    (VARIABLES_CONTROLLERS & controller.lookup_context.prefixes).any? || (controller.lookup_context.prefixes.include?('collection_associations') && variable_id)
+  end
+
+  def variable_id
+    return params[:variable_id] if params[:variable_id]
+    return nil unless params[:id]
+
+    params[:id] if params[:id].split('-').first.starts_with?(/V\d/)
   end
 
   def is_services_controller?

--- a/app/views/cmr_search/shared/_search_results.html.erb
+++ b/app/views/cmr_search/shared/_search_results.html.erb
@@ -26,7 +26,9 @@
                 <td class="align-c">
                   <!-- use check boxes or radio buttons to select collection(s) -->
                   <% if local_assigns.fetch(:use_radio_buttons, false) %>
-                    <%= radio_button_tag('selected_collection', collection.fetch('meta', {})['concept-id'], false, class: 'selected_collection_radio_button align-c') %>
+                    <% unless local_assigns.fetch(:ignored_concept_ids, false) && ignored_concept_ids.include?(collection.fetch('meta', {})['concept-id']) %>
+                      <%= radio_button_tag('selected_collection', collection.fetch('meta', {})['concept-id'], false, class: 'selected_collection_radio_button align-c') %>
+                    <% end %>
                   <% else %>
                     <% unless local_assigns.fetch(:ignored_concept_ids, false) && ignored_concept_ids.include?(collection.fetch('meta', {})['concept-id']) %>
                       <%= check_box_tag('selected_collections[]', collection.fetch('meta', {})['concept-id'], false, class: 'selected_collections') %>

--- a/app/views/collection_associations/edit.html.erb
+++ b/app/views/collection_associations/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="row row-content">
+  <section>
+    <h2><%= current_user.provider_id %> <%= resource_name %> Collection Association Search</h2>
+    <%= render partial: 'cmr_search/shared/search_form', locals: { submit_path: send("edit_#{lower_resource_name}_collection_association_path", @concept_id) } %>
+    <p><span class="fa fa-info-circle"></span> <%= "Disabled rows in the results below represent collections that are already associated with this #{lower_resource_name}." %></p>
+    <%= render partial: 'cmr_search/shared/search_results', locals: { collections: @collections, ignored_concept_ids: @previously_associated_collections, submit_path: send("#{lower_resource_name}_collection_associations_path", @concept_id, method: :post), submit_text: 'Submit', use_radio_buttons: variable? ? true : false } %>
+  </section>
+</div>

--- a/app/views/collection_associations/index.html.erb
+++ b/app/views/collection_associations/index.html.erb
@@ -71,7 +71,7 @@
       <% end %>
 
       <% if @variable %>
-        <%= link_to "Change Collection Association", send("edit_#{lower_resource_name}_collection_association_path", resource_id), class: 'eui-btn--blue' %>
+        <%= link_to "Update Collection Association", send("edit_#{lower_resource_name}_collection_association_path", resource_id), class: 'eui-btn--blue' %>
       <% end %>
     <% end %>
 

--- a/app/views/collection_associations/index.html.erb
+++ b/app/views/collection_associations/index.html.erb
@@ -26,7 +26,9 @@
       <table id="collection-associations">
         <thead>
           <tr>
-            <th class="align-c"><input type="checkbox" name="checkall" class="checkall" data-group="selected_collections[]" /></th>
+            <% if not_variable? %>
+              <th class="align-c"><input type="checkbox" name="checkall" class="checkall" data-group="selected_collections[]" /></th>
+            <% end %>
             <th>Entry Title</th>
             <th>Short Name</th>
             <th>Version</th>

--- a/app/views/collection_associations/index.html.erb
+++ b/app/views/collection_associations/index.html.erb
@@ -43,7 +43,9 @@
           <% else %>
             <% @associations.each do |collection| %>
               <tr class='<%= cycle("alt", "") %>'>
-                <td class="align-c"><%= check_box_tag('selected_collections[]', collection.fetch('meta', {})['concept-id'], false, class: 'selected_collections') %></td>
+                <% if not_variable? %>
+                  <td class="align-c"><%= check_box_tag('selected_collections[]', collection.fetch('meta', {})['concept-id'], false, class: 'selected_collections') %></td>
+                <% end %>
                 <td><%= link_to collection.fetch('umm', {}).fetch('entry-title'), collection_path(collection.fetch('meta', {}).fetch('concept-id')) %></td>
                 <td><%= collection.fetch('umm', {}).fetch('short-name') %></td>
                 <td><%= collection.fetch('umm', {}).fetch('version-id') %></td>
@@ -59,11 +61,6 @@
 
           <div id='delete-associations-modal' class="eui-modal-content">
             <a href="#" class="modal-close float-r"><i class="fa fa-times"></i><span class="is-invisible">Close</span></a>
-            <% if @variable %>
-              <p>Deleting a variable association will also delete the associated variable. If you wish to associate this variable to a different collection, before deleting this association, you should <%= link_to "clone the associated variable", send("clone_variable_path", id: params[:variable_id], revision_id: @revision_id), target: :_blank %> and associate the clone to the correct collection.
-                <%= " If you have any questions or need any help, please contact "%> <%= mail_to('support@earthdata.nasa.gov', 'Earthdata Support') %>.
-              </p>
-            <% end %>
             <p><%= "Are you sure you want to delete the selected collection #{association_text.downcase}" %>?</p>
             <p>
               <a href="javascript:void(0)" class="eui-btn modal-close">No</a>
@@ -71,6 +68,10 @@
             </p>
           </div>
         </fieldset>
+      <% end %>
+
+      <% if @variable %>
+        <%= link_to "Change Collection Association", send("edit_#{lower_resource_name}_collection_association_path", resource_id), class: 'eui-btn--blue' %>
       <% end %>
     <% end %>
 

--- a/app/views/drafts/shared/_collection_association_progress_panel.html.erb
+++ b/app/views/drafts/shared/_collection_association_progress_panel.html.erb
@@ -7,12 +7,10 @@
         <%= single_form_circle('Collection Association', get_resource.collection_concept_id.present?) %>
       </div>
       <div class="meta-info">
-        <% association_form_link = @editing ? '#editing-variable-collection-association-notice' : collection_search_variable_draft_path(get_resource) %>
-        <% association_form_link_class = @editing ? 'display-modal' : nil %>
-        <%= link_to 'Collection Association', association_form_link, class: "#{association_form_link_class}" %>
+        <%= link_to 'Collection Association', collection_search_variable_draft_path(get_resource) %>
         <div class="progress-indicators">
           <% status = get_resource.collection_concept_id.blank? ? 'empty' : 'complete' %>
-          <%= single_preview_circle(association_form_link, 'collection_association', status) %>
+          <%= single_preview_circle(collection_search_variable_draft_path(get_resource), 'collection_association', status) %>
         </div>
       </div>
     </li>
@@ -28,10 +26,5 @@
       <li>A variable can only be associated with a collection in the same Provider.</li>
     </ul>
     <a class="eui-btn--blue modal-close" href="javascript:void(0);">Close</a>
-  </div>
-
-  <div id="editing-variable-collection-association-notice" class="eui-modal-content">
-    <p>This Variable Draft is associated with a published Variable. Modifying a Variable's Collection Association is temporarily disabled.</p>
-    <a class="eui-btn modal-close" href="javascript:void(0);">Close</a>
   </div>
 </section>

--- a/app/views/variable_drafts_collection_searches/new.html.erb
+++ b/app/views/variable_drafts_collection_searches/new.html.erb
@@ -33,7 +33,7 @@
           </tbody>
         </table>
 
-        <% unless @draft.collection_concept_id.blank? %>
+        <% if @draft.collection_concept_id.present? %>
           <%= button_to 'Clear Collection Association', update_associated_collection_variable_draft_path(@draft), method: :post, params: { selected_collection: nil }, class: 'eui-btn eui-btn--red'  %>
         <% end %>
       </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,10 @@ en:
           error: 'Tool revision was not created successfully'
     collection_associations:
       variables:
+        update:
+          flash:
+            success: 'Collection Association Updated Successfully!'
+            error: 'Collection Associaiton was not updated successfully.'
         destroy:
           flash:
             success: 'Collection Association Deleted Successfully!'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,8 +82,14 @@ Rails.application.routes.draw do
   end
 
   resources :variables, only: [:show, :create, :edit, :destroy] do
-    resources :collection_associations, only: [:index]
+    resources :collection_associations, only: [:index] do
+      collection do
+        match '/' => 'collection_associations#edit', via: :edit
+        match '/' => 'collection_associations#update', via: :post
+      end
+    end
   end
+  get '/variables/:id/collection_associations/edit' => 'collection_associations#edit', as: 'edit_variable_collection_association'
   get '/variables/:id/revisions' => 'variables#revisions', as: 'variable_revisions'
   get '/variables/:id/revert/:revision_id' => 'variables#revert', as: 'revert_variable'
   get '/variables/:id/clone' => 'variables#clone', as: 'clone_variable'

--- a/spec/features/collections/downloading_xml_spec.rb
+++ b/spec/features/collections/downloading_xml_spec.rb
@@ -27,8 +27,8 @@ describe 'Downloading Collection XML', js: true do
           @file = "#{Rails.root}/#{@concept_id}.echo10"
           click_on 'ECHO 10'
 
-          # Seems to need a brief (>0.01) pause to actually find the file.
-          sleep(0.1)
+          # Seems to need a brief (>0.1) pause to actually find the file.
+          sleep(1)
         end
 
         after do
@@ -78,8 +78,8 @@ describe 'Downloading Collection XML', js: true do
           @file = "#{Rails.root}/#{@concept_id}.iso-smap"
           click_on 'ISO 19115 (SMAP) (Native)'
 
-          # Seems to need a brief (>0.01) pause to actually find the file.
-          sleep(0.1)
+          # Seems to need a brief (>0.1) pause to actually find the file.
+          sleep(1)
         end
 
         after do

--- a/spec/features/proposal/search/collection_search_spec.rb
+++ b/spec/features/proposal/search/collection_search_spec.rb
@@ -65,11 +65,12 @@ describe 'Searching for published collections in proposal mode', js: true do
           before do
             @file = "#{Rails.root}/#{@ingest_response['concept-id']}.echo10"
             click_on 'ECHO 10'
+
+            # Seems to need a brief (>0.1) pause to actually find the file.
+            sleep(1)
           end
 
           after do
-            # Seems to need a brief (>0.01) pause to actually find the file.
-            sleep(0.1)
             FileUtils.rm @file if File.exist?(@file)
           end
 

--- a/spec/features/services/download_json_spec.rb
+++ b/spec/features/services/download_json_spec.rb
@@ -13,14 +13,14 @@ describe 'Downloading Service JSON', js: true do
     it 'renders the download link' do
       expect(page).to have_link('Download JSON', href: download_json_service_path(@ingest_response['concept-id']))
     end
-    
+
     context 'when downloading the json' do
       before do
         @file = "#{Rails.root}/#{@ingest_response['concept-id']}.json"
         click_on 'Download JSON'
 
-        # Seems to need a brief (>0.01) pause to actually find the file.
-        sleep(0.1)
+        # Seems to need a brief (>0.1) pause to actually find the file.
+        sleep(1)
       end
 
       after do

--- a/spec/features/tools/download_json_spec.rb
+++ b/spec/features/tools/download_json_spec.rb
@@ -19,8 +19,8 @@ describe 'Downloading Tool JSON', reset_provider: true, js: true do
         @file = "#{Rails.root}/#{@ingest_response['concept-id']}.json"
         click_on 'Download JSON'
 
-        # Seems to need a brief (>0.01) pause to actually find the file.
-        sleep(0.1)
+        # Seems to need a brief (>0.1) pause to actually find the file.
+        sleep(1)
       end
 
       after do

--- a/spec/features/variable_drafts/create_variable_draft_from_variable_spec.rb
+++ b/spec/features/variable_drafts/create_variable_draft_from_variable_spec.rb
@@ -42,41 +42,15 @@ describe 'Create new draft from variable', reset_provider: true do
     end
 
     context 'when clicking on the Collection Association form link' do
-      # this is temporarily blocked so we should test it is blocked correctly
       before do
         click_on 'Collection Association'
       end
 
-      it 'displays a modal indicating that the Collection Association cannot be modified' do
-        expect(page).to have_content("This Variable Draft is associated with a published Variable. Modifying a Variable's Collection Association is temporarily disabled.")
-
-        expect(page).to have_content('Publish Variable Draft')
-        expect(page).to have_content('Metadata Fields')
-        expect(page).to have_content('Variable Information')
-
-        expect(page).to have_no_content('Collection Association Search')
-        expect(page).to have_no_css('#variable-draft-collection-association-table')
-        expect(page).to have_no_select('Search Field')
-        expect(page).to have_no_css("input[id$='query_text']")
-      end
-    end
-
-    context 'when attempting to visit the collection association form directly' do
-      # this is temporarily blocked so we should test it is blocked correctly
-      before do
-        collection_association_link = page.current_path + '/collection_search'
-        visit collection_association_link
-      end
-
-      it 'does not display the Collection Association Form' do
-        expect(page).to have_content('Publish Variable Draft')
-        expect(page).to have_content('Metadata Fields')
-        expect(page).to have_content('Variable Information')
-
-        expect(page).to have_no_content('Collection Association Search')
-        expect(page).to have_no_css('#variable-draft-collection-association-table')
-        expect(page).to have_no_select('Search Field')
-        expect(page).to have_no_css("input[id$='query_text']")
+      it 'allows a user to modify the collection association' do
+        expect(page).to have_content('Collection Association Search')
+        expect(page).to have_css('#variable-draft-collection-association-table')
+        expect(page).to have_select('Search Field')
+        expect(page).to have_css("input[id$='query_text']")
       end
     end
   end

--- a/spec/features/variables/download_json_spec.rb
+++ b/spec/features/variables/download_json_spec.rb
@@ -20,8 +20,8 @@ describe 'Downloading Variable JSON', js: true do
         @file = "#{Rails.root}/#{@ingest_response['concept-id']}.json"
         click_on 'Download JSON'
 
-        # Seems to need a brief (>0.01) pause to actually find the file.
-        sleep(0.1)
+        # Seems to need a brief (>0.1) pause to actually find the file.
+        sleep(1)
       end
 
       after do

--- a/spec/features/variables/manage_collection_association_spec.rb
+++ b/spec/features/variables/manage_collection_association_spec.rb
@@ -1,7 +1,8 @@
-describe 'Manage Variable Collection Association' do
+describe 'Manage Variable Collection Association', js:true do
   before :all do
     collection_ingest_response, @collection_concept_response = publish_collection_draft
     @collection_ingest_response2, @collection_concept_response2 = publish_collection_draft
+    @collection_ingest_response3, @collection_concept_response3 = publish_collection_draft
     @variable_ingest_response, @variable_concept_response = publish_variable_draft(collection_concept_id: collection_ingest_response['concept-id'])
   end
 
@@ -79,15 +80,31 @@ describe 'Manage Variable Collection Association' do
           # has not always synchronized, even with the wait. Adding this refresh
           # reduced erroneous failures and is explicitly why this link is on the
           # page
-          context 'when refreshing the page' do
-            before do
-              click_on 'refresh the page'
-            end
+        end
+      end
 
-            it 'shows the correct collection' do
-              expect(page).to have_content(@collection_concept_response2.body['EntryTitle'])
-            end
+      context 'when refreshing the page after updating' do
+        before do
+          click_on 'Update Collection Association'
+
+          within '#collection-search' do
+            select 'Entry Title', from: 'Search Field'
+            find(:css, "input[id$='query_text']").set(@collection_concept_response3.body['EntryTitle'])
+            click_button 'Submit'
           end
+
+          within '#collections-select' do
+            find("input[value='#{@collection_ingest_response3['concept-id']}']").set(true)
+
+            click_on 'Submit'
+          end
+          wait_for_cmr
+
+          click_on 'refresh the page'
+        end
+
+        it 'shows the correct collection' do
+          expect(page).to have_content(@collection_concept_response3.body['EntryTitle'])
         end
       end
     end

--- a/spec/features/variables/manage_collection_association_spec.rb
+++ b/spec/features/variables/manage_collection_association_spec.rb
@@ -1,4 +1,4 @@
-describe 'Manage Variable Collection Association', js:true do
+describe 'Manage Variable Collection Association' do
   before :all do
     collection_ingest_response, @collection_concept_response = publish_collection_draft
     @collection_ingest_response2, @collection_concept_response2 = publish_collection_draft
@@ -75,15 +75,11 @@ describe 'Manage Variable Collection Association', js:true do
           it 'shows a success message' do
             expect(page).to have_content('Collection Association Updated Successfully!')
           end
-
-          # This test is not consistent without the page refresh because CMR
-          # has not always synchronized, even with the wait. Adding this refresh
-          # reduced erroneous failures and is explicitly why this link is on the
-          # page
         end
       end
 
-      context 'when refreshing the page after updating' do
+      # This test needs js:true because of the page refresh uses JS
+      context 'when refreshing the page after updating', js: true do
         before do
           click_on 'Update Collection Association'
 
@@ -100,7 +96,11 @@ describe 'Manage Variable Collection Association', js:true do
           end
           wait_for_cmr
 
-          click_on 'refresh the page'
+          # This test is not consistent without the page refresh because CMR
+          # has not always synchronized, even with the wait. Adding this refresh
+          # reduced erroneous failures and is explicitly why this link is on the
+          # page
+          click_link 'refresh the page'
         end
 
         it 'shows the correct collection' do

--- a/spec/features/variables/manage_collection_association_spec.rb
+++ b/spec/features/variables/manage_collection_association_spec.rb
@@ -1,6 +1,7 @@
 describe 'Manage Variable Collection Association' do
   before :all do
     collection_ingest_response, @collection_concept_response = publish_collection_draft
+    @collection_ingest_response2, @collection_concept_response2 = publish_collection_draft
     @variable_ingest_response, @variable_concept_response = publish_variable_draft(collection_concept_id: collection_ingest_response['concept-id'])
   end
 
@@ -35,8 +36,59 @@ describe 'Manage Variable Collection Association' do
       end
 
       it 'does not display buttons for blocked actions' do
-        expect(page).to have_no_button('Add Collection Association')
-        expect(page).to have_no_button('Delete Selected Associations')
+        expect(page).to have_no_link('Add Collection Association')
+        expect(page).to have_no_link('Delete Selected Associations')
+      end
+
+      it 'displays an update button' do
+        expect(page).to have_link('Update Collection Association')
+      end
+
+      context 'when searching for a collection to update the collection association' do
+        before do
+          click_on 'Update Collection Association'
+
+          within '#collection-search' do
+            select 'Entry Title', from: 'Search Field'
+            find(:css, "input[id$='query_text']").set(@collection_concept_response2.body['EntryTitle'])
+            click_button 'Submit'
+          end
+        end
+
+        it 'displays the collection' do
+          within '#collection-search-results' do
+            expect(page).to have_content(@collection_concept_response2.body['EntryTitle'])
+          end
+        end
+
+        context 'when updating the collection association' do
+          before do
+            within '#collections-select' do
+              find("input[value='#{@collection_ingest_response2['concept-id']}']").set(true)
+
+              click_on 'Submit'
+            end
+            wait_for_cmr
+          end
+
+          it 'shows a success message' do
+            expect(page).to have_content('Collection Association Updated Successfully!')
+          end
+
+          # This test is not consistent without the page refresh because CMR
+          # has not always synchronized, even with the wait. Adding this refresh
+          # reduced erroneous failures and is explicitly why this link is on the
+          # page
+          context 'when refreshing the page' do
+            before do
+              click_on 'refresh the page'
+            end
+
+            it 'shows the correct collection' do
+              expect(page).to have_content(@collection_concept_response2.body['EntryTitle'])
+            end
+          end
+        end
       end
     end
   end

--- a/spec/features/variables/variable_with_draft_spec.rb
+++ b/spec/features/variables/variable_with_draft_spec.rb
@@ -49,29 +49,11 @@ describe 'Variable with draft' do
 
         it 'displays the correct Collection Association form links' do
           within '#collection-association-progress' do
-            expect(page).to have_link('Collection Association', href: '#editing-variable-collection-association-notice')
+            expect(page).to have_link('Collection Association', href: collection_search_variable_draft_path(VariableDraft.last.id))
 
             within '.progress-indicators' do
-              expect(page).to have_link('Collection Association - Required', href: '#editing-variable-collection-association-notice')
+              expect(page).to have_link('Collection Association - Required', href: collection_search_variable_draft_path(VariableDraft.last.id))
             end
-          end
-        end
-
-        context 'when clicking on the Collection Association form link' do
-          before do
-            click_on 'Collection Association'
-          end
-
-          it 'does not leave the preview page' do
-            expect(page).to have_content("This Variable Draft is associated with a published Variable. Modifying a Variable's Collection Association is temporarily disabled.")
-            expect(page).to have_content('Publish Variable Draft')
-            expect(page).to have_content('Metadata Fields')
-            expect(page).to have_content('Variable Information')
-
-            expect(page).to have_no_content('Collection Association Search')
-            expect(page).to have_no_css('#variable-draft-collection-association-table')
-            expect(page).to have_no_select('Search Field')
-            expect(page).to have_no_css("input[id$='query_text']")
           end
         end
       end


### PR DESCRIPTION
Allowed user to update collection association from published variable's 'manage collection association' page.
Allowed user to update collection association for drafts which have published counterparts.
Updated logic for reverting a variable to always use the association of the last non-deleted revision.
Updated wait time on download json tests