### PR TITLE
hotfix/MMT-2591-1: Fix SIT-test error that was occurring for provider EDF_DEV07

### DIFF
--- a/app/controllers/manage_cmr_controller.rb
+++ b/app/controllers/manage_cmr_controller.rb
@@ -61,7 +61,9 @@ class ManageCmrController < ApplicationController
       guids_response = echo_client.get_order_options_names(echo_provider_token)
 
       guids = if guids_response.success?
-                Array.wrap(guids_response.parsed_body(parser: 'libxml').fetch('Item', []).map { |option| option['Guid'] })
+                parsed_response = guids_response.parsed_body(parser: 'libxml').fetch('Item', [])
+                Rails.logger.info("#{request.uuid} - ManageCmrController#get_order_option_list - #{parsed_response}")
+                Array.wrap(parsed_response.map { |option| option['Guid'] })
               else
                 Rails.logger.error("#{request.uuid} - ManageCmrController#get_order_option_list - Retrieve Order Options List Error: #{guids_response.clean_inspect}")
                 []
@@ -116,7 +118,7 @@ class ManageCmrController < ApplicationController
         return {'Result' => []}
       end
     end
-    
+
     return {'Result' => service_options}
   end
 

--- a/app/controllers/manage_cmr_controller.rb
+++ b/app/controllers/manage_cmr_controller.rb
@@ -61,9 +61,7 @@ class ManageCmrController < ApplicationController
       guids_response = echo_client.get_order_options_names(echo_provider_token)
 
       guids = if guids_response.success?
-                parsed_response = guids_response.parsed_body(parser: 'libxml').fetch('Item', [])
-                Rails.logger.info("#{request.uuid} - ManageCmrController#get_order_option_list - #{parsed_response}")
-                Array.wrap(parsed_response.map { |option| option['Guid'] })
+                Array.wrap(guids_response.parsed_body(parser: 'libxml').fetch('Item', [])).map { |option| option['Guid'] }
               else
                 Rails.logger.error("#{request.uuid} - ManageCmrController#get_order_option_list - Retrieve Order Options List Error: #{guids_response.clean_inspect}")
                 []
@@ -95,7 +93,7 @@ class ManageCmrController < ApplicationController
       guids_response = echo_client.get_service_options_names(echo_provider_token)
 
       guids = if guids_response.success?
-                Array.wrap(guids_response.parsed_body(parser: 'libxml').fetch('Item', []).map { |option| option['Guid'] })
+                Array.wrap(guids_response.parsed_body(parser: 'libxml').fetch('Item', [])).map { |option| option['Guid'] }
               else
                 Rails.logger.error("#{request.uuid} - ManageCmrController#get_order_option_list - Retrieve Service Options Names Error: #{guids_response.clean_inspect}")
                 []


### PR DESCRIPTION
- the merge of MMT-2591 caused a bug - specifically `TypeError (no implicit conversion of String into Integer)` for the EDF_DEV07 provider
- this was investigated (splunk logs revealed the error message). The error was caused by a simple bug in the code where a `.map` method was called on an object that was expected to be an `Array` but was a `Hash`.
- the appropriate changes were made - just had to move a parenthesis. 