### PR TITLE
MMT-951: On Metadata Draft Forms, clicking on the info button on a subform will open/close the accordion as well as showing the help modal.

### DIFF
--- a/app/assets/javascripts/accordion.coffee
+++ b/app/assets/javascripts/accordion.coffee
@@ -7,8 +7,6 @@ $(document).ready ->
   # operation allows the below click listener to take priority and achieves the desired accordion/help
   # icon behavior without editing the vendor file (eui.js)
   $('.eui-accordion__header').not('.eui-accordion__header.disable-toggle').unbind('click')
-  $('.eui-accordion__header').not('.eui-accordion__header.disable-toggle').bind('click')
-  
   $(".eui-accordion__header").not('.eui-accordion__header.disable-toggle').click (e) ->
     if !$(e.target).is('i.eui-fa-info-circle')
       $(this).siblings(".eui-accordion__body").slideToggle("fast")

--- a/app/assets/javascripts/accordion.coffee
+++ b/app/assets/javascripts/accordion.coffee
@@ -2,6 +2,18 @@ $(document).ready ->
   # Disable toggle
   $('.eui-accordion__header.disable-toggle').unbind('click')
 
+  # the eui-accordion__header listener in eui.js that is responsible for opening/closing the accordions
+  # allows the accordions to open/close when the help icon is clicked. Performing this unbind/rebind
+  # operation allows the below click listener to take priority and achieves the desired accordion/help
+  # icon behavior without editing the vendor file (eui.js)
+  $('.eui-accordion__header').not('.eui-accordion__header.disable-toggle').unbind('click')
+  $('.eui-accordion__header').not('.eui-accordion__header.disable-toggle').bind('click')
+  
+  $(".eui-accordion__header").not('.eui-accordion__header.disable-toggle').click (e) ->
+    if !$(e.target).is('i.eui-fa-info-circle')
+      $(this).siblings(".eui-accordion__body").slideToggle("fast")
+      $(this).closest(".eui-accordion").toggleClass("is-closed")
+
   # if viewing Collection Descriptive Keywords form and Keyword Recommendations
   # are presented to the user, indicate that they have been viewed
   indicateIfKeywordRecommendationsViewed = () ->

--- a/spec/features/collection_drafts/form_accordions_spec.rb
+++ b/spec/features/collection_drafts/form_accordions_spec.rb
@@ -76,10 +76,9 @@ describe 'Draft form accordions', js: true do
       end
     end
 
-    # TODO This test is broken, but should be fixed by MMT-951
-    # it 'does not open the accordion' do
-    #   expect(page).to have_no_field('Metadata Language')
-    # end
+    it 'does not open the accordion' do
+      expect(page).to have_no_field('Metadata Language')
+    end
   end
 
   context 'when clicking the Expand All link' do

--- a/vendor/assets/javascripts/eui-1.0.0/eui.js
+++ b/vendor/assets/javascripts/eui-1.0.0/eui.js
@@ -124,9 +124,11 @@
   // FUNCTIONALITY: #Accordion
 
     // Basic Accordion Functionality
-    $(".eui-accordion__header").click(function() {
-      $(this).siblings(".eui-accordion__body").slideToggle("fast");
-      $(this).closest(".eui-accordion").toggleClass("is-closed");
+    $(".eui-accordion__header").click(function(e) {
+      if (!$(e.target).is('i.eui-fa-info-circle')) {
+        $(this).siblings(".eui-accordion__body").slideToggle("fast");
+        $(this).closest(".eui-accordion").toggleClass("is-closed");
+      }
     });
 
     $(".eui-accordion__icon").on("keyup", function(e) {

--- a/vendor/assets/javascripts/eui-1.0.0/eui.js
+++ b/vendor/assets/javascripts/eui-1.0.0/eui.js
@@ -124,11 +124,9 @@
   // FUNCTIONALITY: #Accordion
 
     // Basic Accordion Functionality
-    $(".eui-accordion__header").click(function(e) {
-      if (!$(e.target).is('i.eui-fa-info-circle')) {
-        $(this).siblings(".eui-accordion__body").slideToggle("fast");
-        $(this).closest(".eui-accordion").toggleClass("is-closed");
-      }
+    $(".eui-accordion__header").click(function() {
+      $(this).siblings(".eui-accordion__body").slideToggle("fast");
+      $(this).closest(".eui-accordion").toggleClass("is-closed");
     });
 
     $(".eui-accordion__icon").on("keyup", function(e) {


### PR DESCRIPTION
- Adjusted eui.js handler
- uncommented spec