### PR TITLE
MMT-2366 Adding tools tab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem 'browser'
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
 # make sure to delete the local config when done making changes to merge into master
 # bundle config --delete local.cmr_metadata_preview
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', branch: 'MMT-2366'
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '07fb716bbc0e4b74a6546895fa61ef1fef2614f4'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem 'browser'
 # bundle config local.cmr_metadata_preview /path/to/local/git/repository
 # make sure to delete the local config when done making changes to merge into master
 # bundle config --delete local.cmr_metadata_preview
-gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: '40320c29933'
+gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', branch: 'MMT-2366'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: f3db9870161d3f2bcb3d287890ace6d90c650f80
+  revision: 92d1f27b61f728236a47bc5519fc6449322c7e6f
   branch: MMT-2366
   specs:
     cmr_metadata_preview (0.2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: 92d1f27b61f728236a47bc5519fc6449322c7e6f
+  revision: 81301a68fa856ad5972d7d3738add5d4555989f0
   branch: MMT-2366
   specs:
     cmr_metadata_preview (0.2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: 40320c299336c68047b27110ef1e5dae5a20a24f
-  ref: 40320c29933
+  revision: f3db9870161d3f2bcb3d287890ace6d90c650f80
+  branch: MMT-2366
   specs:
-    cmr_metadata_preview (0.2.5)
+    cmr_metadata_preview (0.2.6)
       georuby
       rails (~> 5.2.0)
       sprockets (< 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git
-  revision: 81301a68fa856ad5972d7d3738add5d4555989f0
-  branch: MMT-2366
+  revision: 07fb716bbc0e4b74a6546895fa61ef1fef2614f4
+  ref: 07fb716bbc0e4b74a6546895fa61ef1fef2614f4
   specs:
     cmr_metadata_preview (0.2.6)
       georuby

--- a/app/assets/stylesheets/components/_metadata-preview.scss
+++ b/app/assets/stylesheets/components/_metadata-preview.scss
@@ -271,7 +271,7 @@ ul.sub-field {
       }
     }
 
-    .associated-services-tab-panel {
+    .associated-services-tab-panel, .associated-tools-tab-panel {
       padding: 20px 15px 15px;
     }
   }

--- a/app/concerns/cmr_collections_helper.rb
+++ b/app/concerns/cmr_collections_helper.rb
@@ -27,21 +27,21 @@ module CMRCollectionsHelper
     revisions
   end
 
-  def get_associated_concepts(response, concepts = ['tools', 'services'])
+  def get_associated_concepts(metadata, concepts = ['tools', 'services'])
     concepts.each do |concept_type|
-      if response.present?
-        concept_ids = response.dig(0, 'meta', 'associations', concept_type)
+      if metadata.present?
+        concept_ids = metadata.dig(0, 'meta', 'associations', concept_type)
         # This can happen when there are variable associations and probably tool
         # in the future.
         instance_variable_set("@#{concept_type}".to_sym, []) && next unless concept_ids
 
-        cmr_service_response = cmr_client.send("get_#{concept_type}", concept_id: concept_ids)
+        cmr_concept_response = cmr_client.send("get_#{concept_type}", concept_id: concept_ids)
 
         instance_variable_set("@#{concept_type}".to_sym,
-                              if cmr_service_response.success?
-                                cmr_service_response.body['items']
+                              if cmr_concept_response.success?
+                                cmr_concept_response.body['items']
                               else
-                                Rails.logger.error("Error searching for associated services in 'set_associated_services': #{cmr_service_response.clean_inspect}")
+                                Rails.logger.error("Error searching for associated #{concept_type} in 'set_associated_concepts': #{cmr_concept_response.clean_inspect}")
                                 []
                               end)
       else

--- a/app/concerns/cmr_collections_helper.rb
+++ b/app/concerns/cmr_collections_helper.rb
@@ -27,28 +27,8 @@ module CMRCollectionsHelper
     revisions
   end
 
-  def get_associated_services(response)
-    if response.present?
-      service_ids = response.dig(0, 'meta', 'associations', 'services')
-      # This can happen when there are variable associations and probably tool
-      # in the future.
-      @services = [] and return unless service_ids
-
-      cmr_service_response = cmr_client.get_services(concept_id: service_ids)
-
-      @services = if cmr_service_response.success?
-                    cmr_service_response.body['items']
-                  else
-                    Rails.logger.error("Error searching for associated services in 'set_associated_services': #{cmr_service_response.clean_inspect}")
-                    []
-                  end
-    else
-      @services = []
-    end
-  end
-
-  def get_associated_concepts(response)
-    ['tools', 'services'].each do |concept_type|
+  def get_associated_concepts(response, concepts = ['tools', 'services'])
+    concepts.each do |concept_type|
       if response.present?
         concept_ids = response.dig(0, 'meta', 'associations', concept_type)
         # This can happen when there are variable associations and probably tool

--- a/app/controllers/collection_drafts_controller.rb
+++ b/app/controllers/collection_drafts_controller.rb
@@ -7,7 +7,7 @@ class CollectionDraftsController < BaseDraftsController
   before_action :load_umm_c_schema, only: [:new, :edit, :show, :publish]
   before_action :collection_validation_setup, only: [:show, :publish]
   before_action :verify_valid_metadata, only: [:publish]
-  before_action :set_associated_services, only: [:show]
+  before_action :set_associated_concepts, only: [:show]
 
   layout 'collection_preview', only: [:show]
 
@@ -510,11 +510,11 @@ class CollectionDraftsController < BaseDraftsController
     redirect_to send("#{resource_name}_path", get_resource) and return
   end
 
-  def set_associated_services
+  def set_associated_concepts
     # get collection
     collection_response = cmr_client.get_collections(native_id: get_resource.native_id)
-    @services = [] and return unless collection_response.success? and collection_response.body['hits'] > 0
+    @services = [] && @tools = [] && return unless collection_response.success? && collection_response.body['hits'] > 0
 
-    get_associated_services(collection_response.body['items'])
+    get_associated_concepts(collection_response.body['items'])
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -7,7 +7,7 @@ class CollectionsController < ManageCollectionsController
   before_action :set_collection
   before_action :ensure_correct_collection_provider, only: [:edit, :clone, :revert, :destroy]
   before_action :set_tags, only: [:show, :destroy]
-  before_action :set_associated_services, only: [:show]
+  before_action :set_associated_concepts, only: [:show]
 
   layout 'collection_preview', only: [:show]
 
@@ -290,7 +290,7 @@ class CollectionsController < ManageCollectionsController
     end
   end
 
-  def set_associated_services
-    get_associated_services(@revisions)
+  def set_associated_concepts
+    get_associated_concepts(@revisions)
   end
 end

--- a/app/views/collection_drafts/show.html.erb
+++ b/app/views/collection_drafts/show.html.erb
@@ -85,6 +85,6 @@
 
     <%= render partial: 'collection_drafts/progress/preview_progress', locals: { unpublished_resource: get_resource, metadata_errors: @errors || @ingest_errors } %>
 
-    <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: get_resource.draft, is_mmt: true, editable: true, edsc_url: nil, concept_id: nil, additional_information: { 'root_url' => root_url, 'services' => @services } } %>
+    <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: get_resource.draft, is_mmt: true, editable: true, edsc_url: nil, concept_id: nil, additional_information: { 'root_url' => root_url, 'services' => @services, 'tools' => @tools } } %>
   </div>
 <% end %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -171,7 +171,7 @@
         var numVariables = <%= @num_variables %>;
       </script>
 
-      <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @collection, is_mmt: true, editable: false, edsc_url: nil, concept_id: nil, additional_information: { 'root_url' => root_url, 'services' => @services } } %>
+      <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @collection, is_mmt: true, editable: false, edsc_url: nil, concept_id: nil, additional_information: { 'root_url' => root_url, 'services' => @services, 'tools' => @tools } } %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/manage_tools/show.html.erb
+++ b/app/views/manage_tools/show.html.erb
@@ -6,12 +6,11 @@
         <div class="question-group">
           <%= link_to 'Create New Record', new_tool_draft_path, class: 'eui-btn--blue submit' %>
         </div>
-        <!--
         <div class="question-group">
           <div class="row">
             <p><strong>OR</strong> use the <a id="search-focus" href="#">search</a> in the top right corner to find published tools to clone or edit.</p>
           </div>
-        </div> -->
+        </div>
       </div>
     </section>
 

--- a/app/views/proposal/collection_draft_proposals/show.html.erb
+++ b/app/views/proposal/collection_draft_proposals/show.html.erb
@@ -41,5 +41,5 @@
 
   <%= render partial: 'collection_drafts/progress/preview_progress', locals: { unpublished_resource: get_resource, metadata_errors: @errors || @ingest_errors } if get_resource.in_work? %>
 
-  <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: get_resource.draft, is_mmt: true, editable: true, edsc_url: nil, concept_id: nil, additional_information: { 'root_url' => "#{cmr_search_root_url}/", 'services' => @services, 'is_dmmt' => true }} %>
+  <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: get_resource.draft, is_mmt: true, editable: true, edsc_url: nil, concept_id: nil, additional_information: { 'root_url' => "#{cmr_search_root_url}/", 'services' => @services, 'tools' => @tools, 'is_dmmt' => true }} %>
 </div>

--- a/app/views/proposal/collections/show.html.erb
+++ b/app/views/proposal/collections/show.html.erb
@@ -42,7 +42,7 @@
       </p>
     </div>
 
-    <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @collection, is_mmt: true, editable: false, edsc_url: nil, concept_id: nil, additional_information: { 'root_url' => "#{cmr_search_root_url}/", 'services' => @services, 'is_dmmt' => true } } %>
+    <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: @collection, is_mmt: true, editable: false, edsc_url: nil, concept_id: nil, additional_information: { 'root_url' => "#{cmr_search_root_url}/", 'services' => @services, 'tools' => @tools, 'is_dmmt' => true } } %>
     <%= render partial: 'shared/download_xml', locals: {
       concept_id: @concept_id,
       revision_id: @revision_id,

--- a/spec/features/collection_drafts/create_collection_draft_from_collection_spec.rb
+++ b/spec/features/collection_drafts/create_collection_draft_from_collection_spec.rb
@@ -1,4 +1,4 @@
-describe 'Create new draft from collection' do
+describe 'Create new draft from collection', reset_provider: true do
   native_id = SecureRandom.uuid
 
   context 'when editing a CMR collection' do
@@ -33,21 +33,45 @@ describe 'Create new draft from collection' do
     end
   end
 
-  context 'when editing a CMR collection with associated services' do
+  context 'when editing a CMR collection with associated tools and services' do
     before do
       login
       ingest_response, @concept_response = publish_collection_draft(native_id: native_id)
-      @service_ingest_response, service_concept_response = publish_service_draft
-      assoc_response = create_service_collection_association(@service_ingest_response['concept-id'], ingest_response['concept-id'])
+      @service_ingest_response, _service_concept_response = publish_service_draft
+      create_service_collection_association(@service_ingest_response['concept-id'], ingest_response['concept-id'])
+      @tool_ingest_response, _tool_concept_response = publish_tool_draft
+      create_tool_collection_association(@tool_ingest_response['concept-id'], ingest_response['concept-id'])
 
       visit collection_path(ingest_response['concept-id'])
+    end
 
-      click_on 'Edit Collection Record'
+    it 'has an associated tool with the correct tool record link' do
+      within '#associated-tools-panel' do
+        expect(page).to have_link('View Tool Record', href: "#{root_url}tools/#{@tool_ingest_response['concept-id']}")
+      end
     end
 
     it 'has an associated service with the correct service record link' do
       within '#associated-services-panel' do
         expect(page).to have_link('View Service Record', href: "#{root_url}services/#{@service_ingest_response['concept-id']}")
+      end
+    end
+
+    context 'when creating a new draft' do
+      before do
+        click_on 'Edit Collection Record'
+      end
+
+      it 'has an associated tool with the correct tool record link' do
+        within '#associated-tools-panel' do
+          expect(page).to have_link('View Tool Record', href: "#{root_url}tools/#{@tool_ingest_response['concept-id']}")
+        end
+      end
+
+      it 'has an associated service with the correct service record link' do
+        within '#associated-services-panel' do
+          expect(page).to have_link('View Service Record', href: "#{root_url}services/#{@service_ingest_response['concept-id']}")
+        end
       end
     end
   end

--- a/spec/features/collection_previews/service_and_tool_tab_spec.rb
+++ b/spec/features/collection_previews/service_and_tool_tab_spec.rb
@@ -1,18 +1,48 @@
 describe 'Service and Tool Tabs', reset_provider: true do
+  before do
+    login
+    @ingest_response, @concept_response = publish_collection_draft
+  end
+
+  context 'when viewing a collection with no associated concepts' do
+    before do
+      visit collection_path(@ingest_response['concept-id'])
+    end
+
+    context 'when examining the services tab' do
+      before do
+        find('.tab-label', text: 'Services').click
+      end
+
+      it 'has the correct text' do
+        expect(page).to have_content('This collection does not have any associated services at this time.')
+      end
+    end
+
+    context 'when examining the Tools tab' do
+      before do
+        find('.tab-label', text: 'Tools').click
+      end
+
+      it 'has the correct text' do
+        expect(page).to have_content('This collection does not have any associated tools at this time.')
+      end
+    end
+  end
+
   context 'when viewing a collection with a pair of services and tools' do
     before do
-      login
-      ingest_response, @concept_response = publish_collection_draft
       @tool_ingest_response, @tool_concept_response = publish_tool_draft(name: "A Tool #{Faker::Number.number(digits: 6)}")
-      create_tool_collection_association(@tool_ingest_response['concept-id'], ingest_response['concept-id'])
+      create_tool_collection_association(@tool_ingest_response['concept-id'], @ingest_response['concept-id'])
       @tool_ingest_response2, @tool_concept_response2 = publish_tool_draft(name: "B Tool #{Faker::Number.number(digits: 6)}")
-      create_tool_collection_association(@tool_ingest_response2['concept-id'], ingest_response['concept-id'])
+      create_tool_collection_association(@tool_ingest_response2['concept-id'], @ingest_response['concept-id'])
       @service_ingest_response, @service_concept_response = publish_service_draft(name: "A Service #{Faker::Number.number(digits: 6)}")
-      create_service_collection_association(@service_ingest_response['concept-id'], ingest_response['concept-id'])
+      create_service_collection_association(@service_ingest_response['concept-id'], @ingest_response['concept-id'])
       @service_ingest_response2, @service_concept_response2 = publish_service_draft(name: "B Service #{Faker::Number.number(digits: 6)}")
-      create_service_collection_association(@service_ingest_response2['concept-id'], ingest_response['concept-id'])
+      create_service_collection_association(@service_ingest_response2['concept-id'], @ingest_response['concept-id'])
+      wait_for_cmr
 
-      visit collection_path(ingest_response['concept-id'])
+      visit collection_path(@ingest_response['concept-id'])
     end
 
     context 'when examining the tools' do
@@ -62,18 +92,17 @@ describe 'Service and Tool Tabs', reset_provider: true do
 
   context 'when viewing a collection with many associated tools', js: true do
     before do
-      login
-      ingest_response, @concept_response = publish_collection_draft
       @tool_ingest_response, @tool_concept_response = publish_tool_draft(name: "A Tool #{Faker::Number.number(digits: 6)}")
-      create_tool_collection_association(@tool_ingest_response['concept-id'], ingest_response['concept-id'])
+      create_tool_collection_association(@tool_ingest_response['concept-id'], @ingest_response['concept-id'])
       @tool_ingest_response2, @tool_concept_response2 = publish_tool_draft(name: "B Tool #{Faker::Number.number(digits: 6)}")
-      create_tool_collection_association(@tool_ingest_response2['concept-id'], ingest_response['concept-id'])
+      create_tool_collection_association(@tool_ingest_response2['concept-id'], @ingest_response['concept-id'])
       @tool_ingest_response3, @tool_concept_response3 = publish_tool_draft(name: "C Tool #{Faker::Number.number(digits: 6)}")
-      create_tool_collection_association(@tool_ingest_response3['concept-id'], ingest_response['concept-id'])
+      create_tool_collection_association(@tool_ingest_response3['concept-id'], @ingest_response['concept-id'])
       @tool_ingest_response4, @tool_concept_response4 = publish_tool_draft(name: "D Tool #{Faker::Number.number(digits: 6)}")
-      create_tool_collection_association(@tool_ingest_response4['concept-id'], ingest_response['concept-id'])
+      create_tool_collection_association(@tool_ingest_response4['concept-id'], @ingest_response['concept-id'])
+      wait_for_cmr
 
-      visit collection_path(ingest_response['concept-id'])
+      visit collection_path(@ingest_response['concept-id'])
 
       find('.tab-label', text: 'Tools').click
     end
@@ -119,6 +148,70 @@ describe 'Service and Tool Tabs', reset_provider: true do
             expect(page).to have_content(@tool_concept_response2.body['Name'])
             expect(page).to have_content(@tool_concept_response3.body['Name'])
             expect(page).to have_no_content(@tool_concept_response4.body['Name'])
+          end
+        end
+      end
+    end
+  end
+
+  context 'when viewing a collection with many associated services', js: true do
+    before do
+      @service_ingest_response, @service_concept_response = publish_service_draft(name: "A service #{Faker::Number.number(digits: 6)}")
+      create_service_collection_association(@service_ingest_response['concept-id'], @ingest_response['concept-id'])
+      @service_ingest_response2, @service_concept_response2 = publish_service_draft(name: "B service #{Faker::Number.number(digits: 6)}")
+      create_service_collection_association(@service_ingest_response2['concept-id'], @ingest_response['concept-id'])
+      @service_ingest_response3, @service_concept_response3 = publish_service_draft(name: "C service #{Faker::Number.number(digits: 6)}")
+      create_service_collection_association(@service_ingest_response3['concept-id'], @ingest_response['concept-id'])
+      @service_ingest_response4, @service_concept_response4 = publish_service_draft(name: "D service #{Faker::Number.number(digits: 6)}")
+      create_service_collection_association(@service_ingest_response4['concept-id'], @ingest_response['concept-id'])
+      wait_for_cmr
+
+      visit collection_path(@ingest_response['concept-id'])
+
+      find('.tab-label', text: 'Services').click
+    end
+
+    it 'has a show more link' do
+      within '#associated-services-panel' do
+        expect(page).to have_link('Show More')
+        expect(page).to have_no_link('Show Less')
+      end
+    end
+
+    it 'displays the correct records' do
+      within '#associated-services-panel' do
+        expect(page).to have_content(@service_concept_response.body['Name'])
+        expect(page).to have_content(@service_concept_response2.body['Name'])
+        expect(page).to have_content(@service_concept_response3.body['Name'])
+        expect(page).to have_no_content(@service_concept_response4.body['Name'])
+      end
+    end
+
+    context 'when clicking the show more link' do
+      before do
+        click_on 'Show More'
+      end
+
+      it 'displays all four records' do
+        within '#associated-services-panel' do
+          expect(page).to have_content(@service_concept_response.body['Name'])
+          expect(page).to have_content(@service_concept_response2.body['Name'])
+          expect(page).to have_content(@service_concept_response3.body['Name'])
+          expect(page).to have_content(@service_concept_response4.body['Name'])
+        end
+      end
+
+      context 'when clicking the show less link' do
+        before do
+          click_on 'Show Less'
+        end
+
+        it 'displays the correct records' do
+          within '#associated-services-panel' do
+            expect(page).to have_content(@service_concept_response.body['Name'])
+            expect(page).to have_content(@service_concept_response2.body['Name'])
+            expect(page).to have_content(@service_concept_response3.body['Name'])
+            expect(page).to have_no_content(@service_concept_response4.body['Name'])
           end
         end
       end

--- a/spec/features/collection_previews/service_and_tool_tab_spec.rb
+++ b/spec/features/collection_previews/service_and_tool_tab_spec.rb
@@ -1,0 +1,127 @@
+describe 'Service and Tool Tabs', reset_provider: true do
+  context 'when viewing a collection with a pair of services and tools' do
+    before do
+      login
+      ingest_response, @concept_response = publish_collection_draft
+      @tool_ingest_response, @tool_concept_response = publish_tool_draft(name: "A Tool #{Faker::Number.number(digits: 6)}")
+      create_tool_collection_association(@tool_ingest_response['concept-id'], ingest_response['concept-id'])
+      @tool_ingest_response2, @tool_concept_response2 = publish_tool_draft(name: "B Tool #{Faker::Number.number(digits: 6)}")
+      create_tool_collection_association(@tool_ingest_response2['concept-id'], ingest_response['concept-id'])
+      @service_ingest_response, @service_concept_response = publish_service_draft(name: "A Service #{Faker::Number.number(digits: 6)}")
+      create_service_collection_association(@service_ingest_response['concept-id'], ingest_response['concept-id'])
+      @service_ingest_response2, @service_concept_response2 = publish_service_draft(name: "B Service #{Faker::Number.number(digits: 6)}")
+      create_service_collection_association(@service_ingest_response2['concept-id'], ingest_response['concept-id'])
+
+      visit collection_path(ingest_response['concept-id'])
+    end
+
+    context 'when examining the tools' do
+      before do
+        find('.tab-label', text: 'Tools').click
+      end
+
+      it 'has the correct tool metadata' do
+        within '#associated-tools-panel' do
+          within all('.preview-gem-card')[0] do
+            expect(page).to have_content(@tool_concept_response.body['Name'])
+            expect(page).to have_content("Type: #{@tool_concept_response.body['Type']}")
+            expect(page).to have_content("Description: #{@tool_concept_response.body['Description']}")
+          end
+
+          within all('.preview-gem-card')[1] do
+            expect(page).to have_content(@tool_concept_response2.body['Name'])
+            expect(page).to have_content("Type: #{@tool_concept_response2.body['Type']}")
+            expect(page).to have_content("Description: #{@tool_concept_response2.body['Description']}")
+          end
+        end
+      end
+    end
+
+    context 'when examining the services' do
+      before do
+        find('.tab-label', text: 'Services').click
+      end
+
+      it 'has the correct service metadata' do
+        within '#associated-services-panel' do
+          within all('.preview-gem-card')[0] do
+            expect(page).to have_content(@service_concept_response.body['Name'])
+            expect(page).to have_content("Type: #{@service_concept_response.body['Type']}")
+            expect(page).to have_content("Description: #{@service_concept_response.body['Description']}")
+          end
+
+          within all('.preview-gem-card')[1] do
+            expect(page).to have_content(@service_concept_response2.body['Name'])
+            expect(page).to have_content("Type: #{@service_concept_response2.body['Type']}")
+            expect(page).to have_content("Description: #{@service_concept_response2.body['Description']}")
+          end
+        end
+      end
+    end
+  end
+
+  context 'when viewing a collection with many associated tools', js: true do
+    before do
+      login
+      ingest_response, @concept_response = publish_collection_draft
+      @tool_ingest_response, @tool_concept_response = publish_tool_draft(name: "A Tool #{Faker::Number.number(digits: 6)}")
+      create_tool_collection_association(@tool_ingest_response['concept-id'], ingest_response['concept-id'])
+      @tool_ingest_response2, @tool_concept_response2 = publish_tool_draft(name: "B Tool #{Faker::Number.number(digits: 6)}")
+      create_tool_collection_association(@tool_ingest_response2['concept-id'], ingest_response['concept-id'])
+      @tool_ingest_response3, @tool_concept_response3 = publish_tool_draft(name: "C Tool #{Faker::Number.number(digits: 6)}")
+      create_tool_collection_association(@tool_ingest_response3['concept-id'], ingest_response['concept-id'])
+      @tool_ingest_response4, @tool_concept_response4 = publish_tool_draft(name: "D Tool #{Faker::Number.number(digits: 6)}")
+      create_tool_collection_association(@tool_ingest_response4['concept-id'], ingest_response['concept-id'])
+
+      visit collection_path(ingest_response['concept-id'])
+
+      find('.tab-label', text: 'Tools').click
+    end
+
+    it 'has a show more link' do
+      within '#associated-tools-panel' do
+        expect(page).to have_link('Show More')
+        expect(page).to have_no_link('Show Less')
+      end
+    end
+
+    it 'displays the correct records' do
+      within '#associated-tools-panel' do
+        expect(page).to have_content(@tool_concept_response.body['Name'])
+        expect(page).to have_content(@tool_concept_response2.body['Name'])
+        expect(page).to have_content(@tool_concept_response3.body['Name'])
+        expect(page).to have_no_content(@tool_concept_response4.body['Name'])
+      end
+    end
+
+    context 'when clicking the show more link' do
+      before do
+        click_on 'Show More'
+      end
+
+      it 'displays all four records' do
+        within '#associated-tools-panel' do
+          expect(page).to have_content(@tool_concept_response.body['Name'])
+          expect(page).to have_content(@tool_concept_response2.body['Name'])
+          expect(page).to have_content(@tool_concept_response3.body['Name'])
+          expect(page).to have_content(@tool_concept_response4.body['Name'])
+        end
+      end
+
+      context 'when clicking the show less link' do
+        before do
+          click_on 'Show Less'
+        end
+
+        it 'displays the correct records' do
+          within '#associated-tools-panel' do
+            expect(page).to have_content(@tool_concept_response.body['Name'])
+            expect(page).to have_content(@tool_concept_response2.body['Name'])
+            expect(page).to have_content(@tool_concept_response3.body['Name'])
+            expect(page).to have_no_content(@tool_concept_response4.body['Name'])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_create_from_collection_spec.rb
+++ b/spec/features/proposal/collection_draft_proposals/collection_draft_proposal_create_from_collection_spec.rb
@@ -44,32 +44,61 @@ describe 'Collection Draft Proposal creation from collection', js: true do
     end
   end
 
-  context 'when viewing a collection with service associations' do
+  context 'when viewing a collection with service and tool associations' do
     before do
       ingest_response, _concept_response = publish_collection_draft
-      @service_ingest_response, service_concept_response = publish_service_draft
-      assoc_response = create_service_collection_association(@service_ingest_response['concept-id'], ingest_response['concept-id'])
+      @service_ingest_response, _service_concept_response = publish_service_draft
+      create_service_collection_association(@service_ingest_response['concept-id'], ingest_response['concept-id'])
+      @tool_ingest_response, _tool_concept_response = publish_tool_draft
+      create_tool_collection_association(@tool_ingest_response['concept-id'], ingest_response['concept-id'])
       set_as_proposal_mode_mmt(with_required_acl: true)
       visit collection_path(ingest_response['concept-id'])
-
-      find('.tab-label', text: 'Services').click
     end
 
-    it 'displays the correct service record link when viewing the collection' do
-      expect(page).to have_link('View Service Record', href: "http://localhost:3003/concepts/#{@service_ingest_response['concept-id']}")
+    context 'when examining the services tab' do
+      before do
+        find('.tab-label', text: 'Services').click
+      end
+
+      it 'displays the correct service record link when viewing the collection' do
+        expect(page).to have_link('View Service Record', href: "http://localhost:3003/concepts/#{@service_ingest_response['concept-id']}")
+      end
     end
 
+    context 'when examining the tools tab' do
+      before do
+        find('.tab-label', text: 'Tools').click
+      end
+
+      it 'displays the correct tool record link when viewing the collection' do
+        expect(page).to have_link('View Tool Record', href: "http://localhost:3003/concepts/#{@tool_ingest_response['concept-id']}")
+      end
+    end
 
     context 'when creating a proposal' do
       before do
         click_on 'Create Update Request'
         click_on 'Yes'
-
-        find('.tab-label', text: 'Services').click
       end
 
-      it 'displays the correct service record link when viewing the proposal' do
-        expect(page).to have_link('View Service Record', href: "http://localhost:3003/concepts/#{@service_ingest_response['concept-id']}")
+      context 'when examining the services tab' do
+        before do
+          find('.tab-label', text: 'Services').click
+        end
+
+        it 'displays the correct service record link when viewing the proposal' do
+          expect(page).to have_link('View Service Record', href: "http://localhost:3003/concepts/#{@service_ingest_response['concept-id']}")
+        end
+      end
+
+      context 'when examining the tools tab' do
+        before do
+          find('.tab-label', text: 'Tools').click
+        end
+
+        it 'displays the correct tool record link when viewing the proposal' do
+          expect(page).to have_link('View Tool Record', href: "http://localhost:3003/concepts/#{@tool_ingest_response['concept-id']}")
+        end
       end
     end
   end

--- a/spec/tasks/ingesting_cmr_data_spec.rb
+++ b/spec/tasks/ingesting_cmr_data_spec.rb
@@ -1,0 +1,23 @@
+describe 'Using rake tasks to ingest data into CMR for manual testing', reset_provider: true do
+  context 'when using testing:ingest_tabs_test' do
+    before do
+      Rake::Task.define_task(:environment)
+      Rake.application.rake_require 'tasks/testing'
+      # the task being tested uses cmr_client which is defined in tasks/collections
+      # so we need to include that to not error out when running it here
+      Rake.application.rake_require 'tasks/collections'
+      Rake::Task['testing:ingest_tabs_test'].invoke(1, 4)
+
+      # wait because CMR needs a moment to update for the associations
+      wait_for_cmr
+    end
+
+    it 'creates a record with one service association and four tool associations' do
+      # include_granule_counts gets us the association list, which is... weird.
+      response = cmr_client.get_collections(provider_id: 'MMT_2', include_granule_counts: true)
+      associations = response.body['items'][0]['meta']['associations']
+      expect(associations['services'].count).to eq(1)
+      expect(associations['tools'].count).to eq(4)
+    end
+  end
+end


### PR DESCRIPTION
Updated css so services and tools match.
Updated get_associated_services to get_associated_concepts and it gets both services and tools.
Uncommented text on Manage Tools page
Added a helper rake task that ingests and associated specified numbers of tools and services to save time manual testing
Added tests for service and tool tab metadata and javascript, also for helper task.