### PR TITLE
MMT-2386 updating preview gem and removing same error from json schema previews in MMT

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem 'browser'
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
 # make sure to delete the local config when done making changes to merge into master
 # bundle config --delete local.cmr_metadata_preview
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '1aaef8d08e9636968e84dead10d52c7c1aae09c7'
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: 'e8323939630270416b7ddc1f41a12f0558598324'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: 1aaef8d08e9636968e84dead10d52c7c1aae09c7
-  ref: 1aaef8d08e9636968e84dead10d52c7c1aae09c7
+  revision: e8323939630270416b7ddc1f41a12f0558598324
+  ref: e8323939630270416b7ddc1f41a12f0558598324
   specs:
-    cmr_metadata_preview (0.2.4)
+    cmr_metadata_preview (0.2.5)
       georuby
       rails (~> 5.2.0)
       sprockets (< 4.0)

--- a/lib/json_schema_form/umm_preview_elements/umm_preview_link.rb
+++ b/lib/json_schema_form/umm_preview_elements/umm_preview_link.rb
@@ -5,6 +5,22 @@
 class UmmPreviewLink < UmmPreviewElement
   def render
     title = 'Use Service API' if schema_type == 'service' && full_key == 'URL/URLValue'
-    link_to element_value, element_value, title: title
+    valid_url = validate_link_url(element_value)
+
+    if valid_url
+      link_to element_value, element_value, title: title
+    else
+      content_tag(:p, element_value)
+    end
+  end
+
+  # Return nil if cannot be parsed as a URI or if URI does not have a protocol/
+  # scheme.
+  def validate_link_url(url)
+    begin
+      url if URI.parse(url).scheme
+    rescue URI::InvalidURIError
+      nil
+    end
   end
 end

--- a/spec/features/service_drafts/preview/valid/service_information_preview_spec.rb
+++ b/spec/features/service_drafts/preview/valid/service_information_preview_spec.rb
@@ -4,10 +4,13 @@ describe 'Valid Service Draft Service Information Preview' do
 
   before do
     login
-    visit service_draft_path(service_draft)
   end
 
   context 'When examining the Service Information section' do
+    before do
+      visit service_draft_path(service_draft)
+    end
+
     it 'displays the form title as an edit link' do
       within '#service_information-progress' do
         expect(page).to have_link('Service Information', href: edit_service_draft_path(service_draft, 'service_information'))
@@ -71,6 +74,21 @@ describe 'Valid Service Draft Service Information Preview' do
         within '#service_draft_draft_url_preview' do
           expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_url'))
         end
+      end
+    end
+  end
+
+  context 'when examining the Service Information section with a url with no protocol' do
+    before do
+      service_draft.draft['URL']['URLValue'] = 'Not Provided'
+      service_draft.save
+      visit service_draft_path(service_draft)
+    end
+
+    it 'does not make a link for the invalid url' do
+      within '#service_draft_draft_url_preview' do
+        expect(page).to have_content('Not Provided')
+        expect(page).to have_no_link('Not Provided')
       end
     end
   end


### PR DESCRIPTION
Updating preview gem commit to take care of rendering URLs that turn into routes in rails.
Updating same problem in MMT json schema previews.