### PR TITLE
MMT-2948: Collection preview in MMT does not resize the width very well.

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-metadata_preview_js_url="https://access.sit.earthdata.nasa.gov/plugin/metadata-preview.0.0.38.js"
-metadata_preview_css_url="https://access.sit.earthdata.nasa.gov/plugin/metadata-preview.0.0.38.min.css"
+metadata_preview_js_url="https://access.sit.earthdata.nasa.gov/plugin/metadata-preview.22.2.4-3.js"
+metadata_preview_css_url="https://access.sit.earthdata.nasa.gov/plugin/metadata-preview.22.2.4-3.min.css"

--- a/README.md
+++ b/README.md
@@ -406,8 +406,8 @@ And to start the server, use the following:
 
 Note: MMT will use the following urls for loading the snippet (see .env file):
 
-    metadata_preview_js_url="https://access.sit.earthdata.nasa.gov/plugin/metadata-preview.0.0.38.js"
-    metadata_preview_css_url="https://access.sit.earthdata.nasa.gov/plugin/metadata-preview.0.0.38.min.css"
+    metadata_preview_js_url="https://access.sit.earthdata.nasa.gov/plugin/metadata-preview.22.2.4-3.js"
+    metadata_preview_css_url="https://access.sit.earthdata.nasa.gov/plugin/metadata-preview.22.2.4-3.min.css"
 
 So you'll need to be on the VPN to use the latest snippet.  If it doesn't matter if you
 are using the latest, you can point to `access.earthdata.nasa.gov` instead and MMT

--- a/app/assets/stylesheets/overrides/_metadatapreview.scss
+++ b/app/assets/stylesheets/overrides/_metadatapreview.scss
@@ -6,14 +6,14 @@
   background: white;
 }
 #metadata-preview table th {
-  padding: 0.5em;
+  padding: 0.325em;
   background: white;
   text-align: left;
   border: none
 
 }
 #metadata-preview table td {
-  padding: 0.5em;
+  padding: 0.325em;
 }
 #metadata-preview table img {
   border: none;
@@ -36,5 +36,5 @@
 }
 
 th {
-  white-space: nowrap;
+  word-wrap: normal ;
 }


### PR DESCRIPTION
- Fixed the width issue in collection preview in MMT where the table was going out of the screen.
- Updated the .env file to point to the latest metadata-preview version 22.2.4-3
- Updated the readme with the new metadata-preview version 