### PR TITLE
MMT-2384 Preventing test from redefining rake tasks

### DIFF
--- a/spec/features/proposal/deleting_old_proposals_spec.rb
+++ b/spec/features/proposal/deleting_old_proposals_spec.rb
@@ -1,6 +1,7 @@
 describe 'Deleting old proposals via rake task' do
   before do
-    Mmt::Application.load_tasks
+    Rake::Task.define_task(:environment)
+    Rake.application.rake_require 'tasks/proposals'
     set_as_proposal_mode_mmt(with_draft_approver_acl: true)
     @in_work_collection_draft_proposal = create(:full_collection_draft_proposal)
     @submitted_collection_draft_proposal = create(:full_collection_draft_proposal)


### PR DESCRIPTION
`<App>::Application.load_tasks` causes rake to define tasks.  If tasks have already been defined this causes them to be added together. This was causing duplication of the reset_provider function which was ultimately causing CMR to run out of memory.  

This branch + it-2 have run 10 times with these changes and passed 9 of them.  The failure case was for a different intermittent issue, so I think this change resolves the main thrust of this ticket.