### PR TITLE
MMT-2386 removing text-decoration underline as previously intended

### DIFF
--- a/app/assets/stylesheets/components/_preview-gem-cards.scss
+++ b/app/assets/stylesheets/components/_preview-gem-cards.scss
@@ -81,5 +81,4 @@
   flex: 1 1 60%; // Higher values or auto in the basis cause long titles to
                  // squish the links in the cards
   font-weight: normal;
-  text-decoration: underline;
 }


### PR DESCRIPTION
Missed this in previous PR.