### PR TITLE
MMT-2655: Update the chooser-widget to visually show which collections have s3 access

### DIFF
--- a/app/assets/javascripts/data_management.coffee
+++ b/app/assets/javascripts/data_management.coffee
@@ -32,6 +32,7 @@ $(document).ready ->
           text: ''
         },
         allowRemoveAll: true,
+        showS3Buckets: true, 
         errorCallback: ->
           $('<div class="eui-banner--danger">' +
             'A server error occurred. Unable to get collections.' +

--- a/app/assets/javascripts/order_option_assignments.coffee
+++ b/app/assets/javascripts/order_option_assignments.coffee
@@ -28,6 +28,7 @@ $(document).ready ->
         text: ''
       },
       allowRemoveAll: true,
+      showS3Buckets: true,
       errorCallback: ->
         $('<div class="eui-banner--danger">' +
             'A server error occurred. Unable to get collections.' +
@@ -72,7 +73,7 @@ $(document).ready ->
       rules:
         'order_option_assignment[]':
           required: true
-          
+
       messages:
         'order_option_assignment[]':
           'You must select at least 1 assignment.'
@@ -114,6 +115,7 @@ $(document).ready ->
         text: ''
       },
       allowRemoveAll: true,
+      showS3Buckets: true,
       errorCallback: ->
         $('<div class="eui-banner--danger">' +
             'A server error occurred. Unable to get collections.' +

--- a/app/assets/javascripts/order_option_assignments.coffee
+++ b/app/assets/javascripts/order_option_assignments.coffee
@@ -73,7 +73,7 @@ $(document).ready ->
       rules:
         'order_option_assignment[]':
           required: true
-
+          
       messages:
         'order_option_assignment[]':
           'You must select at least 1 assignment.'

--- a/app/assets/javascripts/order_policies.coffee
+++ b/app/assets/javascripts/order_policies.coffee
@@ -63,6 +63,7 @@ $(document).ready ->
           text: ''
         },
         allowRemoveAll: true,
+        showS3Buckets: true,
         errorCallback: ->
           $('<div class="eui-banner--danger">' +
             'A server error occurred. Unable to get collections.' +

--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -16,6 +16,7 @@ handleCollectionOptions = (selectedCollections) ->
     $('#chooser-widget').fadeOut(100)
 
 $(document).ready ->
+
   $('#permission-collection-list').tablesorter
     sortList: [[0,0]]
 

--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -16,7 +16,6 @@ handleCollectionOptions = (selectedCollections) ->
     $('#chooser-widget').fadeOut(100)
 
 $(document).ready ->
-
   $('#permission-collection-list').tablesorter
     sortList: [[0,0]]
 

--- a/app/assets/javascripts/permissions.coffee
+++ b/app/assets/javascripts/permissions.coffee
@@ -81,6 +81,7 @@ $(document).ready ->
           text: ''
         },
         allowRemoveAll: true,
+        showS3Buckets: true,
         errorCallback: ->
           $('<div class="eui-banner--danger">' +
               'A server error occurred. Unable to get collections.' +

--- a/app/assets/javascripts/service_management.coffee
+++ b/app/assets/javascripts/service_management.coffee
@@ -76,6 +76,7 @@ $(document).ready ->
           text: ''
         },
         allowRemoveAll: true,
+        showS3Buckets: true,
         errorCallback: ->
           $('<div class="eui-banner--danger">' +
             'A server error occurred. Unable to get collections.' +
@@ -263,6 +264,7 @@ $(document).ready ->
           text: ''
         },
         allowRemoveAll: true,
+        showS3Buckets: true,
         errorCallback: ->
           $('<div class="eui-banner--danger">' +
             'A server error occurred. Unable to get collections.' +

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -236,9 +236,9 @@ window.Chooser = (config) ->
 
       # Ensure each option has a title so that mouse hover reveals the full value
       # if it overflows the bounding box.
-      $(TO_LIST).find('option').each (key, tmpVal) ->
-        $(tmpVal).attr 'title', $(tmpVal).text()
-        return
+      # $(TO_LIST).find('option').each (key, tmpVal) ->
+      #   $(tmpVal).attr 'title', $(tmpVal).text()
+      #   return
       return
 
     $(FROM_LIST).change ->
@@ -253,9 +253,9 @@ window.Chooser = (config) ->
         $(LOWER_FROM_LABEL).text(lowerFromLabelText)
       # Ensure each option has a title so that mouse hover reveals the full value
       # if it overflows the bounding box.
-      $(FROM_LIST).find('option').each (key, tmpVal) ->
-        $(tmpVal).attr 'title', $(tmpVal).text()
-        return
+      # $(FROM_LIST).find('option').each (key, tmpVal) ->
+      #   $(tmpVal).attr 'title', $(tmpVal).text()
+      #   return
       return
 
     $(FROM_FILTER_TEXTBOX).keyup initFromFilter
@@ -377,7 +377,7 @@ window.Chooser = (config) ->
           dispVal = optVal = tmpVal[0]
         else
           dispVal = optVal = tmpVal
-        opt = $('<option>').val(optVal).text(dispVal)
+        opt = $('<option>').val(optVal).text(dispVal).addClass('icon-s3')
         $(which).append opt
         return
       $(which).trigger 'change'

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -370,6 +370,7 @@ window.Chooser = (config) ->
       $.each values, (tmpKey, tmpVal) ->
         dispVal = undefined
         optVal = undefined
+        s3Prefixes = tmpVal?[2]
         if typeof tmpVal == 'object' and tmpVal.length == 2
           optVal = tmpVal[0]
           dispVal = tmpVal[1]
@@ -377,7 +378,7 @@ window.Chooser = (config) ->
           dispVal = optVal = tmpVal[0]
         else
           dispVal = optVal = tmpVal
-        opt = $('<option>').val(optVal).text(dispVal).addClass('icon-s3')
+        opt = $('<option>').val(optVal).text(dispVal).attr('title', s3Prefixes).addClass('icon-s3' if s3Prefixes)
         $(which).append opt
         return
       $(which).trigger 'change'

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -370,7 +370,7 @@ window.Chooser = (config) ->
       $.each values, (tmpKey, tmpVal) ->
         dispVal = undefined
         optVal = undefined
-        s3Prefixes = if config.showS3Buckets then 'tmpVal?[2]' else undefined
+        s3Prefixes = if config.showS3Buckets then tmpVal?[2] else undefined
         if typeof tmpVal == 'object' and tmpVal.length == 2
           optVal = tmpVal[0]
           dispVal = tmpVal[1]

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -368,17 +368,18 @@ window.Chooser = (config) ->
     if values and typeof values == 'object'
       $(which).empty()
       $.each values, (tmpKey, tmpVal) ->
-        dispVal = undefined
-        optVal = undefined
-        s3Prefixes = if config.showS3Buckets then tmpVal?[2] else undefined
-        if typeof tmpVal == 'object' and tmpVal.length == 2
+
+        s3Prefixes = tmpVal?[2] if config.showS3Buckets
+
+        if typeof tmpVal == 'object' and tmpVal.length > 1
           optVal = tmpVal[0]
           dispVal = tmpVal[1]
         else if typeof tmpVal == 'object' and tmpVal.length == 1
           dispVal = optVal = tmpVal[0]
         else
           dispVal = optVal = tmpVal
-        opt = $('<option>').val(optVal).text(dispVal).attr('title', s3Prefixes).addClass('icon-s3' if s3Prefixes)
+
+        opt = $('<option>').val(optVal).text(dispVal).attr('title', s3Prefixes or dispVal).addClass('icon-s3' if s3Prefixes)
         $(which).append opt
         return
       $(which).trigger 'change'

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -233,12 +233,7 @@ window.Chooser = (config) ->
 
       if hasProp('attachTo', 'object')
         $(config.attachTo).val SELF.val().join(config.delimiter)
-
-      # Ensure each option has a title so that mouse hover reveals the full value
-      # if it overflows the bounding box.
-      # $(TO_LIST).find('option').each (key, tmpVal) ->
-      #   $(tmpVal).attr 'title', $(tmpVal).text()
-      #   return
+        
       return
 
     $(FROM_LIST).change ->
@@ -251,11 +246,7 @@ window.Chooser = (config) ->
         lowerFromLabelText = lowerFromLabelText.replace '{{n}}', n
         lowerFromLabelText = lowerFromLabelText.replace('{{s}}', pluralize(n))
         $(LOWER_FROM_LABEL).text(lowerFromLabelText)
-      # Ensure each option has a title so that mouse hover reveals the full value
-      # if it overflows the bounding box.
-      # $(FROM_LIST).find('option').each (key, tmpVal) ->
-      #   $(tmpVal).attr 'title', $(tmpVal).text()
-      #   return
+
       return
 
     $(FROM_FILTER_TEXTBOX).keyup initFromFilter

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -233,7 +233,7 @@ window.Chooser = (config) ->
 
       if hasProp('attachTo', 'object')
         $(config.attachTo).val SELF.val().join(config.delimiter)
-        
+
       return
 
     $(FROM_LIST).change ->
@@ -360,7 +360,7 @@ window.Chooser = (config) ->
       $(which).empty()
       $.each values, (tmpKey, tmpVal) ->
 
-        s3Prefixes = tmpVal?[2] if config.showS3Buckets
+        s3Prefixes = tmpVal[2] if config.showS3Buckets
 
         if typeof tmpVal == 'object' and tmpVal.length > 1
           optVal = tmpVal[0]

--- a/app/assets/javascripts/widgets/Chooser/Chooser.coffee
+++ b/app/assets/javascripts/widgets/Chooser/Chooser.coffee
@@ -370,7 +370,7 @@ window.Chooser = (config) ->
       $.each values, (tmpKey, tmpVal) ->
         dispVal = undefined
         optVal = undefined
-        s3Prefixes = tmpVal?[2]
+        s3Prefixes = if config.showS3Buckets then 'tmpVal?[2]' else undefined
         if typeof tmpVal == 'object' and tmpVal.length == 2
           optVal = tmpVal[0]
           dispVal = tmpVal[1]

--- a/app/assets/stylesheets/components/_icons.scss
+++ b/app/assets/stylesheets/components/_icons.scss
@@ -86,8 +86,14 @@
   &:before {
     content: '\f111';
     font-family: "FontAwesome";
-    color: $orange;
     margin-right: 0.75em;
+    background: -moz-linear-gradient(top, #ffdc6c 10%, #dd7f00 50%);
+    background: -webkit-linear-gradient(top, #ffdc6c 10%, #dd7f00 50%);
+    background: linear-gradient(to bottom, #ffdc6c 10%, #dd7f00 50%);
+    background-clip: text;
+    -webkit-background-clip: text;
+    -moz-background-clip: text;
+    -webkit-text-fill-color: transparent;
   }
 }
 

--- a/app/assets/stylesheets/components/_icons.scss
+++ b/app/assets/stylesheets/components/_icons.scss
@@ -82,6 +82,15 @@
   }
 }
 
+.icon-s3 {
+  &:before {
+    content: '\f111';
+    font-family: "FontAwesome";
+    color: $orange;
+    margin-right: 0.75em;
+  }
+}
+
 .eui-circle-left {
   &:before {
     font-family: "EUI-Icon-Library";

--- a/app/concerns/chooser_endpoints.rb
+++ b/app/concerns/chooser_endpoints.rb
@@ -10,13 +10,14 @@ module ChooserEndpoints
     render json: {
       'hits': collections.fetch('hits', 0),
       'items': items.map do |collection|
-        [
-          collection.fetch('meta', {}).fetch('concept-id'),
-          [
-            collection.fetch('umm', {}).fetch('entry-id'),
-            collection.fetch('umm', {}).fetch('entry-title')
-          ].join(' | ')
+        s3_links = Array.wrap(collection.dig('meta','s3-links')).join(', ')
+
+        bucket = [
+          collection.dig('meta','concept-id'),
+          "#{collection.dig('umm','entry-id')} | #{collection.dig('umm','entry-title')}"
         ]
+        bucket << s3_links unless s3_links.blank?
+        bucket
       end
     }
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/spec/features/chooser/chooser_disable_selected_options.rb
+++ b/spec/features/chooser/chooser_disable_selected_options.rb
@@ -30,13 +30,17 @@ describe 'Chooser Disable Selected Options', js: true do
       end
     end
 
-    # TODO: add [title="s3 buckets"] for each collection with s3 buckets
     it 'disables the selected items in the from list' do
       within '#catalog_item_guid_fromList' do
-        expect(page).to have_css('option[value="C1200060160-MMT_2"]:disabled')
+        expect(page).to have_css('option.icon-s3[value="C1200060160-MMT_2"]:disabled')
         expect(page).to have_css('option[value="C1200189951-MMT_2"]:disabled')
         expect(page).to have_css('option[value="C1200189943-MMT_2"]:disabled')
       end
+
+      # checks the hover-over values
+      expect(page).to have_css('.ui-tooltip-content', text: 'bucket1, bucket2, bucket3', count: 1)
+      expect(page).to have_css('.ui-tooltip-content', text: 'testing 03_002 | Test test title 03', count: 1)
+      expect(page).to have_css('.ui-tooltip-content', text: 'testing 02_01 | My testing title 02', count: 1)
     end
 
     context 'when removing those values from the right hand side of the chooser individually' do
@@ -57,13 +61,17 @@ describe 'Chooser Disable Selected Options', js: true do
         end
       end
 
-      # TODO: add [title="s3 buckets"] for each collection with s3 buckets
       it 'enables the items on the left hand side' do
         within '#catalog_item_guid_fromList' do
-          expect(page).to have_css('option[value="C1200060160-MMT_2"]:enabled')
+          expect(page).to have_css('option.icon-s3[value="C1200060160-MMT_2"]:enabled')
           expect(page).to have_css('option[value="C1200189951-MMT_2"]:enabled')
           expect(page).to have_css('option[value="C1200189943-MMT_2"]:enabled')
         end
+
+        # checks the hover-over values
+        expect(page).to have_css('.ui-tooltip-content', text: 'bucket1, bucket2, bucket3', count: 1)
+        expect(page).to have_css('.ui-tooltip-content', text: 'testing 03_002 | Test test title 03', count: 1)
+        expect(page).to have_css('.ui-tooltip-content', text: 'testing 02_01 | My testing title 02', count: 1)
       end
     end
 
@@ -74,13 +82,17 @@ describe 'Chooser Disable Selected Options', js: true do
         end
       end
 
-      # TODO: add [title="s3 buckets"] for each collection with s3 buckets
       it 'enables the items on the left hand side' do
         within '#catalog_item_guid_fromList' do
-          expect(page).to have_css('option[value="C1200060160-MMT_2"]:enabled')
+          expect(page).to have_css('option[value="C1200060160-MMT_2"].icon-s3:enabled')
           expect(page).to have_css('option[value="C1200189951-MMT_2"]:enabled')
           expect(page).to have_css('option[value="C1200189943-MMT_2"]:enabled')
         end
+        
+        # checks the hover-over values
+        expect(page).to have_css('.ui-tooltip-content', text: 'bucket1, bucket2, bucket3', count: 1)
+        expect(page).to have_css('.ui-tooltip-content', text: 'testing 03_002 | Test test title 03', count: 1)
+        expect(page).to have_css('.ui-tooltip-content', text: 'testing 02_01 | My testing title 02', count: 1)
       end
     end
   end

--- a/spec/features/chooser/chooser_disable_selected_options.rb
+++ b/spec/features/chooser/chooser_disable_selected_options.rb
@@ -30,6 +30,7 @@ describe 'Chooser Disable Selected Options', js: true do
       end
     end
 
+    # TODO: add [title="s3 buckets"] for each collection with s3 buckets
     it 'disables the selected items in the from list' do
       within '#catalog_item_guid_fromList' do
         expect(page).to have_css('option[value="C1200060160-MMT_2"]:disabled')
@@ -56,6 +57,7 @@ describe 'Chooser Disable Selected Options', js: true do
         end
       end
 
+      # TODO: add [title="s3 buckets"] for each collection with s3 buckets
       it 'enables the items on the left hand side' do
         within '#catalog_item_guid_fromList' do
           expect(page).to have_css('option[value="C1200060160-MMT_2"]:enabled')
@@ -72,6 +74,7 @@ describe 'Chooser Disable Selected Options', js: true do
         end
       end
 
+      # TODO: add [title="s3 buckets"] for each collection with s3 buckets
       it 'enables the items on the left hand side' do
         within '#catalog_item_guid_fromList' do
           expect(page).to have_css('option[value="C1200060160-MMT_2"]:enabled')

--- a/spec/features/chooser/chooser_to_filter_spec.rb
+++ b/spec/features/chooser/chooser_to_filter_spec.rb
@@ -31,6 +31,7 @@ describe 'Chooser To Filter', js: true do
     it 'moves the items to the TO list' do
       within '#catalog_item_guid_toList' do
         expect(page).to have_css('option', count: 3)
+        # TODO: add expectation for s3 icon and title
       end
     end
 
@@ -52,6 +53,7 @@ describe 'Chooser To Filter', js: true do
         within '#catalog_item_guid_toList' do
           # Selenium is picking up the '.is-hidden' element(s) for some reason, so we need to specify not having the class
           expect(page).to have_css('option:not(.is-hidden)', count: 2)
+          # TODO: add expectation for s3 icon and title of the non-hidden s3 collections
         end
       end
 
@@ -78,6 +80,7 @@ describe 'Chooser To Filter', js: true do
           within '#catalog_item_guid_toList' do
             # Selenium is picking up the '.is-hidden' element(s) for some reason, so we need to specify not having the class
             expect(page).to have_css('option:not(.is-hidden)', count: 3)
+            # TODO: add expectation for s3 icon and title of the non-hidden s3 collections
           end
         end
 
@@ -105,6 +108,7 @@ describe 'Chooser To Filter', js: true do
           within '#catalog_item_guid_toList' do
             # Selenium is picking up the '.is-hidden' element(s) for some reason, so we need to specify not having the class
             expect(page).to have_css('option:not(.is-hidden)', count: 2)
+            # TODO: add expectation for s3 icon and title of the non-hidden s3 collections
           end
         end
 

--- a/spec/features/chooser/chooser_to_filter_spec.rb
+++ b/spec/features/chooser/chooser_to_filter_spec.rb
@@ -31,8 +31,13 @@ describe 'Chooser To Filter', js: true do
     it 'moves the items to the TO list' do
       within '#catalog_item_guid_toList' do
         expect(page).to have_css('option', count: 3)
-        # TODO: add expectation for s3 icon and title
+        expect(page).to have_css('option.icon-s3', count: 1)
       end
+
+      # checks the hover-over values
+      expect(page).to have_css('.ui-tooltip-content', text: 'bucket1, bucket2, bucket3', count: 1)
+      expect(page).to have_css('.ui-tooltip-content', text: 'testing 03_002 | Test test title 03', count: 1)
+      expect(page).to have_css('.ui-tooltip-content', text: 'testing 02_01 | My testing title 02', count: 1)
     end
 
     it 'displays the correct number of collections in the TO list' do
@@ -53,8 +58,13 @@ describe 'Chooser To Filter', js: true do
         within '#catalog_item_guid_toList' do
           # Selenium is picking up the '.is-hidden' element(s) for some reason, so we need to specify not having the class
           expect(page).to have_css('option:not(.is-hidden)', count: 2)
-          # TODO: add expectation for s3 icon and title of the non-hidden s3 collections
+          expect(page).to have_css('option.icon-s3', count: 1)
         end
+
+        # checks the hover-over values
+        expect(page).to have_css('.ui-tooltip-content', text: 'bucket1, bucket2, bucket3', count: 1)
+        expect(page).to have_css('.ui-tooltip-content', text: 'testing 03_002 | Test test title 03', count: 1)
+        expect(page).to have_css('.ui-tooltip-content', text: 'testing 02_01 | My testing title 02', count: 1)
       end
 
       it 'displays the correct number of collections in the TO list' do
@@ -80,8 +90,13 @@ describe 'Chooser To Filter', js: true do
           within '#catalog_item_guid_toList' do
             # Selenium is picking up the '.is-hidden' element(s) for some reason, so we need to specify not having the class
             expect(page).to have_css('option:not(.is-hidden)', count: 3)
-            # TODO: add expectation for s3 icon and title of the non-hidden s3 collections
+            expect(page).to have_css('option.icon-s3', count: 1)
           end
+
+          # checks the hover-over values
+          expect(page).to have_css('.ui-tooltip-content', text: 'bucket1, bucket2, bucket3', count: 1)
+          expect(page).to have_css('.ui-tooltip-content', text: 'testing 03_002 | Test test title 03', count: 1)
+          expect(page).to have_css('.ui-tooltip-content', text: 'testing 02_01 | My testing title 02', count: 1)
         end
 
         it 'displays the correct number of collections in the TO list' do
@@ -108,8 +123,13 @@ describe 'Chooser To Filter', js: true do
           within '#catalog_item_guid_toList' do
             # Selenium is picking up the '.is-hidden' element(s) for some reason, so we need to specify not having the class
             expect(page).to have_css('option:not(.is-hidden)', count: 2)
-            # TODO: add expectation for s3 icon and title of the non-hidden s3 collections
+            expect(page).to have_css('option.icon-s3', count: 1)
           end
+
+          # checks the hover-over values
+          expect(page).to have_css('.ui-tooltip-content', text: 'bucket1, bucket2, bucket3', count: 1)
+          expect(page).to have_css('.ui-tooltip-content', text: 'testing 03_002 | Test test title 03', count: 1)
+          expect(page).to have_css('.ui-tooltip-content', text: 'testing 02_01 | My testing title 02', count: 1)
         end
 
         it 'displays the correct number of collections in the TO list' do

--- a/spec/fixtures/cmr_search.json
+++ b/spec/fixtures/cmr_search.json
@@ -31,7 +31,12 @@
         "native-id": "mmt_collection_64",
         "concept-id": "C1200060160-MMT_2",
         "revision-date": "2016-02-01T17:10:13Z",
-        "concept-type": "collection"
+        "concept-type": "collection",
+        "s3-links": [
+          "bucket1",
+          "bucket2",
+          "bucket3"
+        ]
       },
       "umm": {
         "entry-title": "Mark's Test",


### PR DESCRIPTION
- Adjusted method to add `s3-links` for Chooser widget consumption
- Adjusted Chooser widget to show s3 icon and buckets if s3 links are available
- wrote tests