### PR TITLE
MMT-2541: hotfix

### DIFF
--- a/app/assets/javascripts/validation.coffee
+++ b/app/assets/javascripts/validation.coffee
@@ -471,6 +471,14 @@ $(document).ready ->
       # should not be displayed
       error = null
       return
+    if error.keyword == 'required' && error.dataPath == '/UseConstraints/LicenseText'
+      # this error only shows up for the License Text field when there is a
+      # validation error to be shown for License URL fields, when the License
+      # URL radio button was selected. For this oneOf option with License URL
+      # fields, License Text is not required, so the validation error
+      # should not be displayed
+      error = null
+      return
 
     if id.indexOf('cdf4') >= 0
       labelFor = id

--- a/spec/features/collection_drafts/forms/data_identification_form_spec.rb
+++ b/spec/features/collection_drafts/forms/data_identification_form_spec.rb
@@ -20,6 +20,14 @@ describe 'Data identification form', js: true do
       # Data Dates
       add_dates
 
+      # Metadata Association
+      add_metadata_association
+      puts 'finished filling out metadata association'
+
+      # Publication Reference
+      add_publication_reference
+      puts 'finished filling out publication reference'
+
       # CollectionDataType
       within '#collection-data-type' do
         select 'Other', from: 'Collection Data Type'
@@ -56,14 +64,6 @@ describe 'Data identification form', js: true do
         fill_in 'Description', with: 'Access constraint description'
       end
       puts 'finished filling out access constraints'
-
-      # Metadata Association
-      add_metadata_association
-      puts 'finished filling out metadata association'
-
-      # Publication Reference
-      add_publication_reference
-      puts 'finished filling out publication reference'
     end
 
     context 'when clicking "Save" to stay on the form' do

--- a/spec/features/collection_drafts/forms/data_identification_form_spec.rb
+++ b/spec/features/collection_drafts/forms/data_identification_form_spec.rb
@@ -40,13 +40,17 @@ describe 'Data identification form', js: true do
 
       # Use Constraints
       within '.use-constraints' do
-        find('#use_constraint_type_Url_LicenseURL').click
-
-        within '.license-description-field' do
-          fill_in 'Description', with: 'These are some use constraints'
+        within '.use_constraint_type_group' do
+          choose 'use_constraint_type_Url_LicenseURL'
         end
 
-        fill_in 'Linkage', with: 'https://linkage.example.com'
+        within '.license-description-field' do
+          fill_in 'Description', with: 'These are some use constraints for the data identification form spec'
+        end
+
+        within '.license-url-fields' do
+          fill_in 'Linkage', with: 'https://data-identification-form-spec-linkage.example.com'
+        end
       end
 
       # Access Constraints
@@ -66,10 +70,6 @@ describe 'Data identification form', js: true do
       end
       # output_schema_validation Draft.first.draft
       click_on 'Expand All'
-    end
-
-    it 'displays a confirmation message' do
-      expect(page).to have_content('Collection Draft Updated Successfully!')
     end
 
     it 'populates the form with the values' do
@@ -99,10 +99,10 @@ describe 'Data identification form', js: true do
       # Use Constraints
       within '.use-constraints' do
         within '.license-description-field' do
-          expect(page).to have_field('Description', with: 'These are some use constraints')
+          expect(page).to have_field('Description', with: 'These are some use constraints for the data identification form spec')
         end
         within '.license-url-fields' do
-          expect(page).to have_field('Linkage', with: 'https://linkage.example.com')
+          expect(page).to have_field('Linkage', with: 'https://data-identification-form-spec-linkage.example.com')
         end
       end
 
@@ -160,12 +160,13 @@ describe 'Data identification form', js: true do
       end
     end
 
-    it 'has proper progress circle icons in green ' do
+    it 'has proper progress circle icons in green and displays a confirmation message' do
       within '.nav-top' do
         click_on 'Done'
       end
 
       expect(page).to have_content('Collection Draft Updated Successfully!')
+
       within '#data-identification a[title="Use Constraints"]' do
         expect(page).to have_css('.eui-fa-circle')
       end
@@ -187,7 +188,9 @@ describe 'Data identification form', js: true do
       context 'when a required icon should not be shown' do
         context 'when Description Only is selected' do
           before do
-            find('#use_constraint_type_Description_DescriptionOnly').click
+            within '.use_constraint_type_group' do
+              choose 'use_constraint_type_Description_DescriptionOnly'
+            end
           end
 
           it 'displays the description field correctly' do
@@ -201,7 +204,9 @@ describe 'Data identification form', js: true do
 
         context 'when License URL is selected' do
           before do
-            find('#use_constraint_type_Url_LicenseURL').click
+            within '.use_constraint_type_group' do
+              choose 'use_constraint_type_Url_LicenseURL'
+            end
           end
 
           it 'shows the license url fields correctly' do
@@ -217,7 +222,9 @@ describe 'Data identification form', js: true do
 
         context 'when License Text is selected' do
           before do
-            find('#use_constraint_type_Text_LicenseText').click
+            within '.use_constraint_type_group' do
+              choose 'use_constraint_type_Text_LicenseText'
+            end
           end
 
           it 'shows the license text fields correctly' do
@@ -236,10 +243,12 @@ describe 'Data identification form', js: true do
 
         context 'when Description Only is selected' do
           before do
-            find('#use_constraint_type_Description_DescriptionOnly').click
+            within '.use_constraint_type_group' do
+              choose 'use_constraint_type_Description_DescriptionOnly'
+            end
 
             within '.license-description-field' do
-              fill_in 'Description', with: 'These are some use constraints'
+              fill_in 'Description', with: 'These are some use constraints for the data identification form spec'
             end
 
             find('body').click
@@ -257,10 +266,12 @@ describe 'Data identification form', js: true do
 
         context 'when License URL is selected' do
           before do
-            find('#use_constraint_type_Url_LicenseURL').click
+            within '.use_constraint_type_group' do
+              choose 'use_constraint_type_Url_LicenseURL'
+            end
 
             within '.license-url-fields' do
-              fill_in 'Linkage', with: 'https://linkage.example.com'
+              fill_in 'Linkage', with: 'https://data-identification-form-spec-linkage.example.com'
             end
 
             find('body').click
@@ -283,7 +294,10 @@ describe 'Data identification form', js: true do
 
         context 'when License Text is selected' do
           before do
-            find('#use_constraint_type_Text_LicenseText').click
+            within '.use_constraint_type_group' do
+              choose 'use_constraint_type_Text_LicenseText'
+            end
+
             fill_in 'License Text', with: 'This is a License Text'
             find('body').click
           end

--- a/spec/features/collection_drafts/forms/data_identification_form_spec.rb
+++ b/spec/features/collection_drafts/forms/data_identification_form_spec.rb
@@ -22,11 +22,9 @@ describe 'Data identification form', js: true do
 
       # Metadata Association
       add_metadata_association
-      puts 'finished filling out metadata association'
 
       # Publication Reference
       add_publication_reference
-      puts 'finished filling out publication reference'
 
       # CollectionDataType
       within '#collection-data-type' do
@@ -56,23 +54,20 @@ describe 'Data identification form', js: true do
           fill_in 'Linkage', with: 'https://data-identification-form-spec-linkage.example.com'
         end
       end
-      puts 'finished filling out use constraints'
 
       # Access Constraints
       within '.access-constraints' do
         fill_in 'Value', with: 42.0
         fill_in 'Description', with: 'Access constraint description'
       end
-      puts 'finished filling out access constraints'
     end
 
     context 'when clicking "Save" to stay on the form' do
       before do
-        puts 'about to click Save'
         within '.nav-top' do
           click_on 'Save'
         end
-        puts 'after save'
+
         # output_schema_validation Draft.first.draft
         click_on 'Expand All'
       end

--- a/spec/features/collection_drafts/forms/data_identification_form_spec.rb
+++ b/spec/features/collection_drafts/forms/data_identification_form_spec.rb
@@ -1,7 +1,7 @@
 describe 'Data identification form', js: true do
   before do
     login
-    draft = create(:collection_draft, user: User.where(urs_uid: 'testuser').first, entry_title: 'Empty Draft for Data Identificaiton form')
+    draft = create(:collection_draft, user: User.where(urs_uid: 'testuser').first)
     visit edit_collection_draft_path(draft, 'data_identification')
   end
 

--- a/spec/features/collection_drafts/forms/data_identification_form_spec.rb
+++ b/spec/features/collection_drafts/forms/data_identification_form_spec.rb
@@ -64,117 +64,126 @@ describe 'Data identification form', js: true do
 
       # Publication Reference
       add_publication_reference
-
-      within '.nav-top' do
-        click_on 'Save'
-      end
-      # output_schema_validation Draft.first.draft
-      click_on 'Expand All'
     end
 
-    it 'populates the form with the values' do
-      within '.multiple.dates' do
-        within '.multiple-item-0' do
-          expect(page).to have_field('Type', with: 'CREATE')
-          expect(page).to have_field('Date', with: '2015-07-01T00:00:00Z')
+    context 'when clicking "Save" to stay on the form' do
+      before do
+        within '.nav-top' do
+          click_on 'Save'
         end
-        within '.multiple-item-1' do
-          expect(page).to have_field('Type', with: 'REVIEW')
-          expect(page).to have_field('Date', with: '2015-07-02T00:00:00Z')
-        end
+        # output_schema_validation Draft.first.draft
+        click_on 'Expand All'
       end
 
-      # CollectionDataType
-      expect(page).to have_field('Collection Data Type', with: 'OTHER')
-
-      # Processing Level
-      within '.processing-level-fields' do
-        expect(page).to have_field('ID', with: '1A')
-        expect(page).to have_field('Description', with: 'Level 1 Description')
-      end
-
-      expect(page).to have_field('Collection Progress', with: 'ACTIVE')
-      expect(page).to have_field('Quality', with: 'Metadata quality summary')
-
-      # Use Constraints
-      within '.use-constraints' do
-        within '.license-description-field' do
-          expect(page).to have_field('Description', with: 'These are some use constraints for the data identification form spec')
-        end
-        within '.license-url-fields' do
-          expect(page).to have_field('Linkage', with: 'https://data-identification-form-spec-linkage.example.com')
-        end
-      end
-
-      # Access constraints
-      within '.row.access-constraints' do
-        expect(page).to have_field('Value', with: '42.0')
-        expect(page).to have_field('Description', with: 'Access constraint description')
-      end
-
-      ##### Metadata Association
-      within '.multiple.metadata-associations' do
-        within '.multiple-item-0' do
-          expect(page).to have_field('Type', with: 'SCIENCE ASSOCIATED')
-          expect(page).to have_field('Entry Id', with: '12345')
-          expect(page).to have_field('Description', with: 'Metadata association description')
-          expect(page).to have_field('Version', with: '23')
-        end
-        within '.multiple-item-1' do
-          expect(page).to have_field('Type', with: 'LARGER CITATION WORKS')
-          expect(page).to have_field('Entry Id', with: '123abc')
-        end
-      end
-
-      #### PublicationReference
-      within '.multiple.publication-references' do
-        within '.multiple-item-0' do
-          expect(page).to have_field('draft_publication_references_0_title', with: 'Publication reference title') # Title
-          expect(page).to have_field('Publisher', with: 'Publication reference publisher')
-          expect(page).to have_field('DOI', with: 'Publication reference DOI')
-          expect(page).to have_field('Authority', with: 'Publication reference authority')
-          expect(page).to have_field('Author', with: 'Publication reference author')
-          expect(page).to have_field('Publication Date', with: '2015-07-01T00:00:00Z')
-          expect(page).to have_field('Series', with: 'Publication reference series')
-          expect(page).to have_field('Edition', with: 'Publication reference edition')
-          expect(page).to have_field('Volume', with: 'Publication reference volume')
-          expect(page).to have_field('Issue', with: 'Publication reference issue')
-          expect(page).to have_field('Report Number', with: 'Publication reference report number')
-          expect(page).to have_field('Publication Place', with: 'Publication reference publication place')
-          expect(page).to have_field('Pages', with: 'Publication reference pages')
-          expect(page).to have_field('ISBN', with: '1234567890123')
-          expect(page).to have_field('Other Reference Details', with: 'Publication reference details')
-          within '.online-resource' do
-            expect(page).to have_field('Name', with: 'Online Resource Name')
-            expect(page).to have_field('Linkage', with: 'http://www.example.com')
-            expect(page).to have_field('Description', with: 'Online Resource Description')
-            expect(page).to have_field('Protocol', with: 'http')
-            expect(page).to have_field('Application Profile', with: 'website')
-            expect(page).to have_field('Function', with: 'information')
+      it 'populates the form with the values' do
+        within '.multiple.dates' do
+          within '.multiple-item-0' do
+            expect(page).to have_field('Type', with: 'CREATE')
+            expect(page).to have_field('Date', with: '2015-07-01T00:00:00Z')
+          end
+          within '.multiple-item-1' do
+            expect(page).to have_field('Type', with: 'REVIEW')
+            expect(page).to have_field('Date', with: '2015-07-02T00:00:00Z')
           end
         end
-        within '.multiple-item-1' do
-          expect(page).to have_field('draft_publication_references_1_title', with: 'Publication reference title 1') # Title
-          expect(page).to have_field('ISBN', with: '9876543210987')
+
+        # CollectionDataType
+        expect(page).to have_field('Collection Data Type', with: 'OTHER')
+
+        # Processing Level
+        within '.processing-level-fields' do
+          expect(page).to have_field('ID', with: '1A')
+          expect(page).to have_field('Description', with: 'Level 1 Description')
+        end
+
+        expect(page).to have_field('Collection Progress', with: 'ACTIVE')
+        expect(page).to have_field('Quality', with: 'Metadata quality summary')
+
+        # Use Constraints
+        within '.use-constraints' do
+          within '.license-description-field' do
+            expect(page).to have_field('Description', with: 'These are some use constraints for the data identification form spec')
+          end
+          within '.license-url-fields' do
+            expect(page).to have_field('Linkage', with: 'https://data-identification-form-spec-linkage.example.com')
+          end
+        end
+
+        # Access constraints
+        within '.row.access-constraints' do
+          expect(page).to have_field('Value', with: '42.0')
+          expect(page).to have_field('Description', with: 'Access constraint description')
+        end
+
+        ##### Metadata Association
+        within '.multiple.metadata-associations' do
+          within '.multiple-item-0' do
+            expect(page).to have_field('Type', with: 'SCIENCE ASSOCIATED')
+            expect(page).to have_field('Entry Id', with: '12345')
+            expect(page).to have_field('Description', with: 'Metadata association description')
+            expect(page).to have_field('Version', with: '23')
+          end
+          within '.multiple-item-1' do
+            expect(page).to have_field('Type', with: 'LARGER CITATION WORKS')
+            expect(page).to have_field('Entry Id', with: '123abc')
+          end
+        end
+
+        #### PublicationReference
+        within '.multiple.publication-references' do
+          within '.multiple-item-0' do
+            expect(page).to have_field('draft_publication_references_0_title', with: 'Publication reference title') # Title
+            expect(page).to have_field('Publisher', with: 'Publication reference publisher')
+            expect(page).to have_field('DOI', with: 'Publication reference DOI')
+            expect(page).to have_field('Authority', with: 'Publication reference authority')
+            expect(page).to have_field('Author', with: 'Publication reference author')
+            expect(page).to have_field('Publication Date', with: '2015-07-01T00:00:00Z')
+            expect(page).to have_field('Series', with: 'Publication reference series')
+            expect(page).to have_field('Edition', with: 'Publication reference edition')
+            expect(page).to have_field('Volume', with: 'Publication reference volume')
+            expect(page).to have_field('Issue', with: 'Publication reference issue')
+            expect(page).to have_field('Report Number', with: 'Publication reference report number')
+            expect(page).to have_field('Publication Place', with: 'Publication reference publication place')
+            expect(page).to have_field('Pages', with: 'Publication reference pages')
+            expect(page).to have_field('ISBN', with: '1234567890123')
+            expect(page).to have_field('Other Reference Details', with: 'Publication reference details')
+            within '.online-resource' do
+              expect(page).to have_field('Name', with: 'Online Resource Name')
+              expect(page).to have_field('Linkage', with: 'http://www.example.com')
+              expect(page).to have_field('Description', with: 'Online Resource Description')
+              expect(page).to have_field('Protocol', with: 'http')
+              expect(page).to have_field('Application Profile', with: 'website')
+              expect(page).to have_field('Function', with: 'information')
+            end
+          end
+          within '.multiple-item-1' do
+            expect(page).to have_field('draft_publication_references_1_title', with: 'Publication reference title 1') # Title
+            expect(page).to have_field('ISBN', with: '9876543210987')
+          end
         end
       end
     end
 
-    it 'has proper progress circle icons in green and displays a confirmation message' do
-      within '.nav-top' do
-        click_on 'Done'
+    context 'when clicking "Done" to go to the show page' do
+      before do
+        within '.nav-top' do
+          click_on 'Done'
+        end
       end
 
-      expect(page).to have_content('Collection Draft Updated Successfully!')
+      it 'has proper progress circle icons in green and displays a confirmation message' do
 
-      within '#data-identification a[title="Use Constraints"]' do
-        expect(page).to have_css('.eui-fa-circle')
-      end
-      within '#data-identification a[title="Collection Progress - Required field complete"]' do
-        expect(page).to have_css('.eui-required.icon-green')
-      end
-      within '#data-identification a[title="Processing Level - Required field complete"]' do
-        expect(page).to have_css('.eui-required.icon-green')
+        expect(page).to have_content('Collection Draft Updated Successfully!')
+
+        within '#data-identification a[title="Use Constraints"]' do
+          expect(page).to have_css('.eui-fa-circle')
+        end
+        within '#data-identification a[title="Collection Progress - Required field complete"]' do
+          expect(page).to have_css('.eui-required.icon-green')
+        end
+        within '#data-identification a[title="Processing Level - Required field complete"]' do
+          expect(page).to have_css('.eui-required.icon-green')
+        end
       end
     end
   end

--- a/spec/features/collection_drafts/forms/data_identification_form_spec.rb
+++ b/spec/features/collection_drafts/forms/data_identification_form_spec.rb
@@ -2,10 +2,7 @@ describe 'Data identification form', js: true do
   before do
     login
     draft = create(:collection_draft, user: User.where(urs_uid: 'testuser').first)
-    visit collection_draft_path(draft)
-    within '.metadata' do
-      click_on 'Data Identification'
-    end
+    visit edit_collection_draft_path(draft, 'data_identification')
   end
 
   context 'when checking the accordion headers for required icons' do
@@ -18,7 +15,6 @@ describe 'Data identification form', js: true do
 
   context 'when submitting the form' do
     before do
-
       click_on 'Expand All'
 
       # Data Dates
@@ -75,7 +71,9 @@ describe 'Data identification form', js: true do
         click_on 'Expand All'
       end
 
-      it 'populates the form with the values' do
+      it 'displays a confirmation message and populates the form with the values' do
+        expect(page).to have_content('Collection Draft Updated Successfully!')
+
         within '.multiple.dates' do
           within '.multiple-item-0' do
             expect(page).to have_field('Type', with: 'CREATE')
@@ -163,29 +161,6 @@ describe 'Data identification form', js: true do
         end
       end
     end
-
-    context 'when clicking "Done" to go to the show page' do
-      before do
-        within '.nav-top' do
-          click_on 'Done'
-        end
-      end
-
-      it 'has proper progress circle icons in green and displays a confirmation message' do
-
-        expect(page).to have_content('Collection Draft Updated Successfully!')
-
-        within '#data-identification a[title="Use Constraints"]' do
-          expect(page).to have_css('.eui-fa-circle')
-        end
-        within '#data-identification a[title="Collection Progress - Required field complete"]' do
-          expect(page).to have_css('.eui-required.icon-green')
-        end
-        within '#data-identification a[title="Processing Level - Required field complete"]' do
-          expect(page).to have_css('.eui-required.icon-green')
-        end
-      end
-    end
   end
 
   context 'when viewing the Use Constraints fields' do
@@ -245,11 +220,9 @@ describe 'Data identification form', js: true do
             end
           end
         end
-
       end
 
       context 'when a required icon should be shown' do
-
         context 'when Description Only is selected' do
           before do
             within '.use_constraint_type_group' do

--- a/spec/features/collection_drafts/forms/data_identification_form_spec.rb
+++ b/spec/features/collection_drafts/forms/data_identification_form_spec.rb
@@ -1,7 +1,7 @@
 describe 'Data identification form', js: true do
   before do
     login
-    draft = create(:collection_draft, user: User.where(urs_uid: 'testuser').first)
+    draft = create(:collection_draft, user: User.where(urs_uid: 'testuser').first, entry_title: 'Empty Draft for Data Identificaiton form')
     visit edit_collection_draft_path(draft, 'data_identification')
   end
 
@@ -48,25 +48,31 @@ describe 'Data identification form', js: true do
           fill_in 'Linkage', with: 'https://data-identification-form-spec-linkage.example.com'
         end
       end
+      puts 'finished filling out use constraints'
 
       # Access Constraints
       within '.access-constraints' do
         fill_in 'Value', with: 42.0
         fill_in 'Description', with: 'Access constraint description'
       end
+      puts 'finished filling out access constraints'
 
       # Metadata Association
       add_metadata_association
+      puts 'finished filling out metadata association'
 
       # Publication Reference
       add_publication_reference
+      puts 'finished filling out publication reference'
     end
 
     context 'when clicking "Save" to stay on the form' do
       before do
+        puts 'about to click Save'
         within '.nav-top' do
           click_on 'Save'
         end
+        puts 'after save'
         # output_schema_validation Draft.first.draft
         click_on 'Expand All'
       end

--- a/spec/features/collection_previews/data_identification_preview_spec.rb
+++ b/spec/features/collection_previews/data_identification_preview_spec.rb
@@ -1,90 +1,220 @@
+# this test is a little different from the other preview tests
+# it has been modified to also check the progress circles and match the format
+# tool draft tests were organized.
+# we should re-organize collection previews to have the metadata preview verify
+# all the data types that also use the preview gem (collection drafts, collections,
+# templates, proposals)
+# and have tests just for the progress circles for collection drafts
+
 describe 'Data identification preview' do
   context 'when viewing the preview page' do
     context 'when there is no metadata' do
+      let(:empty_collection_draft) { create(:collection_draft, user: User.where(urs_uid: 'testuser').first) }
+
       before do
         login
-        draft = create(:collection_draft, user: User.where(urs_uid: 'testuser').first)
-        visit collection_draft_path(draft)
+        visit collection_draft_path(empty_collection_draft)
 
         find('.tab-label', text: 'Additional Information').click
       end
 
-      it 'does not display metadata' do
-        within 'ul.data-identification-preview' do
-          expect(page).to have_no_content('Data Dates')
-          expect(page).to have_content("This collection's processing level has not been specified.")
-          expect(page).to have_no_content('Use Constraints')
-          expect(page).to have_no_content('Access Constraints')
-          expect(page).to have_no_content('Metadata Associations')
-          expect(page).to have_no_content('Publication References')
+      context 'when examining the progress circles section' do
+        it 'displays the correct status icon' do
+          within '#data-identification' do
+            within '.status' do
+              expect(page).to have_css('.eui-icon.icon-green.eui-fa-circle-o', text: 'Data Identification is incomplete')
+            end
+          end
+        end
+
+        it 'displays the form title as an edit link' do
+          within '#data-identification .meta-info' do
+            expect(page).to have_link('Data Identification', href: edit_collection_draft_path(empty_collection_draft, 'data_identification'))
+          end
+        end
+
+        it 'displays the correct progress indicators for required fields' do
+          within '#data-identification .progress-indicators' do
+            expect(page).to have_css('.eui-icon.eui-required-o.icon-green.processing-level')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(empty_collection_draft, 'data_identification', anchor: 'processing-level'))
+
+            expect(page).to have_css('.eui-icon.eui-required-o.icon-green.collection-progress')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(empty_collection_draft, 'data_identification', anchor: 'collection-progress'))
+          end
+        end
+
+        it 'displays the correct progress indicators for non required fields' do
+          within '#data-identification .progress-indicators' do
+            expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.collection-data-type')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(empty_collection_draft, 'data_identification', anchor: 'data-dates'))
+
+            expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.collection-data-type')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(empty_collection_draft, 'data_identification', anchor: 'collection-data-type'))
+
+            expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.quality')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(empty_collection_draft, 'data_identification', anchor: 'quality'))
+
+            expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.use-constraints')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(empty_collection_draft, 'data_identification', anchor: 'use-constraints'))
+
+            expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.access-constraints')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(empty_collection_draft, 'data_identification', anchor: 'access-constraints'))
+
+            expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.metadata-associations')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(empty_collection_draft, 'data_identification', anchor: 'metadata-associations'))
+
+            expect(page).to have_css('.eui-icon.eui-fa-circle-o.icon-grey.publication-references')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(empty_collection_draft, 'data_identification', anchor: 'publication-references'))
+          end
+        end
+      end
+
+      context 'when examining the metadata preview section', js: true do
+        before do
+          find('.tab-label', text: 'Additional Information').click
+        end
+
+        it 'does not display metadata' do
+          within '#additional-information-panel' do
+            within 'ul.data-identification-preview' do
+              expect(page).to have_no_content('Data Dates')
+              expect(page).to have_content("This collection's processing level has not been specified.")
+              expect(page).to have_content("This collection's collection progress has not been specified.")
+              # the Quality title shows but no content
+              expect(page).to have_no_content('Use Constraints')
+              expect(page).to have_no_content('Access Constraints')
+              expect(page).to have_no_content('Metadata Associations')
+              expect(page).to have_no_content('Publication References')
+            end
+          end
         end
       end
     end
 
     context 'when there is metadata' do
+      let(:full_collection_draft) { create(:full_collection_draft, user: User.where(urs_uid: 'testuser').first) }
+
       before do
         login
-        draft = create(:full_collection_draft, user: User.where(urs_uid: 'testuser').first)
-        visit collection_draft_path(draft)
+        visit collection_draft_path(full_collection_draft)
 
         find('.tab-label', text: 'Additional Information').click
       end
 
-      it 'displays the metadata' do
-        within '.data-identification-preview' do
-          within '.data-dates-table' do
-            within all('tr')[0] do
-              expect(page).to have_content('Creation 2015-07-01T00:00:00Z', normalize_ws: true)
-            end
-            within all('tr')[1] do
-              expect(page).to have_content('Last Revision 2015-07-05T00:00:00Z', normalize_ws: true)
+      context 'when examining the progress circles section' do
+        it 'displays the correct status icon' do
+          within '#data-identification' do
+            within '.status' do
+              expect(page).to have_css('.eui-icon.icon-green.eui-check', text: 'Data Identification is valid')
             end
           end
+        end
 
-          within '.processing-level' do
-            expect(page).to have_content('1A')
-            expect(page).to have_content('Level 1 Description')
+        it 'displays the form title as an edit link' do
+          within '#data-identification .meta-info' do
+            expect(page).to have_link('Data Identification', href: edit_collection_draft_path(full_collection_draft, 'data_identification'))
           end
+        end
 
-          within '.quality' do
-            expect(page).to have_content('Metadata quality summary')
+        it 'displays the correct progress indicators for required fields' do
+          within '#data-identification .progress-indicators' do
+            expect(page).to have_css('.eui-icon.eui-required.icon-green.processing-level')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(full_collection_draft, 'data_identification', anchor: 'processing-level'))
+
+            expect(page).to have_css('.eui-icon.eui-required.icon-green.collection-progress')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(full_collection_draft, 'data_identification', anchor: 'collection-progress'))
           end
+        end
 
-          expect(page).to have_content('Collection Progress')
-          expect(page).to have_content('Active')
+        it 'displays the correct progress indicators for non required fields' do
+          within '#data-identification .progress-indicators' do
+            expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.collection-data-type')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(full_collection_draft, 'data_identification', anchor: 'data-dates'))
 
-          expect(page).to have_content('These are some use constraints')
+            expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.collection-data-type')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(full_collection_draft, 'data_identification', anchor: 'collection-data-type'))
 
-          expect(page).to have_content('42')
-          expect(page).to have_content('Access constraint description')
+            expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.quality')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(full_collection_draft, 'data_identification', anchor: 'quality'))
 
-          within '.metadata-associations-table' do
-            within all('tr')[1] do
-              expect(page).to have_content('Science Associated 12345 Metadata association description 23', normalize_ws: true)
-            end
-            within all('tr')[2] do
-              expect(page).to have_content('Larger Citation Works 123abc', normalize_ws: true)
-            end
+            expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.use-constraints')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(full_collection_draft, 'data_identification', anchor: 'use-constraints'))
+
+            expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.access-constraints')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(full_collection_draft, 'data_identification', anchor: 'access-constraints'))
+
+            expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.metadata-associations')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(full_collection_draft, 'data_identification', anchor: 'metadata-associations'))
+
+            expect(page).to have_css('.eui-icon.eui-fa-circle.icon-grey.publication-references')
+            expect(page).to have_link(nil, href: edit_collection_draft_path(full_collection_draft, 'data_identification', anchor: 'publication-references'))
           end
+        end
+      end
 
-          within '.publication-reference-preview' do
-            within all('li.publication-reference')[0] do
-              expect(page).to have_content('Title: Publication reference title')
-              expect(page).to have_content('Publication Date: 2015-07-01')
-              expect(page).to have_content('Publisher: Publication reference publisher')
-              expect(page).to have_content('Author(s): Publication reference author')
-              expect(page).to have_content('Series: Publication reference series')
-              expect(page).to have_content('Edition: Publication reference edition')
-              expect(page).to have_content('Volume: Publication reference volume')
-              expect(page).to have_content('Issue: Publication reference issue')
-              expect(page).to have_content('Pages: Publication reference pages')
-              expect(page).to have_content('DOI: Publication reference DOI')
-              expect(page).to have_content('Online Resource: http://example.com')
-              expect(page).to have_link('http://example.com', href: 'http://example.com')
-            end
+      context 'when examining the metadata preview section', js: true do
+        before do
+          find('.tab-label', text: 'Additional Information').click
+        end
 
-            within all('li.publication-reference')[1] do
-              expect(page).to have_content('Title: Publication reference title 1')
+        it 'displays the metadata' do
+          within '#additional-information-panel' do
+            within 'ul.data-identification-preview' do
+              within '.data-dates-table' do
+                within all('tr')[0] do
+                  expect(page).to have_content('Creation 2015-07-01T00:00:00Z', normalize_ws: true)
+                end
+                within all('tr')[1] do
+                  expect(page).to have_content('Last Revision 2015-07-05T00:00:00Z', normalize_ws: true)
+                end
+              end
+
+              within '.processing-level' do
+                expect(page).to have_content('1A')
+                expect(page).to have_content('Level 1 Description')
+              end
+
+              within '.quality' do
+                expect(page).to have_content('Metadata quality summary')
+              end
+
+              expect(page).to have_content('Collection Progress')
+              expect(page).to have_content('Active')
+
+              expect(page).to have_content('These are some use constraints')
+
+              expect(page).to have_content('42')
+              expect(page).to have_content('Access constraint description')
+
+              within '.metadata-associations-table' do
+                within all('tr')[1] do
+                  expect(page).to have_content('Science Associated 12345 Metadata association description 23', normalize_ws: true)
+                end
+                within all('tr')[2] do
+                  expect(page).to have_content('Larger Citation Works 123abc', normalize_ws: true)
+                end
+              end
+
+              within '.publication-reference-preview' do
+                within all('li.publication-reference')[0] do
+                  expect(page).to have_content('Title: Publication reference title')
+                  expect(page).to have_content('Publication Date: 2015-07-01')
+                  expect(page).to have_content('Publisher: Publication reference publisher')
+                  expect(page).to have_content('Author(s): Publication reference author')
+                  expect(page).to have_content('Series: Publication reference series')
+                  expect(page).to have_content('Edition: Publication reference edition')
+                  expect(page).to have_content('Volume: Publication reference volume')
+                  expect(page).to have_content('Issue: Publication reference issue')
+                  expect(page).to have_content('Pages: Publication reference pages')
+                  expect(page).to have_content('DOI: Publication reference DOI')
+                  expect(page).to have_content('Online Resource: http://example.com')
+                  expect(page).to have_link('http://example.com', href: 'http://example.com')
+                end
+
+                within all('li.publication-reference')[1] do
+                  expect(page).to have_content('Title: Publication reference title 1')
+                end
+              end
             end
           end
         end

--- a/spec/features/manage_cmr/subscriptions/create_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/create_subscriptions_spec.rb
@@ -27,7 +27,7 @@ describe 'Creating Subscriptions', reset_provider: true do
 
       context 'when submitting the form without errors', js: true do
         let(:name) { "Exciting Subscription with Important Data #{SecureRandom.uuid}" }
-        let(:query) { 'point=100,20&attribute\[\]=float,X\Y\Z,7&instrument\[\]=1B&cloud_cover=-70.0,120.0&equator_crossing_date=2000-01-01T10:00:00Z,2010-03-10T12:00:00Z&cycle[]=1&passes[0][pass]=1&passes[0][tiles]=1L,2F' }
+        let(:query) { 'point=100,20&attribute[]=float,X\Y\Z,7&instrument=1B&cloud_cover=-70.0,120.0&equator_crossing_date=2000-01-01T10:00:00Z,2010-03-10T12:00:00Z&cycle[]=1&passes[0][pass]=1&passes[0][tiles]=1L,2F' }
         let(:collection_concept_id) { @c_ingest_response['concept-id'] }
 
         before do
@@ -64,7 +64,7 @@ describe 'Creating Subscriptions', reset_provider: true do
           # Generating a genuine failure by violating uniqueness constraints
           # in the CMR.
           let(:name2) { 'Exciting Subscription with Important Data4' }
-          let(:query2) { 'point=100,20&attribute\[\]=float,X\Y\Z,7&instrument\[\]=1B&cloud_cover=-80.0,120.0&equator_crossing_date=2000-01-01T10:00:00Z,2010-03-10T12:00:00Z&cycle[]=1' }
+          let(:query2) { 'point=100,20&attribute[]=float,X\Y\Z,7&instrument=1B&cloud_cover=-80.0,120.0&equator_crossing_date=2000-01-01T10:00:00Z,2010-03-10T12:00:00Z&cycle[]=1' }
           before do
             @native_id_failure = 'test_native_id'
             @ingest_response, _search_response, _subscription = publish_new_subscription(name: name2, query: query2, collection_concept_id: collection_concept_id, native_id: @native_id_failure)

--- a/spec/support/draft_helpers.rb
+++ b/spec/support/draft_helpers.rb
@@ -269,8 +269,8 @@ module Helpers
           fill_in 'draft_publication_references_0_title', with: 'Publication reference title' # Title
           fill_in 'Publisher', with: 'Publication reference publisher'
 
-          script = '$("#draft_publication_references_0_doi_Available").click();'
-          page.execute_script script
+          choose 'draft_publication_references_0_doi_Available'
+
           fill_in 'DOI', with: 'Publication reference DOI'
           fill_in 'Authority', with: 'Publication reference authority'
           fill_in 'Author', with: 'Publication reference author'


### PR DESCRIPTION
* don't show validation error for License Text (shows up when License URL is chosen)
* modify data identification tests to prevent cascading errors