### PR TITLE
MMT-3080: Update MMT Status page to only check status of MMT database

### DIFF
--- a/app/middleware/middleware_healthcheck.rb
+++ b/app/middleware/middleware_healthcheck.rb
@@ -18,22 +18,16 @@ class MiddlewareHealthcheck
         # checks the database health when /status?checkDatabase is passed
         if check_database
           response_output = process_database_check
-        else
-          response_output = response_output
         end
 
         # checks the health of launchpad when /status?checkLaunchpad is passed
         if check_launchpad
           response_output = process_launchpad_check
-        else 
-          response_output = response_output
-        end 
+        end
 
         # checks health of both database and launchpad when /status is passed
         if !check_database && !check_launchpad
           response_output = process_status_check
-        else
-          response_output = response_output
         end
 
         response[2] = response_output

--- a/app/middleware/middleware_healthcheck.rb
+++ b/app/middleware/middleware_healthcheck.rb
@@ -8,14 +8,74 @@ class MiddlewareHealthcheck
       Rails.logger.tagged "middleware database health check" do
         response = [503, {'Content-Type' => 'application/json', 'X-Powered-By' => 'Metadata-Management-Tool', 'X-Version' => Rails.configuration.version}]
 
-        # checks the database health
-        begin
-          db_healthy = ActiveRecord::Migrator.current_version != 0
-        rescue StandardError => e
-          Rails.logger.error "Database error: #{e}"
-          db_healthy = false
+        queryParams = env['QUERY_STRING']
+        check_database = (queryParams == 'checkDatabase')
+        check_launchpad = (queryParams == 'checkLaunchpad')
+        responseOutput = ""
+
+        # checks the database health when /status?checkDatabase is passed
+        if check_database
+          begin
+            db_healthy = ActiveRecord::Migrator.current_version != 0
+          rescue StandardError => e
+            Rails.logger.error "Database error: #{e}"
+            db_healthy = false
+          end
+          responseOutput = ["{\"database\": #{db_healthy}}"]
+        else
+          responseOutput = responseOutput
         end
-        response[2] = ["{\"database\": #{db_healthy}}"]
+
+        # checks the health of launchpad when /status?checkLaunchpad is passed
+        if check_launchpad
+          cmr_client = Cmr::Client.client_for_environment(Rails.configuration.cmr_env, Rails.configuration.services)
+          cmr_client.timeout = 10
+          begin
+            launchpad_healthy = cmr_client.launchpad_healthcheck.body == 'OK'.freeze
+          rescue Faraday::TimeoutError
+            Rails.logger.error "Faraday timeout healthcheck error: #{e}"
+            launchpad_healthy = false
+          rescue Faraday::ConnectionFailed
+            Rails.logger.error "Faraday connection failed healthcheck error: #{e}"
+            launchpad_healthy = false
+          rescue StandardError => e
+            Rails.logger.error "Other healthcheck error: #{e.class} #{e}"
+            launchpad_healthy = false
+          end
+          responseOutput = ["{\"launchpad\": #{launchpad_healthy}}"]
+        else 
+          responseOutput = responseOutput
+        end 
+
+        # checks health of both database and launchpad when /status is passed
+        if !check_database && !check_launchpad
+          begin
+            db_healthy = ActiveRecord::Migrator.current_version != 0
+          rescue StandardError => e
+            Rails.logger.error "Database error: #{e}"
+            db_healthy = false
+          end
+
+          cmr_client = Cmr::Client.client_for_environment(Rails.configuration.cmr_env, Rails.configuration.services)
+          cmr_client.timeout = 10
+          begin
+            launchpad_healthy = cmr_client.launchpad_healthcheck.body == 'OK'.freeze
+          rescue Faraday::TimeoutError
+            Rails.logger.error "Faraday timeout healthcheck error: #{e}"
+            launchpad_healthy = false
+          rescue Faraday::ConnectionFailed
+            Rails.logger.error "Faraday connection failed healthcheck error: #{e}"
+            launchpad_healthy = false
+          rescue StandardError => e
+            Rails.logger.error "Other healthcheck error: #{e.class} #{e}"
+            launchpad_healthy = false
+          end
+          responseOutput = ["{\"database\": #{db_healthy}, \"launchpad\": #{launchpad_healthy}}"]
+        else
+          responseOutput = responseOutput
+        end
+
+        response[2] = responseOutput
 
         if db_healthy
           response[0] = 200

--- a/app/middleware/middleware_healthcheck.rb
+++ b/app/middleware/middleware_healthcheck.rb
@@ -8,76 +8,38 @@ class MiddlewareHealthcheck
       Rails.logger.tagged "middleware database health check" do
         response = [503, {'Content-Type' => 'application/json', 'X-Powered-By' => 'Metadata-Management-Tool', 'X-Version' => Rails.configuration.version}]
 
-        queryParams = env['QUERY_STRING']
-        check_database = (queryParams == 'checkDatabase')
-        check_launchpad = (queryParams == 'checkLaunchpad')
-        responseOutput = ""
+        query_params = env['QUERY_STRING']
+        check_database = (query_params == 'checkDatabase')
+        check_launchpad = (query_params == 'checkLaunchpad')
+        db_healthy = false
+        launchpad_healthy = false
+        response_output = ""
 
         # checks the database health when /status?checkDatabase is passed
         if check_database
-          begin
-            db_healthy = ActiveRecord::Migrator.current_version != 0
-          rescue StandardError => e
-            Rails.logger.error "Database error: #{e}"
-            db_healthy = false
-          end
-          responseOutput = ["{\"database\": #{db_healthy}}"]
+          response_output = process_database_check
         else
-          responseOutput = responseOutput
+          response_output = response_output
         end
 
         # checks the health of launchpad when /status?checkLaunchpad is passed
         if check_launchpad
-          cmr_client = Cmr::Client.client_for_environment(Rails.configuration.cmr_env, Rails.configuration.services)
-          cmr_client.timeout = 10
-          begin
-            launchpad_healthy = cmr_client.launchpad_healthcheck.body == 'OK'.freeze
-          rescue Faraday::TimeoutError
-            Rails.logger.error "Faraday timeout healthcheck error: #{e}"
-            launchpad_healthy = false
-          rescue Faraday::ConnectionFailed
-            Rails.logger.error "Faraday connection failed healthcheck error: #{e}"
-            launchpad_healthy = false
-          rescue StandardError => e
-            Rails.logger.error "Other healthcheck error: #{e.class} #{e}"
-            launchpad_healthy = false
-          end
-          responseOutput = ["{\"launchpad\": #{launchpad_healthy}}"]
+          response_output = process_launchpad_check
         else 
-          responseOutput = responseOutput
+          response_output = response_output
         end 
 
         # checks health of both database and launchpad when /status is passed
         if !check_database && !check_launchpad
-          begin
-            db_healthy = ActiveRecord::Migrator.current_version != 0
-          rescue StandardError => e
-            Rails.logger.error "Database error: #{e}"
-            db_healthy = false
-          end
-
-          cmr_client = Cmr::Client.client_for_environment(Rails.configuration.cmr_env, Rails.configuration.services)
-          cmr_client.timeout = 10
-          begin
-            launchpad_healthy = cmr_client.launchpad_healthcheck.body == 'OK'.freeze
-          rescue Faraday::TimeoutError
-            Rails.logger.error "Faraday timeout healthcheck error: #{e}"
-            launchpad_healthy = false
-          rescue Faraday::ConnectionFailed
-            Rails.logger.error "Faraday connection failed healthcheck error: #{e}"
-            launchpad_healthy = false
-          rescue StandardError => e
-            Rails.logger.error "Other healthcheck error: #{e.class} #{e}"
-            launchpad_healthy = false
-          end
-          responseOutput = ["{\"database\": #{db_healthy}, \"launchpad\": #{launchpad_healthy}}"]
+          response_output = process_status_check
         else
-          responseOutput = responseOutput
+          response_output = response_output
         end
 
-        response[2] = responseOutput
+        response[2] = response_output
 
-        if db_healthy
+        # If launchpad is disabled then we will not report a 503 error if launchpad still fails
+        if db_healthy && (ENV['launchpad_login_required'] != 'true' || launchpad_healthy)
           response[0] = 200
         end
         response
@@ -85,5 +47,60 @@ class MiddlewareHealthcheck
     else
       @app.call(env)
     end
+  end
+
+  private 
+
+  def process_database_check
+    begin
+      db_healthy = ActiveRecord::Migrator.current_version != 0
+    rescue StandardError => e
+      Rails.logger.error "Database error: #{e}"
+      db_healthy = false
+    end
+    response_output = ["{\"database\": #{db_healthy}}"]
+  end
+
+  def process_launchpad_check
+    cmr_client = Cmr::Client.client_for_environment(Rails.configuration.cmr_env, Rails.configuration.services)
+    cmr_client.timeout = 10
+    begin
+      launchpad_healthy = cmr_client.launchpad_healthcheck.body == 'OK'.freeze
+    rescue Faraday::TimeoutError
+      Rails.logger.error "Faraday timeout healthcheck error: #{e}"
+      launchpad_healthy = false
+    rescue Faraday::ConnectionFailed
+      Rails.logger.error "Faraday connection failed healthcheck error: #{e}"
+      launchpad_healthy = false
+    rescue StandardError => e
+      Rails.logger.error "Other healthcheck error: #{e.class} #{e}"
+      launchpad_healthy = false
+    end
+    response_output = ["{\"launchpad\": #{launchpad_healthy}}"]
+  end
+
+  def process_status_check
+    begin
+      db_healthy = ActiveRecord::Migrator.current_version != 0
+    rescue StandardError => e
+      Rails.logger.error "Database error: #{e}"
+      db_healthy = false
+    end
+
+    cmr_client = Cmr::Client.client_for_environment(Rails.configuration.cmr_env, Rails.configuration.services)
+    cmr_client.timeout = 10
+    begin
+      launchpad_healthy = cmr_client.launchpad_healthcheck.body == 'OK'.freeze
+    rescue Faraday::TimeoutError
+      Rails.logger.error "Faraday timeout healthcheck error: #{e}"
+      launchpad_healthy = false
+    rescue Faraday::ConnectionFailed
+      Rails.logger.error "Faraday connection failed healthcheck error: #{e}"
+      launchpad_healthy = false
+    rescue StandardError => e
+      Rails.logger.error "Other healthcheck error: #{e.class} #{e}"
+      launchpad_healthy = false
+    end
+    response_output = ["{\"database\": #{db_healthy}, \"launchpad\": #{launchpad_healthy}}"]
   end
 end

--- a/app/middleware/middleware_healthcheck.rb
+++ b/app/middleware/middleware_healthcheck.rb
@@ -5,7 +5,7 @@ class MiddlewareHealthcheck
 
   def call(env)
     if env['PATH_INFO'.freeze] == '/status'.freeze
-      Rails.logger.tagged "middleware health check" do
+      Rails.logger.tagged "middleware database health check" do
         response = [503, {'Content-Type' => 'application/json', 'X-Powered-By' => 'Metadata-Management-Tool', 'X-Version' => Rails.configuration.version}]
 
         # checks the database health
@@ -15,26 +15,9 @@ class MiddlewareHealthcheck
           Rails.logger.error "Database error: #{e}"
           db_healthy = false
         end
+        response[2] = ["{\"database\": #{db_healthy}}"]
 
-        # checks the health of launchpad
-        cmr_client = Cmr::Client.client_for_environment(Rails.configuration.cmr_env, Rails.configuration.services)
-        cmr_client.timeout = 10
-        begin
-          launchpad_healthy = cmr_client.launchpad_healthcheck.body == 'OK'.freeze
-        rescue Faraday::TimeoutError
-          Rails.logger.error "Faraday timeout healthcheck error: #{e}"
-          launchpad_healthy = false
-        rescue Faraday::ConnectionFailed
-          Rails.logger.error "Faraday connection failed healthcheck error: #{e}"
-          launchpad_healthy = false
-        rescue StandardError => e
-          Rails.logger.error "Other healthcheck error: #{e.class} #{e}"
-          launchpad_healthy = false
-        end
-        response[2] = ["{\"database\": #{db_healthy}, \"launchpad\": #{launchpad_healthy}}"]
-
-        # If launchpad is disabled then we will not report a 503 error if launchpad still fails
-        if db_healthy && (ENV['launchpad_login_required'] != 'true' || launchpad_healthy)
+        if db_healthy
           response[0] = 200
         end
         response

--- a/app/middleware/middleware_healthcheck.rb
+++ b/app/middleware/middleware_healthcheck.rb
@@ -42,7 +42,8 @@ class MiddlewareHealthcheck
           db_healthy = process_database_check(db_healthy)
           launchpad_healthy = process_launchpad_check(launchpad_healthy)
 
-          if db_healthy && launchpad_healthy
+          # If launchpad is disabled then we will not report a 503 error if launchpad still fails
+          if db_healthy && (ENV['launchpad_login_required'] != 'true' || launchpad_healthy)
             response[0] = 200
           end
 
@@ -50,12 +51,8 @@ class MiddlewareHealthcheck
         end
 
         response[2] = response_output
-
-        # If launchpad is disabled then we will not report a 503 error if launchpad still fails
-        if db_healthy && (ENV['launchpad_login_required'] != 'true' || launchpad_healthy)
-          response[0] = 200
-        end
         response
+        
       end
     else
       @app.call(env)


### PR DESCRIPTION
Update the MMT status page to only check the status of MMT database.
https://mmt.earthdata.nasa.gov/status

{"database": true}
