### PR TITLE
MMT-2422 Adjusting permitted parameters so that we aren't blocking the service option assignment workflow

### DIFF
--- a/app/controllers/manage_cmr/service_option_assignments_controller.rb
+++ b/app/controllers/manage_cmr/service_option_assignments_controller.rb
@@ -130,7 +130,7 @@ class ServiceOptionAssignmentsController < ManageCmrController
   def destroy
     authorize :service_option_assignment
 
-    response = echo_client.remove_service_option_assignments(echo_provider_token, params.fetch('service_option_assignment', []))
+    response = echo_client.remove_service_option_assignments(echo_provider_token, service_option_assignment_params.fetch('service_option_assignment', []))
 
     if response.success?
       redirect_to service_option_assignments_path, flash: { success: 'Successfully deleted the selected service option assignments.' }
@@ -142,8 +142,18 @@ class ServiceOptionAssignmentsController < ManageCmrController
 
   private
 
+  # params used in controller:
+  # In create:
+  #   :service_entry_guid,
+  #   :service_option_definition_guid,
+  #   :applies_only_to_granules,
+  #   :service_option_assignment_catalog_guid_toList
+  # In update:
+  #   :service_entries_toList
+  # In destroy:
+  #   :service_option_assignment
   def service_option_assignment_params
-    params.permit(:service_entry_guid, :service_option_definition_guid, :applies_only_to_granules, service_option_assignment_catalog_guid_toList: [], service_entries_toList: [])
+    params.permit(:service_entry_guid, :service_option_definition_guid, :applies_only_to_granules, service_option_assignment_catalog_guid_toList: [], service_entries_toList: [], service_option_assignment: [])
   end
 
   def set_service_entries

--- a/app/controllers/manage_cmr/service_option_assignments_controller.rb
+++ b/app/controllers/manage_cmr/service_option_assignments_controller.rb
@@ -143,7 +143,7 @@ class ServiceOptionAssignmentsController < ManageCmrController
   private
 
   def service_option_assignment_params
-    params.permit(:service_entry_guid, :service_option_definition_guid, :applies_only_to_granules, service_option_assignment_catalog_guid_toList: [])
+    params.permit(:service_entry_guid, :service_option_definition_guid, :applies_only_to_granules, service_option_assignment_catalog_guid_toList: [], service_entries_toList: [])
   end
 
   def set_service_entries

--- a/spec/controllers/service_option_assignments_controller_spec.rb
+++ b/spec/controllers/service_option_assignments_controller_spec.rb
@@ -1,0 +1,28 @@
+describe ServiceOptionAssignmentsController do
+  context 'when checking the permitted parameters' do
+    # It is not generally advised to test private controller methods, but
+    # there is value in verifying that our permitted parameters methods
+    # are working as expected. Failures here can sometimes cause silent or
+    # difficult to observe failures. This is particularly true for sections of
+    # MMT that are used less often and are difficult to thoroughly test (i.e.
+    # anything involving legacy services).
+    let(:entry_guid) { 'entry_guid' }
+    let(:option_definition_guid) { 'option_definition_guid' }
+    let(:toList) { ['item1', 'item2'] }
+    let(:service_option_assignment) { ['item1', 'item2'] }
+    before do
+      controller.params = ActionController::Parameters.new({bad_key: 'bad_value', service_entry_guid: entry_guid, service_option_definition_guid: option_definition_guid, applies_only_to_granules: true, service_option_assignment_catalog_guid_toList: toList, service_entries_toList: toList, service_option_assignment: service_option_assignment })
+    end
+
+    it 'has the correct params' do
+      params = controller.send 'service_option_assignment_params'
+      expect(params.keys).to eq(['service_entry_guid', 'service_option_definition_guid', 'applies_only_to_granules', 'service_option_assignment_catalog_guid_toList', 'service_entries_toList', 'service_option_assignment'])
+      expect(params['service_entry_guid']).to eq(entry_guid)
+      expect(params['service_option_definition_guid']).to eq(option_definition_guid)
+      expect(params['applies_only_to_granules']).to eq(true)
+      expect(params['service_option_assignment_catalog_guid_toList']).to eq(toList)
+      expect(params['service_entries_toList']).to eq(toList)
+      expect(params['service_option_assignment']).to eq(service_option_assignment)
+    end
+  end
+end


### PR DESCRIPTION
- Checked controller actions to verify which parameters we were explicitly using. Documented above permitted params method
- Updated destroy action so that it uses permitted params method
- Added test to verify the expected keys.