### PR TITLE
MMT-2707: handle both ingest error formats from CMR 

### DIFF
--- a/app/assets/javascripts/drafts.coffee
+++ b/app/assets/javascripts/drafts.coffee
@@ -420,6 +420,24 @@ $(document).ready ->
       # Find input children that have not been intentionally hidden with type='hidden'
       .find(':not("[type=\'hidden\']")input').val("")
 
+  validationErrorMessage = (error) ->
+    # construct error message from ingest error structure
+    if error.field && error.page
+      formText = $('<a/>',
+        href: "#{draftId}/edit/#{error.page}",
+        text: error.field
+      )
+    else
+      formText = $('<span/>',
+        text: error.field
+      )
+
+    errorText = $('<span/>',
+      html: " #{error.error}"
+    )
+
+    errorText.prepend(formText)
+
   # check cmr validation button for collection drafts
   $('#check-cmr-validation-button').on 'click', (event) ->
     $.ajax "#{draftId}/check_cmr_validation",
@@ -467,12 +485,10 @@ $(document).ready ->
         $errorList = $('<ul/>', class: 'no-bullet')
         for error in response.responseJSON.errors
           $listElement = $('<li/>',
-            text: error
+            html: validationErrorMessage(error)
           )
           $listElement.appendTo($errorList)
         $errorList.appendTo($modalText)
-
-
 
         $('.check-cmr-validation-text').html($modalText)
 

--- a/app/controllers/collection_drafts_controller.rb
+++ b/app/controllers/collection_drafts_controller.rb
@@ -187,6 +187,8 @@ class CollectionDraftsController < BaseDraftsController
       Rails.logger.info("User #{current_user.urs_uid} attempted to ingest collection draft #{get_resource.entry_title} in provider #{current_user.provider_id} but encountered an error.")
 
       @ingest_errors = generate_ingest_errors(ingested_response)
+
+      # ingest errors are handled in the view, so not needed in the flash
       flash[:error] = I18n.t("controllers.draft.#{plural_resource_name}.publish.flash.error")
       render :show
     end
@@ -260,7 +262,7 @@ class CollectionDraftsController < BaseDraftsController
         @modal_response[:status_text] = 'This draft will be published with no issues.'
       end
     else
-      errors = Array.wrap(validation_response.error_messages)
+      errors = generate_ingest_errors(validation_response)
 
       @modal_response[:status_text] = 'This draft is not ready to be published.'
       @modal_response[:errors] = errors
@@ -381,11 +383,7 @@ class CollectionDraftsController < BaseDraftsController
     else # If the error is not about required fields
       # if the last field is an array index, use the last section of the field path that isn't a number
       field = fields.split('/').select do |f|
-        begin
-          false if Float(f)
-        rescue
-          true
-        end
+        !is_number?(f)
       end
       {
         field: field.last,
@@ -420,6 +418,8 @@ class CollectionDraftsController < BaseDraftsController
       'has an invalid selection'
     when /has an invalid selection option/
       'has an invalid selection'
+    when /contains additional properties/
+      'has invalid additional fields'
     end
   end
 

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -80,8 +80,10 @@ class CollectionsController < ManageCollectionsController
       Rails.logger.error("Ingest (Revert) Collection Error: #{ingested_response.clean_inspect}")
       Rails.logger.info("User #{current_user.urs_uid} attempted to revert Collection #{@concept_id} by ingesting a previous revision in provider #{current_user.provider_id} but encountered an error.")
 
-      @errors = generate_ingest_errors(ingested_response)
-      flash[:error] = ingested_response.error_message(i18n: I18n.t('controllers.collections.revert.flash.error'))
+      @ingest_errors = generate_ingest_errors(ingested_response)
+
+      # ingest errors are handled in the view, so not needed in the flash
+      flash[:error] = I18n.t('controllers.collections.revert.flash.error')
       render action: 'revisions'
     end
   end

--- a/app/views/collections/revisions.html.erb
+++ b/app/views/collections/revisions.html.erb
@@ -4,14 +4,18 @@
   <%= nrt_badge(@collection) %>
 <% end %>
 
-<% if @errors && !@errors.empty? %>
+<% if @ingest_errors && !@ingest_errors.empty? %>
   <section class="errors">
     <div class="eui-banner--danger">
       <div class="eui-banner__message">
         <ul class="no-bullet">
-          <% @errors.each do |error| %>
-            <li>
-              <%= "#{error[:field]}, " if error[:field] %>
+          <% @ingest_errors.each do |error, index| %>
+            <li class="ingest-error-<%= index %>">
+              <% if error[:field] && error[:page] %>
+                <%= link_to name_to_title(error[:field].to_s), edit_collection_draft_path(@collection, error[:page]) %>
+              <% else %>
+                <%= "#{error[:field]}," if error[:field] %>
+              <% end %>
               <%= error[:error] %>
               <% if error[:request_id] %>
                 <a href="javascript:feedback.showForm({details: '\nFill in details above this line. Please try to be as specific as possible.\n--------------------\n\nRequest ID: <%= error[:request_id] %>'});">Click here to submit feedback</a>

--- a/spec/features/collection_drafts/progressive_update_collection_spec.rb
+++ b/spec/features/collection_drafts/progressive_update_collection_spec.rb
@@ -37,6 +37,7 @@ describe 'Progressive Update Collection Draft', reset_provider: true, js: true d
       context 'When introducing a new error to the draft and attempting to publish' do
         before do
           # introduce a new error
+          # this is a "General Error" that does not have error and path attributes
           within '.progress-indicator' do
             click_on 'Processing Level - Required field complete'
           end
@@ -55,6 +56,7 @@ describe 'Progressive Update Collection Draft', reset_provider: true, js: true d
           within '#check-cmr-validation-draft-modal' do
             expect(page).to have_content('This draft is not ready to be published.')
             expect(page).to have_content('Please use the progress indicators on the draft preview page to address the following:')
+            expect(page).to have_link('ProcessingLevel')
             expect(page).to have_content('#/ProcessingLevel: required key [Id] not found')
 
             expect(page).to have_no_link('Yes, Publish Collection Draft')
@@ -71,41 +73,138 @@ describe 'Progressive Update Collection Draft', reset_provider: true, js: true d
           within '#check-cmr-validation-draft-modal' do
             expect(page).to have_content('This draft will be published with the following issues:')
             expect(page).to have_content('Existing Errors: After translating item to UMM-C the metadata had the following existing error(s):')
+            expect(page).to have_content('Warnings: After translating item to UMM-C the metadata had the following issue(s):')
+
             expect(page).to have_content('[:TemporalExtents 0 :RangeDateTimes 0] BeginningDateTime [2011-07-04T00:23:48.000Z] must be no later than EndingDateTime [1995-10-01T03:13:03.000Z]')
             expect(page).to have_content('[:Platforms] The Platform ShortName [ERS-3] must be unique. This record contains duplicates')
-            expect(page).to have_content('[:AdditionalAttributes 0] Parameter Range Begin is not allowed for type [STRING]')
             expect(page).to have_content('[:Projects] Projects must be unique. This contains duplicates named [IceBridge]')
+            expect(page).to have_content('[:AdditionalAttributes 0] Parameter Range Begin is not allowed for type [STRING]')
             expect(page).to have_content('[:MetadataAssociations] Metadata Associations must be unique. This contains duplicates named [(EntryId [C1234453343-ECHO_REST] & Version [1])]')
-            expect(page).to have_content('[:TilingIdentificationSystems] Tiling Identification Systems must be unique. This contains duplicates named [CALIPSO]')
-            expect(page).to have_content('Warnings: After translating item to UMM-C the metadata had the following issue(s):')
+
             expect(page).to have_content('[:RelatedUrls 0 :URL] [https=>//vertex.daac.asf.alaska.edu/] is not a valid URL')
+
             expect(page).to have_content('Are you sure you want to publish this draft now?')
             expect(page).to have_link('Yes, Publish Collection Draft')
           end
         end
+      end
 
-        context 'when publishing the draft' do
-          before do
-            click_on 'Yes, Publish Collection Draft'
+      context 'When fixing some errors' do
+        before do
+          click_on 'Tiling Identification Systems'
+          click_on 'Expand All'
+
+          within '#draft_tiling_identification_systems_1' do
+            select 'MISR', from: 'Tiling Identification System Name'
           end
 
-          it 'successfully publishes the update and displays the provided warnings' do
-            expect(page).to have_content('Collection Draft Published Successfully!')
+          within '.nav-top' do
+            click_on 'Done'
+          end
+        end
 
-            expect(page).to have_content('Collection was published with the following issues:')
-            expect(page).to have_content('Existing Errors: After translating item to UMM-C the metadata had the following existing error(s):')
-            expect(page).to have_content('[:TemporalExtents 0 :RangeDateTimes 0] BeginningDateTime [2011-07-04T00:23:48.000Z] must be no later than EndingDateTime [1995-10-01T03:13:03.000Z]')
-            expect(page).to have_content('[:Platforms] The Platform ShortName [ERS-3] must be unique. This record contains duplicates')
-            expect(page).to have_content('[:AdditionalAttributes 0] Parameter Range Begin is not allowed for type [STRING]')
-            expect(page).to have_content('[:Projects] Projects must be unique. This contains duplicates named [IceBridge]')
-            expect(page).to have_content('[:MetadataAssociations] Metadata Associations must be unique. This contains duplicates named [(EntryId [C1234453343-ECHO_REST] & Version [1])]')
-            expect(page).to have_content('[:TilingIdentificationSystems] Tiling Identification Systems must be unique. This contains duplicates named [CALIPSO]')
-            expect(page).to have_content('Warnings: After translating item to UMM-C the metadata had the following issue(s):')
-            expect(page).to have_no_content('Metadata Fields')
-            expect(page).to have_no_css('ul.progress-indicator')
+        context 'when attempting to publish the draft' do
+          before do
+            click_on 'Publish Collection Draft'
+          end
+
+          it 'indicates the draft can be published with errors' do
+            within '#check-cmr-validation-draft-modal' do
+              expect(page).to have_content('This draft will be published with the following issues:')
+              expect(page).to have_content('Existing Errors: After translating item to UMM-C the metadata had the following existing error(s):')
+              expect(page).to have_content('Warnings: After translating item to UMM-C the metadata had the following issue(s):')
+
+              expect(page).to have_content('[:TemporalExtents 0 :RangeDateTimes 0] BeginningDateTime [2011-07-04T00:23:48.000Z] must be no later than EndingDateTime [1995-10-01T03:13:03.000Z];;')
+              expect(page).to have_content('[:Platforms] The Platform ShortName [ERS-3] must be unique. This record contains duplicates')
+              expect(page).to have_content('[:AdditionalAttributes 0] Parameter Range Begin is not allowed for type [STRING]')
+              expect(page).to have_content('[:Projects] Projects must be unique. This contains duplicates named [IceBridge]')
+              expect(page).to have_content('[:MetadataAssociations] Metadata Associations must be unique. This contains duplicates named [(EntryId [C1234453343-ECHO_REST] & Version [1])]')
+
+              expect(page).to have_content('[:RelatedUrls 0 :URL] [https=>//vertex.daac.asf.alaska.edu/] is not a valid URL')
+              expect(page).to have_content('Are you sure you want to publish this draft now?')
+              expect(page).to have_link('Yes, Publish Collection Draft')
+            end
+          end
+
+          context 'when publishing the draft with errors' do
+            before do
+              click_on 'Yes, Publish Collection Draft'
+            end
+
+            it 'successfully publishes the update and displays the provided warnings' do
+              expect(page).to have_content('Collection Draft Published Successfully!')
+
+              expect(page).to have_content('Collection was published with the following issues:')
+              expect(page).to have_content('Warnings: After translating item to UMM-C the metadata had the following issue(s):')
+
+              expect(page).to have_content('Existing Errors: After translating item to UMM-C the metadata had the following existing error(s):')
+              expect(page).to have_content('[:TemporalExtents 0 :RangeDateTimes 0] BeginningDateTime [2011-07-04T00:23:48.000Z] must be no later than EndingDateTime [1995-10-01T03:13:03.000Z]')
+              expect(page).to have_content('[:Platforms] The Platform ShortName [ERS-3] must be unique. This record contains duplicates')
+              expect(page).to have_content('[:AdditionalAttributes 0] Parameter Range Begin is not allowed for type [STRING]')
+              expect(page).to have_content('[:Projects] Projects must be unique. This contains duplicates named [IceBridge]')
+              expect(page).to have_content('[:MetadataAssociations] Metadata Associations must be unique. This contains duplicates named [(EntryId [C1234453343-ECHO_REST] & Version [1])]')
+
+            end
+
+            context 'when adding the fixed errors back into the draft' do
+              before do
+                # add errors back
+                # should be a "UMM Validation Error" which has path and error attributes
+                click_on 'Edit Collection Record'
+
+                click_on 'Tiling Identification Systems'
+                click_on 'Expand All'
+
+                within '#draft_tiling_identification_systems_1' do
+                  select 'CALIPSO', from: 'Tiling Identification System Name'
+                end
+
+                within '.nav-top' do
+                  click_on 'Done'
+                end
+              end
+
+              context 'when attempting to publish the draft' do
+                before do
+                  click_on 'Publish Collection Draft'
+                end
+
+                it 'indicates the draft cannot be published' do
+                  within '#check-cmr-validation-draft-modal' do
+                    expect(page).to have_content('This draft is not ready to be published.')
+                    expect(page).to have_content('Please use the progress indicators on the draft preview page to address the following:')
+                    expect(page).to have_link('TilingIdentificationSystems')
+                    expect(page).to have_content('Tiling Identification Systems must be unique. This contains duplicates named [CALIPSO].')
+
+                    expect(page).to have_no_link('Yes, Publish Collection Draft')
+                  end
+                end
+              end
+            end
+
+            context 'when attempting to revert the collection to the revision with the fixed errors' do
+              before do
+                # go to revisions page
+                click_on 'Revisions'
+
+                # revert to collection with all errors
+                within 'tbody tr:nth-last-child(2)' do
+                  click_on 'Revert to this Revision'
+                end
+                click_on 'Yes'
+              end
+
+              it 'fails to revert and displays the error returned from CMR and a generic error message' do
+                expect(page).to have_content('Revision was not created successfully')
+
+                expect(page).to have_link('Tiling Identification Systems')
+                expect(page).to have_content('Tiling Identification Systems must be unique. This contains duplicates named [CALIPSO].')
+              end
+            end
           end
         end
       end
+
     end
   end
 

--- a/spec/features/collection_drafts/publish_collection_draft_spec.rb
+++ b/spec/features/collection_drafts/publish_collection_draft_spec.rb
@@ -248,11 +248,9 @@ describe 'Publishing collection draft records', js: true do
       click_on 'Publish'
     end
 
-    it 'displays a generic error message' do
+    it 'fails to publish and displays the error returned from CMR and a generic error message' do
       expect(page).to have_content('Collection Draft was not published successfully')
-    end
 
-    it 'displays the error returned from CMR' do
       within 'section.errors' do
         expect(page).to have_content('This draft has the following errors:')
         expect(page).to have_link('Spatial Extent', href: edit_collection_draft_path(draft, 'spatial_information'))
@@ -269,11 +267,9 @@ describe 'Publishing collection draft records', js: true do
       click_on 'Publish'
     end
 
-    it 'displays a generic error message' do
+    it 'fails to publish and displays the error returned from CMR and a generic error message' do
       expect(page).to have_content('Collection Draft was not published successfully')
-    end
 
-    it 'displays the error returned from CMR' do
       within 'section.errors' do
         expect(page).to have_content('This draft has the following errors:')
         within '.ingest-error-0' do


### PR DESCRIPTION
* handle both error formats - array of messages, or hash with path and error attributes
* update to use generate ingest errors
* update flash messages
* update modal messages
* update tests