### PR TITLE
Mmt 2814 - Fixed build failures from latest changes to CMR.

### DIFF
--- a/app/controllers/manage_proposal_controller.rb
+++ b/app/controllers/manage_proposal_controller.rb
@@ -101,7 +101,7 @@ class ManageProposalController < ManageMetadataController
   end
 
   def publish_delete_proposal(proposal, provider)
-    search_response = cmr_client.get_collections({ 'native_id': proposal['native_id'], 'provider_id': provider }, token)
+    search_response = cmr_client.get_collections({ 'native_id': proposal['native_id'], 'provider_id': provider, 'include_granule_counts': true }, token)
 
     if search_response.body['hits'].to_s != '1'
       # If the search has more than one hit or 0 hits, the record was not

--- a/lib/cmr/cmr_client.rb
+++ b/lib/cmr/cmr_client.rb
@@ -431,6 +431,9 @@ module Cmr
     # Create and update
     def ingest_subscription(subscription, provider_id, native_id, token)
       url = if Rails.env.development? || Rails.env.test?
+              # CMR does a check to ensure the subscriber id exists in EDL.
+              # So add this user to local cmr.
+              add_users_to_local_cmr([JSON.parse(subscription)['SubscriberId']], nil)
               "http://localhost:3002/providers/#{provider_id}/subscriptions/#{encode_if_needed(native_id)}"
             else
               "/ingest/providers/#{provider_id}/subscriptions/#{encode_if_needed(native_id)}"

--- a/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
@@ -130,10 +130,6 @@ describe 'Viewing a list of subscriptions', reset_provider: true do
 
       clear_cache
 
-      # CMR does a check to ensure the user 'fakeid' exists in EDL.
-      # So add this user to local cmr.
-      cmr_client.add_users_to_local_cmr(['fakeid'], nil)
-
       _ingest_response2, @search_response3, @subscription3 = publish_new_subscription(provider: 'MMT_1', email_address: 'fake@fake.fake', query: 'polygon=10,10,30,10,30,20,10,20,10,10&equator_crossing_longitude=0,10', subscriber_id: 'fakeid', collection_concept_id: @c_ingest_response2['concept-id'])
 
       allow_any_instance_of(SubscriptionPolicy).to receive(:index?).and_return(true)

--- a/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/index_subscriptions_spec.rb
@@ -130,6 +130,10 @@ describe 'Viewing a list of subscriptions', reset_provider: true do
 
       clear_cache
 
+      # CMR does a check to ensure the user 'fakeid' exists in EDL.
+      # So add this user to local cmr.
+      cmr_client.add_users_to_local_cmr(['fakeid'], nil)
+
       _ingest_response2, @search_response3, @subscription3 = publish_new_subscription(provider: 'MMT_1', email_address: 'fake@fake.fake', query: 'polygon=10,10,30,10,30,20,10,20,10,10&equator_crossing_longitude=0,10', subscriber_id: 'fakeid', collection_concept_id: @c_ingest_response2['concept-id'])
 
       allow_any_instance_of(SubscriptionPolicy).to receive(:index?).and_return(true)

--- a/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
@@ -21,10 +21,6 @@ describe 'When Viewing Subscriptions', js:true, reset_provider: true do
 
   context 'when visiting the show page' do
     before :all do
-      # CMR does a check to ensure the user 'rarxd5taqea' exists in EDL.
-      # So add this user to local cmr.
-      cmr_client.add_users_to_local_cmr(['rarxd5taqea'], nil)
-
       # make a record
       @ingest_response, search_response, @subscription = publish_new_subscription(native_id: @native_id, collection_concept_id: @c_ingest_response['concept-id'])
       @native_id = search_response.body['items'].first['meta']['native-id']

--- a/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
+++ b/spec/features/manage_cmr/subscriptions/show_subscription_spec.rb
@@ -1,4 +1,4 @@
-describe 'When Viewing Subscriptions', reset_provider: true do
+describe 'When Viewing Subscriptions', js:true, reset_provider: true do
   before :all do
     @subscriptions_group = create_group(members: ['testuser', 'typical'])
     # the ACL is currently configured to work like Ingest, U covers CUD (of CRUD)
@@ -21,6 +21,10 @@ describe 'When Viewing Subscriptions', reset_provider: true do
 
   context 'when visiting the show page' do
     before :all do
+      # CMR does a check to ensure the user 'rarxd5taqea' exists in EDL.
+      # So add this user to local cmr.
+      cmr_client.add_users_to_local_cmr(['rarxd5taqea'], nil)
+
       # make a record
       @ingest_response, search_response, @subscription = publish_new_subscription(native_id: @native_id, collection_concept_id: @c_ingest_response['concept-id'])
       @native_id = search_response.body['items'].first['meta']['native-id']


### PR DESCRIPTION
Adds test user to local URS/EDL before creating subscription as CMR wiill check to ensure user exists in EDL. Added include_granule_counts to CMR collection query, as deleting a collection requires a check to ensure there are no granules and this info was missing.