### PR TITLE
MMT-2389 data migration for UMM-S v 1.3.4

### DIFF
--- a/db/migrate/20201013182007_umm_s_1_3_4_data_migration.rb
+++ b/db/migrate/20201013182007_umm_s_1_3_4_data_migration.rb
@@ -35,17 +35,17 @@ class UmmS134DataMigration < ActiveRecord::Migration[5.2]
       return draft
     end
 
-    inputs = options.delete('SupportedInputFormats') || []
-    outputs = options.delete('SupportedOutputFormats') || []
+    inputs = options.delete('SupportedInputFormats')
+    outputs = options.delete('SupportedOutputFormats')
 
     # Need either inputs or outputs, but if both are present, both they need to
     # be arrays if present
     # If they are not arrays, they are bad data and cannot be used.
-    return draft unless (inputs.present? && inputs.is_a?(Array) && outputs.present? && outputs.is_a?(Array)) ||
-                        (inputs.present? && inputs.is_a?(Array) && outputs.blank?) ||
-                        (outputs.present? && outputs.is_a?(Array) && inputs.blank?)
+    return draft unless (inputs.is_a?(Array) && outputs.is_a?(Array)) ||
+                        (inputs.is_a?(Array) && outputs.blank?) ||
+                        (outputs.is_a?(Array) && inputs.blank?)
 
-    reformattings = draft.fetch('ServiceOptions').fetch('SupportedReformattings', nil)
+    reformattings = options.fetch('SupportedReformattings', [])
     reformattings = [] unless reformattings.is_a?(Array)
     if inputs.blank?
       reformattings.push('SupportedOutputFormats' => outputs)
@@ -82,7 +82,7 @@ class UmmS134DataMigration < ActiveRecord::Migration[5.2]
     nil
   end
 
-  # Uses CMR's logic for the expansion, which is tailored to specific existing
+  # Uses CMR's logic for the expansion, which is tailored to specific existing data
   # without more guidance, it's hard/impossible to make a general migration here
   # Deletes old SubsetTypes field.
   def expand_subset_type(draft)

--- a/db/migrate/20201013182007_umm_s_1_3_4_data_migration.rb
+++ b/db/migrate/20201013182007_umm_s_1_3_4_data_migration.rb
@@ -55,7 +55,9 @@ class UmmS134DataMigration < ActiveRecord::Migration[5.2]
 
     if outputs.blank?
       inputs.each do |input|
-        reformattings.push('SupportedInputFormat' => input)
+        # push a new reformatting unless a reformatting with that input already
+        # exists
+        reformattings.push('SupportedInputFormat' => input) unless find_first_reformatting(reformattings, input)
       end
       draft['ServiceOptions']['SupportedReformattings'] = reformattings
       return draft

--- a/db/migrate/20201013182007_umm_s_1_3_4_data_migration.rb
+++ b/db/migrate/20201013182007_umm_s_1_3_4_data_migration.rb
@@ -1,0 +1,153 @@
+class UmmS134DataMigration < ActiveRecord::Migration[5.2]
+  def up
+    drafts = ServiceDraft.where.not(draft: {})
+
+    drafts.each do |draft|
+      metadata = add_formats_to_reformatting(draft.draft)
+      draft.draft = expand_subset_type(metadata)
+
+      draft.save
+    end
+  end
+
+  def down
+    drafts = ServiceDraft.where.not(draft: {})
+
+    drafts.each do |draft|
+      metadata = reduce_subset_type(draft.draft)
+      metadata = remove_new_service_type_enum(metadata)
+      draft.draft = remove_new_reformatting_types(metadata)
+
+      draft.save
+    end
+  end
+
+  ###################### TO UMM-S 1.3.4 #########################
+  # Adds input and output formattings to the supportedreformattings
+  # Deletes old fields (SupportedInputFormats and SupportedOutputFormats) that
+  # are no longer supported.
+  # Overrides SupportedReformattings if it is not an array for some reason.
+  def add_formats_to_reformatting(draft)
+    return draft unless (options = draft.fetch('ServiceOptions', nil))
+    # Delete the service options if they aren't a hash.
+    unless options.is_a?(Hash)
+      draft.delete('ServiceOptions')
+      return draft
+    end
+
+    inputs = options.delete('SupportedInputFormats') || []
+    outputs = options.delete('SupportedOutputFormats') || []
+
+    # Need either inputs or outputs, but if both are present, both they need to
+    # be arrays if present
+    # If they are not arrays, they are bad data and cannot be used.
+    return draft unless (inputs.present? && inputs.is_a?(Array) && outputs.present? && outputs.is_a?(Array)) ||
+                        (inputs.present? && inputs.is_a?(Array) && outputs.blank?) ||
+                        (outputs.present? && outputs.is_a?(Array) && inputs.blank?)
+
+    reformattings = draft.fetch('ServiceOptions').fetch('SupportedReformattings', nil)
+    reformattings = [] unless reformattings.is_a?(Array)
+    if inputs.blank?
+      reformattings.push('SupportedOutputFormats' => outputs)
+      draft['ServiceOptions']['SupportedReformattings'] = reformattings
+      return draft
+    end
+
+    if outputs.blank?
+      inputs.each do |input|
+        reformattings.push('SupportedInputFormat' => input)
+      end
+      draft['ServiceOptions']['SupportedReformattings'] = reformattings
+      return draft
+    end
+
+    inputs.each do |input|
+      if (index = find_first_reformatting(reformattings, input))
+        reformattings[index]['SupportedOutputFormats'] |= outputs
+      else
+        reformattings.push('SupportedInputFormat' => input, 'SupportedOutputFormats' => outputs)
+      end
+    end
+
+    draft['ServiceOptions']['SupportedReformattings'] = reformattings
+    draft
+  end
+
+  def find_first_reformatting(reformattings, input_value)
+    reformattings.each_with_index do |reformatting, index|
+      return index if reformatting['SupportedInputFormat'] == input_value
+    end
+    nil
+  end
+
+  # Uses CMR's logic for the expansion, which is tailored to specific existing
+  # without more guidance, it's hard/impossible to make a general migration here
+  # Deletes old SubsetTypes field.
+  def expand_subset_type(draft)
+    # If ServiceOptions were malformed, the preceding action would remove it,
+    # so this one does not need to validate the structure of it.
+    return draft unless (subset_type = draft.fetch('ServiceOptions', {}).delete('SubsetTypes')) && subset_type.is_a?(Array)
+
+    new_subset_type = {}
+    if subset_type.include?('Spatial')
+      if draft['Type'] == 'OPeNDAP' || draft['Type'] == 'THREDDS'
+        new_subset_type['SpatialSubset'] = { 'BoundingBox' => { 'AllowMultipleValues' => false } }
+      elsif draft['Type'] == 'ESI' || draft['Type'] == 'ECHO ORDERS'
+        new_subset_type['SpatialSubset'] = {
+                                             'BoundingBox' => { 'AllowMultipleValues' => false },
+                                             'Shapefile' => [{'Format' => 'ESRI'}, {'Format' => 'KML'}, {'Format' => 'GeoJSON'}]
+                                           }
+      end
+    end
+
+    new_subset_type['TemporalSubset'] = { 'AllowMultipleValues' => false } if subset_type.include?('Temporal')
+
+    if subset_type.include?('Variable')
+      new_subset_type['VariableSubset'] = if ['OPeNDAP', 'THREDDS', 'ESI', 'ECHO ORDERS'].include?(draft['Type'])
+                                            { 'AllowMultipleValues' => true }
+                                          else
+                                            { 'AllowMultipleValues' => false }
+                                          end
+    end
+
+    draft['ServiceOptions']['Subset'] = new_subset_type
+    draft
+  end
+
+  ###################### TO UMM-S 1.3.3 #########################
+  def reduce_subset_type(draft)
+    return draft unless (options = draft.fetch('ServiceOptions', nil))
+    unless options.is_a?(Hash)
+      draft.delete('ServiceOptions')
+      return draft
+    end
+    return draft unless (subset = options.delete('Subset')) && subset.is_a?(Hash)
+
+    old_subset_type = []
+    old_subset_type << 'Spatial' if subset['SpatialSubset']
+    old_subset_type << 'Temporal' if subset['TemporalSubset']
+    old_subset_type << 'Variable' if subset['VariableSubset']
+
+    draft['ServiceOptions']['SubsetTypes'] = old_subset_type
+    draft
+  end
+
+  def remove_new_service_type_enum(draft)
+    draft.delete('Type') if draft['Type'] == 'Harmony'
+    draft
+  end
+
+  def remove_new_reformatting_types(draft)
+    return draft unless (supported_reformattings = draft.fetch('ServiceOptions', {}).delete('SupportedReformattings')) && supported_reformattings.is_a?(Array)
+
+    supported_reformattings.each do |reformatting|
+      reformatting.delete('SupportedInputFormat') if reformatting['SupportedInputFormat'] == 'Shapefile+zip'
+      reformatting['SupportedOutputFormats']&.delete('Shapefile+zip')
+      reformatting.delete('SupportedOutputFormats') if reformatting['SupportedOutputFormats'].blank?
+    end
+
+    supported_reformattings.delete_if { |item| item == {} }
+    draft['ServiceOptions']['SupportedReformattings'] = supported_reformattings
+    draft
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_150827) do
+ActiveRecord::Schema.define(version: 2020_10_13_182007) do
 
   create_table "draft_proposals", force: :cascade do |t|
     t.integer "user_id"

--- a/spec/factories/data_migration_factories/umm_s_1_3_4_factory.rb
+++ b/spec/factories/data_migration_factories/umm_s_1_3_4_factory.rb
@@ -1,0 +1,342 @@
+FactoryBot.define do
+  factory :full_service_draft_1_3_4, class: ServiceDraft do
+    native_id { 'full_service_draft_native_id' }
+    provider_id { 'MMT_2' }
+    draft_type { 'ServiceDraft' }
+
+    draft {{
+      'Name': "#{Faker::Movies::HitchhikersGuideToTheGalaxy.location.truncate(10, omission: '')}_#{Faker::Number.number(digits: 9)}",
+      'LongName': "#{Faker::Movies::HitchhikersGuideToTheGalaxy.quote.truncate(100, omission: '')}_#{Faker::Number.number(digits: 19)}",
+      'Type': 'ESI',
+      'Version': '1.0',
+      'VersionDescription': 'Description of the Current Version',
+      'LastUpdatedDate': '2020-05-20T00:00:00.000Z',
+      'Description': 'Description of the test service',
+      'URL': {
+        'Description': 'Description of primary url',
+        'URLValue': 'httpx://testurl.earthdata.nasa.gov'
+      },
+      'ServiceQuality': {
+        'QualityFlag': 'Reviewed',
+        'Traceability': 'traceability',
+        'Lineage': 'lineage'
+      },
+      'AccessConstraints': 'access constraint 1',
+      'UseConstraints': {
+        'LicenseURL': 'LicenseUrl Text',
+        'LicenseText': 'LicenseText Text'
+      },
+      'ServiceKeywords': [
+        {
+          'ServiceCategory': 'EARTH SCIENCE SERVICES',
+          'ServiceTopic': 'DATA ANALYSIS AND VISUALIZATION',
+          'ServiceTerm': 'GEOGRAPHIC INFORMATION SYSTEMS',
+          'ServiceSpecificTerm': 'DESKTOP GEOGRAPHIC INFORMATION SYSTEMS'
+        }
+      ],
+      'AncillaryKeywords': ['Ancillary keyword 1', 'Ancillary keyword 2'],
+      'ServiceOrganizations': [
+        {
+          'Roles': ['DEVELOPER', 'PUBLISHER'],
+          'ShortName': 'AARHUS-HYDRO',
+          'LongName': 'Hydrogeophysics Group, Aarhus University ',
+        },
+        {
+          'Roles': ['DEVELOPER', 'PUBLISHER'],
+          'ShortName': 'AARHUS-HYDRO',
+          'LongName': 'Hydrogeophysics Group, Aarhus University ',
+          'OnlineResource': {
+            'Name': 'ORN Text',
+            'Protocol': 'ORP Text',
+            'Linkage': 'ORL Text',
+            'Description': 'ORD Text',
+            'ApplicationProfile': 'ORAP Text',
+            'Function': 'ORF Text'
+          }
+        },
+      ],
+      'ContactGroups': [
+        {
+          'Roles': ['SCIENCE CONTACT', 'TECHNICAL CONTACT'],
+          'GroupName': 'Group 1',
+          'ContactInformation': {
+            'ServiceHours': '9-6, M-F',
+            'ContactInstruction': 'Email only',
+            'ContactMechanisms': [
+              {
+                'Type': 'Email',
+                'Value': 'example@example.com'
+              }, {
+                'Type': 'Email',
+                'Value': 'example2@example.com'
+              }
+            ],
+            'Addresses': [
+              {
+                'StreetAddresses': ['300 E Street Southwest', 'Room 203', 'Address line 3'],
+                'City': 'Washington',
+                'StateProvince': 'DC',
+                'PostalCode': '20546',
+                'Country': 'United States'
+              },
+              {
+                'StreetAddresses': ['8800 Greenbelt Road'],
+                'City': 'Greenbelt',
+                'StateProvince': 'MD',
+                'PostalCode': '20771',
+                'Country': 'United States'
+              }
+            ],
+            'OnlineResources': [
+              {
+                'Name': 'ORN1 Text',
+                'Linkage': 'ORL1 Text',
+                'Description': 'ORD1 Text',
+                'Protocol': 'ORP1 Text',
+                'ApplicationProfile': 'ORAP1 Text',
+                'Function': 'ORF1 Text'
+              },
+              {
+                'Name': 'ORN2 Text',
+                'Linkage': 'ORL2 Text',
+                'Description': 'ORD2 Text',
+                'Protocol': 'ORP2 Text',
+                'ApplicationProfile': 'ORAP2 Text',
+                'Function': 'ORF2 Text'
+              },
+              {
+                'Name': 'ORN3 Text',
+                'Linkage': 'ORL3 Text',
+                'Description': 'ORD3 Text',
+              }
+            ]
+          }
+        },
+        {
+          'Roles': ['SERVICE PROVIDER CONTACT'],
+          'GroupName': 'Group 2'
+        }
+      ],
+      'ContactPersons': [
+        {
+          'Roles': ['SERVICE PROVIDER'],
+          'FirstName': 'First',
+          'MiddleName': 'Middle',
+          'LastName': 'Last',
+          'ContactInformation': {
+            'ServiceHours': '9-6, M-F',
+            'ContactInstruction': 'Email only',
+            'ContactMechanisms': [
+              {
+                'Type': 'Email',
+                'Value': 'example@example.com'
+              }, {
+                'Type': 'Email',
+                'Value': 'example2@example.com'
+              }
+            ],
+            'Addresses': [
+              {
+                'StreetAddresses': ['300 E Street Southwest', 'Room 203', 'Address line 3'],
+                'City': 'Washington',
+                'StateProvince': 'DC',
+                'PostalCode': '20546',
+                'Country': 'United States'
+              },
+              {
+                'StreetAddresses': ['8800 Greenbelt Road'],
+                'City': 'Greenbelt',
+                'StateProvince': 'MD',
+                'PostalCode': '20771',
+                'Country': 'United States'
+              }
+            ],
+            'OnlineResources': [
+              {
+                'Name': 'ORN1 Text',
+                'Linkage': 'ORL1 Text',
+                'Description': 'ORD1 Text',
+                'Protocol': 'ORP1 Text',
+                'ApplicationProfile': 'ORAP1 Text',
+                'Function': 'ORF1 Text'
+              },
+              {
+                'Name': 'ORN2 Text',
+                'Linkage': 'ORL2 Text',
+                'Description': 'ORD2 Text',
+                'Protocol': 'ORP2 Text',
+                'ApplicationProfile': 'ORAP2 Text',
+                'Function': 'ORF2 Text'
+              },
+              {
+                'Name': 'ORN3 Text',
+                'Linkage': 'ORL3 Text',
+                'Description': 'ORD3 Text',
+              }
+            ]
+          }
+        },
+        {
+          'Roles': ['DEVELOPER'],
+          'LastName': 'Last 2'
+        }
+      ],
+      'OperationMetadata': [
+        {
+          'OperationName': 'DescribeCoverage',
+          'OperationDescription': 'The DescribeCoverage operation description...',
+          'DistributedComputingPlatform': ['WEBSERVICES', 'XML'],
+          'InvocationName': 'SOME DAAC WCS Server',
+          'ConnectPoint': {
+            'ResourceName': '1286_2',
+            'ResourceLinkage': 'https://webmap.some.gov/cgi-bin/mapserv?coverage=1286_2&request=DescribeCoverage&service=WCS&version=1.0.0',
+            'ResourceDescription': 'Vegetation classes mapped to LIDAR-derived canopy structure classes in 30-meter, Great Smoky Mountains National Park, 2011'
+          },
+          'OperationChainedMetadata': {
+            'OperationChainName': 'Some Op Chain for Smoky Mountains',
+            'OperationChainDescription': 'Some Op Chain description for Smoky Mountains 30-meter 2011'
+          },
+          'CoupledResource': {
+            'ScopedName': '1286_2',
+            'DataResourceDOI': 'https://doi.org/10.3334/SOMEDAAC/1286',
+            'DataResource': {
+              'DataResourceIdentifier': 'GreatSmokyMountainsNationalPark',
+              'DataResourceSourceType': 'Map',
+              'DataResourceSpatialType': 'GENERAL_GRID',
+              'DataResourceSpatialExtent': {
+                'GeneralGrid': {
+                  'CRSIdentifier': 'EPSG:26917',
+                  'Axis': [
+                    {
+                      'AxisLabel': 'x',
+                      'GridResolution': 30.0,
+                      'Extent':
+                        {
+                          'ExtentLabel': 'axis 1 extent label',
+                          'LowerBound': 0.0,
+                          'UpperBound': 2918.0,
+                          'UOMLabel': 'Meters'
+                        }
+                    },
+                    {
+                      'AxisLabel': 'y',
+                      'GridResolution': 30.0,
+                      'Extent':
+                        {
+                          'ExtentLabel': 'axis 2 extent label',
+                          'LowerBound': 0.0,
+                          'UpperBound': 1340.0,
+                          'UOMLabel': 'Meters'
+                        }
+                    }
+                  ]
+                }
+              },
+              'SpatialResolution': 30.0,
+              'SpatialResolutionUnit': 'Meters',
+              'DataResourceTemporalType': 'TIME_STAMP',
+              'DataResourceTemporalExtent': {
+                'DataResourceTimePoints': [
+                  {
+                    'TimeFormat': '%Y%M%D',
+                    'TimeValue': '2009-01-08',
+                    'Description': 'Time stamp of the granule within the collection'
+                  },
+                  {
+                    'TimeFormat': '%Y',
+                    'TimeValue': '2011',
+                    'Description': 'Time stamp of the layer'
+                  }
+                ]
+              },
+              'TemporalResolution': 1.0,
+              'TemporalResolutionUnit': 'YEAR',
+              'RelativePath': '/cgi-bin/mapserv?coverage=1286_2&request=DescribeCoverage&service=WCS&version=1.0.0'
+            },
+            'CouplingType': 'MIXED'
+          },
+          'Parameters': [
+            {
+              'ParameterName': 'parameter 1',
+              'ParameterDescription': 'parameter 1 description',
+              'ParameterDirection': 'abc direction',
+              'ParameterOptionality': 'optional',
+              'ParameterRepeatability': 'some'
+            },
+            {
+              'ParameterName': 'parameter 2',
+              'ParameterDescription': 'parameter 2 description',
+              'ParameterDirection': 'xyz direction',
+              'ParameterOptionality': 'optional',
+              'ParameterRepeatability': 'some'
+            }
+          ]
+        }
+      ],
+      'ServiceOptions': {
+        'Subset': {
+          'VariableSubset': { 'AllowMultipleValues' => true },
+          'TemporalSubset': { 'AllowMultipleValues' => false },
+          'SpatialSubset':
+            {
+              'BoundingBox' => { 'AllowMultipleValues' => false },
+              'Shapefile' => [{'Format' => 'ESRI'}, {'Format' => 'KML'}, {'Format' => 'GeoJSON'}]
+            }
+        },
+        'VariableAggregationSupportedMethods': ['ANOMOLY'],
+        'SupportedInputProjections': [
+          {
+            'ProjectionName': 'Geographic',
+            'ProjectionLatitudeOfCenter': 10.0,
+            'ProjectionLongitudeOfCenter': 10.0,
+            'ProjectionFalseEasting': 10.0,
+            'ProjectionFalseNorthing': 10.0,
+            'ProjectionAuthority': '4326',
+            'ProjectionUnit': 'Degrees',
+            'ProjectionDatumName': 'World Geodetic System (WGS) 1984'
+          }
+        ],
+        'SupportedOutputProjections': [
+          {
+            'ProjectionName': 'Geographic',
+            'ProjectionLatitudeOfCenter': 10.0,
+            'ProjectionLongitudeOfCenter': 10.0,
+            'ProjectionFalseEasting': 10.0,
+            'ProjectionFalseNorthing': 10.0,
+            'ProjectionAuthority': '4326',
+            'ProjectionUnit': 'Degrees',
+            'ProjectionDatumName': 'World Geodetic System (WGS) 1984'
+          },
+          {
+            'ProjectionName': 'NAD83 / UTM zone 17N',
+            'ProjectionLatitudeOfCenter': 10.0,
+            'ProjectionLongitudeOfCenter': 10.0,
+            'ProjectionFalseEasting': 10.0,
+            'ProjectionFalseNorthing': 10.0,
+            'ProjectionAuthority': '26917',
+            'ProjectionUnit': 'Meters',
+            'ProjectionDatumName': 'North American Datum (NAD) 1983'
+          }
+        ],
+        'InterpolationTypes': ['Bicubic Interpolation', 'Bilinear Interpolation'],
+        'SupportedReformattings': [
+          {
+            'SupportedInputFormat': 'HDF-EOS2',
+            'SupportedOutputFormats': ['Shapefile+zip']
+          },
+          {
+            'SupportedInputFormat': 'Shapefile+zip',
+            'SupportedOutputFormats': ['HDF-EOS2', 'HDF-EOS']
+          },
+          {
+            'SupportedInputFormat': 'Shapefile+zip'
+          },
+          {
+            'SupportedOutputFormats': ['Shapefile+zip']
+          }
+        ],
+        'MaxGranules': 50.0
+      }
+    }}
+  end
+end

--- a/spec/migrations/umm_s_1_3_4_spec.rb
+++ b/spec/migrations/umm_s_1_3_4_spec.rb
@@ -101,9 +101,10 @@ describe 'Migration tests for UMM-S v1.3.3 => 1.3.4' do
       expect(Draft.find(@draft.id).draft['ServiceOptions'].keys).not_to include('SupportedInputFormats', 'SupportedOutputFormats')
 
       expect(Draft.find(@no_inputs_draft.id).draft['ServiceOptions']['SupportedReformattings'].last).to eq({ 'SupportedOutputFormats' => ['HDF-EOS2', 'HDF-EOS5', 'WKT'] })
-      expect(Draft.find(@no_outputs_draft.id).draft['ServiceOptions']['SupportedReformattings'][-3]).to eq('SupportedInputFormat' => 'HDF-EOS2')
-      expect(Draft.find(@no_outputs_draft.id).draft['ServiceOptions']['SupportedReformattings'][-2]).to eq('SupportedInputFormat' => 'HDF-EOS5')
-      expect(Draft.find(@no_outputs_draft.id).draft['ServiceOptions']['SupportedReformattings'][-1]).to eq('SupportedInputFormat' => 'GEOJSON')
+      expect(Draft.find(@no_outputs_draft.id).draft['ServiceOptions']['SupportedReformattings'][-1]).to eq('SupportedInputFormat' => 'HDF-EOS5')
+      # The no_outputs_draft has three inputs but both the hdf-eos2 and geojson
+      # inputs are not added to the reformattings because at least one
+      # reformatting exists with those as the input.
     end
 
     it 'makes correct subsets' do

--- a/spec/migrations/umm_s_1_3_4_spec.rb
+++ b/spec/migrations/umm_s_1_3_4_spec.rb
@@ -1,0 +1,227 @@
+require File.join(Rails.root, 'db', 'migrate', '20201013182007_umm_s_1_3_4_data_migration')
+
+describe 'Migration tests for UMM-S v1.3.3 => 1.3.4' do
+  context 'when doing the up migration' do
+    before :all do
+      @draft = create(:full_service_draft_1_3_3)
+      @draft.draft['ServiceOptions']['SubsetTypes'] = ['Spatial', 'Temporal', 'Variable']
+      @draft.save
+      @empty_draft = create(:empty_service_draft)
+
+      # Draft with type opendap to test subset conversion
+      @opendap_draft = create(:full_service_draft_1_3_3)
+      @opendap_draft.draft['Type'] = 'OPeNDAP'
+      @opendap_draft.draft['ServiceOptions']['SubsetTypes'] = ['Spatial', 'Temporal', 'Variable']
+      @opendap_draft.save
+
+      # draft with type esi to test subset conversion
+      @esi_draft = create(:full_service_draft_1_3_3)
+      @esi_draft.draft['Type'] = 'ESI'
+      @esi_draft.draft['ServiceOptions']['SubsetTypes'] = ['Spatial', 'Variable']
+      @esi_draft.save
+
+      # draft with outputs and no inputs to test reformatting conversion
+      @no_inputs_draft = create(:full_service_draft_1_3_3)
+      @no_inputs_draft.draft['ServiceOptions'].delete('SupportedInputFormats')
+      @no_inputs_draft.save
+
+      #draft with inputs and no outputs to test reformatting conversion
+      @no_outputs_draft = create(:full_service_draft_1_3_3)
+      @no_outputs_draft.draft['ServiceOptions'].delete('SupportedOutputFormats')
+      @no_outputs_draft.save
+
+      # draft with no relevant fields to show migration does not alter draft
+      @no_relevant_fields_draft = create(:full_service_draft_1_3_3)
+      @no_relevant_fields_draft.draft['ServiceOptions'].delete('SubsetTypes')
+      @no_relevant_fields_draft.draft['ServiceOptions'].delete('SupportedInputFormats')
+      @no_relevant_fields_draft.draft['ServiceOptions'].delete('SupportedOutputFormats')
+      @no_relevant_fields_draft.save
+
+      # some malformed drafts for testing the bad data handling
+      @malformed_draft1 = create(:full_service_draft_1_3_3)
+      @malformed_draft1.draft['ServiceOptions'] = ['Totally Invalid']
+      @malformed_draft1.save
+      @malformed_draft2 = create(:full_service_draft_1_3_3)
+      @malformed_draft2.draft['ServiceOptions']['SubsetTypes'] = {'Totally' => 'Invalid'}
+      @malformed_draft2.draft['ServiceOptions']['SupportedInputFormats'] = {'Totally' => 'Invalid'}
+      @malformed_draft2.save
+
+      UmmS134DataMigration.new.up
+    end
+
+    after :all do
+      ServiceDraft.delete([@draft.id, @empty_draft.id, @opendap_draft.id, @esi_draft.id, @no_inputs_draft.id, @no_outputs_draft.id, @no_relevant_fields_draft.id, @malformed_draft1.id, @malformed_draft2.id])
+    end
+
+    it 'adds the output formats to the first input formats' do
+      expect(Draft.find(@draft.id).draft['ServiceOptions']['SupportedReformattings']).to eq(
+        [
+          {
+            'SupportedInputFormat' => 'HDF-EOS2',
+            # This is the first HDF-EOS2 entry, so it gains HDF-EOS2 and WKT as
+            # outputs.
+            'SupportedOutputFormats' => ['HDF-EOS5', 'HDF-EOS2', 'WKT']
+          },
+          {
+            'SupportedInputFormat' => 'HDF-EOS2',
+            'SupportedOutputFormats' => ['HDF-EOS2', 'HDF-EOS']
+          },
+          {
+            'SupportedInputFormat' => 'GEOJSON',
+            # This is the first GEOJSON entry, so it gains 'HDF-EOS5', 'WKT' as
+            # outputs at the end
+            'SupportedOutputFormats' => ['HDF-EOS2', 'HDF-EOS', 'HDF-EOS5', 'WKT']
+          },
+          {
+            'SupportedInputFormat' => 'HDF-EOS2',
+            'SupportedOutputFormats' => ['GEOJSON', 'Shapefile']
+          },
+          {
+            'SupportedInputFormat' => 'HDF-EOS2',
+            'SupportedOutputFormats' => ['ASCII', 'Shapefile']
+          },
+          {
+            'SupportedInputFormat' => 'HDF-EOS2'
+          },
+          {
+            'SupportedOutputFormats' => ['ASCII']
+          },
+          {
+            'SupportedInputFormat' => 'GEOJSON',
+            'SupportedOutputFormats' => ['GEOJSON', 'Shapefile']
+          },
+          # This entry is added because there was previously no HDF-EOS5 input.
+          {
+            'SupportedInputFormat' => 'HDF-EOS5',
+            'SupportedOutputFormats' => ['HDF-EOS2', 'HDF-EOS5', 'WKT']
+          }
+        ]
+      )
+
+      expect(Draft.find(@draft.id).draft['ServiceOptions'].keys).not_to include('SupportedInputFormats', 'SupportedOutputFormats')
+
+      expect(Draft.find(@no_inputs_draft.id).draft['ServiceOptions']['SupportedReformattings'].last).to eq({ 'SupportedOutputFormats' => ['HDF-EOS2', 'HDF-EOS5', 'WKT'] })
+      expect(Draft.find(@no_outputs_draft.id).draft['ServiceOptions']['SupportedReformattings'][-3]).to eq('SupportedInputFormat' => 'HDF-EOS2')
+      expect(Draft.find(@no_outputs_draft.id).draft['ServiceOptions']['SupportedReformattings'][-2]).to eq('SupportedInputFormat' => 'HDF-EOS5')
+      expect(Draft.find(@no_outputs_draft.id).draft['ServiceOptions']['SupportedReformattings'][-1]).to eq('SupportedInputFormat' => 'GEOJSON')
+    end
+
+    it 'makes correct subsets' do
+      expect(Draft.find(@opendap_draft.id).draft['ServiceOptions']['Subset']).to eq(
+        {
+          'SpatialSubset' => { 'BoundingBox' => { 'AllowMultipleValues' => false } },
+          'TemporalSubset' => { 'AllowMultipleValues' => false },
+          'VariableSubset' => { 'AllowMultipleValues' => true }
+        }
+      )
+
+      expect(Draft.find(@esi_draft.id).draft['ServiceOptions']['Subset']).to eq(
+        {
+          'SpatialSubset' =>
+            {
+              'BoundingBox' => { 'AllowMultipleValues' => false },
+              'Shapefile' => [{'Format' => 'ESRI'}, {'Format' => 'KML'}, {'Format' => 'GeoJSON'}]
+            },
+          'VariableSubset' => { 'AllowMultipleValues' => true }
+        }
+      )
+
+      expect(Draft.find(@draft.id).draft['ServiceOptions']['Subset']).to eq(
+        {
+          'TemporalSubset' => { 'AllowMultipleValues' => false },
+          'VariableSubset' => { 'AllowMultipleValues' => false }
+        }
+      )
+
+      expect(Draft.find(@draft.id).draft['ServiceOptions'].keys).not_to include('SubsetTypes')
+    end
+
+    it 'does not modify blank drafts' do
+      expect(Draft.find(@empty_draft.id).draft).to eq({})
+    end
+
+    it 'does not modify drafts which do not contain the expected fields' do
+      expect(Draft.find(@no_relevant_fields_draft.id).draft).to eq(@no_relevant_fields_draft.draft)
+    end
+
+    it 'does not choke on invalidly formatted data' do
+      expected_draft = @malformed_draft1.draft
+      expected_draft.delete('ServiceOptions')
+      expect(Draft.find(@malformed_draft1.id).draft).to eq(expected_draft)
+
+      expected_draft2 = @malformed_draft2.draft
+      expected_draft2['ServiceOptions'].delete('SubsetTypes')
+      expected_draft2['ServiceOptions'].delete('SupportedInputFormats')
+      expected_draft2['ServiceOptions'].delete('SupportedOutputFormats')
+      expect(Draft.find(@malformed_draft2.id).draft).to eq(expected_draft2)
+      expect(Draft.find(@malformed_draft2.id).draft['ServiceOptions'].keys).not_to include('Subset')
+    end
+  end
+
+  context 'when doing the down migration' do
+    before :all do
+      @draft = create(:full_service_draft_1_3_4)
+      @draft.draft['Type'] = 'Harmony' # verify that this value is being cleared
+      @draft.save
+      @empty_draft = create(:empty_service_draft)
+      @no_relevant_fields_draft = create(:full_service_draft_1_3_4)
+      @no_relevant_fields_draft.draft['ServiceOptions'].delete('Subset')
+      @no_relevant_fields_draft.draft['ServiceOptions'].delete('SupportedReformattings')
+      @no_relevant_fields_draft.save
+
+      # some malformed drafts for testing the bad data handling
+      @malformed_draft1 = create(:full_service_draft_1_3_4)
+      @malformed_draft1.draft['ServiceOptions'] = ['Totally Invalid']
+      @malformed_draft1.save
+      @malformed_draft2 = create(:full_service_draft_1_3_4)
+      @malformed_draft2.draft['ServiceOptions']['Subset'] = ['Totally', 'Invalid']
+      @malformed_draft2.draft['ServiceOptions']['SupportedReformattings'] = {'Totally' => 'Invalid'}
+      @malformed_draft2.save
+
+      UmmS134DataMigration.new.down
+    end
+
+    after :all do
+      ServiceDraft.delete([@draft.id, @empty_draft.id, @no_relevant_fields_draft.id, @malformed_draft1.id, @malformed_draft2.id])
+    end
+
+    it 'properly removes new enums' do
+      expect(Draft.find(@draft.id).draft['ServiceOptions']['SupportedReformattings']).to eq(
+        [
+          {
+            'SupportedInputFormat' => 'HDF-EOS2',
+          },
+          {
+            'SupportedOutputFormats' => ['HDF-EOS2', 'HDF-EOS']
+          }
+        ]
+      )
+
+      expect(Draft.find(@draft.id).draft['Type']).to eq(nil)
+    end
+
+    it 'properly reduces subset' do
+      expect(Draft.find(@draft.id).draft['ServiceOptions']['SubsetTypes']).to eq(['Spatial', 'Temporal', 'Variable'])
+    end
+
+    it 'does not change empty records' do
+      expect(Draft.find(@empty_draft.id).draft).to eq({})
+    end
+
+    it 'does not change records without the requisite fields' do
+      expect(Draft.find(@no_relevant_fields_draft.id).draft).to eq(@no_relevant_fields_draft.draft)
+    end
+
+    it 'does not choke on invalid data' do
+      expected_draft = @malformed_draft1.draft
+      expected_draft.delete('ServiceOptions')
+      expect(Draft.find(@malformed_draft1.id).draft).to eq(expected_draft)
+
+      expected_draft2 = @malformed_draft2.draft
+      expected_draft2['ServiceOptions'].delete('Subset')
+      expected_draft2['ServiceOptions'].delete('SupportedReformattings')
+      expect(Draft.find(@malformed_draft2.id).draft).to eq(expected_draft2)
+      expect(Draft.find(@malformed_draft2.id).draft['ServiceOptions'].keys).not_to include('SubsetTypes')
+    end
+  end
+end


### PR DESCRIPTION
I took the logic from CMR's data migration and implemented it on our drafts.  The logic wrt to the new Subset fields was tailored to the existing data in CMR prod.
After my last migration ran into bad data, I tried to make this one a little more robust about what happens when it encounters bad data.  My approach was to delete malformed data in the draft and abort the current operation. This may preserve bad drafts, but it also allows for partial success in this migration.  

Closed and reopened because I pushed another ticket's work onto this branch.