### PR TITLE
MMT-3466: Increase keyword cache to 4 hours

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -126,7 +126,7 @@ Rails.application.configure do
   config.cmr_email_frequency = ENV['cmr_email_frequency']&.to_i || 3600
 
   # Keyword cache expiration in seconds.
-  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 240
+  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 14400
 
   # GraphQl server
   config.graphql_server = 'http://localhost:6005/dev/api'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -124,6 +124,10 @@ Rails.application.configure do
   config.tophat_url = 'https://cdn.sit.earthdata.nasa.gov/tophat2/tophat2.js'
 
   config.cmr_email_frequency = ENV['cmr_email_frequency']&.to_i || 3600
+
+  # Keyword cache expiration in seconds.
+  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 240
+
   # GraphQl server
   config.graphql_server = 'http://localhost:6005/dev/api'
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -160,6 +160,9 @@ Rails.application.configure do
 
   config.cmr_email_frequency = ENV['cmr_email_frequency']&.to_i || 3600
 
+  # Keyword cache expiration in seconds.
+  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 240
+
   # GraphQl server
   config.graphql_server = 'https://graphql.earthdata.nasa.gov/api'
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -161,7 +161,7 @@ Rails.application.configure do
   config.cmr_email_frequency = ENV['cmr_email_frequency']&.to_i || 3600
 
   # Keyword cache expiration in seconds.
-  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 240
+  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 14400
 
   # GraphQl server
   config.graphql_server = 'https://graphql.earthdata.nasa.gov/api'

--- a/config/environments/sit.rb
+++ b/config/environments/sit.rb
@@ -138,6 +138,9 @@ Rails.application.configure do
 
   config.cmr_email_frequency = ENV['cmr_email_frequency']&.to_i || 3600
 
+  # Keyword cache expiration in seconds.
+  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 240
+
   # GraphQl server
   config.graphql_server = 'https://graphql.sit.earthdata.nasa.gov/api'
 

--- a/config/environments/sit.rb
+++ b/config/environments/sit.rb
@@ -139,7 +139,7 @@ Rails.application.configure do
   config.cmr_email_frequency = ENV['cmr_email_frequency']&.to_i || 3600
 
   # Keyword cache expiration in seconds.
-  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 240
+  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 14400
 
   # GraphQl server
   config.graphql_server = 'https://graphql.sit.earthdata.nasa.gov/api'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -100,7 +100,7 @@ Rails.application.configure do
   config.cmr_email_frequency = ENV['cmr_email_frequency']&.to_i || 3600
 
   # Keyword cache expiration in seconds.
-  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 240
+  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 14400
 
   # GraphQl server
   config.graphql_server = 'https://graphql.sit.earthdata.nasa.gov/api'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -98,6 +98,10 @@ Rails.application.configure do
   # config.colorize_logging = false
 
   config.cmr_email_frequency = ENV['cmr_email_frequency']&.to_i || 3600
+
+  # Keyword cache expiration in seconds.
+  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 240
+
   # GraphQl server
   config.graphql_server = 'https://graphql.sit.earthdata.nasa.gov/api'
 

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -138,7 +138,7 @@ Rails.application.configure do
   config.cmr_email_frequency = ENV['cmr_email_frequency']&.to_i || 3600
 
   # Keyword cache expiration in seconds.
-  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 240
+  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 14400
 
   # GraphQl server
   config.graphql_server = 'https://graphql.uat.earthdata.nasa.gov/api'

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -137,6 +137,9 @@ Rails.application.configure do
 
   config.cmr_email_frequency = ENV['cmr_email_frequency']&.to_i || 3600
 
+  # Keyword cache expiration in seconds.
+  config.cmr_keyword_cache_expires_in=ENV['cmr_keyword_cache_expires_in']&.to_i || 240
+
   # GraphQl server
   config.graphql_server = 'https://graphql.uat.earthdata.nasa.gov/api'
 

--- a/lib/cmr/cmr_client.rb
+++ b/lib/cmr/cmr_client.rb
@@ -149,7 +149,8 @@ module Cmr
       # Cache controlled keywords for 30 seconds
       # UMM forms will call get_controlled_keywords for every
       # keyword on the page
-      response = Rails.cache.fetch("#{type}_keywords", expires_in: 30.seconds) do
+      expires_in = (Rails.configuration.cmr_keyword_cache_expires_in).seconds
+      response = Rails.cache.fetch("#{type}_keywords", expires_in: expires_in) do
         get(url)
       end
       response


### PR DESCRIPTION
Currently users are experience really slow load times in MMT.   Rosy and I did some analysis of the logs and it is showing retrievals of keywords from CMR in minutes.

This a hot fix branch that is based on what is currently in UAT.   The purpose of this code is to make the keyword cache held by MMT configurable.   With this change, you can set a bamboo variable `cmr_keyword_cache_expires_in`, currently the default is 14400 seconds (4 hours).   The plan is to test and move this through the env's quickly tomorrow, than rollback the existing env.