### PR TITLE
MMT-2452: Draft Forms add too many required icons (radio buttons with 'clear' link)

### DIFF
--- a/app/assets/javascripts/required_fields.coffee
+++ b/app/assets/javascripts/required_fields.coffee
@@ -373,7 +373,7 @@ $(document).ready ->
   $('.metadata-form, .umm-form').on 'change', 'input[type="radio"], select', ->
     addRequiredIcons(this)
 
-  # MMT-2452: Because the 'clear-radio-button' elements were being handled in draft_form_selectors.coffee,
+  # Because the 'clear-radio-button' elements were being handled in draft_form_selectors.coffee,
   # the data level wasn't being removed from the requiredDataLevels array and the required icon was persistent.
   # Additionally, the eui-required-o class was not being cleared away with the radio button selection in draft_form_selectors.coffee
   $('.clear-radio-button').on 'click', ->
@@ -383,10 +383,9 @@ $(document).ready ->
         requiredDataLevels.splice(index, 1)
         $(label).removeClass('eui-required-o')
 
-  # MMT-2428: Because the dependent-fields-checkboxes are being handled in umm_forms.coffee,
+  # Because the dependent-fields-checkboxes and show-hide-checkboxes are being handled in umm_forms.coffee,
   # the following lines make sure the dependent fields (whose display is toggled by the checkbox) are removed
   # from the requiredDataLevels array (defined above) when they are hidden (parent checkbox is unchecked)
-  # MMT-2452: extended the same functionality to show-hide-checkboxes
   $('.show-hide-checkbox, .dependent-fields-checkbox').on 'change', ->
     unless this.checked
       fieldClass = $(this).data('dependentFieldClass')

--- a/app/assets/javascripts/required_fields.coffee
+++ b/app/assets/javascripts/required_fields.coffee
@@ -380,6 +380,16 @@ $(document).ready ->
     unless this.checked
       fieldClass = $(this).data('dependentFieldClass')
       dependentFields = $(this).closest('.checkbox-dependent-fields-parent').find(".#{fieldClass}-fields")
-      $.each $(dependentFields).find("input[type='radio'], input[type='checkbox']"), (index, field) ->
+      $.each $(dependentFields).find('input, select'), (index, field) ->
         for removeLevel, index in requiredDataLevels by -1
-            requiredDataLevels.splice(index, 1) if removeLevel.topLevel == $(field).attr('data-level')
+          requiredDataLevels.splice(index, 1) if removeLevel.topLevel == $(field).attr('data-level')
+
+  # MMT-2452: Because the 'clear-radio-button' elements were being handled in draft_form_selectors.coffee,
+  # the data level wasn't being removed from the requiredDataLevels array and the required icon was persistent.
+  # Additionally, the eui-required-o class was not being cleared away with the radio button selection in draft_form_selectors.coffee
+  $('.clear-radio-button').on 'click', ->
+    label = $(this).siblings('label')
+    for removeLevel, index in requiredDataLevels by -1
+      if removeLevel.topLevel == $(label).attr('for')
+        requiredDataLevels.splice(index, 1)
+        $(label).removeClass('eui-required-o')

--- a/app/assets/javascripts/required_fields.coffee
+++ b/app/assets/javascripts/required_fields.coffee
@@ -373,17 +373,6 @@ $(document).ready ->
   $('.metadata-form, .umm-form').on 'change', 'input[type="radio"], select', ->
     addRequiredIcons(this)
 
-  # MMT-2428: Because the dependent-fields-checkboxes are being handled in umm_forms.coffee,
-  # the following lines make sure the dependent fields (whose display is toggled by the checkbox) are removed
-  # from the requiredDataLevels array (defined above) when they are hidden (parent checkbox is unchecked)
-  $('.dependent-fields-checkbox').on 'change', ->
-    unless this.checked
-      fieldClass = $(this).data('dependentFieldClass')
-      dependentFields = $(this).closest('.checkbox-dependent-fields-parent').find(".#{fieldClass}-fields")
-      $.each $(dependentFields).find('input, select'), (index, field) ->
-        for removeLevel, index in requiredDataLevels by -1
-          requiredDataLevels.splice(index, 1) if removeLevel.topLevel == $(field).attr('data-level')
-
   # MMT-2452: Because the 'clear-radio-button' elements were being handled in draft_form_selectors.coffee,
   # the data level wasn't being removed from the requiredDataLevels array and the required icon was persistent.
   # Additionally, the eui-required-o class was not being cleared away with the radio button selection in draft_form_selectors.coffee
@@ -393,3 +382,14 @@ $(document).ready ->
       if removeLevel.topLevel == $(label).attr('for')
         requiredDataLevels.splice(index, 1)
         $(label).removeClass('eui-required-o')
+
+  # MMT-2428: Because the dependent-fields-checkboxes are being handled in umm_forms.coffee,
+  # the following lines make sure the dependent fields (whose display is toggled by the checkbox) are removed
+  # from the requiredDataLevels array (defined above) when they are hidden (parent checkbox is unchecked)
+  # MMT-2452: extended the same functionality to show-hide-checkboxes
+  $('.show-hide-checkbox, .dependent-fields-checkbox').on 'change', ->
+    unless this.checked
+      fieldClass = $(this).data('dependentFieldClass')
+      $(this).siblings(".#{fieldClass}-fields").find('input, select').each (index, field) ->
+        for removeLevel, index in requiredDataLevels by -1
+          requiredDataLevels.splice(index, 1) if removeLevel.topLevel == $(field).attr('data-level')

--- a/app/assets/javascripts/umm_forms.coffee
+++ b/app/assets/javascripts/umm_forms.coffee
@@ -4,11 +4,10 @@ $(document).ready ->
 
     $('.dependent-fields-checkbox').on 'change', ->
       fieldClass = $(this).data('dependentFieldClass')
-      dependentFields = $(this).closest('.checkbox-dependent-fields-parent').find(".#{fieldClass}-fields")
-      if $(this).prop('checked') == true
+      dependentFields = $(this).siblings(".#{fieldClass}-fields")
+      if this.checked
         $(dependentFields).removeClass('is-hidden')
-
-      else if $(this).prop('checked') == false
+      else
         # clear field values
         $.each $(dependentFields).find('input, select').not("input[type='radio']"), (index, field) ->
           $(field).val('')
@@ -18,5 +17,4 @@ $(document).ready ->
         $(dependentFields).find('label').removeClass('eui-required-o')
         # hide any nested checkbox dependent fields
         $(dependentFields).find('.checkbox-dependent-fields').addClass('is-hidden')
-
         $(dependentFields).addClass('is-hidden')

--- a/app/views/collection_drafts/forms/fields/_geometry_fields.html.erb
+++ b/app/views/collection_drafts/forms/fields/_geometry_fields.html.erb
@@ -62,7 +62,7 @@
   <label class="eui-required-o space-top">Geometry Type</label>
   <div class="geometry-type-group">
     <div class="checkbox-group">
-      <%= check_box_tag(name_to_param("#{name_prefix}points"), nil, points_checked, class: 'geometry-picker points show-hide-checkbox', name: nil) %>
+      <%= check_box_tag(name_to_param("#{name_prefix}points"), nil, points_checked, class: 'geometry-picker points show-hide-checkbox', name: nil, data: { 'dependent-field-class': 'geometry' }) %>
       <%= mmt_label(
         name: 'points',
         title: 'Points',
@@ -79,7 +79,7 @@
       </div>
     </div>
     <div class="checkbox-group">
-      <%= check_box_tag(name_to_param("#{name_prefix}bounding_rectangles"), nil, bounding_rectangles_checked, class: 'geometry-picker bounding-rectangles show-hide-checkbox', name: nil) %>
+      <%= check_box_tag(name_to_param("#{name_prefix}bounding_rectangles"), nil, bounding_rectangles_checked, class: 'geometry-picker bounding-rectangles show-hide-checkbox', name: nil, data: { 'dependent-field-class': 'geometry' }) %>
       <%= mmt_label(
         name: 'bounding_rectangles',
         title: 'Bounding Rectangles',
@@ -96,7 +96,7 @@
       </div>
     </div>
     <div class="checkbox-group">
-      <%= check_box_tag(name_to_param("#{name_prefix}g_polygons"), nil, g_polygons_checked, class: 'geometry-picker g-polygons show-hide-checkbox', name: nil) %>
+      <%= check_box_tag(name_to_param("#{name_prefix}g_polygons"), nil, g_polygons_checked, class: 'geometry-picker g-polygons show-hide-checkbox', name: nil, data: { 'dependent-field-class': 'geometry' }) %>
       <%= mmt_label(
         name: 'g_polygons',
         title: 'G Polygons',
@@ -113,7 +113,7 @@
       </div>
     </div>
     <div class="checkbox-group">
-      <%= check_box_tag(name_to_param("#{name_prefix}lines"), nil, lines_checked, class: 'geometry-picker lines show-hide-checkbox', name: nil) %>
+      <%= check_box_tag(name_to_param("#{name_prefix}lines"), nil, lines_checked, class: 'geometry-picker lines show-hide-checkbox', name: nil, data: { 'dependent-field-class': 'geometry' }) %>
       <%= mmt_label(
         name: 'lines',
         title: 'Lines',

--- a/app/views/collection_drafts/forms/fields/_horizontal_data_resolution_fields.html.erb
+++ b/app/views/collection_drafts/forms/fields/_horizontal_data_resolution_fields.html.erb
@@ -38,7 +38,7 @@
       </div>
 
       <div class="checkbox-group">
-        <%= check_box_tag(name_to_param("#{name_prefix}|non_gridded_resolutions|_checkbox"), nil, non_gridded_resolutions_checked, class: 'horizontal-data-resolution-picker non-gridded-resolutions show-hide-checkbox', name: nil) %>
+        <%= check_box_tag(name_to_param("#{name_prefix}|non_gridded_resolutions|_checkbox"), nil, non_gridded_resolutions_checked, class: 'horizontal-data-resolution-picker non-gridded-resolutions show-hide-checkbox', name: nil, data: { 'dependent-field-class': 'horizontal-data-resolution' }) %>
         <%= mmt_label(
           name: 'non_gridded_resolutions_checkbox',
           title: 'Non Gridded Resolutions',
@@ -66,7 +66,7 @@
       </div>
 
       <div class="checkbox-group">
-        <%= check_box_tag(name_to_param("#{name_prefix}|non_gridded_range_resolutions|_checkbox"), nil, non_gridded_range_resolutions_checked, class: 'horizontal-data-resolution-picker non-gridded-range-resolutions show-hide-checkbox', name: nil) %>
+        <%= check_box_tag(name_to_param("#{name_prefix}|non_gridded_range_resolutions|_checkbox"), nil, non_gridded_range_resolutions_checked, class: 'horizontal-data-resolution-picker non-gridded-range-resolutions show-hide-checkbox', name: nil, data: { 'dependent-field-class': 'horizontal-data-resolution' }) %>
         <%= mmt_label(
           name: 'non_gridded_range_resolutions_checkbox',
           title: 'Non Gridded Range Resolutions',
@@ -94,7 +94,7 @@
       </div>
 
       <div class="checkbox-group">
-        <%= check_box_tag(name_to_param("#{name_prefix}|gridded_resolutions|_checkbox"), nil, gridded_resolutions_checked, class: 'horizontal-data-resolution-picker gridded-resolutions show-hide-checkbox', name: nil) %>
+        <%= check_box_tag(name_to_param("#{name_prefix}|gridded_resolutions|_checkbox"), nil, gridded_resolutions_checked, class: 'horizontal-data-resolution-picker gridded-resolutions show-hide-checkbox', name: nil, data: { 'dependent-field-class': 'horizontal-data-resolution' }) %>
         <%= mmt_label(
           name: 'gridded_resolutions_checkbox',
           title: 'Gridded Resolutions',
@@ -122,7 +122,7 @@
       </div>
 
       <div class="checkbox-group">
-        <%= check_box_tag(name_to_param("#{name_prefix}|gridded_range_resolutions|_checkbox"), nil, gridded_range_resolutions_checked, class: 'horizontal-data-resolution-picker gridded-range-resolutions show-hide-checkbox', name: nil) %>
+        <%= check_box_tag(name_to_param("#{name_prefix}|gridded_range_resolutions|_checkbox"), nil, gridded_range_resolutions_checked, class: 'horizontal-data-resolution-picker gridded-range-resolutions show-hide-checkbox', name: nil, data: { 'dependent-field-class': 'horizontal-data-resolution' }) %>
         <%= mmt_label(
           name: 'gridded_range_resolutions_checkbox',
           title: 'Gridded Range Resolutions',
@@ -150,7 +150,7 @@
       </div>
 
       <div class="checkbox-group">
-        <%= check_box_tag(name_to_param("#{name_prefix}|generic_resolutions|_checkbox"), nil, generic_resolutions_checked, class: 'horizontal-data-resolution-picker generic-resolutions show-hide-checkbox', name: nil) %>
+        <%= check_box_tag(name_to_param("#{name_prefix}|generic_resolutions|_checkbox"), nil, generic_resolutions_checked, class: 'horizontal-data-resolution-picker generic-resolutions show-hide-checkbox', name: nil, data: { 'dependent-field-class': 'horizontal-data-resolution' }) %>
         <%= mmt_label(
           name: 'generic_resolutions_checkbox',
           title: 'Generic Resolutions',

--- a/lib/json_schema_form/umm_form_elements/umm_checkbox_dependent_fields.rb
+++ b/lib/json_schema_form/umm_form_elements/umm_checkbox_dependent_fields.rb
@@ -13,9 +13,8 @@ class UmmCheckboxDependentFields < UmmFormElement
   def render_markup
 
     content_tag(:div, class: "#{form_fragment['htmlClass']} #{dependent_field_class} checkbox-dependent-fields-parent") do
-
+      concat(check_box_tag("#{dependent_field_class}_checkbox", 'show', element_value.present?, class: "dependent-fields-checkbox #{dependent_field_class}-checkbox", data: { 'dependent-field-class': dependent_field_class }))
       concat(label_tag("#{dependent_field_class}_checkbox") do
-        concat(check_box_tag("#{dependent_field_class}_checkbox", 'show', element_value.present?, class: "dependent-fields-checkbox #{dependent_field_class}-checkbox", data: { 'dependent-field-class': dependent_field_class }))
         concat(title)
       end)
 

--- a/spec/features/collection_drafts/forms/spatial_information_form_spec.rb
+++ b/spec/features/collection_drafts/forms/spatial_information_form_spec.rb
@@ -124,6 +124,28 @@ describe 'Spatial information form', js: true do
         click_on 'Expand All'
       end
 
+      context 'when viewing required icons' do
+        before do
+          uncheck 'Point Resolution'
+          uncheck 'Varies Resolution'
+          uncheck 'Gridded Resolutions'
+          uncheck 'Gridded Range Resolutions'
+          uncheck 'Generic Resolutions'
+
+          uncheck 'Non Gridded Range Resolutions'
+          check 'Non Gridded Range Resolutions'
+          within '.horizontal-data-resolution-fields.non-gridded-resolutions' do
+            first('label.eui-required-o').double_click 
+          end
+        end
+
+        it 'displays the appropriate number of required icons' do
+          within '.horizontal-data-resolution-fields.non-gridded-range-resolutions' do
+            expect(page).to have_no_css('label.eui-required-o')
+          end
+        end
+      end
+
       it 'displays a confirmation message' do
         expect(page).to have_content('Collection Draft Updated Successfully!')
       end
@@ -654,6 +676,28 @@ describe 'Spatial information form', js: true do
       end
       # output_schema_validation Draft.first.draft
       click_on 'Expand All'
+    end
+
+    context 'when viewing required icons' do
+      # MMT-2452: clearing the Points form should clear it's required icons visually and from the requiredDataLevels array.
+      # Choosing Geodetic from the Coordinate System radio group will cause the required icons of the Points form to
+      # reappear if those data-levels are still in the requiredDataLevels array. Thus, we expect only the required icon of the
+      # Coordinate System radio group label to remain visible hence the count: 1
+      before do
+        within '.geometry-type-group' do
+          uncheck 'Points'
+          check 'Points'
+        end
+        within '.coordinate-system-type-group' do
+          choose 'Geodetic'
+        end
+      end
+
+      it 'displays the appropriate number of required icons' do
+        within '.geometry' do
+          expect(page).to have_css('label.eui-required-o', count: 1)
+        end
+      end
     end
 
     it 'displays a confirmation message' do

--- a/spec/features/collection_drafts/forms/unselect_radio_buttons_spec.rb
+++ b/spec/features/collection_drafts/forms/unselect_radio_buttons_spec.rb
@@ -27,6 +27,7 @@ describe 'Unselecting radio buttons', js: true do
         within '.geometry' do
           expect(page).to have_no_checked_field('Cartesian')
           expect(page).to have_no_checked_field('Geodetic')
+          expect(page).to have_no_css('label.required.eui-required-icon')
         end
       end
     end


### PR DESCRIPTION
- Added extra listener for `show-hide-checkboxes` 
- Added data field for `show-hide-checkboxes` so functionality can be shared between `dependent-fields-checkboxes`
- wrote tests that mimic the error recreation on the ticket