### PR TITLE
MM-2365: UMM-V/S/T draft progress circle links do not take users to appropriate field

### DIFF
--- a/app/views/drafts/shared/_form_progress_panel.html.erb
+++ b/app/views/drafts/shared/_form_progress_panel.html.erb
@@ -12,11 +12,11 @@
             <!-- this only needs to loop through top level elements -->
             <% form_section.top_elements.each do |field| %>
               <% if json_form.invalid?(field.top_key) %>
-                <%= invalid_circle(field.title, resource, form_section.parsed_json['id'], field.accordion_id) %>
+                <%= invalid_circle(field.title, resource, form_section.parsed_json['id'], field.anchor) %>
               <% elsif field.value? %>
-                <%= complete_circle(field.title, resource, form_section.parsed_json['id'], field.accordion_id, schema.required_field?(field.top_key)) %>
+                <%= complete_circle(field.title, resource, form_section.parsed_json['id'], field.anchor, schema.required_field?(field.top_key)) %>
               <% else %>
-                <%= empty_circle(field.title, resource, form_section.parsed_json['id'], field.accordion_id, schema.required_field?(field.top_key)) %>
+                <%= empty_circle(field.title, resource, form_section.parsed_json['id'], field.anchor, schema.required_field?(field.top_key)) %>
               <% end %>
             <% end %>
 

--- a/lib/json_schema_form/umm_form.rb
+++ b/lib/json_schema_form/umm_form.rb
@@ -312,8 +312,7 @@ class UmmForm < JsonObj
   def label_id
     value = parsed_json.fetch('key','').split('/').first
     value = parsed_json.fetch('key','').split('/')[1] if value.blank?
-    # the conditionals in this method should only be used to ensure that id's are not given to labels that aren't top level fields
-    p field_title_differs_from_accordion_title?, 'afewasdf'
+    
     if value == top_key && !parsed_json['noLabel'] && field_title_differs_from_accordion_title?
       top_key.underscore.dasherize + '-label'
     else

--- a/lib/json_schema_form/umm_form.rb
+++ b/lib/json_schema_form/umm_form.rb
@@ -308,11 +308,10 @@ class UmmForm < JsonObj
     accordion_titles.none? { |accordion_title| accordion_title == title }
   end
 
-
   def label_id
     value = parsed_json.fetch('key','').split('/').first
     value = parsed_json.fetch('key','').split('/')[1] if value.blank?
-    
+
     if value == top_key && !parsed_json['noLabel'] && field_title_differs_from_accordion_title?
       top_key.underscore.dasherize + '-label'
     else

--- a/lib/json_schema_form/umm_form.rb
+++ b/lib/json_schema_form/umm_form.rb
@@ -316,7 +316,7 @@ class UmmForm < JsonObj
     # value == top_key: checks if the label is a top-level field (we don't want to put label id's on fields that aren't
       # linked via progress circle)
     # !parsed_json['noLabel']: there are no progress circles that link to fields with a truthy 'noLabel' key.
-    # field_title_differs_from_accordion_title?: makes sure the fields that share the same title as their accordion don't
+    # field_title_not_accordion_title?: makes sure the fields that share the same title as their accordion don't
       # get a label_id (we don't want to put label id's on fields that aren't linked via progress circle); handles cases
       # like Tool Keywords where the field label = accordion title
 

--- a/lib/json_schema_form/umm_form.rb
+++ b/lib/json_schema_form/umm_form.rb
@@ -299,7 +299,7 @@ class UmmForm < JsonObj
     end
   end
 
-  def field_title_differs_from_accordion_title?
+  def field_title_not_accordion_title?
     accordion_titles = Array.new
     json_form.parsed_json['forms'].each do |form|
       form['items'].each { |accordion| accordion_titles << accordion['title'] }
@@ -312,7 +312,15 @@ class UmmForm < JsonObj
     value = parsed_json.fetch('key','').split('/').first
     value = parsed_json.fetch('key','').split('/')[1] if value.blank?
 
-    if value == top_key && !parsed_json['noLabel'] && field_title_differs_from_accordion_title?
+    # note: field != form != accordion in the context of the below comment:
+    # value == top_key: checks if the label is a top-level field (we don't want to put label id's on fields that aren't
+      # linked via progress circle)
+    # !parsed_json['noLabel']: there are no progress circles that link to fields with a truthy 'noLabel' key.
+    # field_title_differs_from_accordion_title?: makes sure the fields that share the same title as their accordion don't
+      # get a label_id (we don't want to put label id's on fields that aren't linked via progress circle); handles cases
+      # like Tool Keywords where the field label = accordion title
+
+    if value == top_key && !parsed_json['noLabel'] && field_title_not_accordion_title?
       top_key.underscore.dasherize + '-label'
     else
       nil
@@ -320,6 +328,13 @@ class UmmForm < JsonObj
   end
 
   def anchor
+    # !parsed_json['noLabel']: if noLabel = true, then we know the accordion_id should be anchored because there are no
+      # progress circles that link to fields with a truthy 'noLabel' key.
+    # parsed_json['field']: if the form fragment has a falsy 'field' key, we know the accordion_id should be anchored,
+      # because there are no accordions that have a truthy 'field' key (if they even have one)
+    # These ^ are preliminary checks to ensure that a label_id *could* be the correct anchor - the conditionals in label_id will
+    # further determine if a label_id is the appropriate anchor (by returning nil or not)
+
     if parsed_json.fetch('type','').include?('accordion')
       accordion_id
     elsif !parsed_json['noLabel'] || parsed_json['field']

--- a/spec/features/service_drafts/preview/empty/descriptive_keywords_preview_spec.rb
+++ b/spec/features/service_drafts/preview/empty/descriptive_keywords_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Empty Service Draft Descriptive Keywords Preview' do
   it 'displays the correct progress indicators for required fields' do
     within '#descriptive_keywords-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-required-o.icon-green.service-keywords')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'descriptive_keywords', anchor: 'service-keywords'))
     end
   end
 
@@ -49,6 +50,7 @@ describe 'Empty Service Draft Descriptive Keywords Preview' do
   it 'displays the correct progress indicators for non required fields' do
     within '#descriptive_keywords-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.ancillary-keywords')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'descriptive_keywords', anchor: 'ancillary-keywords'))
     end
   end
 end

--- a/spec/features/service_drafts/preview/empty/operation_metadata_preview_spec.rb
+++ b/spec/features/service_drafts/preview/empty/operation_metadata_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Empty Service Draft Operation Metadata Preview' do
   it 'displays the correct progress indicators for non required fields' do
     within '#operation_metadata-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.operation-metadata')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'operation_metadata', anchor: 'operation-metadata'))
     end
   end
 end

--- a/spec/features/service_drafts/preview/empty/options_preview_spec.rb
+++ b/spec/features/service_drafts/preview/empty/options_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Empty Service Draft Options Preview' do
   it 'displays the correct progress indicators for non required fields' do
     within '#options-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.service-options')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'options', anchor: 'service-options'))
     end
   end
 end

--- a/spec/features/service_drafts/preview/empty/service_contacts_preview_spec.rb
+++ b/spec/features/service_drafts/preview/empty/service_contacts_preview_spec.rb
@@ -26,6 +26,8 @@ describe 'Empty Service Draft Service Contacts Preview' do
     within '#service_contacts-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.contact-groups')
       expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.contact-persons')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_contacts', anchor: 'contact-groups'))
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_contacts', anchor: 'contact-persons'))
     end
   end
 

--- a/spec/features/service_drafts/preview/empty/service_identification_preview_spec.rb
+++ b/spec/features/service_drafts/preview/empty/service_identification_preview_spec.rb
@@ -27,6 +27,9 @@ describe 'Empty Service Draft Service Identification Preview' do
       expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.service-quality')
       expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.access-constraints')
       expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.use-constraints')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_identification', anchor: 'service-quality'))
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_identification', anchor: 'access-constraints'))
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_identification', anchor: 'use-constraints'))
     end
   end
 

--- a/spec/features/service_drafts/preview/empty/service_information_preview_spec.rb
+++ b/spec/features/service_drafts/preview/empty/service_information_preview_spec.rb
@@ -23,12 +23,13 @@ describe 'Empty Service Draft Service Information Preview' do
   end
 
   it 'displays the correct progress indicators for required fields' do
+    anchors = ['name-label','long-name-label','type-label','version-label','description-label']
+
     within '#service_information-progress .progress-indicators' do
-      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name-label')
-      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name-label')
-      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.type-label')
-      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.version-label')
-      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.description-label')
+      anchors.each do |anchor|
+        expect(page).to have_css(".eui-icon.eui-required-o.icon-green.#{anchor}")
+        expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: anchor))
+      end
     end
   end
 

--- a/spec/features/service_drafts/preview/empty/service_information_preview_spec.rb
+++ b/spec/features/service_drafts/preview/empty/service_information_preview_spec.rb
@@ -24,11 +24,11 @@ describe 'Empty Service Draft Service Information Preview' do
 
   it 'displays the correct progress indicators for required fields' do
     within '#service_information-progress .progress-indicators' do
-      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name')
-      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name')
-      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.type')
-      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.version')
-      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.description')
+      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name-label')
+      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name-label')
+      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.type-label')
+      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.version-label')
+      expect(page).to have_css('.eui-icon.eui-required-o.icon-green.description-label')
     end
   end
 

--- a/spec/features/service_drafts/preview/empty/service_information_preview_spec.rb
+++ b/spec/features/service_drafts/preview/empty/service_information_preview_spec.rb
@@ -7,89 +7,90 @@ describe 'Empty Service Draft Service Information Preview' do
   end
 
   context 'When examining the Service Information section' do
+    let(:anchors) { %w[name-label long-name-label type-label version-label description-label] }
+
     it 'displays the form title as an edit link' do
       within '#service_information-progress' do
         expect(page).to have_link('Service Information', href: edit_service_draft_path(service_draft, 'service_information'))
       end
     end
-  end
 
-  it 'displays the correct status icon' do
-    within '#service_information-progress' do
-      within '.status' do
-        expect(page).to have_content('Service Information is incomplete')
+
+    it 'displays the correct status icon' do
+      within '#service_information-progress' do
+        within '.status' do
+          expect(page).to have_content('Service Information is incomplete')
+        end
       end
     end
-  end
 
-  it 'displays the correct progress indicators for required fields' do
-    anchors = ['name-label','long-name-label','type-label','version-label','description-label']
-
-    within '#service_information-progress .progress-indicators' do
-      anchors.each do |anchor|
-        expect(page).to have_css(".eui-icon.eui-required-o.icon-green.#{anchor}")
-        expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: anchor))
+    it 'displays the correct progress indicators for required fields' do
+      within '#service_information-progress .progress-indicators' do
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-required-o.icon-green.#{anchor}")
+          expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: anchor))
+        end
       end
     end
-  end
 
-  it 'displays the stored values correctly within the preview' do
-    within '.umm-preview.service_information' do
-      expect(page).to have_css('.umm-preview-field-container', count: 8)
+    it 'displays the stored values correctly within the preview' do
+      within '.umm-preview.service_information' do
+        expect(page).to have_css('.umm-preview-field-container', count: 8)
 
-      within '#service_draft_draft_name_preview' do
-        expect(page).to have_css('h5', text: 'Name')
-        expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_name'))
+        within '#service_draft_draft_name_preview' do
+          expect(page).to have_css('h5', text: 'Name')
+          expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_name'))
 
-        expect(page).to have_css('p', text: 'No value for Name provided.')
-      end
+          expect(page).to have_css('p', text: 'No value for Name provided.')
+        end
 
-      within '#service_draft_draft_long_name_preview' do
-        expect(page).to have_css('h5', text: 'Long Name')
-        expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_long_name'))
+        within '#service_draft_draft_long_name_preview' do
+          expect(page).to have_css('h5', text: 'Long Name')
+          expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_long_name'))
 
-        expect(page).to have_css('p', text: 'No value for Long Name provided.')
-      end
+          expect(page).to have_css('p', text: 'No value for Long Name provided.')
+        end
 
-      within '#service_draft_draft_type_preview' do
-        expect(page).to have_css('h5', text: 'Type')
-        expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_type'))
+        within '#service_draft_draft_type_preview' do
+          expect(page).to have_css('h5', text: 'Type')
+          expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_type'))
 
-        expect(page).to have_css('p', text: 'No value for Type provided.')
-      end
+          expect(page).to have_css('p', text: 'No value for Type provided.')
+        end
 
-      within '#service_draft_draft_version_preview' do
-        expect(page).to have_css('h5', text: 'Version')
-        expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_version'))
+        within '#service_draft_draft_version_preview' do
+          expect(page).to have_css('h5', text: 'Version')
+          expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_version'))
 
-        expect(page).to have_css('p', text: 'No value for Version provided.')
-      end
+          expect(page).to have_css('p', text: 'No value for Version provided.')
+        end
 
-      within '#service_draft_draft_description_preview' do
-        expect(page).to have_css('h5', text: 'Description')
-        expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_description'))
+        within '#service_draft_draft_description_preview' do
+          expect(page).to have_css('h5', text: 'Description')
+          expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_description'))
 
-        expect(page).to have_css('p', text: 'No value for Description provided.')
-      end
+          expect(page).to have_css('p', text: 'No value for Description provided.')
+        end
 
-      within '#service_draft_draft_version_description_preview' do
-        expect(page).to have_css('h5', text: 'Version Description')
-        expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_version_description'))
+        within '#service_draft_draft_version_description_preview' do
+          expect(page).to have_css('h5', text: 'Version Description')
+          expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_version_description'))
 
-        expect(page).to have_css('p', text: 'No value for Version Description provided.')
-      end
+          expect(page).to have_css('p', text: 'No value for Version Description provided.')
+        end
 
-      within '#service_draft_draft_last_updated_date_preview' do
-        expect(page).to have_css('h5', text: 'Last Updated Date')
-        expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_last_updated_date'))
+        within '#service_draft_draft_last_updated_date_preview' do
+          expect(page).to have_css('h5', text: 'Last Updated Date')
+          expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_last_updated_date'))
 
-        expect(page).to have_css('p', text: 'No value for Last Updated Date provided.')
-      end
+          expect(page).to have_css('p', text: 'No value for Last Updated Date provided.')
+        end
 
-      within '#service_draft_draft_url_preview' do
-        expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_url'))
+        within '#service_draft_draft_url_preview' do
+          expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: 'service_draft_draft_url'))
 
-        expect(page).to have_css('p', text: 'No value for URL provided')
+          expect(page).to have_css('p', text: 'No value for URL provided')
+        end
       end
     end
   end

--- a/spec/features/service_drafts/preview/empty/service_organizations_preview_spec.rb
+++ b/spec/features/service_drafts/preview/empty/service_organizations_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Empty Service Draft Service Organizations Preview' do
   it 'displays the correct progress indicators for required fields' do
     within '#service_organizations-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-required-o.icon-green.service-organizations')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_organizations', anchor: 'service-organizations'))
     end
   end
 

--- a/spec/features/service_drafts/preview/invalid/descriptive_keywords_preview_spec.rb
+++ b/spec/features/service_drafts/preview/invalid/descriptive_keywords_preview_spec.rb
@@ -18,6 +18,8 @@ describe 'Invalid Service Draft Descriptive Keywords Preview' do
     within '#descriptive_keywords-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.service-keywords')
       expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.ancillary-keywords')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'descriptive_keywords', anchor: 'service-keywords'))
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'descriptive_keywords', anchor: 'ancillary-keywords'))
     end
   end
 

--- a/spec/features/service_drafts/preview/invalid/operation_metadata_preview_spec.rb
+++ b/spec/features/service_drafts/preview/invalid/operation_metadata_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Invalid Service Draft Operation Metadata Preview' do
   it 'displays the correct progress indicators for non required fields' do
     within '#operation_metadata-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.operation-metadata')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'operation_metadata', anchor: 'operation-metadata'))
     end
   end
 end

--- a/spec/features/service_drafts/preview/invalid/options_preview_spec.rb
+++ b/spec/features/service_drafts/preview/invalid/options_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Invalid Service Draft Options Preview' do
   it 'displays the correct progress indicators for non required fields' do
     within '#options-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.service-options')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'options', anchor: 'service-options'))
     end
   end
 end

--- a/spec/features/service_drafts/preview/invalid/service_contacts_preview_spec.rb
+++ b/spec/features/service_drafts/preview/invalid/service_contacts_preview_spec.rb
@@ -27,6 +27,8 @@ describe 'Invalid Service Draft Service Contacts Preview' do
     within '#service_contacts-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.contact-groups')
       expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.contact-persons')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_contacts', anchor: 'contact-groups'))
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_contacts', anchor: 'contact-persons'))
     end
   end
 

--- a/spec/features/service_drafts/preview/invalid/service_identification_preview_spec.rb
+++ b/spec/features/service_drafts/preview/invalid/service_identification_preview_spec.rb
@@ -28,6 +28,9 @@ describe 'Invalid Service Draft Service Identification Preview' do
       expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.service-quality')
       expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.access-constraints')
       expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.use-constraints')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_identification', anchor: 'service-quality'))
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_identification', anchor: 'access-constraints'))
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_identification', anchor: 'use-constraints'))
     end
   end
 

--- a/spec/features/service_drafts/preview/invalid/service_information_preview_spec.rb
+++ b/spec/features/service_drafts/preview/invalid/service_information_preview_spec.rb
@@ -24,11 +24,11 @@ describe 'Invalid Service Draft Service Information Preview' do
 
     it 'displays the correct progress indicators for invalid fields' do
       within '#service_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.name')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.long-name')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.type')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.version')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.description')
+        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.name-label')
+        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.long-name-label')
+        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.type-label')
+        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.version-label')
+        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.description-label')
         expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.url')
       end
     end

--- a/spec/features/service_drafts/preview/invalid/service_information_preview_spec.rb
+++ b/spec/features/service_drafts/preview/invalid/service_information_preview_spec.rb
@@ -23,13 +23,13 @@ describe 'Invalid Service Draft Service Information Preview' do
     end
 
     it 'displays the correct progress indicators for invalid fields' do
+      anchors = ['name-label','long-name-label','type-label','version-label','description-label','url']
+
       within '#service_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.name-label')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.long-name-label')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.type-label')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.version-label')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.description-label')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.url')
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-fa-minus-circle.icon-red.#{anchor}")
+          expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: anchor))
+        end
       end
     end
 

--- a/spec/features/service_drafts/preview/invalid/service_information_preview_spec.rb
+++ b/spec/features/service_drafts/preview/invalid/service_information_preview_spec.rb
@@ -1,6 +1,6 @@
 describe 'Invalid Service Draft Service Information Preview' do
   let(:service_draft) { create(:invalid_service_draft, user: User.where(urs_uid: 'testuser').first) }
-  let(:draft) { service_draft.draft }
+  let(:draft)         { service_draft.draft }
 
   before do
     login
@@ -8,6 +8,8 @@ describe 'Invalid Service Draft Service Information Preview' do
   end
 
   context 'When examining the Service Information section' do
+    let(:anchors) { %w[name-label long-name-label type-label version-label description-label url] }
+
     it 'displays the form title as an edit link' do
       within '#service_information-progress' do
         expect(page).to have_link('Service Information', href: edit_service_draft_path(service_draft, 'service_information'))
@@ -23,8 +25,6 @@ describe 'Invalid Service Draft Service Information Preview' do
     end
 
     it 'displays the correct progress indicators for invalid fields' do
-      anchors = ['name-label','long-name-label','type-label','version-label','description-label','url']
-
       within '#service_information-progress .progress-indicators' do
         anchors.each do |anchor|
           expect(page).to have_css(".eui-icon.eui-fa-minus-circle.icon-red.#{anchor}")

--- a/spec/features/service_drafts/preview/invalid/service_organizations_preview_spec.rb
+++ b/spec/features/service_drafts/preview/invalid/service_organizations_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Invalid Service Draft Service Organizations Preview' do
   it 'displays the correct progress indicators for required fields' do
     within '#service_organizations-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.service-organizations')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_organizations', anchor: 'service-organizations'))
     end
   end
 

--- a/spec/features/service_drafts/preview/valid/descriptive_keywords_preview_spec.rb
+++ b/spec/features/service_drafts/preview/valid/descriptive_keywords_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Valid Service Draft Descriptive Keywords Preview' do
   it 'displays the correct progress indicators for required fields' do
     within '#descriptive_keywords-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-required.icon-green.service-keywords')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'descriptive_keywords', anchor: 'service-keywords'))
     end
   end
 
@@ -47,6 +48,7 @@ describe 'Valid Service Draft Descriptive Keywords Preview' do
   it 'displays the correct progress indicators for non required fields' do
     within '#descriptive_keywords-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.ancillary-keywords')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'descriptive_keywords', anchor: 'ancillary-keywords'))
     end
   end
 end

--- a/spec/features/service_drafts/preview/valid/operation_metadata_preview_spec.rb
+++ b/spec/features/service_drafts/preview/valid/operation_metadata_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Valid Service Draft Operation Metadata Preview' do
   it 'displays the correct progress indicators for non required fields' do
     within '#operation_metadata-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.operation-metadata')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'operation_metadata', anchor: 'operation-metadata'))
     end
   end
 end

--- a/spec/features/service_drafts/preview/valid/options_preview_spec.rb
+++ b/spec/features/service_drafts/preview/valid/options_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Valid Service Draft Options Preview' do
   it 'displays the correct progress indicators for non required fields' do
     within '#options-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.service-options')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'options', anchor: 'service-options'))
     end
   end
 end

--- a/spec/features/service_drafts/preview/valid/service_contacts_preview_spec.rb
+++ b/spec/features/service_drafts/preview/valid/service_contacts_preview_spec.rb
@@ -27,6 +27,8 @@ describe 'Valid Service Draft Service Contacts Preview' do
     within '#service_contacts-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.contact-groups')
       expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.contact-persons')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_contacts', anchor: 'contact-groups'))
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_contacts', anchor: 'contact-persons'))
     end
   end
 

--- a/spec/features/service_drafts/preview/valid/service_identification_preview_spec.rb
+++ b/spec/features/service_drafts/preview/valid/service_identification_preview_spec.rb
@@ -28,6 +28,9 @@ describe 'Valid Service Draft Service Identification Preview' do
       expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.service-quality')
       expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.access-constraints')
       expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.use-constraints')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_identification', anchor: 'service-quality'))
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_identification', anchor: 'access-constraints'))
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_identification', anchor: 'use-constraints'))
     end
   end
 

--- a/spec/features/service_drafts/preview/valid/service_information_preview_spec.rb
+++ b/spec/features/service_drafts/preview/valid/service_information_preview_spec.rb
@@ -27,11 +27,11 @@ describe 'Valid Service Draft Service Information Preview' do
 
     it 'displays the correct progress indicators for required fields' do
       within '#service_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.name')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.long-name')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.type')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.version')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.description')
+        expect(page).to have_css('.eui-icon.eui-required.icon-green.name-label')
+        expect(page).to have_css('.eui-icon.eui-required.icon-green.long-name-label')
+        expect(page).to have_css('.eui-icon.eui-required.icon-green.type-label')
+        expect(page).to have_css('.eui-icon.eui-required.icon-green.version-label')
+        expect(page).to have_css('.eui-icon.eui-required.icon-green.description-label')
       end
     end
 

--- a/spec/features/service_drafts/preview/valid/service_information_preview_spec.rb
+++ b/spec/features/service_drafts/preview/valid/service_information_preview_spec.rb
@@ -1,12 +1,14 @@
 describe 'Valid Service Draft Service Information Preview' do
   let(:service_draft) { create(:full_service_draft, draft_entry_title: 'Volume mixing ratio of sum of peroxynitrates in air', draft_short_name: 'PNs_LIF', user: User.where(urs_uid: 'testuser').first) }
-  let(:draft) { service_draft.draft }
+  let(:draft)         { service_draft.draft }
 
   before do
     login
   end
 
   context 'When examining the Service Information section' do
+    let(:anchors) { %w[name-label long-name-label type-label version-label description-label] }
+
     before do
       visit service_draft_path(service_draft)
     end
@@ -26,8 +28,6 @@ describe 'Valid Service Draft Service Information Preview' do
     end
 
     it 'displays the correct progress indicators for required fields' do
-      anchors = ['name-label','long-name-label','type-label','version-label','description-label']
-
       within '#service_information-progress .progress-indicators' do
         anchors.each do |anchor|
           expect(page).to have_css(".eui-icon.eui-required.icon-green.#{anchor}")

--- a/spec/features/service_drafts/preview/valid/service_information_preview_spec.rb
+++ b/spec/features/service_drafts/preview/valid/service_information_preview_spec.rb
@@ -26,12 +26,13 @@ describe 'Valid Service Draft Service Information Preview' do
     end
 
     it 'displays the correct progress indicators for required fields' do
+      anchors = ['name-label','long-name-label','type-label','version-label','description-label']
+
       within '#service_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.name-label')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.long-name-label')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.type-label')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.version-label')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.description-label')
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-required.icon-green.#{anchor}")
+          expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_information', anchor: anchor))
+        end
       end
     end
 

--- a/spec/features/service_drafts/preview/valid/service_organizations_preview_spec.rb
+++ b/spec/features/service_drafts/preview/valid/service_organizations_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Valid Service Draft Service Organizations Preview' do
   it 'displays the correct progress indicators for required fields' do
     within '#service_organizations-progress .progress-indicators' do
       expect(page).to have_css('.eui-icon.eui-required.icon-green.service-organizations')
+      expect(page).to have_link(nil, href: edit_service_draft_path(service_draft, 'service_organizations', anchor: 'service-organizations'))
     end
   end
 

--- a/spec/features/tool_drafts/preview/empty/compatability_and_usability_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/empty/compatability_and_usability_preview_spec.rb
@@ -8,6 +8,8 @@ describe 'Empty Tool Draft Compatibility and Usability Preview' do
 
   context 'when examining the Compatibility and Usability sections' do
     context 'when examining the progress circles section' do
+      let(:anchors) { %w[supported-input-formats-label supported-output-formats-label supported-operating-systems supported-browsers supported-software-languages quality access-constraints-label use-constraints] }
+
       it 'displays the form title as an edit link' do
         within '#compatibility_and_usability-progress' do
           expect(page).to have_link('Compatibility and Usability', href: edit_tool_draft_path(tool_draft, 'compatibility_and_usability'))
@@ -23,11 +25,6 @@ describe 'Empty Tool Draft Compatibility and Usability Preview' do
       end
 
       it 'displays the correct progress indicators for non required fields' do
-        anchors = [
-          'supported-input-formats-label','supported-output-formats-label','supported-operating-systems',
-          'supported-browsers','supported-software-languages','quality','access-constraints-label','use-constraints'
-        ]
-
         within '#compatibility_and_usability-progress .progress-indicators' do
           anchors.each do |anchor|
             expect(page).to have_css(".eui-icon.eui-fa-circle-o.icon-grey.#{anchor}")

--- a/spec/features/tool_drafts/preview/empty/compatability_and_usability_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/empty/compatability_and_usability_preview_spec.rb
@@ -24,13 +24,13 @@ describe 'Empty Tool Draft Compatibility and Usability Preview' do
 
       it 'displays the correct progress indicators for non required fields' do
         within '#compatibility_and_usability-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-input-formats')
-          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-output-formats')
+          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-input-formats-label')
+          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-output-formats-label')
           expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-operating-systems')
           expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-browsers')
           expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-software-languages')
           expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.quality')
-          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.access-constraints')
+          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.access-constraints-label')
           expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.use-constraints')
         end
       end

--- a/spec/features/tool_drafts/preview/empty/compatability_and_usability_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/empty/compatability_and_usability_preview_spec.rb
@@ -23,15 +23,16 @@ describe 'Empty Tool Draft Compatibility and Usability Preview' do
       end
 
       it 'displays the correct progress indicators for non required fields' do
+        anchors = [
+          'supported-input-formats-label','supported-output-formats-label','supported-operating-systems',
+          'supported-browsers','supported-software-languages','quality','access-constraints-label','use-constraints'
+        ]
+
         within '#compatibility_and_usability-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-input-formats-label')
-          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-output-formats-label')
-          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-operating-systems')
-          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-browsers')
-          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.supported-software-languages')
-          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.quality')
-          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.access-constraints-label')
-          expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.use-constraints')
+          anchors.each do |anchor|
+            expect(page).to have_css(".eui-icon.eui-fa-circle-o.icon-grey.#{anchor}")
+            expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'compatibility_and_usability', anchor: anchor))
+          end
         end
       end
     end

--- a/spec/features/tool_drafts/preview/empty/descriptive_keywords_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/empty/descriptive_keywords_preview_spec.rb
@@ -25,12 +25,14 @@ describe 'Empty Tool Draft Descriptive Keywords Preview' do
       it 'displays the correct progress indicators for required fields' do
         within '#descriptive_keywords-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-required-o.icon-green.tool-keywords')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'descriptive_keywords', anchor: 'tool-keywords'))
         end
       end
 
       it 'displays the correct progress indicators for non required fields' do
         within '#descriptive_keywords-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.ancillary-keywords')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'descriptive_keywords', anchor: 'ancillary-keywords'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/empty/related_urls_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/empty/related_urls_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Empty Tool Draft Related URL Preview' do
       it 'displays the correct progress indicators for non required fields' do
         within '#related_urls-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.related-urls')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'related_urls', anchor: 'related-urls'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/empty/smart_handoff_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/empty/smart_handoff_information_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Empty Tool Draft Smart Handoff Information Preview' do
       it 'displays the correct progress indicators for non required fields' do
         within '#smart_handoff_information-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.search-action')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'smart_handoff_information', anchor: 'search-action'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/empty/tool_contacts_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/empty/tool_contacts_preview_spec.rb
@@ -26,6 +26,8 @@ describe 'Empty Tool Draft Tool Contacts Preview' do
         within '#tool_contacts-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.contact-groups')
           expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.contact-persons')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_contacts', anchor: 'contact-groups'))
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_contacts', anchor: 'contact-persons'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/empty/tool_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/empty/tool_information_preview_spec.rb
@@ -23,20 +23,23 @@ describe 'Empty Tool Draft Tool Information Preview' do
       end
 
       it 'displays the correct progress indicators for required fields' do
+        anchors = ['name-label','long-name-label','version-label','type-label','description-label','url']
+
         within '#tool_information-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name-label')
-          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name-label')
-          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.version-label')
-          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.type-label')
-          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.description-label')
-          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.url')
+          anchors.each do |anchor|
+            expect(page).to have_css(".eui-icon.eui-required-o.icon-green.#{anchor}")
+            expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_information', anchor: anchor))
+          end
         end
       end
 
       it 'displays the correct progress indicators for non required fields' do
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.version-description-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.last-updated-date-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.doi-label')
+        anchors = ['version-description-label','last-updated-date-label','doi-label']
+
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-fa-circle-o.icon-grey.#{anchor}")
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_information', anchor: anchor))
+        end
       end
     end
 

--- a/spec/features/tool_drafts/preview/empty/tool_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/empty/tool_information_preview_spec.rb
@@ -24,19 +24,19 @@ describe 'Empty Tool Draft Tool Information Preview' do
 
       it 'displays the correct progress indicators for required fields' do
         within '#tool_information-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name')
-          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name')
-          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.version')
-          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.type')
-          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.description')
+          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name-label')
+          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name-label')
+          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.version-label')
+          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.type-label')
+          expect(page).to have_css('.eui-icon.eui-required-o.icon-green.description-label')
           expect(page).to have_css('.eui-icon.eui-required-o.icon-green.url')
         end
       end
 
       it 'displays the correct progress indicators for non required fields' do
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.version-description')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.last-updated-date')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.doi')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.version-description-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.last-updated-date-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.doi-label')
       end
     end
 

--- a/spec/features/tool_drafts/preview/empty/tool_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/empty/tool_information_preview_spec.rb
@@ -1,5 +1,5 @@
 describe 'Empty Tool Draft Tool Information Preview' do
-  let(:tool_draft) { create(:empty_tool_draft, user: User.where(urs_uid: 'testuser').first) }
+  let(:tool_draft)      { create(:empty_tool_draft, user: User.where(urs_uid: 'testuser').first) }
 
   before do
     login
@@ -8,6 +8,9 @@ describe 'Empty Tool Draft Tool Information Preview' do
 
   context 'when examining the Tool Information sections' do
     context 'when examining the progress circles section' do
+      let(:anchors_req)     { %w[name-label long-name-label version-label type-label description-label url] }
+      let(:anchors_non_req) { %w[version-description-label last-updated-date-label doi-label] }
+
       it 'displays the form title as an edit link' do
         within '#tool_information-progress' do
           expect(page).to have_link('Tool Information', href: edit_tool_draft_path(tool_draft, 'tool_information'))
@@ -23,10 +26,8 @@ describe 'Empty Tool Draft Tool Information Preview' do
       end
 
       it 'displays the correct progress indicators for required fields' do
-        anchors = ['name-label','long-name-label','version-label','type-label','description-label','url']
-
         within '#tool_information-progress .progress-indicators' do
-          anchors.each do |anchor|
+          anchors_req.each do |anchor|
             expect(page).to have_css(".eui-icon.eui-required-o.icon-green.#{anchor}")
             expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_information', anchor: anchor))
           end
@@ -34,9 +35,7 @@ describe 'Empty Tool Draft Tool Information Preview' do
       end
 
       it 'displays the correct progress indicators for non required fields' do
-        anchors = ['version-description-label','last-updated-date-label','doi-label']
-
-        anchors.each do |anchor|
+        anchors_non_req.each do |anchor|
           expect(page).to have_css(".eui-icon.eui-fa-circle-o.icon-grey.#{anchor}")
           expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_information', anchor: anchor))
         end

--- a/spec/features/tool_drafts/preview/empty/tool_organizations_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/empty/tool_organizations_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Empty Tool Draft Tool Organizations Preview' do
       it 'displays the correct progress indicators for required fields' do
         within '#tool_organizations-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-required-o.icon-green.organizations')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_organizations', anchor: 'organizations'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/invalid/compatability_and_usability_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/invalid/compatability_and_usability_preview_spec.rb
@@ -1,6 +1,6 @@
 describe 'Invalid Tool Draft Compatibility and Usability Preview' do
   let(:tool_draft) { create(:invalid_tool_draft, user: User.where(urs_uid: 'testuser').first) }
-  let(:draft) { tool_draft.draft }
+  let(:draft)      { tool_draft.draft }
 
   before do
     login
@@ -9,6 +9,8 @@ describe 'Invalid Tool Draft Compatibility and Usability Preview' do
 
   context 'when examining the Compatibility and Usability sections' do
     context 'when examining the progress circles section' do
+      let(:anchors) { %w[supported-input-formats-label supported-output-formats-label supported-operating-systems supported-browsers supported-software-languages quality access-constraints-label use-constraints] }
+
       it 'displays the form title as an edit link' do
         within '#compatibility_and_usability-progress' do
           expect(page).to have_link('Compatibility and Usability', href: edit_tool_draft_path(tool_draft, 'compatibility_and_usability'))
@@ -24,11 +26,6 @@ describe 'Invalid Tool Draft Compatibility and Usability Preview' do
       end
 
       it 'displays the correct progress indicators for non required fields' do
-        anchors = [
-          'supported-input-formats-label','supported-output-formats-label','supported-operating-systems',
-          'supported-browsers','supported-software-languages','quality','access-constraints-label','use-constraints'
-        ]
-
         within '#compatibility_and_usability-progress .progress-indicators' do
           anchors.each do |anchor|
             expect(page).to have_css(".eui-icon.eui-fa-minus-circle.icon-red.#{anchor}")

--- a/spec/features/tool_drafts/preview/invalid/compatability_and_usability_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/invalid/compatability_and_usability_preview_spec.rb
@@ -24,15 +24,16 @@ describe 'Invalid Tool Draft Compatibility and Usability Preview' do
       end
 
       it 'displays the correct progress indicators for non required fields' do
+        anchors = [
+          'supported-input-formats-label','supported-output-formats-label','supported-operating-systems',
+          'supported-browsers','supported-software-languages','quality','access-constraints-label','use-constraints'
+        ]
+
         within '#compatibility_and_usability-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-input-formats-label')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-output-formats-label')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-operating-systems')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-browsers')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-software-languages')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.quality')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.access-constraints-label')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.use-constraints')
+          anchors.each do |anchor|
+            expect(page).to have_css(".eui-icon.eui-fa-minus-circle.icon-red.#{anchor}")
+            expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'compatibility_and_usability', anchor: anchor))
+          end
         end
       end
     end

--- a/spec/features/tool_drafts/preview/invalid/compatability_and_usability_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/invalid/compatability_and_usability_preview_spec.rb
@@ -25,13 +25,13 @@ describe 'Invalid Tool Draft Compatibility and Usability Preview' do
 
       it 'displays the correct progress indicators for non required fields' do
         within '#compatibility_and_usability-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-input-formats')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-output-formats')
+          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-input-formats-label')
+          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-output-formats-label')
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-operating-systems')
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-browsers')
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.supported-software-languages')
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.quality')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.access-constraints')
+          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.access-constraints-label')
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.use-constraints')
         end
       end

--- a/spec/features/tool_drafts/preview/invalid/descriptive_keywords_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/invalid/descriptive_keywords_preview_spec.rb
@@ -27,6 +27,8 @@ describe 'Inalid Tool Draft Descriptive Keywords Preview' do
         within '#descriptive_keywords-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.tool-keywords')
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.ancillary-keywords')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'descriptive_keywords', anchor: 'tool-keywords'))
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'descriptive_keywords', anchor: 'ancillary-keywords'))
         end
       end
 

--- a/spec/features/tool_drafts/preview/invalid/related_urls_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/invalid/related_urls_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Invalid Tool Draft Related URL Preview' do
       it 'displays the correct progress indicators for invalid fields' do
         within '#related_urls-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.related-urls')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'related_urls', anchor: 'related-urls'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/invalid/smart_handoff_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/invalid/smart_handoff_information_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Invalid Tool Draft Smart Handoff Information Preview' do
       it 'displays the correct progress indicators for non required fields' do
         within '#smart_handoff_information-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.search-action')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'smart_handoff_information', anchor: 'search-action'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/invalid/tool_contacts_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/invalid/tool_contacts_preview_spec.rb
@@ -27,6 +27,8 @@ describe 'Invalid Tool Draft Tool Contacts Preview' do
         within '#tool_contacts-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.contact-groups')
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.contact-persons')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_contacts', anchor: 'contact-groups'))
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_contacts', anchor: 'contact-persons'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/invalid/tool_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/invalid/tool_information_preview_spec.rb
@@ -1,6 +1,6 @@
 describe 'Invalid Tool Draft Tool Information Preview' do
   let(:tool_draft) { create(:invalid_tool_draft, user: User.where(urs_uid: 'testuser').first) }
-  let(:draft) { tool_draft.draft }
+  let(:draft)      { tool_draft.draft }
 
   before do
     login
@@ -9,6 +9,8 @@ describe 'Invalid Tool Draft Tool Information Preview' do
 
   context 'when examining the Tool Information sections' do
     context 'when examining the progress circles section' do
+      let(:anchors) { %w[name-label long-name-label version-label version-description-label type-label last-updated-date-label description-label doi-label url] }
+
       it 'displays the form title as an edit link' do
         within '#tool_information-progress' do
           expect(page).to have_link('Tool Information', href: edit_tool_draft_path(tool_draft, 'tool_information'))
@@ -24,11 +26,6 @@ describe 'Invalid Tool Draft Tool Information Preview' do
       end
 
       it 'displays the correct progress indicators for invalid fields' do
-        anchors = [
-          'name-label','long-name-label','version-label','version-description-label',
-          'type-label','last-updated-date-label','description-label','doi-label','url'
-        ]
-
         within '#tool_information-progress .progress-indicators' do
           anchors.each do |anchor|
             expect(page).to have_css(".eui-icon.eui-fa-minus-circle.icon-red.#{anchor}")

--- a/spec/features/tool_drafts/preview/invalid/tool_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/invalid/tool_information_preview_spec.rb
@@ -24,16 +24,16 @@ describe 'Invalid Tool Draft Tool Information Preview' do
       end
 
       it 'displays the correct progress indicators for invalid fields' do
+        anchors = [
+          'name-label','long-name-label','version-label','version-description-label',
+          'type-label','last-updated-date-label','description-label','doi-label','url'
+        ]
+
         within '#tool_information-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.name-label')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.long-name-label')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.version-label')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.version-description-label')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.type-label')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.last-updated-date-label')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.description-label')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.doi-label')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.url')
+          anchors.each do |anchor|
+            expect(page).to have_css(".eui-icon.eui-fa-minus-circle.icon-red.#{anchor}")
+            expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_information', anchor: anchor))
+          end
         end
       end
     end

--- a/spec/features/tool_drafts/preview/invalid/tool_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/invalid/tool_information_preview_spec.rb
@@ -25,14 +25,14 @@ describe 'Invalid Tool Draft Tool Information Preview' do
 
       it 'displays the correct progress indicators for invalid fields' do
         within '#tool_information-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.name')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.long-name')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.version')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.version-description')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.type')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.last-updated-date')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.description')
-          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.doi')
+          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.name-label')
+          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.long-name-label')
+          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.version-label')
+          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.version-description-label')
+          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.type-label')
+          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.last-updated-date-label')
+          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.description-label')
+          expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.doi-label')
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.url')
         end
       end

--- a/spec/features/tool_drafts/preview/invalid/tool_organizations_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/invalid/tool_organizations_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Invalid Tool Draft Tool Organizations Preview' do
       it 'displays the correct progress indicators for invalid fields' do
         within '#tool_organizations-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.organizations')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_organizations', anchor: 'organizations'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/valid/compatability_and_usability_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/compatability_and_usability_preview_spec.rb
@@ -1,6 +1,6 @@
 describe 'Valid Tool Draft Compatibility and Usability Preview' do
   let(:tool_draft) { create(:full_tool_draft, user: User.where(urs_uid: 'testuser').first) }
-  let(:draft) { tool_draft.draft }
+  let(:draft)      { tool_draft.draft }
 
   before do
     login
@@ -9,6 +9,8 @@ describe 'Valid Tool Draft Compatibility and Usability Preview' do
 
   context 'when examining the Compatibility and Usability sections' do
     context 'when examining the progress circles section' do
+      let(:anchors) { %w[supported-input-formats-label supported-output-formats-label supported-operating-systems supported-browsers supported-software-languages quality access-constraints-label use-constraints] }
+
       it 'displays the form title as an edit link' do
         within '#compatibility_and_usability-progress' do
           expect(page).to have_link('Compatibility and Usability', href: edit_tool_draft_path(tool_draft, 'compatibility_and_usability'))
@@ -24,11 +26,6 @@ describe 'Valid Tool Draft Compatibility and Usability Preview' do
       end
 
       it 'displays the correct progress indicators for non required fields' do
-        anchors = [
-          'supported-input-formats-label','supported-output-formats-label','supported-operating-systems',
-          'supported-browsers','supported-software-languages','quality','access-constraints-label','use-constraints'
-        ]
-
         within '#compatibility_and_usability-progress .progress-indicators' do
           anchors.each do |anchor|
             expect(page).to have_css(".eui-icon.eui-fa-circle.icon-grey.#{anchor}")

--- a/spec/features/tool_drafts/preview/valid/compatability_and_usability_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/compatability_and_usability_preview_spec.rb
@@ -25,13 +25,13 @@ describe 'Valid Tool Draft Compatibility and Usability Preview' do
 
       it 'displays the correct progress indicators for non required fields' do
         within '#compatibility_and_usability-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-input-formats')
-          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-output-formats')
+          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-input-formats-label')
+          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-output-formats-label')
           expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-operating-systems')
           expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-browsers')
           expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-software-languages')
           expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.quality')
-          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.access-constraints')
+          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.access-constraints-label')
           expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.use-constraints')
         end
       end

--- a/spec/features/tool_drafts/preview/valid/compatability_and_usability_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/compatability_and_usability_preview_spec.rb
@@ -24,15 +24,16 @@ describe 'Valid Tool Draft Compatibility and Usability Preview' do
       end
 
       it 'displays the correct progress indicators for non required fields' do
+        anchors = [
+          'supported-input-formats-label','supported-output-formats-label','supported-operating-systems',
+          'supported-browsers','supported-software-languages','quality','access-constraints-label','use-constraints'
+        ]
+
         within '#compatibility_and_usability-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-input-formats-label')
-          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-output-formats-label')
-          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-operating-systems')
-          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-browsers')
-          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.supported-software-languages')
-          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.quality')
-          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.access-constraints-label')
-          expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.use-constraints')
+          anchors.each do |anchor|
+            expect(page).to have_css(".eui-icon.eui-fa-circle.icon-grey.#{anchor}")
+            expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'compatibility_and_usability', anchor: anchor))
+          end
         end
       end
     end

--- a/spec/features/tool_drafts/preview/valid/descriptive_keywords_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/descriptive_keywords_preview_spec.rb
@@ -25,12 +25,14 @@ describe 'Valid Tool Draft Descriptive Keywords Preview' do
       it 'displays the correct progress indicators for required fields' do
         within '#descriptive_keywords-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-required.icon-green.tool-keywords')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'descriptive_keywords', anchor: 'tool-keywords'))
         end
       end
 
       it 'displays the correct progress indicators for non required fields' do
         within '#descriptive_keywords-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.ancillary-keywords')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'descriptive_keywords', anchor: 'ancillary-keywords'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/valid/related_urls_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/related_urls_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Valid Tool Draft Related URL Preview' do
       it 'displays the correct progress indicators for non required fields' do
         within '#related_urls-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.related-urls')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'related_urls', anchor: 'related-urls'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/valid/smart_handoff_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/smart_handoff_information_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Valid Tool Draft Smart Handoff Information Preview' do
       it 'displays the correct progress indicators for non required fields' do
         within '#smart_handoff_information-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.search-action')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'smart_handoff_information', anchor: 'search-action'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/valid/tool_contacts_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/tool_contacts_preview_spec.rb
@@ -27,6 +27,8 @@ describe 'Valid Tool Draft Tool Contacts Preview' do
         within '#tool_contacts-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.contact-groups')
           expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.contact-persons')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_contacts', anchor: 'contact-groups'))
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_contacts', anchor: 'contact-persons'))
         end
       end
     end

--- a/spec/features/tool_drafts/preview/valid/tool_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/tool_information_preview_spec.rb
@@ -1,6 +1,6 @@
 describe 'Valid Tool Draft Tool Information Preview' do
-  let(:tool_draft) { create(:full_tool_draft, user: User.where(urs_uid: 'testuser').first) }
-  let(:draft) { tool_draft.draft }
+  let(:tool_draft)      { create(:full_tool_draft, user: User.where(urs_uid: 'testuser').first) }
+  let(:draft)           { tool_draft.draft }
 
   before do
     login
@@ -9,6 +9,9 @@ describe 'Valid Tool Draft Tool Information Preview' do
 
   context 'when examining the Tool Information sections' do
     context 'when examining the progress circles section' do
+      let(:anchors_req)     { %w[name-label long-name-label type-label version-label description-label url] }
+      let(:anchors_non_req) { %w[version-description-label last-updated-date-label doi-label] }
+
       it 'displays the form title as an edit link' do
         within '#tool_information-progress' do
           expect(page).to have_link('Tool Information', href: edit_tool_draft_path(tool_draft, 'tool_information'))
@@ -24,10 +27,8 @@ describe 'Valid Tool Draft Tool Information Preview' do
       end
 
       it 'displays the correct progress indicators for required fields' do
-        anchors = ['name-label','long-name-label','type-label','version-label','description-label','url']
-
         within '#tool_information-progress .progress-indicators' do
-          anchors.each do |anchor|
+          anchors_req.each do |anchor|
             expect(page).to have_css(".eui-icon.eui-required.icon-green.#{anchor}")
             expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_information', anchor: anchor))
           end
@@ -35,9 +36,7 @@ describe 'Valid Tool Draft Tool Information Preview' do
       end
 
       it 'displays the correct progress indicators for non required fields' do
-        anchors = ['version-description-label','last-updated-date-label','doi-label']
-
-        anchors.each do |anchor|
+        anchors_non_req.each do |anchor|
           expect(page).to have_css(".eui-icon.eui-fa-circle.icon-grey.#{anchor}")
           expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_information', anchor: anchor))
         end

--- a/spec/features/tool_drafts/preview/valid/tool_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/tool_information_preview_spec.rb
@@ -25,19 +25,19 @@ describe 'Valid Tool Draft Tool Information Preview' do
 
       it 'displays the correct progress indicators for required fields' do
         within '#tool_information-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-required.icon-green.name')
-          expect(page).to have_css('.eui-icon.eui-required.icon-green.long-name')
-          expect(page).to have_css('.eui-icon.eui-required.icon-green.type')
-          expect(page).to have_css('.eui-icon.eui-required.icon-green.version')
-          expect(page).to have_css('.eui-icon.eui-required.icon-green.description')
+          expect(page).to have_css('.eui-icon.eui-required.icon-green.name-label')
+          expect(page).to have_css('.eui-icon.eui-required.icon-green.long-name-label')
+          expect(page).to have_css('.eui-icon.eui-required.icon-green.type-label')
+          expect(page).to have_css('.eui-icon.eui-required.icon-green.version-label')
+          expect(page).to have_css('.eui-icon.eui-required.icon-green.description-label')
           expect(page).to have_css('.eui-icon.eui-required.icon-green.url')
         end
       end
 
       it 'displays the correct progress indicators for non required fields' do
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.version-description')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.last-updated-date')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.doi')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.version-description-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.last-updated-date-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.doi-label')
       end
     end
 

--- a/spec/features/tool_drafts/preview/valid/tool_information_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/tool_information_preview_spec.rb
@@ -24,20 +24,23 @@ describe 'Valid Tool Draft Tool Information Preview' do
       end
 
       it 'displays the correct progress indicators for required fields' do
+        anchors = ['name-label','long-name-label','type-label','version-label','description-label','url']
+
         within '#tool_information-progress .progress-indicators' do
-          expect(page).to have_css('.eui-icon.eui-required.icon-green.name-label')
-          expect(page).to have_css('.eui-icon.eui-required.icon-green.long-name-label')
-          expect(page).to have_css('.eui-icon.eui-required.icon-green.type-label')
-          expect(page).to have_css('.eui-icon.eui-required.icon-green.version-label')
-          expect(page).to have_css('.eui-icon.eui-required.icon-green.description-label')
-          expect(page).to have_css('.eui-icon.eui-required.icon-green.url')
+          anchors.each do |anchor|
+            expect(page).to have_css(".eui-icon.eui-required.icon-green.#{anchor}")
+            expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_information', anchor: anchor))
+          end
         end
       end
 
       it 'displays the correct progress indicators for non required fields' do
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.version-description-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.last-updated-date-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.doi-label')
+        anchors = ['version-description-label','last-updated-date-label','doi-label']
+
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-fa-circle.icon-grey.#{anchor}")
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_information', anchor: anchor))
+        end
       end
     end
 

--- a/spec/features/tool_drafts/preview/valid/tool_organizations_preview_spec.rb
+++ b/spec/features/tool_drafts/preview/valid/tool_organizations_preview_spec.rb
@@ -25,6 +25,7 @@ describe 'Valid Tool Draft Tool Organizations Preview' do
       it 'displays the correct progress indicators for required fields' do
         within '#tool_organizations-progress .progress-indicators' do
           expect(page).to have_css('.eui-icon.eui-required.icon-green.organizations')
+          expect(page).to have_link(nil, href: edit_tool_draft_path(tool_draft, 'tool_organizations', anchor: 'organizations'))
         end
       end
     end

--- a/spec/features/variable_drafts/preview/empty/dimensions_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/empty/dimensions_preview_spec.rb
@@ -23,6 +23,7 @@ describe 'Empty Variable Draft Dimensions Preview' do
     it 'displays the correct progress indicators for non-required fields' do
       within '#dimensions-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.dimensions')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'dimensions', anchor: 'dimensions'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/empty/fill_value_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/empty/fill_value_preview_spec.rb
@@ -29,6 +29,7 @@ describe 'Empty Variable Draft Fill Value Preview' do
     it 'displays the correct progress indicators for non required fields' do
       within '#fill_values-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.fill-values')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'fill_values', anchor: 'fill-values'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/empty/measurement_identifiers_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/empty/measurement_identifiers_preview_spec.rb
@@ -27,6 +27,7 @@ describe 'Empty Variable Draft Measurement Identifiers Preview' do
     it 'displays the correct progress indicators for non required fields' do
       within '#measurement_identifiers-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.measurement-identifiers')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'measurement_identifiers', anchor: 'measurement-identifiers'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/empty/sampling_identifiers_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/empty/sampling_identifiers_preview_spec.rb
@@ -27,6 +27,7 @@ describe 'Empty Variable Draft Sampling Identifiers Preview' do
     it 'displays the correct progress indicators for non required fields' do
       within '#sampling_identifiers-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.sampling-identifiers')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'sampling_identifiers', anchor: 'sampling-identifiers'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/empty/science_keywords_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/empty/science_keywords_preview_spec.rb
@@ -23,6 +23,7 @@ describe 'Empty Variable Draft Science Keywords Preview' do
     it 'displays no progress indicators for non required fields' do
       within '#science_keywords-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.science-keywords')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'science_keywords', anchor: 'science-keywords'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/empty/set_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/empty/set_preview_spec.rb
@@ -23,6 +23,7 @@ describe 'Empty Variable Draft Set Preview' do
     it 'displays the correct progress indicators for non-required fields' do
       within '#sets-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.sets')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'sets', anchor: 'sets'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/empty/variable_information_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/empty/variable_information_preview_spec.rb
@@ -6,6 +6,9 @@ describe 'Empty Variable Draft Variable Information Preview', js:true do
   end
 
   context 'When examining the Variable Information section' do
+    let(:anchors_req)      { %w[name-label long-name-label definition-label] }
+    let(:anchors_non_req) { %w[standard-name-label additional-identifiers-label variable-type-label variable-sub-type-label units-label data-type-label scale-label offset-label valid-ranges-label index-ranges-label]}
+
     it 'displays the form title as an edit link' do
       within '#variable_information-progress' do
         expect(page).to have_link('Variable Information', href: edit_variable_draft_path(@draft, 'variable_information'))
@@ -21,10 +24,8 @@ describe 'Empty Variable Draft Variable Information Preview', js:true do
     end
 
     it 'displays the correct progress indicators for required fields' do
-      anchors = ['name-label', 'long-name-label', 'definition-label']
-
       within '#variable_information-progress .progress-indicators' do
-        anchors.each do |anchor|
+        anchors_req.each do |anchor|
           expect(page).to have_css(".eui-icon.eui-required-o.icon-green.#{anchor}")
           expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
         end
@@ -32,13 +33,8 @@ describe 'Empty Variable Draft Variable Information Preview', js:true do
     end
 
     it 'displays the correct progress indicators for non required fields' do
-      anchors = [
-        'standard-name-label', 'additional-identifiers-label', 'variable-type-label', 'variable-sub-type-label',
-        'units-label', 'data-type-label', 'scale-label', 'offset-label', 'valid-ranges-label', 'index-ranges-label'
-      ]
-
       within '#variable_information-progress .progress-indicators' do
-        anchors.each do |anchor|
+        anchors_non_req.each do |anchor|
           expect(page).to have_css(".eui-icon.eui-fa-circle-o.icon-grey.#{anchor}")
           expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
         end

--- a/spec/features/variable_drafts/preview/empty/variable_information_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/empty/variable_information_preview_spec.rb
@@ -22,24 +22,24 @@ describe 'Empty Variable Draft Variable Information Preview', js:true do
 
     it 'displays the correct progress indicators for required fields' do
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name')
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name')
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.definition')
+        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name-label')
+        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name-label')
+        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.definition-label')
       end
     end
 
     it 'displays the correct progress indicators for non required fields' do
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.standard-name')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.additional-identifiers')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-type')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-sub-type')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.units')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.data-type')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.scale')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.offset')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.valid-ranges')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.index-ranges')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.standard-name-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.additional-identifiers-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-type-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-sub-type-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.units-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.data-type-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.scale-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.offset-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.valid-ranges-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.index-ranges-label')
       end
     end
 

--- a/spec/features/variable_drafts/preview/empty/variable_information_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/empty/variable_information_preview_spec.rb
@@ -21,25 +21,27 @@ describe 'Empty Variable Draft Variable Information Preview', js:true do
     end
 
     it 'displays the correct progress indicators for required fields' do
+      anchors = ['name-label', 'long-name-label', 'definition-label']
+
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name-label')
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name-label')
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.definition-label')
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-required-o.icon-green.#{anchor}")
+          expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
+        end
       end
     end
 
     it 'displays the correct progress indicators for non required fields' do
+      anchors = [
+        'standard-name-label', 'additional-identifiers-label', 'variable-type-label', 'variable-sub-type-label',
+        'units-label', 'data-type-label', 'scale-label', 'offset-label', 'valid-ranges-label', 'index-ranges-label'
+      ]
+
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.standard-name-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.additional-identifiers-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-type-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-sub-type-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.units-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.data-type-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.scale-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.offset-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.valid-ranges-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.index-ranges-label')
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-fa-circle-o.icon-grey.#{anchor}")
+          expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
+        end
       end
     end
 

--- a/spec/features/variable_drafts/preview/invalid/dimensions_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/invalid/dimensions_preview_spec.rb
@@ -35,6 +35,7 @@ describe 'Invalid Variable Draft Dimensions Preview' do
     it 'displays the correct progress indicators for invalid fields' do
       within '#dimensions-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.dimensions')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'dimensions', anchor: 'dimensions'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/invalid/fill_value_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/invalid/fill_value_preview_spec.rb
@@ -35,6 +35,7 @@ describe 'Invalid Variable Draft Fill Value Preview' do
     it 'displays the correct progress indicators for invalid fields' do
       within '#fill_values-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.fill-values')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'fill_values', anchor: 'fill-values'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/invalid/set_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/invalid/set_preview_spec.rb
@@ -35,6 +35,7 @@ describe 'Invalid Variable Draft Set Preview' do
     it 'displays the correct progress indicators for invalid fields' do
       within '#sets-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.sets')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'sets', anchor: 'sets'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/invalid/variable_information_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/invalid/variable_information_preview_spec.rb
@@ -22,29 +22,29 @@ describe 'Invalid Variable Draft Variable Information Preview' do
 
     it 'displays the correct progress indicators for required fields' do
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name')
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name')
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.definition')
+        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name-label')
+        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name-label')
+        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.definition-label')
       end
     end
 
     it 'displays the correct progress indicators for non required fields' do
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.standard-name')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.additional-identifiers')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-type')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-sub-type')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.units')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.data-type')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.standard-name-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.additional-identifiers-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-type-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-sub-type-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.units-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.data-type-label')
       end
     end
 
     it 'displays the correct progress indicators for invalid fields' do
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.scale')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.offset')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.valid-ranges')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.index-ranges')
+        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.scale-label')
+        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.offset-label')
+        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.valid-ranges-label')
+        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.index-ranges-label')
       end
     end
 

--- a/spec/features/variable_drafts/preview/invalid/variable_information_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/invalid/variable_information_preview_spec.rb
@@ -6,6 +6,9 @@ describe 'Invalid Variable Draft Variable Information Preview' do
   end
 
   context 'When examining the Variable Information section' do
+    let(:anchors_req)     { %w[name-label long-name-label definition-label] }
+    let(:anchors_non_req) { %w[standard-name-label additional-identifiers-label variable-type-label variable-sub-type-label units-label data-type-label] }
+ 
     it 'displays the form title as an edit link' do
       within '#variable_information-progress' do
         expect(page).to have_link('Variable Information', href: edit_variable_draft_path(@draft, 'variable_information'))
@@ -21,10 +24,8 @@ describe 'Invalid Variable Draft Variable Information Preview' do
     end
 
     it 'displays the correct progress indicators for required fields' do
-      anchors = ['name-label', 'long-name-label', 'definition-label']
-
       within '#variable_information-progress .progress-indicators' do
-        anchors.each do |anchor|
+        anchors_req.each do |anchor|
           expect(page).to have_css(".eui-icon.eui-required-o.icon-green.#{anchor}")
           expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
         end
@@ -32,13 +33,8 @@ describe 'Invalid Variable Draft Variable Information Preview' do
     end
 
     it 'displays the correct progress indicators for non required fields' do
-      anchors = [
-        'standard-name-label','additional-identifiers-label','variable-type-label',
-        'variable-sub-type-label','units-label','data-type-label'
-      ]
-
       within '#variable_information-progress .progress-indicators' do
-        anchors.each do |anchor|
+        anchors_non_req.each do |anchor|
           expect(page).to have_css(".eui-icon.eui-fa-circle-o.icon-grey.#{anchor}")
           expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
         end

--- a/spec/features/variable_drafts/preview/invalid/variable_information_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/invalid/variable_information_preview_spec.rb
@@ -21,30 +21,38 @@ describe 'Invalid Variable Draft Variable Information Preview' do
     end
 
     it 'displays the correct progress indicators for required fields' do
+      anchors = ['name-label', 'long-name-label', 'definition-label']
+
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.name-label')
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.long-name-label')
-        expect(page).to have_css('.eui-icon.eui-required-o.icon-green.definition-label')
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-required-o.icon-green.#{anchor}")
+          expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
+        end
       end
     end
 
     it 'displays the correct progress indicators for non required fields' do
+      anchors = [
+        'standard-name-label','additional-identifiers-label','variable-type-label',
+        'variable-sub-type-label','units-label','data-type-label'
+      ]
+
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.standard-name-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.additional-identifiers-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-type-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.variable-sub-type-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.units-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.data-type-label')
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-fa-circle-o.icon-grey.#{anchor}")
+          expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
+        end
       end
     end
 
     it 'displays the correct progress indicators for invalid fields' do
+      anchors = ['scale-label', 'offset-label', 'valid-ranges-label', 'index-ranges-label']
+
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.scale-label')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.offset-label')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.valid-ranges-label')
-        expect(page).to have_css('.eui-icon.eui-fa-minus-circle.icon-red.index-ranges-label')
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-fa-minus-circle.icon-red.#{anchor}")
+          expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
+        end
       end
     end
 

--- a/spec/features/variable_drafts/preview/valid/dimensions_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/valid/dimensions_preview_spec.rb
@@ -23,6 +23,7 @@ describe 'Valid Variable Draft Dimensions Preview' do
     it 'displays the correct progress indicators for non-required fields' do
       within '#dimensions-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.dimensions')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'dimensions', anchor: 'dimensions'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/valid/fill_value_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/valid/fill_value_preview_spec.rb
@@ -29,6 +29,7 @@ describe 'Valid Variable Draft Fill Value Preview' do
     it 'displays the correct progress indicators for non required fields' do
       within '#fill_values-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.fill-values')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'fill_values', anchor: 'fill-values'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/valid/measurement_identifiers_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/valid/measurement_identifiers_preview_spec.rb
@@ -21,6 +21,7 @@ describe 'Valid Variable Draft Measurement Identifiers Preview' do
     it 'displays the correct progress indicators for non required fields' do
       within '#measurement_identifiers-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.measurement-identifiers')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'measurement_identifiers', anchor: 'measurement-identifiers'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/valid/sampling_identifiers_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/valid/sampling_identifiers_preview_spec.rb
@@ -21,6 +21,7 @@ describe 'Valid Variable Draft Sampling Identifiers Preview' do
     it 'displays the correct progress indicators for non required fields' do
       within '#sampling_identifiers-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.sampling-identifiers')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'sampling_identifiers', anchor: 'sampling-identifiers'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/valid/science_keywords_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/valid/science_keywords_preview_spec.rb
@@ -23,6 +23,7 @@ describe 'Valid Variable Draft Science Keywords Preview' do
     it 'displays the correct progress indicators for non required fields' do
       within '#science_keywords-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.science-keywords')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'science_keywords', anchor: 'science-keywords'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/valid/set_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/valid/set_preview_spec.rb
@@ -23,6 +23,7 @@ describe 'Valid Variable Draft Set Preview' do
     it 'displays the correct progress indicators for non-required fields' do
       within '#sets-progress .progress-indicators' do
         expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.sets')
+        expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'sets', anchor: 'sets'))
       end
     end
 

--- a/spec/features/variable_drafts/preview/valid/variable_information_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/valid/variable_information_preview_spec.rb
@@ -6,6 +6,9 @@ describe 'Valid Variable Draft Variable Information Preview' do
   end
 
   context 'When examining the Variable Information section' do
+    let(:anchors_req)     { %w[name-label definition-label long-name-label] }
+    let(:anchors_non_req) { %w[standard-name-label additional-identifiers-label variable-type-label variable-sub-type-label units-label data-type-label scale-label offset-label valid-ranges-label index-ranges-label] }
+
     it 'displays the form title as an edit link' do
       within '#variable_information-progress' do
         expect(page).to have_link('Variable Information', href: edit_variable_draft_path(@draft, 'variable_information'))
@@ -21,10 +24,8 @@ describe 'Valid Variable Draft Variable Information Preview' do
     end
 
     it 'displays the correct progress indicators for required fields' do
-      anchors = ['name-label', 'definition-label', 'long-name-label']
-
       within '#variable_information-progress .progress-indicators' do
-        anchors.each do |anchor|
+        anchors_req.each do |anchor|
           expect(page).to have_css(".eui-icon.eui-required.icon-green.#{anchor}")
           expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
         end
@@ -32,13 +33,8 @@ describe 'Valid Variable Draft Variable Information Preview' do
     end
 
     it 'displays the correct progress indicators for non required fields' do
-      anchors = [
-        'standard-name-label','additional-identifiers-label','variable-type-label','variable-sub-type-label',
-        'units-label','data-type-label','scale-label','offset-label','valid-ranges-label','index-ranges-label'
-      ]
-
       within '#variable_information-progress .progress-indicators' do
-        anchors.each do |anchor|
+        anchors_non_req.each do |anchor|
           expect(page).to have_css(".eui-icon.eui-fa-circle.icon-grey.#{anchor}")
           expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
         end

--- a/spec/features/variable_drafts/preview/valid/variable_information_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/valid/variable_information_preview_spec.rb
@@ -21,25 +21,27 @@ describe 'Valid Variable Draft Variable Information Preview' do
     end
 
     it 'displays the correct progress indicators for required fields' do
+      anchors = ['name-label', 'definition-label', 'long-name-label']
+
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.name-label')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.definition-label')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.long-name-label')
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-required.icon-green.#{anchor}")
+          expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
+        end
       end
     end
 
     it 'displays the correct progress indicators for non required fields' do
+      anchors = [
+        'standard-name-label','additional-identifiers-label','variable-type-label','variable-sub-type-label',
+        'units-label','data-type-label','scale-label','offset-label','valid-ranges-label','index-ranges-label'
+      ]
+
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.standard-name-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.additional-identifiers-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.variable-type-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.variable-sub-type-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.units-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.data-type-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.scale-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.offset-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.valid-ranges-label')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.index-ranges-label')
+        anchors.each do |anchor|
+          expect(page).to have_css(".eui-icon.eui-fa-circle.icon-grey.#{anchor}")
+          expect(page).to have_link(nil, href: edit_variable_draft_path(@draft, 'variable_information', anchor: anchor))
+        end
       end
     end
 

--- a/spec/features/variable_drafts/preview/valid/variable_information_preview_spec.rb
+++ b/spec/features/variable_drafts/preview/valid/variable_information_preview_spec.rb
@@ -22,24 +22,24 @@ describe 'Valid Variable Draft Variable Information Preview' do
 
     it 'displays the correct progress indicators for required fields' do
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.name')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.definition')
-        expect(page).to have_css('.eui-icon.eui-required.icon-green.long-name')
+        expect(page).to have_css('.eui-icon.eui-required.icon-green.name-label')
+        expect(page).to have_css('.eui-icon.eui-required.icon-green.definition-label')
+        expect(page).to have_css('.eui-icon.eui-required.icon-green.long-name-label')
       end
     end
 
     it 'displays the correct progress indicators for non required fields' do
       within '#variable_information-progress .progress-indicators' do
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.standard-name')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.additional-identifiers')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.variable-type')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.variable-sub-type')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.units')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.data-type')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.scale')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.offset')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.valid-ranges')
-        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.index-ranges')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.standard-name-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.additional-identifiers-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.variable-type-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.variable-sub-type-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.units-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.data-type-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.scale-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.offset-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.valid-ranges-label')
+        expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.index-ranges-label')
       end
     end
 


### PR DESCRIPTION
- created `anchor` method to ensure that the correct link is applied to each progress circle by checking specific fields in the schema form
- added tests that checked the links of the progress circles as only the classes were being checked (for incomplete, valid, optional, invalid, required, etc) 


