### PR TITLE
MMT-3595: Reorganizing context and providers

### DIFF
--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -2,14 +2,6 @@ import React, { useLayoutEffect } from 'react'
 import { Route, Routes } from 'react-router'
 import { BrowserRouter, Navigate } from 'react-router-dom'
 
-import {
-  ApolloClient,
-  ApolloProvider,
-  InMemoryCache,
-  createHttpLink
-} from '@apollo/client'
-import { setContext } from '@apollo/client/link/context'
-
 import Layout from './components/Layout/Layout'
 import ManagePage from './pages/ManagePage/ManagePage'
 import ManageCmrPage from './pages/ManageCmrPage/ManageCmrPage'
@@ -24,11 +16,9 @@ import AuthCallbackContainer from './components/AuthCallbackContainer/AuthCallba
 
 import REDIRECTS from './constants/redirectsMap/redirectsMap'
 
-import { getApplicationConfig } from './utils/getConfig'
+import withProviders from './providers/withProviders/withProviders'
 
 import '../css/index.scss'
-import useAppContext from './hooks/useAppContext'
-import withProviders from './providers/withProviders/withProviders'
 
 const redirectKeys = Object.keys(REDIRECTS)
 
@@ -54,50 +44,13 @@ const Redirects = redirectKeys.map(
  *   <App />
  * )
  */
-const App = () => {
+export const App = () => {
   useLayoutEffect(() => {
     document.body.classList.remove('is-loading')
   }, [])
 
-  const { graphQlHost } = getApplicationConfig()
-  const { user } = useAppContext()
-  const { token } = user
-  const { tokenValue } = token || {}
-
-  const httpLink = createHttpLink({
-    uri: graphQlHost
-  })
-
-  console.log('using token ', tokenValue)
-
-  const authLink = setContext((_, { headers }) => ({
-    headers: {
-      ...headers,
-      Authorization: tokenValue
-    }
-  }))
-
-  const client = new ApolloClient({
-    cache: new InMemoryCache(),
-
-    link: authLink.concat(httpLink),
-    defaultOptions: {
-      query: {
-        fetchPolicy: 'no-cache'
-      },
-      watchQuery: {
-        fetchPolicy: 'no-cache'
-      }
-    }
-  })
-  // http://localhost:5173/tool-drafts/TD1200000093-MMT_2/
-  // appContext = {
-  //   statusMessage
-  //   errorMessage
-  // }
-
   return (
-    <ApolloProvider client={client}>
+    <>
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Layout />}>
@@ -155,7 +108,7 @@ const App = () => {
         </Routes>
       </BrowserRouter>
       <Notifications />
-    </ApolloProvider>
+    </>
   )
 }
 

--- a/static/src/js/components/CollectionAssociation/__tests__/CollectionAssociation.test.js
+++ b/static/src/js/components/CollectionAssociation/__tests__/CollectionAssociation.test.js
@@ -23,6 +23,8 @@ jest.mock('../../ErrorBanner/ErrorBanner')
 jest.mock('../../../utils/errorLogger')
 jest.mock('../../../utils/removeMetadataKeys')
 
+global.fetch = jest.fn()
+
 const mockedUsedNavigate = jest.fn()
 
 jest.mock('react-router-dom', () => ({
@@ -126,7 +128,6 @@ const setup = ({
   cookie.HAS_DOCUMENT_COOKIE = false
 
   render(
-
     <CookiesProvider defaultSetOptions={{ path: '/' }} cookies={cookie}>
       <MemoryRouter initialEntries={overrideInitialEntries}>
         <Providers>
@@ -145,10 +146,8 @@ const setup = ({
             </Routes>
           </MockedProvider>
         </Providers>
-
       </MemoryRouter>
     </CookiesProvider>
-
   )
 
   return {

--- a/static/src/js/components/DraftPreview/__tests__/DraftPreview.test.js
+++ b/static/src/js/components/DraftPreview/__tests__/DraftPreview.test.js
@@ -32,6 +32,8 @@ jest.mock('../../ErrorBanner/ErrorBanner')
 jest.mock('../../PreviewProgress/PreviewProgress')
 jest.mock('../../../utils/errorLogger')
 
+global.fetch = jest.fn()
+
 const mockedUsedNavigate = jest.fn()
 
 jest.mock('react-router-dom', () => ({
@@ -119,10 +121,10 @@ const setup = ({
   }, ...additionalMocks]
 
   render(
-    <MockedProvider
-      mocks={overrideMocks || mocks}
-    >
-      <Providers>
+    <Providers>
+      <MockedProvider
+        mocks={overrideMocks || mocks}
+      >
         <MemoryRouter initialEntries={[pageUrl]}>
           <Routes>
             <Route
@@ -135,8 +137,8 @@ const setup = ({
             </Route>
           </Routes>
         </MemoryRouter>
-      </Providers>
-    </MockedProvider>
+      </MockedProvider>
+    </Providers>
   )
 
   return {

--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -120,7 +120,6 @@ const MetadataForm = () => {
       setDraft(fetchedDraft)
     }
   })
-
   if (loading) {
     return (
       <Page>

--- a/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.js
+++ b/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.js
@@ -49,17 +49,6 @@ import OneOfField from '../../OneOfField/OneOfField'
 import { PUBLISH_DRAFT } from '../../../operations/mutations/publishDraft'
 import encodeCookie from '../../../utils/encodeCookie'
 
-jest.mock('@apollo/client', () => ({
-  ...jest.requireActual('@apollo/client'),
-  __esModule: true,
-  ApolloClient: jest.fn(),
-  InMemoryCache: jest.fn(() => ({ mockCache: {} })),
-  ApolloProvider: jest.fn(({ children }) => children),
-  createHttpLink: jest.fn(
-    (args) => jest.requireActual('@apollo/client').createHttpLink(args)
-  )
-}))
-
 jest.mock('@rjsf/core', () => jest.fn(({
   onChange,
   onBlur,
@@ -209,28 +198,26 @@ const setup = ({
         <MockedProvider
           mocks={overrideMocks || mocks}
         >
-          <Providers>
-            <MemoryRouter initialEntries={[pageUrl]}>
-              <Routes>
+          <MemoryRouter initialEntries={[pageUrl]}>
+            <Routes>
+              <Route
+                path="/drafts/:draftType"
+              >
                 <Route
-                  path="/drafts/:draftType"
-                >
-                  <Route
-                    element={<MetadataForm />}
-                    path="new"
-                  />
-                  <Route
-                    path=":conceptId/:sectionName"
-                    element={<MetadataForm />}
-                  />
-                  <Route
-                    path=":conceptId/:sectionName/:fieldName"
-                    element={<MetadataForm />}
-                  />
-                </Route>
-              </Routes>
-            </MemoryRouter>
-          </Providers>
+                  element={<MetadataForm />}
+                  path="new"
+                />
+                <Route
+                  path=":conceptId/:sectionName"
+                  element={<MetadataForm />}
+                />
+                <Route
+                  path=":conceptId/:sectionName/:fieldName"
+                  element={<MetadataForm />}
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
         </MockedProvider>
       </Providers>
     </CookiesProvider>

--- a/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.js
+++ b/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.js
@@ -49,6 +49,17 @@ import OneOfField from '../../OneOfField/OneOfField'
 import { PUBLISH_DRAFT } from '../../../operations/mutations/publishDraft'
 import encodeCookie from '../../../utils/encodeCookie'
 
+jest.mock('@apollo/client', () => ({
+  ...jest.requireActual('@apollo/client'),
+  __esModule: true,
+  ApolloClient: jest.fn(),
+  InMemoryCache: jest.fn(() => ({ mockCache: {} })),
+  ApolloProvider: jest.fn(({ children }) => children),
+  createHttpLink: jest.fn(
+    (args) => jest.requireActual('@apollo/client').createHttpLink(args)
+  )
+}))
+
 jest.mock('@rjsf/core', () => jest.fn(({
   onChange,
   onBlur,
@@ -81,6 +92,8 @@ jest.mock('../../ErrorBanner/ErrorBanner')
 jest.mock('../../JsonPreview/JsonPreview')
 jest.mock('../../FormNavigation/FormNavigation')
 jest.mock('../../../utils/errorLogger')
+
+global.fetch = jest.fn()
 
 const mockedUsedNavigate = jest.fn()
 
@@ -192,33 +205,34 @@ const setup = ({
 
   render(
     <CookiesProvider defaultSetOptions={{ path: '/' }} cookies={cookie}>
-      <MockedProvider
-        mocks={overrideMocks || mocks}
-      >
-        <Providers>
-          <MemoryRouter initialEntries={[pageUrl]}>
-            <Routes>
-              <Route
-                path="/drafts/:draftType"
-              >
+      <Providers>
+        <MockedProvider
+          mocks={overrideMocks || mocks}
+        >
+          <Providers>
+            <MemoryRouter initialEntries={[pageUrl]}>
+              <Routes>
                 <Route
-                  element={<MetadataForm />}
-                  path="new"
-                />
-                <Route
-                  path=":conceptId/:sectionName"
-                  element={<MetadataForm />}
-                />
-                <Route
-                  path=":conceptId/:sectionName/:fieldName"
-                  element={<MetadataForm />}
-                />
-              </Route>
-            </Routes>
-          </MemoryRouter>
-        </Providers>
-      </MockedProvider>
-
+                  path="/drafts/:draftType"
+                >
+                  <Route
+                    element={<MetadataForm />}
+                    path="new"
+                  />
+                  <Route
+                    path=":conceptId/:sectionName"
+                    element={<MetadataForm />}
+                  />
+                  <Route
+                    path=":conceptId/:sectionName/:fieldName"
+                    element={<MetadataForm />}
+                  />
+                </Route>
+              </Routes>
+            </MemoryRouter>
+          </Providers>
+        </MockedProvider>
+      </Providers>
     </CookiesProvider>
   )
 

--- a/static/src/js/components/Notifications/__tests__/Notifications.test.js
+++ b/static/src/js/components/Notifications/__tests__/Notifications.test.js
@@ -11,6 +11,8 @@ import Notifications from '../Notifications'
 import Providers from '../../../providers/Providers/Providers'
 import useNotificationsContext from '../../../hooks/useNotificationsContext'
 
+global.fetch = jest.fn()
+
 const MockComponent = () => {
   const { addNotification } = useNotificationsContext()
 

--- a/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.js
+++ b/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.js
@@ -26,6 +26,8 @@ jest.mock('../../MetadataPreview/MetadataPreview')
 jest.mock('../../ErrorBanner/ErrorBanner')
 jest.mock('../../../utils/errorLogger')
 
+global.fetch = jest.fn()
+
 const mockedUsedNavigate = jest.fn()
 
 jest.mock('react-router-dom', () => ({
@@ -140,10 +142,10 @@ const setup = ({
 
   render(
     <CookiesProvider defaultSetOptions={{ path: '/' }} cookies={cookie}>
-      <MockedProvider
-        mocks={overrideMocks || mocks}
-      >
-        <Providers>
+      <Providers>
+        <MockedProvider
+          mocks={overrideMocks || mocks}
+        >
           <MemoryRouter initialEntries={['/tools/T1000000-MMT/1']}>
             <Routes>
               <Route
@@ -156,8 +158,8 @@ const setup = ({
               </Route>
             </Routes>
           </MemoryRouter>
-        </Providers>
-      </MockedProvider>
+        </MockedProvider>
+      </Providers>
     </CookiesProvider>
   )
 

--- a/static/src/js/context/AuthContext.js
+++ b/static/src/js/context/AuthContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+
+const AuthContext = createContext()
+
+export default AuthContext

--- a/static/src/js/hooks/__tests__/useControlledKeywords.test.js
+++ b/static/src/js/hooks/__tests__/useControlledKeywords.test.js
@@ -4,12 +4,15 @@ import {
   screen,
   waitFor
 } from '@testing-library/react'
+import { Cookies, CookiesProvider } from 'react-cookie'
 
 import useControlledKeywords from '../useControlledKeywords'
 import Providers from '../../providers/Providers/Providers'
 import fetchCmrKeywords from '../../utils/fetchCmrKeywords'
+import encodeCookie from '../../utils/encodeCookie'
 
 jest.mock('../../utils/fetchCmrKeywords')
+global.fetch = jest.fn()
 
 const TestComponent = ({
   /* eslint-disable react/prop-types */
@@ -40,14 +43,32 @@ const TestComponent = ({
 }
 
 const setup = (keywordType, schemaKeywords, controlledKeywordsMap) => {
+  let expires = new Date()
+  expires.setMinutes(expires.getMinutes() + 15)
+  expires = new Date(expires)
+
+  const cookie = new Cookies({
+    loginInfo: encodeCookie({
+      name: 'User Name',
+      token: {
+        tokenValue: 'ABC-1',
+        tokenExp: expires
+      },
+      providerId: 'MMT_2'
+    })
+  })
+  cookie.HAS_DOCUMENT_COOKIE = false
+
   render(
-    <Providers>
-      <TestComponent
-        keywordType={keywordType}
-        schemaKeywords={schemaKeywords}
-        controlledKeywordsMap={controlledKeywordsMap}
-      />
-    </Providers>
+    <CookiesProvider defaultSetOptions={{ path: '/' }} cookies={cookie}>
+      <Providers>
+        <TestComponent
+          keywordType={keywordType}
+          schemaKeywords={schemaKeywords}
+          controlledKeywordsMap={controlledKeywordsMap}
+        />
+      </Providers>
+    </CookiesProvider>
   )
 }
 

--- a/static/src/js/hooks/useAuthContext.js
+++ b/static/src/js/hooks/useAuthContext.js
@@ -1,0 +1,7 @@
+import { useContext } from 'react'
+
+import AuthContext from '../context/AuthContext'
+
+const useAuthContext = () => useContext(AuthContext)
+
+export default useAuthContext

--- a/static/src/js/providers/AppContextProvider/AppContextProvider.jsx
+++ b/static/src/js/providers/AppContextProvider/AppContextProvider.jsx
@@ -9,10 +9,10 @@ import useAuthContext from '../../hooks/useAuthContext'
  * @property {ReactNode} children The children to be rendered.
 
 /**
- * Renders any children wrapped with AppContext.
+ * Renders any children wrapped with access to AppContext.
  * @param {AppContextProviderProps} props
  *
- * @example <caption>Renders children wrapped with AppContext.</caption>
+ * @example <caption>Renders children wrapped with access to AppContext.</caption>
  *
  * return (
  *   <AppContextProvider>

--- a/static/src/js/providers/AppContextProvider/AppContextProvider.jsx
+++ b/static/src/js/providers/AppContextProvider/AppContextProvider.jsx
@@ -1,16 +1,8 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState
-} from 'react'
+import React, { useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
-import { useCookies } from 'react-cookie'
 import useKeywords from '../../hooks/useKeywords'
 import AppContext from '../../context/AppContext'
-import { getApplicationConfig } from '../../utils/getConfig'
-import decodeCookie from '../../utils/decodeCookie'
-import checkAndRefreshToken from '../../utils/checkAndRefreshToken'
+import useAuthContext from '../../hooks/useAuthContext'
 
 /**
  * @typedef {Object} AppContextProviderProps
@@ -29,74 +21,30 @@ import checkAndRefreshToken from '../../utils/checkAndRefreshToken'
  * )
  */
 const AppContextProvider = ({ children }) => {
-  const keywordsContext = useKeywords()
+  const { login, logout, user } = useAuthContext()
+  const { addKeywordsData, keywords } = useKeywords()
   const [originalDraft, setOriginalDraft] = useState()
   const [draft, setDraft] = useState()
   const [savedDraft, setSavedDraft] = useState()
-  const [user, setUser] = useState({})
-
-  const { keywords } = keywordsContext
-
-  const [cookies] = useCookies(['loginInfo'])
-  const { token } = user
-
-  const {
-    loginInfo
-  } = cookies
-
-  useEffect(() => {
-    if (loginInfo) {
-      const {
-        auid, name, token: cookieToken
-      } = decodeCookie(loginInfo)
-
-      setUser({
-        ...user,
-        token: cookieToken,
-        name,
-        auid,
-        providerId: 'MMT_2'
-      })
-    }
-  }, [loginInfo])
-
-  useEffect(() => {
-    const interval = setInterval(async () => {
-      checkAndRefreshToken(token, user, setUser)
-    }, 1000)
-
-    return () => clearInterval(interval)
-  }, [token])
-
-  const login = useCallback(() => {
-    const { apiHost } = getApplicationConfig()
-    window.location.href = `${apiHost}/saml-login?target=${encodeURIComponent('/manage/collections')}`
-  })
-
-  const logout = useCallback(() => {
-    setUser({})
-  })
 
   const providerValue = useMemo(() => ({
-    ...keywordsContext,
-    draft,
+    user,
     login,
     logout,
+    addKeywordsData,
+    keywords,
+    draft,
     originalDraft,
     savedDraft,
     setDraft,
     setOriginalDraft,
-    setSavedDraft,
-    setUser,
-    user
+    setSavedDraft
   }), [
+    user,
     draft,
     originalDraft,
     keywords,
-    savedDraft,
-    user,
-    login,
-    logout
+    savedDraft
   ])
 
   return (

--- a/static/src/js/providers/AppContextProvider/__tests__/AppContextProvider.test.js
+++ b/static/src/js/providers/AppContextProvider/__tests__/AppContextProvider.test.js
@@ -5,9 +5,16 @@ import userEvent from '@testing-library/user-event'
 import { Cookies, CookiesProvider } from 'react-cookie'
 import useAppContext from '../../../hooks/useAppContext'
 import AppContextProvider from '../AppContextProvider'
-import { getApplicationConfig } from '../../../utils/getConfig'
-import * as getConfig from '../../../utils/getConfig'
 import encodeCookie from '../../../utils/encodeCookie'
+import AuthContextProvider from '../../AuthContextProvider/AuthContextProvider'
+
+jest.mock('../../../utils/getConfig', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../../utils/getConfig'),
+  getApplicationConfig: jest.fn(() => ({
+    apiHost: 'http://test.com/dev'
+  }))
+}))
 
 const MockComponent = () => {
   const { user, login, logout } = useAppContext()
@@ -63,11 +70,12 @@ const setup = (overrideCookie) => {
 
   render(
     <CookiesProvider defaultSetOptions={{ path: '/' }} cookies={cookie}>
-      <AppContextProvider>
-        <MockComponent />
-      </AppContextProvider>
+      <AuthContextProvider>
+        <AppContextProvider>
+          <MockComponent />
+        </AppContextProvider>
+      </AuthContextProvider>
     </CookiesProvider>
-
   )
 }
 
@@ -75,10 +83,6 @@ describe('AppContextProvider component', () => {
   describe('when app starts up', () => {
     beforeEach(() => {
       jest.resetAllMocks()
-
-      jest.spyOn(getConfig, 'getApplicationConfig').mockImplementation(() => ({
-        cookie: null
-      }))
     })
 
     describe('when log in is triggered', () => {
@@ -91,8 +95,7 @@ describe('AppContextProvider component', () => {
         const user = userEvent.setup()
         const button = screen.getByRole('button', { name: 'Log in' })
         await user.click(button)
-        const { apiHost } = getApplicationConfig()
-        const expectedPath = `${apiHost}/saml-login?target=${encodeURIComponent('/manage/collections')}`
+        const expectedPath = `http://test.com/dev/saml-login?target=${encodeURIComponent('/manage/collections')}`
         expect(window.location.href).toEqual(expectedPath)
       })
     })

--- a/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
+++ b/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
@@ -66,11 +66,11 @@ const AuthContextProvider = ({ children }) => {
 
   const login = useCallback(() => {
     window.location.href = `${apiHost}/saml-login?target=${encodeURIComponent('/manage/collections')}`
-  })
+  }, [])
 
   const logout = useCallback(() => {
     setUser({})
-  })
+  }, [])
 
   const providerValue = useMemo(() => ({
     login,

--- a/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
+++ b/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
@@ -18,10 +18,10 @@ const { apiHost } = getApplicationConfig()
  * @property {ReactNode} children The children to be rendered.
 
 /**
- * Renders any children wrapped with Auth.
+ * Renders any children and provides access to AuthContext.
  * @param {AuthContextProviderProps} props
  *
- * @example <caption>Renders children wrapped with Auth.</caption>
+ * @example <caption>Renders any children and provides access to AuthContext.</caption>
  *
  * return (
  *   <AuthContextProvider>

--- a/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
+++ b/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
@@ -1,0 +1,101 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
+import PropTypes from 'prop-types'
+import { useCookies } from 'react-cookie'
+import AuthContext from '../../context/AuthContext'
+import { getApplicationConfig } from '../../utils/getConfig'
+import decodeCookie from '../../utils/decodeCookie'
+import checkAndRefreshToken from '../../utils/checkAndRefreshToken'
+
+const { apiHost } = getApplicationConfig()
+
+/**
+ * @typedef {Object} AuthContextProviderProps
+ * @property {ReactNode} children The children to be rendered.
+
+/**
+ * Renders any children wrapped with Auth.
+ * @param {AuthContextProviderProps} props
+ *
+ * @example <caption>Renders children wrapped with Auth.</caption>
+ *
+ * return (
+ *   <AuthContextProvider>
+ *     {children}
+ *   </AuthContextProvider>
+ * )
+ */
+const AuthContextProvider = ({ children }) => {
+  const [user, setUser] = useState({})
+
+  const [cookies] = useCookies(['loginInfo'])
+  const { token } = user
+  const { loginInfo } = cookies
+
+  useEffect(() => {
+    if (loginInfo) {
+      const {
+        auid,
+        name,
+        token: cookieToken
+      } = decodeCookie(loginInfo)
+
+      setUser({
+        ...user,
+        token: cookieToken,
+        name,
+        auid,
+        providerId: 'MMT_2'
+      })
+    }
+  }, [loginInfo])
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      checkAndRefreshToken(user, setUser)
+    }, 1000)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [token])
+
+  const login = useCallback(() => {
+    window.location.href = `${apiHost}/saml-login?target=${encodeURIComponent('/manage/collections')}`
+  })
+
+  const logout = useCallback(() => {
+    setUser({})
+  })
+
+  const providerValue = useMemo(() => ({
+    login,
+    logout,
+    setUser,
+    user
+  }), [
+    user,
+    login,
+    logout
+  ])
+
+  return (
+    <AuthContext.Provider value={providerValue}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+AuthContextProvider.defaultProps = {
+  children: null
+}
+
+AuthContextProvider.propTypes = {
+  children: PropTypes.node
+}
+
+export default AuthContextProvider

--- a/static/src/js/providers/AuthContextProvider/__tests__/AuthContextProvider.test.js
+++ b/static/src/js/providers/AuthContextProvider/__tests__/AuthContextProvider.test.js
@@ -1,0 +1,183 @@
+import React from 'react'
+import {
+  act,
+  render,
+  screen
+} from '@testing-library/react'
+
+import userEvent from '@testing-library/user-event'
+import { Cookies, CookiesProvider } from 'react-cookie'
+import AuthContextProvider from '../AuthContextProvider'
+import encodeCookie from '../../../utils/encodeCookie'
+import useAuthContext from '../../../hooks/useAuthContext'
+import checkAndRefreshToken from '../../../utils/checkAndRefreshToken'
+
+jest.mock('../../../utils/getConfig', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../../utils/getConfig'),
+  getApplicationConfig: jest.fn(() => ({
+    apiHost: 'http://test.com/dev'
+  }))
+}))
+
+jest.mock('../../../utils/checkAndRefreshToken', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+const MockComponent = () => {
+  const { user, login, logout } = useAuthContext()
+
+  return (
+    <div>
+      <div>
+        User Name:
+        {' '}
+        {user?.name}
+      </div>
+      <button
+        type="button"
+        onClick={
+          () => {
+            login()
+          }
+        }
+      >
+        Log in
+      </button>
+      <button
+        type="button"
+        onClick={
+          () => {
+            logout()
+          }
+        }
+      >
+        Log out
+      </button>
+    </div>
+  )
+}
+
+const setup = (overrideCookie) => {
+  let expires = new Date()
+  expires.setMinutes(expires.getMinutes() + 15)
+  expires = new Date(expires)
+
+  const cookie = new Cookies(
+    overrideCookie || {
+      loginInfo: encodeCookie({
+        auid: 'username',
+        name: 'User Name',
+        token: {
+          tokenValue: 'ABC-1',
+          tokenExp: expires
+        }
+      })
+    }
+  )
+  cookie.HAS_DOCUMENT_COOKIE = false
+
+  render(
+    <CookiesProvider defaultSetOptions={{ path: '/' }} cookies={cookie}>
+      <AuthContextProvider>
+        <MockComponent />
+      </AuthContextProvider>
+    </CookiesProvider>
+  )
+}
+
+describe('AuthContextProvider component', () => {
+  describe('when app starts up', () => {
+    beforeEach(() => {
+      jest.resetAllMocks()
+    })
+
+    describe('when log in is triggered', () => {
+      test('logs the user in', async () => {
+        delete window.location
+        window.location = {}
+
+        setup({})
+
+        const user = userEvent.setup()
+        const button = screen.getByRole('button', { name: 'Log in' })
+        await user.click(button)
+        const expectedPath = `http://test.com/dev/saml-login?target=${encodeURIComponent('/manage/collections')}`
+        expect(window.location.href).toEqual(expectedPath)
+      })
+    })
+
+    describe('when logged in', () => {
+      describe('when log out is triggered', () => {
+        beforeEach(() => {
+          jest.useFakeTimers()
+          jest.setSystemTime(new Date('2024-01-01'))
+        })
+
+        afterEach(() => {
+          jest.useRealTimers()
+        })
+
+        test('logs the user out', async () => {
+          delete window.location
+          window.location = {}
+
+          setup()
+
+          const user = userEvent.setup({ delay: null })
+          const loginButton = screen.getByRole('button', { name: 'Log in' })
+
+          await user.click(loginButton)
+
+          const userName = screen.getByText('User Name: User Name', { exact: true })
+          expect(userName).toBeInTheDocument()
+
+          act(() => {
+            jest.advanceTimersByTime(1500)
+          })
+
+          expect(checkAndRefreshToken).toHaveBeenCalledTimes(1)
+          expect(checkAndRefreshToken).toHaveBeenCalledWith(
+            expect.objectContaining({
+              name: 'User Name',
+              auid: 'username',
+              providerId: 'MMT_2',
+              token: {
+                tokenExp: '2024-01-01T00:15:00.000Z',
+                tokenValue: 'ABC-1'
+              }
+            }),
+            expect.any(Function)
+          )
+        })
+      })
+
+      describe('when log out is triggered', () => {
+        test('logs the user out', async () => {
+          delete window.location
+          window.location = {}
+
+          setup()
+
+          const user = userEvent.setup()
+          const loginButton = screen.getByRole('button', { name: 'Log in' })
+
+          await user.click(loginButton)
+
+          const userName = screen.getByText('User Name: User Name', { exact: true })
+
+          expect(userName).toBeInTheDocument()
+
+          const logoutButton = screen.getByRole('button', { name: 'Log out' })
+
+          await user.click(logoutButton)
+
+          const newUserName = screen.queryByText('User Name: User Name', { exact: true })
+
+          expect(newUserName).not.toBeInTheDocument()
+        })
+      })
+    })
+  })
+})

--- a/static/src/js/providers/GraphQLProvider/GraphQLProvider.jsx
+++ b/static/src/js/providers/GraphQLProvider/GraphQLProvider.jsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  ApolloClient,
+  ApolloProvider,
+  InMemoryCache,
+  createHttpLink
+} from '@apollo/client'
+import { setContext } from '@apollo/client/link/context'
+
+import { getApplicationConfig } from '../../utils/getConfig'
+
+import useAppContext from '../../hooks/useAppContext'
+
+/**
+ * @typedef {Object} GraphQLProviderProps
+ * @property {ReactNode} children The children to be rendered.
+
+/**
+ * Renders any children wrapped with Auth.
+ * @param {GraphQLProviderProps} props
+ *
+ * @example <caption>Renders children wrapped with Auth.</caption>
+ *
+ * return (
+ *   <GraphQLProvider>
+ *     {children}
+ *   </GraphQLProvider>
+ * )
+ */
+const GraphQLProvider = ({ children }) => {
+  const { graphQlHost } = getApplicationConfig()
+  const appContext = useAppContext()
+  const { user } = appContext
+  const { token } = user
+  const { tokenValue } = token || {}
+
+  const httpLink = createHttpLink({
+    uri: graphQlHost
+  })
+
+  const authLink = setContext((_, { headers }) => ({
+    headers: {
+      ...headers,
+      Authorization: tokenValue
+    }
+  }))
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: authLink.concat(httpLink),
+    defaultOptions: {
+      query: {
+        fetchPolicy: 'no-cache'
+      },
+      watchQuery: {
+        fetchPolicy: 'no-cache'
+      }
+    }
+  })
+
+  return (
+    <ApolloProvider client={client}>
+      {children}
+    </ApolloProvider>
+  )
+}
+
+GraphQLProvider.defaultProps = {
+  children: null
+}
+
+GraphQLProvider.propTypes = {
+  children: PropTypes.node
+}
+
+export default GraphQLProvider

--- a/static/src/js/providers/GraphQLProvider/GraphQLProvider.jsx
+++ b/static/src/js/providers/GraphQLProvider/GraphQLProvider.jsx
@@ -17,10 +17,10 @@ import useAppContext from '../../hooks/useAppContext'
  * @property {ReactNode} children The children to be rendered.
 
 /**
- * Renders any children wrapped with Auth.
+ * Renders any children wrapped with access to the Apollo context.
  * @param {GraphQLProviderProps} props
  *
- * @example <caption>Renders children wrapped with Auth.</caption>
+ * @example <caption>Renders children wrapped with access to the Apollo context.</caption>
  *
  * return (
  *   <GraphQLProvider>

--- a/static/src/js/providers/GraphQLProvider/__tests__/GraphQLProvider.test.js
+++ b/static/src/js/providers/GraphQLProvider/__tests__/GraphQLProvider.test.js
@@ -1,0 +1,162 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import {
+  ApolloClient,
+  ApolloLink,
+  createHttpLink
+} from '@apollo/client'
+
+import { setContext } from '@apollo/client/link/context'
+import GraphQLProvider from '../GraphQLProvider'
+import AppContextProvider from '../../AppContextProvider/AppContextProvider'
+import AuthContext from '../../../context/AuthContext'
+
+jest.mock('@apollo/client', () => ({
+  ...jest.requireActual('@apollo/client'),
+  __esModule: true,
+  ApolloClient: jest.fn(),
+  InMemoryCache: jest.fn(() => ({ mockCache: {} })),
+  ApolloProvider: jest.fn(({ children }) => children),
+  createHttpLink: jest.fn(
+    (args) => jest.requireActual('@apollo/client').createHttpLink(args)
+  )
+}))
+
+jest.mock('@apollo/client/link/context', () => ({
+  __esModule: true,
+  ...jest.requireActual('@apollo/client/link/context'),
+  setContext: jest.fn(
+    (args) => jest.requireActual('@apollo/client/link/context').setContext(args)
+  )
+}))
+
+jest.mock('../../../context/AuthContext', () => ({
+  __esModule: true,
+  default: jest.requireActual('react').createContext()
+}))
+
+global.fetch = jest.fn()
+
+jest.mock('../../../utils/getConfig', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../../utils/getConfig'),
+  getApplicationConfig: jest.fn(() => ({
+    graphQlHost: 'http://graphqlhost.com/dev/api'
+  }))
+}))
+
+const defaultAuthContext = {
+  login: jest.fn(),
+  logout: jest.fn(),
+  setUser: jest.fn(),
+  user: {
+    name: 'User Name',
+    auid: 'username',
+    token: {
+      tokenValue: 'launchpad_token',
+      tokenExp: 1234
+    }
+  }
+}
+
+const setup = (authContextOverride) => {
+  render(
+    <AuthContext.Provider value={
+      {
+        ...defaultAuthContext,
+        ...authContextOverride
+      }
+    }
+    >
+      <AppContextProvider>
+        <GraphQLProvider>
+          <div />
+        </GraphQLProvider>
+      </AppContextProvider>
+    </AuthContext.Provider>
+  )
+}
+
+describe('GraphQLProvider component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('when the token exists', () => {
+    test('creates the ApolloClient', async () => {
+      setup()
+
+      expect(ApolloClient).toHaveBeenCalledTimes(1)
+      expect(ApolloClient).toHaveBeenCalledWith(
+        expect.objectContaining(
+          {
+            cache: { mockCache: {} },
+            defaultOptions: {
+              query: {
+                fetchPolicy: 'no-cache'
+              },
+              watchQuery: {
+                fetchPolicy: 'no-cache'
+              }
+            },
+            link: expect.any(ApolloLink)
+          }
+        )
+      )
+
+      // Check that createHttpLink is called properly
+      expect(createHttpLink).toHaveBeenCalledTimes(1)
+      expect(createHttpLink).toHaveBeenCalledWith({
+        uri: 'http://graphqlhost.com/dev/api'
+      })
+
+      // Check that the authLink is called properly
+      expect(setContext).toHaveBeenCalledTimes(1)
+      expect(setContext.mock.calls[0][0](null, {})).toEqual({ headers: { Authorization: 'launchpad_token' } })
+    })
+  })
+
+  describe('when the token does not exist', () => {
+    test('creates the ApolloClient', async () => {
+      const undefinedUserAuthContext = { ...defaultAuthContext }
+      delete undefinedUserAuthContext.user.token
+      setup({
+        user: {
+          ...undefinedUserAuthContext.user
+        }
+      })
+
+      expect(ApolloClient).toHaveBeenCalledTimes(1)
+      expect(ApolloClient).toHaveBeenCalledWith(
+        expect.objectContaining(
+          {
+            cache: { mockCache: {} },
+            defaultOptions: {
+              query: {
+                fetchPolicy: 'no-cache'
+              },
+              watchQuery: {
+                fetchPolicy: 'no-cache'
+              }
+            },
+            link: expect.any(ApolloLink)
+          }
+        )
+      )
+
+      // Check that createHttpLink is called properly
+      expect(createHttpLink).toHaveBeenCalledTimes(1)
+      expect(createHttpLink).toHaveBeenCalledWith({
+        uri: 'http://graphqlhost.com/dev/api'
+      })
+
+      // Check that the authLink is called properly
+      expect(setContext).toHaveBeenCalledTimes(1)
+      expect(setContext.mock.calls[0][0](null, {})).toEqual(
+        {
+          headers: { Authorization: undefined }
+        }
+      )
+    })
+  })
+})

--- a/static/src/js/providers/Providers/Providers.jsx
+++ b/static/src/js/providers/Providers/Providers.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 
 import AppContextProvider from '../AppContextProvider/AppContextProvider'
 import NotificationsContextProvider from '../NotificationsContextProvider/NotificationsContextProvider'
+import AuthContextProvider from '../AuthContextProvider/AuthContextProvider'
+import GraphQLProvider from '../GraphQLProvider/GraphQLProvider'
 
 /**
  * @typedef {Object} ProvidersProps
@@ -22,7 +24,9 @@ import NotificationsContextProvider from '../NotificationsContextProvider/Notifi
  */
 const Providers = ({ children }) => {
   const providers = [
-    <AppContextProvider key="provider_app-context" />,
+    <AuthContextProvider key="provider_auth-context-provider" />,
+    <AppContextProvider key="provider_app-context-provider" />,
+    <GraphQLProvider key="provider_graphql-provider" />,
     <NotificationsContextProvider key="provider_notifications-context" />
   ]
 

--- a/static/src/js/providers/Providers/__tests__/Providers.test.js
+++ b/static/src/js/providers/Providers/__tests__/Providers.test.js
@@ -39,22 +39,6 @@ jest.mock('../../NotificationsContextProvider/NotificationsContextProvider', () 
 
 describe('Providers', () => {
   test('renders all providers', () => {
-    let expires = new Date()
-    expires.setMinutes(expires.getMinutes() + 15)
-    expires = new Date(expires)
-
-    const cookie = new Cookies({
-      loginInfo: encodeCookie({
-        name: 'User Name',
-        token: {
-          tokenValue: 'ABC-1',
-          tokenExp: expires
-        },
-        providerId: 'MMT_2'
-      })
-    })
-    cookie.HAS_DOCUMENT_COOKIE = false
-
     render(
       <Providers>
         Test

--- a/static/src/js/providers/Providers/__tests__/Providers.test.js
+++ b/static/src/js/providers/Providers/__tests__/Providers.test.js
@@ -1,13 +1,11 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { Cookies } from 'react-cookie'
 
 import Providers from '../Providers'
 
 import AppContextProvider from '../../AppContextProvider/AppContextProvider'
 import NotificationsContextProvider from '../../NotificationsContextProvider/NotificationsContextProvider'
 
-import encodeCookie from '../../../utils/encodeCookie'
 import AuthContextProvider from '../../AuthContextProvider/AuthContextProvider'
 import GraphQLProvider from '../../GraphQLProvider/GraphQLProvider'
 

--- a/static/src/js/providers/Providers/__tests__/Providers.test.js
+++ b/static/src/js/providers/Providers/__tests__/Providers.test.js
@@ -1,10 +1,29 @@
 import React from 'react'
 import { render } from '@testing-library/react'
+import { Cookies } from 'react-cookie'
 
 import Providers from '../Providers'
 
 import AppContextProvider from '../../AppContextProvider/AppContextProvider'
 import NotificationsContextProvider from '../../NotificationsContextProvider/NotificationsContextProvider'
+
+import encodeCookie from '../../../utils/encodeCookie'
+import AuthContextProvider from '../../AuthContextProvider/AuthContextProvider'
+import GraphQLProvider from '../../GraphQLProvider/GraphQLProvider'
+
+global.fetch = jest.fn()
+
+jest.mock('../../AuthContextProvider/AuthContextProvider', () => jest.fn(({ children }) => (
+  <mock-Component data-testid="AuthContextProvider">
+    {children}
+  </mock-Component>
+)))
+
+jest.mock('../../GraphQLProvider/GraphQLProvider', () => jest.fn(({ children }) => (
+  <mock-Component data-testid="GraphQLProvider">
+    {children}
+  </mock-Component>
+)))
 
 jest.mock('../../AppContextProvider/AppContextProvider', () => jest.fn(({ children }) => (
   <mock-Component data-testid="AppContextProvider">
@@ -20,9 +39,31 @@ jest.mock('../../NotificationsContextProvider/NotificationsContextProvider', () 
 
 describe('Providers', () => {
   test('renders all providers', () => {
-    render(<Providers>Test</Providers>)
+    let expires = new Date()
+    expires.setMinutes(expires.getMinutes() + 15)
+    expires = new Date(expires)
 
+    const cookie = new Cookies({
+      loginInfo: encodeCookie({
+        name: 'User Name',
+        token: {
+          tokenValue: 'ABC-1',
+          tokenExp: expires
+        },
+        providerId: 'MMT_2'
+      })
+    })
+    cookie.HAS_DOCUMENT_COOKIE = false
+
+    render(
+      <Providers>
+        Test
+      </Providers>
+    )
+
+    expect(AuthContextProvider).toHaveBeenCalledTimes(1)
     expect(AppContextProvider).toHaveBeenCalledTimes(1)
+    expect(GraphQLProvider).toHaveBeenCalledTimes(1)
     expect(NotificationsContextProvider).toHaveBeenCalledTimes(1)
   })
 })

--- a/static/src/js/utils/__tests__/checkAndRefreshToken.test.js
+++ b/static/src/js/utils/__tests__/checkAndRefreshToken.test.js
@@ -31,7 +31,7 @@ describe('check and refresh token', () => {
     }))
 
     const setUserFn = jest.fn()
-    await checkAndRefreshToken(token, {
+    await checkAndRefreshToken({
       name: 'mock name',
       token
     }, setUserFn)
@@ -57,7 +57,7 @@ describe('check and refresh token', () => {
     }
 
     const setUserFn = jest.fn()
-    await checkAndRefreshToken(token, {
+    await checkAndRefreshToken({
       name: 'mock name',
       token
     }, setUserFn)
@@ -73,7 +73,7 @@ describe('check and refresh token', () => {
     const token = null
 
     const setUserFn = jest.fn()
-    await checkAndRefreshToken(token, {
+    await checkAndRefreshToken({
       name: 'mock name',
       token
     }, setUserFn)

--- a/static/src/js/utils/checkAndRefreshToken.js
+++ b/static/src/js/utils/checkAndRefreshToken.js
@@ -9,7 +9,8 @@ import refreshToken from './refreshToken'
  * @param {*} user the user object
  * @param {*} setUser the setUser function to be used to update the token
  */
-const checkAndRefreshToken = async (token, user, setUser) => {
+const checkAndRefreshToken = async (user, setUser) => {
+  const { token } = user
   const { tokenValue, tokenExp } = token || {}
 
   if (tokenValue && tokenExp) {
@@ -21,7 +22,7 @@ const checkAndRefreshToken = async (token, user, setUser) => {
 
     if (isTokenExpired(offsetTokenInfo)) {
       const newToken = await refreshToken(tokenValue)
-      console.log('refreshed token to ', newToken)
+
       setUser({
         ...user,
         token: newToken


### PR DESCRIPTION
This PR reorganizes the creates a new provider for authorization `AuthContextProvider`, separate from the app context,  and a new `GraphQLProvider` component that instantiates the Apollo provider, and moves them both into the Providers component. The `AppContext` now uses the AuthContext to grab the user authentication information and store it for global use.

This creates the following structure
```jsx
<AuthProvider> // Deals with authentication
    <AppContextProvider> // Stores app wide state
        <GraphQLProvider> // initializes Apollo
            <NotificationsProvider> // Notifications
                <App/>
            </NotificationsProvider>
        </GraphQLProvider>
    </AppContextProvider>
</AuthProvider>
```

These changes to the `Providers` component will prevent us from being limited when trying to use any of the Providers within `App.jsx`.