### PR TITLE
hotfix/MMT-2534: turn csp logs back on

### DIFF
--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -112,7 +112,7 @@ Rails.application.configure do
   config.subscriptions_enabled = true
 
   # Feature toggle for Content Security Policy (CSP) logging.
-  config.csplog_enabled = false
+  config.csplog_enabled = true
 
   # Feature toggle for UMM-T
   config.umm_t_enabled = true


### PR DESCRIPTION
In the previous hotfix, csp logs were turned off during the development process and never turned back on.