### PR TITLE
MMT-2355: Create a variable draft with the associated collection filled out

### DIFF
--- a/app/assets/javascripts/change_current_provider.coffee
+++ b/app/assets/javascripts/change_current_provider.coffee
@@ -50,6 +50,8 @@ $(document).ready ->
         'Editing this group'
       when 'delete-group'
         'Deleting this group'
+      when 'create-associated-variable'
+        'Creating an associated variable'
       when 'edit-variable'
         'Editing this variable'
       when 'clone-variable'

--- a/app/controllers/base_drafts_controller.rb
+++ b/app/controllers/base_drafts_controller.rb
@@ -57,7 +57,7 @@ class BaseDraftsController < DraftsController
 
     get_resource.draft = draft['draft']
 
-    get_resource.update(collection_concept_id: params[:associated_collection_id]) if params[:associated_collection_id]
+    get_resource.collection_concept_id = params[:associated_collection_id] if params[:associated_collection_id]
 
     if get_resource.save
       # Successful flash message

--- a/app/controllers/base_drafts_controller.rb
+++ b/app/controllers/base_drafts_controller.rb
@@ -36,6 +36,7 @@ class BaseDraftsController < DraftsController
     set_form
 
     set_current_form
+    byebug
   end
 
   def edit

--- a/app/controllers/base_drafts_controller.rb
+++ b/app/controllers/base_drafts_controller.rb
@@ -36,7 +36,6 @@ class BaseDraftsController < DraftsController
     set_form
 
     set_current_form
-    byebug
   end
 
   def edit
@@ -57,6 +56,12 @@ class BaseDraftsController < DraftsController
     draft = @json_form.sanitize_form_input(resource_params, params[:form])
 
     get_resource.draft = draft['draft']
+
+    if get_resource.update(collection_concept_id: params[:associated_collection_id])
+      flash[:success] = I18n.t("controllers.draft.variable_drafts.update_associated_collection.flash.success")
+    else
+      flash[:error] = I18n.t("controllers.draft.variable_drafts.update_associated_collection.flash.error")
+    end
 
     if get_resource.save
       # Successful flash message

--- a/app/controllers/base_drafts_controller.rb
+++ b/app/controllers/base_drafts_controller.rb
@@ -57,11 +57,7 @@ class BaseDraftsController < DraftsController
 
     get_resource.draft = draft['draft']
 
-    if get_resource.update(collection_concept_id: params[:associated_collection_id])
-      flash[:success] = I18n.t("controllers.draft.variable_drafts.update_associated_collection.flash.success")
-    else
-      flash[:error] = I18n.t("controllers.draft.variable_drafts.update_associated_collection.flash.error")
-    end
+    get_resource.update(collection_concept_id: params[:associated_collection_id]) if params[:associated_collection_id]
 
     if get_resource.save
       # Successful flash message

--- a/app/controllers/variable_drafts_controller.rb
+++ b/app/controllers/variable_drafts_controller.rb
@@ -25,6 +25,8 @@ class VariableDraftsController < BaseDraftsController
       )
 
       if current_collection_response.success? && current_collection_response.body['hits'] > 0
+        # this banner needs to be deliberated
+        flash[:success] = I18n.t("controllers.draft.variable_drafts.update_associated_collection.flash.success")
         super
       else
         Rails.logger.info("Error retrieving Collection - Concept ID: #{@associated_collection_id}")

--- a/app/controllers/variable_drafts_controller.rb
+++ b/app/controllers/variable_drafts_controller.rb
@@ -17,17 +17,21 @@ class VariableDraftsController < BaseDraftsController
   end
 
   def new
-    @associated_collection_id = params[:associated_collection_id]
+    unless params[:associated_collection_id].blank?
+      @associated_collection_id = params[:associated_collection_id].strip
 
-    current_collection_response = cmr_client.get_collections_by_post(
-      { concept_id: @associated_collection_id }, token
-    )
+      current_collection_response = cmr_client.get_collections_by_post(
+        { concept_id: @associated_collection_id }, token
+      )
 
-    if current_collection_response.success? && current_collection_response.body['hits'] > 0
-      super
+      if current_collection_response.success? && current_collection_response.body['hits'] > 0
+        super
+      else
+        Rails.logger.info("Error retrieving Collection - Concept ID: #{@associated_collection_id}")
+        redirect_to manage_variables_path, flash: { error: 'Concept ID invalid.'}
+      end
     else
-      Rails.logger.info("Error retrieving Collection")
-      redirect_to manage_variables_path, flash: { error: 'Concept ID invalid.'}
+      super
     end
   end
 

--- a/app/controllers/variable_drafts_controller.rb
+++ b/app/controllers/variable_drafts_controller.rb
@@ -24,13 +24,14 @@ class VariableDraftsController < BaseDraftsController
         { concept_id: @associated_collection_id }, token
       )
 
-      if current_collection_response.success? && current_collection_response.body['hits'] > 0
-        # this banner needs to be deliberated
-        flash[:success] = I18n.t("controllers.draft.variable_drafts.update_associated_collection.flash.success")
+      if current_collection_response.success? && current_collection_response.body['hits'] > 0 && current_provider?(current_collection_response.body.dig('items',0,'meta','provider-id'))
         super
-      else
-        Rails.logger.info("Error retrieving Collection - Concept ID: #{@associated_collection_id}")
-        redirect_to manage_variables_path, flash: { error: 'Concept ID invalid.'}
+      elsif !current_collection_response.success?
+        redirect_to manage_variables_path, flash: { error: 'Unable to search CMR.' }
+      elsif current_collection_response.body['hits'] == 0
+        redirect_to manage_variables_path, flash: { error: 'Collection not found.' }
+      elsif !current_provider?(current_collection_response.body.dig('items',0,'meta','provider-id'))
+        redirect_to manage_variables_path, flash: { error: 'Provider context must be changed.' }
       end
     else
       super

--- a/app/controllers/variable_drafts_controller.rb
+++ b/app/controllers/variable_drafts_controller.rb
@@ -27,7 +27,7 @@ class VariableDraftsController < BaseDraftsController
       if current_collection_response.success? && current_collection_response.body['hits'] > 0 && current_provider?(current_collection_response.body.dig('items',0,'meta','provider-id'))
         super
       elsif !current_collection_response.success?
-        redirect_to manage_variables_path, flash: { error: 'Unable to search CMR.' }
+        redirect_to manage_variables_path, flash: { error: current_collection_response.body['errors'].first }
       elsif current_collection_response.body['hits'] == 0
         redirect_to manage_variables_path, flash: { error: 'Collection not found.' }
       elsif !current_provider?(current_collection_response.body.dig('items',0,'meta','provider-id'))

--- a/app/controllers/variable_drafts_controller.rb
+++ b/app/controllers/variable_drafts_controller.rb
@@ -17,21 +17,19 @@ class VariableDraftsController < BaseDraftsController
   end
 
   def new
-    unless params[:associated_collection_id].blank?
-      @associated_collection_id = params[:associated_collection_id].strip
-      current_collection_response = cmr_client.get_collections_by_post({ concept_id: @associated_collection_id }, token)
+    super and return if params[:associated_collection_id].blank?
 
-      if current_collection_response.success? && current_collection_response.body['hits'] > 0 && current_provider?(current_collection_response.body.dig('items',0,'meta','provider-id'))
-        super
-      elsif !current_collection_response.success?
-        redirect_to manage_variables_path, flash: { error: current_collection_response.body['errors'].first }
-      elsif current_collection_response.body['hits'] == 0
-        redirect_to manage_variables_path, flash: { error: "No matches were found for #{@associated_collection_id}" }
-      elsif !current_provider?(current_collection_response.body.dig('items',0,'meta','provider-id'))
-        redirect_to manage_variables_path, flash: { error: "Variables can only be associated to collections within the same provider. To create a variable for #{@associated_collection_id} you must change your provider context." }
-      end
-    else
+    @associated_collection_id = params[:associated_collection_id].strip
+    current_collection_response = cmr_client.get_collections_by_post({ concept_id: @associated_collection_id }, token)
+
+    if current_collection_response.success? && current_collection_response.body['hits'] > 0 && current_provider?(current_collection_response.body.dig('items',0,'meta','provider-id'))
       super
+    elsif !current_collection_response.success?
+      redirect_to manage_variables_path, flash: { error: current_collection_response.body['errors'].first }
+    elsif current_collection_response.body['hits'] == 0
+      redirect_to manage_variables_path, flash: { error: "No matches were found for #{@associated_collection_id}" }
+    elsif !current_provider?(current_collection_response.body.dig('items',0,'meta','provider-id'))
+      redirect_to manage_variables_path, flash: { error: "Variables can only be associated to collections within the same provider. To create a variable for #{@associated_collection_id} you must change your provider context." }
     end
   end
 

--- a/app/controllers/variable_drafts_controller.rb
+++ b/app/controllers/variable_drafts_controller.rb
@@ -16,6 +16,21 @@ class VariableDraftsController < BaseDraftsController
     set_measurement_names if @current_form == 'measurement_identifiers'
   end
 
+  def new
+    @associated_collection_id = params[:associated_collection_id]
+
+    current_collection_response = cmr_client.get_collections_by_post(
+      { concept_id: @associated_collection_id }, token
+    )
+
+    if current_collection_response.success? && current_collection_response.body['hits'] > 0
+      super
+    else
+      Rails.logger.info("Error retrieving Collection")
+      redirect_to manage_variables_path, flash: { error: 'Concept ID invalid.'}
+    end
+  end
+
   def update_associated_collection
     authorize get_resource
 

--- a/app/controllers/variable_drafts_controller.rb
+++ b/app/controllers/variable_drafts_controller.rb
@@ -19,19 +19,16 @@ class VariableDraftsController < BaseDraftsController
   def new
     unless params[:associated_collection_id].blank?
       @associated_collection_id = params[:associated_collection_id].strip
-
-      current_collection_response = cmr_client.get_collections_by_post(
-        { concept_id: @associated_collection_id }, token
-      )
+      current_collection_response = cmr_client.get_collections_by_post({ concept_id: @associated_collection_id }, token)
 
       if current_collection_response.success? && current_collection_response.body['hits'] > 0 && current_provider?(current_collection_response.body.dig('items',0,'meta','provider-id'))
         super
       elsif !current_collection_response.success?
         redirect_to manage_variables_path, flash: { error: current_collection_response.body['errors'].first }
       elsif current_collection_response.body['hits'] == 0
-        redirect_to manage_variables_path, flash: { error: 'Collection not found.' }
+        redirect_to manage_variables_path, flash: { error: "No matches were found for #{@associated_collection_id}" }
       elsif !current_provider?(current_collection_response.body.dig('items',0,'meta','provider-id'))
-        redirect_to manage_variables_path, flash: { error: 'Provider context must be changed.' }
+        redirect_to manage_variables_path, flash: { error: "Variables can only be associated to collections within the same provider. To create a variable for #{@associated_collection_id} you must change your provider context." }
       end
     else
       super

--- a/app/views/collection_drafts/forms/_archive_and_distribution_information.html.erb
+++ b/app/views/collection_drafts/forms/_archive_and_distribution_information.html.erb
@@ -2,7 +2,7 @@
 <fieldset class="eui-accordion is-closed" id="file-archive-information">
   <% file_archive_information_value = draft.draft['ArchiveAndDistributionInformation']['FileArchiveInformation'] if draft.draft.key?('ArchiveAndDistributionInformation') %>
   <div class="eui-accordion__header">
-    <h3 class="eui-accordion__title">File Archive Information</h3>
+    <h3 class="eui-accordion__title eui-required-o">File Archive Information</h3>
     <%= mmt_help_icon(
           title: 'File Archive Information',
           help: 'definitions/FileArchiveInformationType'
@@ -31,7 +31,7 @@
 <fieldset class="eui-accordion is-closed" id="file-distribution-information">
   <% file_distribution_information_value = draft.draft['ArchiveAndDistributionInformation']['FileDistributionInformation'] if draft.draft.key?('ArchiveAndDistributionInformation') %>
   <div class="eui-accordion__header">
-    <h3 class="eui-accordion__title">File Distribution Information</h3>
+    <h3 class="eui-accordion__title eui-required-o">File Distribution Information</h3>
     <%= mmt_help_icon(
           title: 'File Distribution Information',
           help: 'definitions/FileDistributionInformationType'

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -81,7 +81,12 @@
 
             <%= link_to "Tags (#{@num_tags || 0})", '#tags-modal', class: 'display-modal bar-after' %>
 
-            <%= link_to "Create Associated Variable", new_variable_draft_path(associated_collection_id: @concept_id), class: 'eui-btn--link bar-after' %>
+            <% if current_provider?(@provider_id) %>
+              <%= link_to 'Create Associated Variable', new_variable_draft_path(associated_collection_id: @concept_id), class: 'eui-btn--link bar-after' %>
+            <% elsif available_provider?(@provider_id) %>
+              <%= link_to 'Create Associated Variable', '#not-current-provider-modal', class: 'display-modal delete-collection not-current-provider eui-btn--link bar-after', data: { provider: @provider_id, record_action: 'create-associated-variable' } %>
+            <% end %>
+
 
             <% if Rails.configuration.templates_enabled %>
               <% if current_provider?(@provider_id) %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -84,7 +84,7 @@
             <% if current_provider?(@provider_id) %>
               <%= link_to 'Create Associated Variable', new_variable_draft_path(associated_collection_id: @concept_id), class: 'eui-btn--link bar-after' %>
             <% elsif available_provider?(@provider_id) %>
-              <%= link_to 'Create Associated Variable', '#not-current-provider-modal', class: 'display-modal delete-collection not-current-provider eui-btn--link bar-after', data: { provider: @provider_id, record_action: 'create-associated-variable' } %>
+              <%= link_to 'Create Associated Variable', '#not-current-provider-modal', class: 'display-modal not-current-provider eui-btn--link bar-after', data: { provider: @provider_id, record_action: 'create-associated-variable' } %>
             <% end %>
 
 

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -81,6 +81,8 @@
 
             <%= link_to "Tags (#{@num_tags || 0})", '#tags-modal', class: 'display-modal bar-after' %>
 
+            <%= link_to "Create Associated Variable", new_variable_draft_path(associated_collection_id: @concept_id), class: 'eui-btn--link bar-after' %>
+
             <% if Rails.configuration.templates_enabled %>
               <% if current_provider?(@provider_id) %>
                 <%= link_to 'Save as Template', '#save-as-template-modal', id: 'save_as_template_link' %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -77,23 +77,25 @@
 
             <%= link_to "Revisions (#{@revisions.size})", collection_revisions_path, class: 'eui-btn--link bar-after' %>
 
-            <%= link_to "Granules (#{@num_granules})", '#', class: 'collection-granule-count disabled bar-after' %>
+            <%= link_to "Granules (#{@num_granules})", '#', class: 'collection-granule-count disabled eui-btn--link bar-after' %>
 
-            <%= link_to "Tags (#{@num_tags || 0})", '#tags-modal', class: 'display-modal bar-after' %>
-
-            <% if current_provider?(@provider_id) %>
-              <%= link_to 'Create Associated Variable', new_variable_draft_path(associated_collection_id: @concept_id), class: 'eui-btn--link bar-after' %>
-            <% elsif available_provider?(@provider_id) %>
-              <%= link_to 'Create Associated Variable', '#not-current-provider-modal', class: 'display-modal not-current-provider eui-btn--link bar-after', data: { provider: @provider_id, record_action: 'create-associated-variable' } %>
-            <% end %>
-
+            <%= link_to "Tags (#{@num_tags || 0})", '#tags-modal', class: 'display-modal eui-btn--link bar-after' %>
 
             <% if Rails.configuration.templates_enabled %>
               <% if current_provider?(@provider_id) %>
-                <%= link_to 'Save as Template', '#save-as-template-modal', id: 'save_as_template_link' %>
+                <%= link_to 'Save as Template', '#save-as-template-modal', id: 'save_as_template_link', class: 'eui-btn--link bar-after' %>
               <% elsif available_provider?(@provider_id) %>
-                <%= link_to 'Save as Template', '#not-current-provider-modal', class: 'display-modal not-current-provider eui-btn--link', data: { provider: @provider_id, record_action: 'create-template-collection' } %>
+                <%= link_to 'Save as Template', '#not-current-provider-modal', class: 'display-modal not-current-provider eui-btn--link bar-after', data: { provider: @provider_id, record_action: 'create-template-collection' } %>
               <% end %>
+            <% end %>
+
+            <% if current_provider?(@provider_id) %>
+              <%= link_to 'Create Associated Variable', new_variable_draft_path(associated_collection_id: @concept_id), class: 'eui-btn--link' %>
+            <% elsif available_provider?(@provider_id) %>
+              <%= link_to 'Create Associated Variable', '#not-current-provider-modal', class: 'display-modal not-current-provider eui-btn--link', data: { provider: @provider_id, record_action: 'create-associated-variable' } %>
+            <% end %>
+
+            <% if Rails.configuration.templates_enabled %>
               <%= form_tag new_from_existing_collection_template_path, method: :post, class: "template_creation_form" do %>
                 <%= hidden_field_tag "collection_id", params[:id] %>
                 <%= hidden_field_tag "origin", "Collection" %>

--- a/app/views/drafts/new.html.erb
+++ b/app/views/drafts/new.html.erb
@@ -4,7 +4,7 @@
 
 <div class="row row-content">
   <section>
-    <%= form_tag(send("#{plural_resource_name}_path"), method: :post, id: 'umm_form', class: "umm-form #{published_resource_name}-form", novalidate: 'novalidate') do %>
+    <%= form_tag(send("#{plural_resource_name}_path", associated_collection_id: @associated_collection_id), method: :post, id: 'umm_form', class: "umm-form #{published_resource_name}-form", novalidate: 'novalidate') do %>
       <%= render partial: 'form', locals: { resource: get_resource, json_form: @json_form, current_form: @current_form } %>
     <% end %>
   </section>

--- a/app/views/manage_variables/show.html.erb
+++ b/app/views/manage_variables/show.html.erb
@@ -4,7 +4,7 @@
       <h3 class="eui-callout-box__title green">Create Variable Record</h3>
       <div class="eui-callout-box__list">
         <div class="question-group">
-          <%= link_to 'Create New Record', new_variable_draft_path, class: 'eui-btn--blue submit' %>
+          <%= link_to 'Create New Record', new_variable_draft_path(ac_id: 'C12-TEST'), class: 'eui-btn--blue submit' %>
         </div>
         <div class="question-group">
           <div class="row">
@@ -21,7 +21,7 @@
 
     <section class="eui-callout-box col-left">
       <div class="open-drafts">
-        <h3 class="eui-callout-box__title green"><%= current_user.provider_id %> Variable Drafts</h2>
+        <h3 class="eui-callout-box__title green"><%= current_user.provider_id %> Variable Drafts</h3>
         <div class="eui-callout-box__list">
           <ul>
             <% unless @drafts.any? %>

--- a/app/views/manage_variables/show.html.erb
+++ b/app/views/manage_variables/show.html.erb
@@ -4,7 +4,10 @@
       <h3 class="eui-callout-box__title green">Create Variable Record</h3>
       <div class="eui-callout-box__list">
         <div class="question-group">
-          <%= link_to 'Create New Record', new_variable_draft_path(ac_id: 'C12-TEST'), class: 'eui-btn--blue submit' %>
+          <%= form_tag(new_variable_draft_with_associated_collection_path, method: :post, id: 'new-draft-form') do %>
+            <%= text_field_tag('associated_collection_id', nil, placeholder: 'Concept ID') %>
+            <%= submit_tag('Create New Record', class: 'eui-btn--blue submit') %>
+          <% end %>
         </div>
         <div class="question-group">
           <div class="row">

--- a/app/views/manage_variables/show.html.erb
+++ b/app/views/manage_variables/show.html.erb
@@ -4,7 +4,7 @@
       <h3 class="eui-callout-box__title green">Create Variable Record</h3>
       <div class="eui-callout-box__list">
         <div class="question-group">
-          <%= form_tag(new_variable_draft_with_associated_collection_path, method: :post, id: 'new-draft-form') do %>
+          <%= form_tag(new_variable_draft_path, method: :get, id: 'new-draft-form') do %>
             <%= text_field_tag('associated_collection_id', nil, placeholder: 'Concept ID') %>
             <%= submit_tag('Create New Record', class: 'eui-btn--blue submit') %>
           <% end %>

--- a/app/views/manage_variables/show.html.erb
+++ b/app/views/manage_variables/show.html.erb
@@ -5,8 +5,9 @@
       <div class="eui-callout-box__list">
         <div class="question-group">
           <%= form_tag(new_variable_draft_path, method: :get, id: 'new-draft-form') do %>
-            <%= text_field_tag('associated_collection_id', nil, placeholder: 'Concept ID') %>
             <%= submit_tag('Create New Record', class: 'eui-btn--blue submit') %>
+            <p>(Optional) Enter the Concept ID of the collection to associate this variable:</p>
+            <%= text_field_tag('associated_collection_id', nil, placeholder: 'Concept ID', class: 'full-width') %>
           <% end %>
         </div>
         <div class="question-group">
@@ -16,7 +17,7 @@
         </div>
         <div class="question-group">
           <div class="row">
-            <p>A Collection Association must be selected in order to publish Variable Drafts. Each Variable can only be associated with a single Collection.</p>
+            <p>A Collection Association must be selected in order to publish Variable Drafts.</p>
           </div>
         </div>
       </div>

--- a/app/views/shared/_not_current_provider_modal.html.erb
+++ b/app/views/shared/_not_current_provider_modal.html.erb
@@ -23,6 +23,7 @@
       <%= link_to 'Yes', edit_collection_path(options[:concept_id], revision_id: options[:revision_id]), class: 'eui-btn--blue spinner is-invisible', id: 'not-current-provider-edit-collection-link' %>
       <%= link_to 'Yes', clone_collection_path(options[:concept_id]), class: 'eui-btn--blue spinner is-invisible', id: 'not-current-provider-clone-collection-link' %>
       <%= link_to 'Yes', collection_path(options[:concept_id]), method: :delete, class: 'eui-btn--blue spinner is-invisible', id: 'not-current-provider-delete-collection-link' %>
+      <%= link_to 'Yes', new_variable_draft_path(associated_collection_id: options[:concept_id]), class: 'eui-btn--blue spinner is-invisible', id: 'not-current-provider-create-associated-variable-link' %>
     <% elsif options[:variable] %>
       <%= link_to 'Yes', edit_variable_path(options[:concept_id], revision_id: options[:revision_id]), class: 'eui-btn--blue spinner is-invisible', id: 'not-current-provider-edit-variable-link' %>
       <%= link_to 'Yes', clone_variable_path(options[:concept_id], revision_id: options[:revision_id]), class: 'eui-btn--blue spinner is-invisible', id: 'not-current-provider-clone-variable-link' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,7 +120,6 @@ Rails.application.routes.draw do
       post 'update_associated_collection'
     end
   end
-  post 'variable_drafts/new' => 'variable_drafts#new', as: 'new_variable_draft_with_associated_collection'
 
   resources :service_drafts, controller: 'service_drafts', draft_type: 'ServiceDraft' do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Rails.application.routes.draw do
       post 'update_associated_collection'
     end
   end
+  post 'variable_drafts/new' => 'variable_drafts#new', as: 'new_variable_draft_with_associated_collection'
 
   resources :service_drafts, controller: 'service_drafts', draft_type: 'ServiceDraft' do
     member do

--- a/spec/features/variable_drafts/create_variable_draft_with_associated_collection_spec.rb
+++ b/spec/features/variable_drafts/create_variable_draft_with_associated_collection_spec.rb
@@ -48,7 +48,7 @@ describe 'Associating a collection upon variable draft creation', js: true do
       end
 
       it 'notifies the user that the concept supplied was not found' do
-        expect(page).to have_content('Collection not found.')
+        expect(page).to have_content("No matches were found for C1-INVALID")
       end
     end
 
@@ -65,7 +65,7 @@ describe 'Associating a collection upon variable draft creation', js: true do
       end
 
       it 'notifies the user that the provider context needs to be changed' do
-        expect(page).to have_content('Provider context must be changed.') #subject to change
+        expect(page).to have_content("Variables can only be associated to collections within the same provider. To create a variable for #{not_current_provider_concept_id} you must change your provider context.") 
       end
     end
 

--- a/spec/features/variable_drafts/create_variable_draft_with_associated_collection_spec.rb
+++ b/spec/features/variable_drafts/create_variable_draft_with_associated_collection_spec.rb
@@ -84,6 +84,8 @@ describe 'Associating a collection upon variable draft creation', js: true do
         expect(page).to have_no_content('Variable Information')
         expect(page).to have_no_css('.umm-form')
         expect(page).to have_no_css('.variable-form')
+        expect(page).to have_content('Create Variable Record')
+        expect(page).to have_content('(Optional) Enter the Concept ID of the collection to associate this variable:')
       end
     end
 

--- a/spec/features/variable_drafts/create_variable_draft_with_associated_collection_spec.rb
+++ b/spec/features/variable_drafts/create_variable_draft_with_associated_collection_spec.rb
@@ -37,7 +37,7 @@ describe 'Associating a collection upon variable draft creation', js: true do
         click_on 'Create New Record'
       end
 
-      it 'does not navigate to the new_variable_draft_path' do
+      it 'remains on the manage variables page' do
         expect(page).to have_no_content('Variable Information')
         expect(page).to have_no_css('.umm-form')
         expect(page).to have_no_css('.variable-form')
@@ -56,7 +56,7 @@ describe 'Associating a collection upon variable draft creation', js: true do
         click_on 'Create New Record'
       end
 
-      it 'does not navigate to the new_variable_draft_path' do
+      it 'remains on the manage variables page' do
         expect(page).to have_no_content('Variable Information')
         expect(page).to have_no_css('.umm-form')
         expect(page).to have_no_css('.variable-form')
@@ -80,7 +80,7 @@ describe 'Associating a collection upon variable draft creation', js: true do
         expect(page).to have_content('Concept-id [asdf] is not valid.')
       end
 
-      it 'does not navigate to the new_variable_draft_path' do
+      it 'remains on the manage variables page' do
         expect(page).to have_no_content('Variable Information')
         expect(page).to have_no_css('.umm-form')
         expect(page).to have_no_css('.variable-form')

--- a/spec/features/variable_drafts/create_variable_draft_with_associated_collection_spec.rb
+++ b/spec/features/variable_drafts/create_variable_draft_with_associated_collection_spec.rb
@@ -1,7 +1,9 @@
 describe 'Associating a collection upon variable draft creation', js: true do
   let(:collection_concept_id)           { cmr_client.get_collections({'EntryTitle': 'Anthropogenic Biomes of the World, Version 2: 1700'}).body.dig('items',0,'meta','concept-id') }
-  let(:collection_short_name)           { 'CIESIN_SEDAC_ANTHROMES_v2_1700' }
   let(:not_current_provider_concept_id) { cmr_client.get_collections({'EntryTitle': 'MISR Level 1B1 Radiance Data V002'}).body.dig('items',0,'meta','concept-id') }
+  let(:not_found_concept_id)            { 'C1-NOTFOUND' }
+  let(:invalid_concept_id)              { 'asdf' }
+  let(:variable_draft)                  { VariableDraft.last }
 
   before do
     login(provider: 'SEDAC', providers: %w(SEDAC LARC))
@@ -16,28 +18,22 @@ describe 'Associating a collection upon variable draft creation', js: true do
       before do
         fill_in 'associated_collection_id', with: collection_concept_id
         click_on 'Create New Record'
-      end
-
-      it 'associates the collection upon draft creation' do
         within '.nav-top' do
           click_on 'Done'
         end
         within '#invalid-draft-modal.eui-modal-content' do
           click_on 'Yes'
         end
-        within '.collection-association' do
-          click_on 'Collection Association'
-        end
-        within '#variable-draft-collection-association-table tbody' do
-          expect(page).to have_content('CIESIN_SEDAC_ANTHROMES_v2_1700')
-          expect(page).to have_css('tr', count: 1)
-        end
+      end
+
+      it 'associates the collection upon draft creation' do
+        expect(variable_draft.collection_concept_id).to eq(collection_concept_id)
       end
     end
 
     context 'when the supplied concept-id is not found' do
       before do
-        fill_in 'associated_collection_id', with: 'C1-INVALID'
+        fill_in 'associated_collection_id', with: not_found_concept_id
         click_on 'Create New Record'
       end
 
@@ -45,10 +41,12 @@ describe 'Associating a collection upon variable draft creation', js: true do
         expect(page).to have_no_content('Variable Information')
         expect(page).to have_no_css('.umm-form')
         expect(page).to have_no_css('.variable-form')
+        expect(page).to have_content('Create Variable Record')
+        expect(page).to have_content('(Optional) Enter the Concept ID of the collection to associate this variable:')
       end
 
       it 'notifies the user that the concept supplied was not found' do
-        expect(page).to have_content("No matches were found for C1-INVALID")
+        expect(page).to have_content("No matches were found for #{not_found_concept_id}")
       end
     end
 
@@ -62,24 +60,24 @@ describe 'Associating a collection upon variable draft creation', js: true do
         expect(page).to have_no_content('Variable Information')
         expect(page).to have_no_css('.umm-form')
         expect(page).to have_no_css('.variable-form')
+        expect(page).to have_content('Create Variable Record')
+        expect(page).to have_content('(Optional) Enter the Concept ID of the collection to associate this variable:')
+
       end
 
       it 'notifies the user that the provider context needs to be changed' do
-        expect(page).to have_content("Variables can only be associated to collections within the same provider. To create a variable for #{not_current_provider_concept_id} you must change your provider context.") 
+        expect(page).to have_content("Variables can only be associated to collections within the same provider. To create a variable for #{not_current_provider_concept_id} you must change your provider context.")
       end
     end
 
-    context 'when the cmr search for supplied concept-id is unsuccessful' do
+    context 'when the cmr response for invalid concept-id is unsuccessful' do
       before do
-        error_body = '{"errors": ["Error searching CMR", "2nd message"]}'
-        error_response = Cmr::Response.new(Faraday::Response.new(status: 401, body: JSON.parse(error_body), response_headers: {}))
-        allow_any_instance_of(Cmr::CmrClient).to receive(:get_collections_by_post).and_return(error_response)
-        fill_in 'associated_collection_id', with: collection_concept_id
+        fill_in 'associated_collection_id', with: invalid_concept_id
         click_on 'Create New Record'
       end
 
-      it 'surfaces the first CMR error message' do
-        expect(page).to have_content('Error searching CMR')
+      it 'surfaces the CMR error message' do
+        expect(page).to have_content('Concept-id [asdf] is not valid.')
       end
 
       it 'does not navigate to the new_variable_draft_path' do
@@ -92,23 +90,16 @@ describe 'Associating a collection upon variable draft creation', js: true do
     context 'when no concept-id is supplied' do
       before do
         click_on 'Create New Record'
-      end
-
-      it 'creates a draft with no collection associations' do
         within '.nav-top' do
           click_on 'Done'
         end
         within '#invalid-draft-modal.eui-modal-content' do
           click_on 'Yes'
         end
-        within '.collection-association' do
-          click_on 'Collection Association'
-        end
-        within '#variable-draft-collection-association-table tbody' do
-          expect(page).to have_no_content('CIESIN_SEDAC_ANTHROMES_v2_1700')
-          expect(page).to have_content('No Collection Association found. A Collection must be selected in order to publish this Variable Draft. Each Variable can only be associated with a single Collection.')
-          expect(page).to have_css('tr', count: 1)
-        end
+      end
+
+      it 'creates a draft with no collection associations' do
+        expect(variable_draft.collection_concept_id).to be_nil
       end
     end
   end
@@ -118,22 +109,16 @@ describe 'Associating a collection upon variable draft creation', js: true do
       before do
         visit collection_path(collection_concept_id)
         click_on 'Create Associated Variable'
-      end
-
-      it 'associates the collection upon draft creation' do
         within '.nav-top' do
           click_on 'Done'
         end
         within '#invalid-draft-modal.eui-modal-content' do
           click_on 'Yes'
         end
-        within '.collection-association' do
-          click_on 'Collection Association'
-        end
-        within '#variable-draft-collection-association-table tbody' do
-          expect(page).to have_content('CIESIN_SEDAC_ANTHROMES_v2_1700')
-          expect(page).to have_css('tr', count: 1)
-        end
+      end
+
+      it 'associates the collection upon draft creation' do
+        expect(variable_draft.collection_concept_id).to eq(collection_concept_id)
       end
     end
 
@@ -149,28 +134,26 @@ describe 'Associating a collection upon variable draft creation', js: true do
         end
       end
 
-      it 'changes provider context and successfully associates the collection upon variable draft creation' do
-        within '#not-current-provider-modal' do
-          click_on 'Yes'
+      context 'user changes provider when prompted by the modal' do
+        before do
+          within '#not-current-provider-modal' do
+            click_on 'Yes'
+          end
+          within '.nav-top' do
+            click_on 'Done'
+          end
+          within '#invalid-draft-modal.eui-modal-content' do
+            click_on 'Yes'
+          end
         end
-        within '#provider-badge-link' do
-          expect(page).to have_content('LARC')
-        end
-        within '.nav-top' do
-          click_on 'Done'
-        end
-        within '#invalid-draft-modal.eui-modal-content' do
-          click_on 'Yes'
-        end
-        within '.collection-association' do
-          click_on 'Collection Association'
-        end
-        within '#variable-draft-collection-association-table tbody' do
-          expect(page).to have_content('MI1B1')
-          expect(page).to have_css('tr', count: 1)
+
+        it 'associates the collection upon draft creation' do
+          within '#provider-badge-link' do
+            expect(page).to have_content('LARC')
+          end
+          expect(variable_draft.collection_concept_id).to eq(not_current_provider_concept_id)
         end
       end
-
     end
   end
 end

--- a/spec/features/variable_drafts/create_variable_draft_with_associated_collection_spec.rb
+++ b/spec/features/variable_drafts/create_variable_draft_with_associated_collection_spec.rb
@@ -1,0 +1,112 @@
+describe 'Associating a collection upon variable draft creation' do
+  let(:collection_concept_id) { cmr_client.get_collections({'EntryTitle': 'Anthropogenic Biomes of the World, Version 2: 1700'}).body.dig('items',0,'meta','concept-id') }
+  let(:collection_short_name) { 'CIESIN_SEDAC_ANTHROMES_v2_1700' }
+
+  before do
+    login
+  end
+
+  context 'when creating a variable draft and associating a collection from the manage variables page' do
+    before do
+      visit manage_variables_path
+    end
+
+    context 'when a valid concept-id is supplied' do
+      before do
+        fill_in 'associated_collection_id', with: collection_concept_id
+        click_on 'Create New Record'
+      end
+
+      it 'notifies user that their collection was successfully retrieved' do
+        expect(page).to have_content('Collection Association was Updated Successfully!') #subject to change
+      end
+
+      it 'associates the collection upon draft creation' do
+        within '.nav-top' do
+          click_on 'Done'
+        end
+        # within '#invalid-draft-modal.eui-modal-content' do
+        #   click_on 'Yes'
+        # end
+        within '.collection-association' do
+          click_on 'Collection Association'
+        end
+        within '#variable-draft-collection-association-table tbody' do
+          expect(page).to have_content('CIESIN_SEDAC_ANTHROMES_v2_1700')
+          expect(page).to have_css('tr', count: 1)
+        end
+      end
+    end
+
+    context 'when an invalid concept-id is supplied' do
+      before do
+        fill_in 'associated_collection_id', with: 'C-INVALID'
+        click_on 'Create New Record'
+      end
+
+      it 'does not navigate to the new_variable_draft_path' do
+        expect(page).to have_no_content('Variable Information')
+        expect(page).to have_no_css('.umm-form')
+        expect(page).to have_no_css('.variable-form')
+      end
+
+      it 'notifies the user that the concept supplied was not found' do
+        expect(page).to have_content('Concept ID invalid.') #subject to change
+      end
+    end
+
+    context 'when no concept-id is supplied' do
+      before do
+        click_on 'Create New Record'
+      end
+
+      it 'does not notify the user of a collection association' do
+        expect(page).to have_no_content('Collection Association was Updated Successfully!') #subject to change
+      end
+
+      it 'creates a draft with no collection associations' do
+        within '.nav-top' do
+          click_on 'Done'
+        end
+        # within '#invalid-draft-modal.eui-modal-content' do
+        #   click_on 'Yes'
+        # end
+        within '.collection-association' do
+          click_on 'Collection Association'
+        end
+        within '#variable-draft-collection-association-table tbody' do
+          expect(page).to have_no_content('CIESIN_SEDAC_ANTHROMES_v2_1700')
+          expect(page).to have_content('No Collection Association found. A Collection must be selected in order to publish this Variable Draft. Each Variable can only be associated with a single Collection.')
+          expect(page).to have_css('tr', count: 1)
+        end
+      end
+    end
+  end
+
+  context "when creating a variable draft and associating a collection from the collection's show page" do
+    before do
+      visit collection_path(collection_concept_id)
+      click_on 'Create Associated Variable' #subject to change
+    end
+
+    it 'notifies user that their collection was successfully retrieved' do
+      expect(page).to have_content('Collection Association was Updated Successfully!') #subject to change
+    end
+
+    it 'associates the collection upon draft creation' do
+      within '.nav-top' do
+        click_on 'Done'
+      end
+      # within '#invalid-draft-modal.eui-modal-content' do
+      #   click_on 'Yes'
+      # end
+      within '.collection-association' do
+        click_on 'Collection Association'
+      end
+      within '#variable-draft-collection-association-table tbody' do
+        expect(page).to have_content('CIESIN_SEDAC_ANTHROMES_v2_1700')
+        expect(page).to have_css('tr', count: 1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Added text field on manage variables page for user to supply concept-id of collection they want to associate the variable with
- Added link on collection show page that allows a user to create an associated variable draft
- added functionality to the _not_current_provider_modal and change_current_provider.coffee files so that the not-current-provider-modal is displayed when a user clicks on the 'Create Associated Variable' link 
- added a child `new` method to the variable_drafts_controller  