### PR TITLE
MMT-2486: UMM-C draft progress circle links do not take users to appropriate field

### DIFF
--- a/app/controllers/collection_drafts_controller.rb
+++ b/app/controllers/collection_drafts_controller.rb
@@ -59,7 +59,7 @@ class CollectionDraftsController < BaseDraftsController
       end
     else # record update failed
       flash[:error] = I18n.t("controllers.draft.#{plural_resource_name}.create.flash.error", error_message: generate_model_error)
-      # For collection_template, the unsaved draft now has associated_dois which is a hash. This hash needs to be corrected/converted 
+      # For collection_template, the unsaved draft now has associated_dois which is a hash. This hash needs to be corrected/converted
       # to an array to work properly with _type.html.erb
       get_resource.correct_unsaved_draft if resource_name == 'collection_template'
       load_umm_c_schema
@@ -118,7 +118,7 @@ class CollectionDraftsController < BaseDraftsController
     draft = get_resource.draft
 
     ingested_response = cmr_client.ingest_collection(draft.to_json, get_resource.provider_id, get_resource.native_id, token)
-    
+
     if ingested_response.success?
       # get information for publication email notification before draft is deleted
       Rails.logger.info("Audit Log: Draft #{get_resource.entry_title} was published by #{current_user.urs_uid} in provider: #{current_user.provider_id}")

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -200,7 +200,7 @@ module FormHelper
   def mmt_label(options)
     options[:name] = add_pipes(options[:name])
     id = remove_pipes(options[:prefix] + options[:name] + '_label') if options[:label_id]
-    label_for = id.nil? ? remove_pipes(options[:prefix] + options[:name]) : nil
+    label_for = remove_pipes(options[:prefix] + options[:name])
 
     classes = []
     classes << 'required' if options[:required]

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -199,7 +199,7 @@ module FormHelper
 
   def mmt_label(options)
     options[:name] = add_pipes(options[:name])
-    id = remove_pipes(options[:prefix] + options[:name]) if options[:set_id]
+    id = remove_pipes(options[:prefix] + options[:name] + '_label') if options[:label_id]
     label_for = id.nil? ? remove_pipes(options[:prefix] + options[:name]) : nil
 
     classes = []

--- a/app/helpers/preview_circles_helper.rb
+++ b/app/helpers/preview_circles_helper.rb
@@ -13,39 +13,39 @@ module PreviewCirclesHelper
     'collection_information' => {
       'ShortName' => {
         required: true,
-        anchor: 'collection-information'
+        anchor: 'draft_short_name_label'
       },
       'Version' => {
         required: true,
-        anchor: 'collection-information'
+        anchor: 'draft_version_label'
       },
       'VersionDescription' => {
         required: false,
-        anchor: 'collection-information'
+        anchor: 'draft_version_description_label'
       },
       'EntryTitle' => {
         required: true,
-        anchor: 'collection-information'
+        anchor: 'draft_entry_title_label'
       },
       'DOI' => {
         required: true,
-        anchor: 'collection-information'
+        anchor: 'draft_doi_label'
       },
       'AssociatedDOIs' => {
         required: false,
-        anchor: 'collection-information'
+        anchor: 'draft_associated_dois_label'
       },
       'Abstract' => {
         required: true,
-        anchor: 'collection-information'
+        anchor: 'draft_abstract_label'
       },
       'Purpose' => {
         required: false,
-        anchor: 'collection-information'
+        anchor: 'draft_purpose_label'
       },
       'DataLanguage' => {
         required: false,
-        anchor: 'collection-information'
+        anchor: 'draft_data_language_label'
       }
     },
     'data_centers' => {
@@ -135,7 +135,7 @@ module PreviewCirclesHelper
       },
       'PaleoTemporalCoverages' => {
         required: false,
-        anchor: 'paleo-temporal-coverages'
+        anchor: 'paleo-temporal-coverage'
       }
     },
     'spatial_information' => {

--- a/app/views/collection_drafts/forms/_collection_information.html.erb
+++ b/app/views/collection_drafts/forms/_collection_information.html.erb
@@ -30,7 +30,8 @@
           value: draft.draft['ShortName'],
           help: 'properties/ShortName',
           validate: true,
-          always_required: true
+          always_required: true,
+          label_id: true
          ) %>
       </div>
       <!-- Version [r] -->
@@ -43,7 +44,8 @@
           help: 'properties/Version',
           validate: true,
           always_required: true,
-          help_url: 'Version'
+          help_url: 'Version',
+          label_id: true
          ) %>
       </div>
     </div>
@@ -58,7 +60,8 @@
           value: draft.draft['VersionDescription'],
           help: 'properties/VersionDescription',
           validate: true,
-          help_url: 'Version+Description'
+          help_url: 'Version+Description',
+          label_id: true
          ) %>
       </div>
     </div>
@@ -74,7 +77,8 @@
           help: 'properties/EntryTitle',
           validate: true,
           always_required: true,
-          help_url: 'Entry+Title'
+          help_url: 'Entry+Title',
+          label_id: true
          ) %>
       </div>
     </div>
@@ -84,7 +88,8 @@
       name: 'doi',
       title: 'DOI',
       prefix: 'draft_',
-      always_required: true
+      always_required: true,
+      label_id: true
     ) %>
     <%= mmt_help_icon(
       title: 'DOI',
@@ -106,6 +111,7 @@
       name: 'associated_dois',
       title: 'Associated DOIs',
       prefix: 'draft_',
+      label_id: true
     ) %>
     <%= mmt_help_icon(
       title: 'Associated DOIs',
@@ -133,7 +139,8 @@
           help: 'properties/Abstract',
           validate: true,
           always_required: true,
-          help_url: 'Abstract'
+          help_url: 'Abstract',
+          label_id: true
          ) %>
       </div>
     </div>
@@ -149,7 +156,8 @@
           value: draft.draft['Purpose'],
           help: 'properties/Purpose',
           help_url: 'Purpose',
-          validate: true
+          validate: true,
+          label_id: true
          ) %>
       </div>
     </div>
@@ -166,7 +174,8 @@
           options: @language_codes,
           help: 'properties/DataLanguage',
           help_url: 'Data+Language',
-          classes: 'mmt-fake-enum'
+          classes: 'mmt-fake-enum',
+          label_id: true
         ) %>
       </div>
     </div>

--- a/app/views/collection_drafts/forms/_data_centers.html.erb
+++ b/app/views/collection_drafts/forms/_data_centers.html.erb
@@ -1,4 +1,4 @@
-<fieldset class="eui-accordion" id="data_centers">
+<fieldset class="eui-accordion" id="data-centers">
   <div class="eui-accordion__header disable-toggle">
     <h3 class="eui-accordion__title eui-required-o always-required">Data Centers</h3>
     <%= mmt_help_icon(

--- a/app/views/collection_drafts/forms/_data_contacts.html.erb
+++ b/app/views/collection_drafts/forms/_data_contacts.html.erb
@@ -1,5 +1,5 @@
 <!-- Data Contacts - multiple -->
-<fieldset class="eui-accordion" id="data-contact">
+<fieldset class="eui-accordion" id="data-contacts">
   <div class="eui-accordion__header disable-toggle">
     <h3 class="eui-accordion__title">Data Contacts</h3>
   </div>

--- a/app/views/collection_drafts/forms/fields/_tiling_identification_system_fields.html.erb
+++ b/app/views/collection_drafts/forms/fields/_tiling_identification_system_fields.html.erb
@@ -13,8 +13,7 @@
   <%= mmt_label(
     title: 'Coordinate 1',
     prefix: name_prefix,
-    required: true,
-    set_id: true
+    required: true
   ) %>
   <%= mmt_help_icon(
     title: 'Coordinate 1',
@@ -31,8 +30,7 @@
   <%= mmt_label(
     title: 'Coordinate 2',
     prefix: name_prefix,
-    required: true,
-    set_id: true
+    required: true
   ) %>
   <%= mmt_help_icon(
     title: 'Coordinate 2',

--- a/spec/features/collection_drafts/forms/country_selection_spec.rb
+++ b/spec/features/collection_drafts/forms/country_selection_spec.rb
@@ -13,7 +13,7 @@ describe 'Country selection', js: true do
 
   context 'when selecting a Country with subregions' do
     before do
-      within '#data_centers' do
+      within '#data-centers' do
         select 'United States', from: 'Country'
       end
     end
@@ -28,7 +28,7 @@ describe 'Country selection', js: true do
 
     context 'when selecting a different country' do
       before do
-        within '#data_centers' do
+        within '#data-centers' do
           select 'United Kingdom', from: 'Country'
         end
       end
@@ -40,7 +40,7 @@ describe 'Country selection', js: true do
 
     context 'when selecting "Select Country" from the country field' do
       before do
-        within '#data_centers' do
+        within '#data-centers' do
           select 'Select Country', from: 'Country'
         end
       end
@@ -53,7 +53,7 @@ describe 'Country selection', js: true do
 
   context 'when selecting a Country without subregions' do
     before do
-      within '#data_centers' do
+      within '#data-centers' do
         select 'Saint Lucia', from: 'Country'
       end
     end

--- a/spec/features/collection_drafts/forms/required_fields_spec.rb
+++ b/spec/features/collection_drafts/forms/required_fields_spec.rb
@@ -166,7 +166,7 @@ describe 'Conditionally required fields', js: true do
       end
 
       it 'displays the required and optionally required icons' do
-        expect(page).to have_css('label.eui-required-o', count: 29)
+        expect(page).to have_css('label.eui-required-o', count: 33)
         expect(page).to have_css('label.eui-required-grey-o', count: 5)
       end
     end


### PR DESCRIPTION
- added `label_id`'s to the appropriate labels, and adjusted the `for` attribute logic in `mmt_label` so that the `for` attribute is added regardless of the presence of the label's id. This is permissible now because the `label_id` no longer equals the input field's id because of the appended `_label` text to the `label_id` 
- For peace of mind I checked everywhere the `set_id` (now called `label_id`) parameter was being used and found that the only place it was being used, it was not needed - in fact, it was causing a bug
- fixed a preexisting bug where Tiling Identification System > Coordinates 1&2 were not getting required icons when they should have been (by removing the `set_id` parameter)
- adjusted the anchors of all appropriate progress circles
- I did not feel the need to write tests because the progress circle anchors are hardcoded along with the `label_id`'s which are quasi-hardcoded.