### PR TITLE
MMT-3559: As a user, I can see how many tags are associated to published collection

### DIFF
--- a/static/src/js/components/CollectionAssociation/__tests__/CollectionAssociation.test.js
+++ b/static/src/js/components/CollectionAssociation/__tests__/CollectionAssociation.test.js
@@ -299,6 +299,15 @@ describe('CollectionAssociation', () => {
                     entryTitle: 'Collection Associations Entry Title 1 ',
                     title: 'Collection Associations Title 1',
                     revisionDate: null,
+                    tagDefinitions: {
+                      items: [{
+                        conceptId: 'C100000',
+                        description: 'Mock tag description',
+                        originatorId: 'test.user',
+                        revisionId: '1',
+                        tagKey: 'Mock tag key'
+                      }]
+                    },
                     __typename: 'Collection'
                   }
                 ],
@@ -411,6 +420,15 @@ describe('CollectionAssociation', () => {
                         shortName: 'Collection Associations Short Name 1',
                         title: 'Collection Associations Title 1',
                         revisionDate: null,
+                        tagDefinitions: {
+                          items: [{
+                            conceptId: 'C100000',
+                            description: 'Mock tag description',
+                            originatorId: 'test.user',
+                            revisionId: '1',
+                            tagKey: 'Mock tag key'
+                          }]
+                        },
                         __typename: 'Collection'
                       }
                     ],
@@ -448,6 +466,15 @@ describe('CollectionAssociation', () => {
                         shortName: 'Collection Associations Short Name 1',
                         title: 'Collection Associations Title 1',
                         revisionDate: null,
+                        tagDefinitions: {
+                          items: [{
+                            conceptId: 'C100000',
+                            description: 'Mock tag description',
+                            originatorId: 'test.user',
+                            revisionId: '1',
+                            tagKey: 'Mock tag key'
+                          }]
+                        },
                         __typename: 'Collection'
                       }
                     ],
@@ -543,6 +570,15 @@ describe('CollectionAssociation', () => {
                         shortName: 'Collection Associations Short Name 1',
                         title: 'Collection Associations Title 1',
                         revisionDate: null,
+                        tagDefinitions: {
+                          items: [{
+                            conceptId: 'C100000',
+                            description: 'Mock tag description',
+                            originatorId: 'test.user',
+                            revisionId: '1',
+                            tagKey: 'Mock tag key'
+                          }]
+                        },
                         __typename: 'Collection'
                       }
                     ],
@@ -639,6 +675,15 @@ describe('CollectionAssociation', () => {
                         granules: null,
                         revisionDate: null,
                         title: 'Collection Associations Title 1',
+                        tagDefinitions: {
+                          items: [{
+                            conceptId: 'C100000',
+                            description: 'Mock tag description',
+                            originatorId: 'test.user',
+                            revisionId: '1',
+                            tagKey: 'Mock tag key'
+                          }]
+                        },
                         __typename: 'Collection'
                       }
                     ],
@@ -741,6 +786,15 @@ describe('CollectionAssociation', () => {
                       granules: null,
                       revisionDate: null,
                       title: 'Collection Associations Title 1',
+                      tagDefinitions: {
+                        items: [{
+                          conceptId: 'C100000',
+                          description: 'Mock tag description',
+                          originatorId: 'test.user',
+                          revisionId: '1',
+                          tagKey: 'Mock tag key'
+                        }]
+                      },
                       __typename: 'Collection'
                     }
                   ],
@@ -779,6 +833,15 @@ describe('CollectionAssociation', () => {
                       tags: null,
                       granules: null,
                       title: 'Collection Associations Title 2',
+                      tagDefinitions: {
+                        items: [{
+                          conceptId: 'C100000',
+                          description: 'Mock tag description',
+                          originatorId: 'test.user',
+                          revisionId: '1',
+                          tagKey: 'Mock tag key'
+                        }]
+                      },
                       __typename: 'Collection'
                     }
                   ],
@@ -817,6 +880,15 @@ describe('CollectionAssociation', () => {
                       tags: null,
                       granules: null,
                       title: 'Collection Associations Title 2',
+                      tagDefinitions: {
+                        items: [{
+                          conceptId: 'C100000',
+                          description: 'Mock tag description',
+                          originatorId: 'test.user',
+                          revisionId: '1',
+                          tagKey: 'Mock tag key'
+                        }]
+                      },
                       __typename: 'Collection'
                     }
                   ],
@@ -883,6 +955,15 @@ describe('CollectionAssociation', () => {
                       granules: null,
                       revisionDate: null,
                       title: 'Collection Associations Title 1',
+                      tagDefinitions: {
+                        items: [{
+                          conceptId: 'C100000',
+                          description: 'Mock tag description',
+                          originatorId: 'test.user',
+                          revisionId: '1',
+                          tagKey: 'Mock tag key'
+                        }]
+                      },
                       __typename: 'Collection'
                     }
                   ],
@@ -921,6 +1002,15 @@ describe('CollectionAssociation', () => {
                       tags: null,
                       granules: null,
                       title: 'Collection Associations Title 2',
+                      tagDefinitions: {
+                        items: [{
+                          conceptId: 'C100000',
+                          description: 'Mock tag description',
+                          originatorId: 'test.user',
+                          revisionId: '1',
+                          tagKey: 'Mock tag key'
+                        }]
+                      },
                       __typename: 'Collection'
                     }
                   ],
@@ -959,6 +1049,15 @@ describe('CollectionAssociation', () => {
                       tags: null,
                       granules: null,
                       title: 'Collection Associations Title 2',
+                      tagDefinitions: {
+                        items: [{
+                          conceptId: 'C100000',
+                          description: 'Mock tag description',
+                          originatorId: 'test.user',
+                          revisionId: '1',
+                          tagKey: 'Mock tag key'
+                        }]
+                      },
                       __typename: 'Collection'
                     }
                   ],

--- a/static/src/js/components/PublishPreview/PublishPreview.jsx
+++ b/static/src/js/components/PublishPreview/PublishPreview.jsx
@@ -62,7 +62,7 @@ const PublishPreview = () => {
   }
 
   const toggleTagModal = (nextState) => {
-    setShowDeleteModal(nextState)
+    setShowTagModal(nextState)
   }
 
   const { addNotification } = useNotificationsContext()
@@ -86,7 +86,6 @@ const PublishPreview = () => {
       }
     },
     onCompleted: (getData) => {
-      console.log('🚀 ~ PublishPreview ~ getData:', getData)
       const fetchedPreviewMetadata = getData[toLowerKebabCase(derivedConceptType)]
       const {
         revisionId: fetchedRevisionId,
@@ -205,7 +204,7 @@ const PublishPreview = () => {
         })
 
         // Hide the modal
-        setShowDeleteModal(false)
+        toggleShowDeleteModal(false)
 
         // Navigate to the manage page
         navigate(`/manage/${pluralize(derivedConceptType).toLowerCase()}`)
@@ -221,7 +220,7 @@ const PublishPreview = () => {
         errorLogger(deleteError, 'PublishPreview: deleteMutation')
 
         // Hide the modal
-        setShowDeleteModal(false)
+        toggleShowDeleteModal(false)
       }
     })
   }
@@ -318,12 +317,12 @@ const PublishPreview = () => {
                   variant="link"
                   onClick={
                     () => {
-                      setShowTagModal(true)
+                      toggleTagModal(true)
                     }
                   }
                 >
                   Tags (
-                  { getTagCount()}
+                  { getTagCount() }
                   )
                 </Button>
                 <Button
@@ -346,7 +345,7 @@ const PublishPreview = () => {
             variant="outline-danger"
             onClick={
               () => {
-                setShowDeleteModal(true)
+                toggleShowDeleteModal(true)
               }
             }
           >
@@ -366,7 +365,7 @@ const PublishPreview = () => {
                 {
                   label: 'No',
                   variant: 'secondary',
-                  onClick: () => { setShowDeleteModal(false) }
+                  onClick: () => { toggleShowDeleteModal(false) }
                 },
                 {
                   label: 'Yes',
@@ -384,7 +383,7 @@ const PublishPreview = () => {
                 {
                   label: 'Close',
                   variant: 'primary',
-                  onClick: () => { setShowTagModal(false) }
+                  onClick: () => { toggleTagModal(false) }
                 }
               ]
             }

--- a/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.js
+++ b/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.js
@@ -1,5 +1,9 @@
 import { MockedProvider } from '@apollo/client/testing'
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen,
+  within
+} from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import {
@@ -20,7 +24,7 @@ import { GET_TOOL } from '../../../operations/queries/getTool'
 import { DELETE_TOOL } from '../../../operations/mutations/deleteTool'
 import { INGEST_DRAFT } from '../../../operations/mutations/ingestDraft'
 import encodeCookie from '../../../utils/encodeCookie'
-import publishedCollectionRecord from './__mocks__/publishPreview'
+import { noTagsCollection, publishCollectionRecord } from './__mocks__/publishPreview'
 
 jest.mock('../../../utils/constructDownloadableFile')
 jest.mock('../../MetadataPreview/MetadataPreview')
@@ -115,7 +119,8 @@ const setup = ({
       query: conceptTypeQueries.Tool,
       variables: {
         params: {
-          conceptId: 'T1000000-MMT'
+          conceptId: 'T1000000-MMT',
+          includeTags: '*'
         }
       }
     },
@@ -254,7 +259,8 @@ describe('PublishPreview', () => {
               query: GET_TOOL,
               variables: {
                 params: {
-                  conceptId: 'T1000000-MMT'
+                  conceptId: 'T1000000-MMT',
+                  includeTags: '*'
                 }
               }
             },
@@ -281,7 +287,8 @@ describe('PublishPreview', () => {
               query: conceptTypeQueries.Tool,
               variables: {
                 params: {
-                  conceptId: 'T1000000-MMT'
+                  conceptId: 'T1000000-MMT',
+                  includeTags: '*'
                 }
               }
             },
@@ -537,66 +544,189 @@ describe('PublishPreview', () => {
     })
   })
 
-  describe('when the collection preview is collections', () => {
-    describe('when clicking on Create Collection', () => {
-      test('should navigate to variable draft preview', async () => {
-        const navigateSpy = jest.fn()
-        jest.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+  describe('Collection Preview', () => {
+    describe('Create Associated Variable', () => {
+      describe('when clicking on Create Collection', () => {
+        test('should navigate to variable draft preview', async () => {
+          const navigateSpy = jest.fn()
+          jest.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
 
-        const { user } = setup({
-          overrideInitialEntries: ['/collections/C1000000-MMT/1'],
-          overridePath: '/collections',
-          overrideMocks: [
-            {
-              request: {
-                query: conceptTypeQueries.Collection,
-                variables: { params: { conceptId: 'C1000000-MMT' } }
-              },
-              result: {
-                data: {
-                  collection: publishedCollectionRecord
-                }
-              }
-            },
-            {
-              request: {
-                query: INGEST_DRAFT,
-                variables: {
-                  conceptType: 'Variable',
-                  metadata: {
-                    _private: {
-                      CollectionAssociation: {
-                        collectionConceptId: 'C1200000100-MMT_2',
-                        shortName: 'Mock Quick Test Services #2',
-                        version: '1'
-                      }
+          const { user } = setup({
+            overrideInitialEntries: ['/collections/C1000000-MMT/1'],
+            overridePath: '/collections',
+            overrideMocks: [
+              {
+                request: {
+                  query: conceptTypeQueries.Collection,
+
+                  variables: {
+                    params: {
+                      conceptId: 'C1000000-MMT',
+                      includeTags: '*'
                     }
-                  },
-                  nativeId: 'MMT_mock-uuid',
-                  providerId: 'MMT_2',
-                  ummVersion: '1.9.0'
+                  }
+                },
+                result: {
+                  data: {
+                    collection: publishCollectionRecord
+                  }
                 }
               },
-              result: {
-                data: {
-                  ingestDraft: {
-                    conceptId: 'VD1000000-MMT',
-                    revisionId: '1'
+              {
+                request: {
+                  query: INGEST_DRAFT,
+                  variables: {
+                    conceptType: 'Variable',
+                    metadata: {
+                      _private: {
+                        CollectionAssociation: {
+                          collectionConceptId: 'C1200000100-MMT_2',
+                          shortName: 'Mock Quick Test Services #2',
+                          version: '1'
+                        }
+                      }
+                    },
+                    nativeId: 'MMT_mock-uuid',
+                    providerId: 'MMT_2',
+                    ummVersion: '1.9.0'
+                  }
+                },
+                result: {
+                  data: {
+                    ingestDraft: {
+                      conceptId: 'VD1000000-MMT',
+                      revisionId: '1'
+                    }
                   }
                 }
               }
-            }
-          ]
+            ]
+          })
+
+          await waitForResponse()
+
+          const createVariableAssociationBtn = screen.getByRole('button', { name: 'Create Associated Variable' })
+
+          await user.click(createVariableAssociationBtn)
+
+          expect(navigateSpy).toHaveBeenCalledTimes(1)
+          expect(navigateSpy).toHaveBeenCalledWith('/drafts/variables/VD1000000-MMT')
         })
+      })
+    })
 
-        await waitForResponse()
+    describe('Tags', () => {
+      describe('when the collection has tags', () => {
+        test('should display the tag modal and close the modal', async () => {
+          const { user } = setup({
+            overrideInitialEntries: ['/collections/C1000000-MMT/1'],
+            overridePath: '/collections',
+            overrideMocks: [
+              {
+                request: {
+                  query: conceptTypeQueries.Collection,
 
-        const createVariableAssociationBtn = screen.getByRole('button', { name: 'Create Associated Variable' })
+                  variables: {
+                    params: {
+                      conceptId: 'C1000000-MMT',
+                      includeTags: '*'
+                    }
+                  }
+                },
+                result: {
+                  data: {
+                    collection: publishCollectionRecord
+                  }
+                }
+              },
+              {
+                request: {
+                  query: INGEST_DRAFT,
+                  variables: {
+                    conceptType: 'Variable',
+                    metadata: {
+                      _private: {
+                        CollectionAssociation: {
+                          collectionConceptId: 'C1200000100-MMT_2',
+                          shortName: 'Mock Quick Test Services #2',
+                          version: '1'
+                        }
+                      }
+                    },
+                    nativeId: 'MMT_mock-uuid',
+                    providerId: 'MMT_2',
+                    ummVersion: '1.9.0'
+                  }
+                },
+                result: {
+                  data: {
+                    ingestDraft: {
+                      conceptId: 'VD1000000-MMT',
+                      revisionId: '1'
+                    }
+                  }
+                }
+              }
+            ]
+          })
 
-        await user.click(createVariableAssociationBtn)
+          await waitForResponse()
 
-        expect(navigateSpy).toHaveBeenCalledTimes(1)
-        expect(navigateSpy).toHaveBeenCalledWith('/drafts/variables/VD1000000-MMT')
+          const tagBtn = screen.getByRole('button', { name: 'Tags (1)' })
+          await user.click(tagBtn)
+
+          const modal = screen.queryByRole('dialog')
+
+          expect(modal).toBeInTheDocument()
+          expect(within(modal).queryByText('1 tag')).toBeInTheDocument()
+          expect(within(modal).queryByText('Tag Key:')).toBeInTheDocument()
+          expect(within(modal).queryByText('Description:')).toBeInTheDocument()
+          expect(within(modal).queryByText('Mock tag description')).toBeInTheDocument()
+
+          const closeButton = within(modal).queryByRole('button', { name: 'Close' })
+
+          await user.click(closeButton)
+
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        })
+      })
+
+      describe('when the collection has no tags', () => {
+        test('should display the with no tag message', async () => {
+          const { user } = setup({
+            overrideInitialEntries: ['/collections/C1000000-MMT/1'],
+            overridePath: '/collections',
+            overrideMocks: [
+              {
+                request: {
+                  query: conceptTypeQueries.Collection,
+
+                  variables: {
+                    params: {
+                      conceptId: 'C1000000-MMT',
+                      includeTags: '*'
+                    }
+                  }
+                },
+                result: {
+                  data: {
+                    collection: noTagsCollection
+                  }
+                }
+              }
+            ]
+          })
+
+          await waitForResponse()
+
+          const tagBtn = screen.getByRole('button', { name: 'Tags (0)' })
+          await user.click(tagBtn)
+
+          const modal = screen.queryByRole('dialog')
+
+          expect(modal).toBeInTheDocument()
+          expect(within(modal).queryByText('There are no tags associated with this collection')).toBeInTheDocument()
+        })
       })
     })
   })

--- a/static/src/js/components/PublishPreview/__tests__/__mocks__/publishPreview.js
+++ b/static/src/js/components/PublishPreview/__tests__/__mocks__/publishPreview.js
@@ -1,4 +1,4 @@
-export const publishPreview = {
+export const publishCollectionRecord = {
   relatedCollections: null,
   abstract: 'Mock Testing Collections',
   accessConstraints: null,
@@ -61,6 +61,15 @@ export const publishPreview = {
   conceptId: 'C1200000100-MMT_2',
   contactGroups: null,
   contactPersons: null,
+  tagDefinitions: {
+    items: [{
+      conceptId: 'C100000',
+      description: 'Mock tag description',
+      originatorId: 'test.user',
+      revisionId: '1',
+      tagKey: 'Mock tag key'
+    }]
+  },
   dataCenters: [
     {
       roles: [
@@ -494,4 +503,499 @@ export const publishPreview = {
   __typename: 'Collection'
 }
 
-export default publishPreview
+export const noTagsCollection = {
+  relatedCollections: null,
+  abstract: 'Mock Testing Collections',
+  accessConstraints: null,
+  additionalAttributes: [
+    {
+      parameterUnitsOfMeasure: 'meters',
+      dataType: 'STRING',
+      parameterValueAccuracy: 'centimeter',
+      valueAccuracyExplanation: 'Mock Text ',
+      description: 'Lorem Ipsum',
+      updateDate: '2020-07-02T00:00:00.000Z',
+      measurementResolution: 'Measurement Resolution test',
+      name: 'Mock additional attribute 1',
+      group: 'Mock Test Group'
+    }
+  ],
+  ancillaryKeywords: [
+    'Test Ancillary keyword'
+  ],
+  archiveAndDistributionInformation: {
+    fileArchiveInformation: [
+      {
+        format: 'Test Archive',
+        formatType: 'Supported',
+        averageFileSize: 1,
+        averageFileSizeUnit: 'TB',
+        totalCollectionFileSize: 2,
+        totalCollectionFileSizeUnit: 'TB',
+        description: 'Lorem Ipsum'
+      }
+    ],
+    fileDistributionInformation: [
+      {
+        format: 'Mock Very Long Text Mock Very Text Mock Very Long Text Mock Very',
+        media: [
+          'Mock Very Long  Text Mock Very Text Mock Very Long Text MockVery'
+        ],
+        averageFileSize: 10,
+        averageFileSizeUnit: 'GB',
+        totalCollectionFileSize: 10,
+        totalCollectionFileSizeUnit: 'GB',
+        description: 'Lorem Ipsum',
+        fees: 'Lorem Ipsum'
+      }
+    ]
+  },
+  associatedDois: [
+    {
+      doi: 'TestDOI'
+    }
+  ],
+  collectionCitations: [
+    {
+      version: '1',
+      title: 'Testing',
+      releaseDate: '2024-01-23T00:00:00.000Z'
+    }
+  ],
+  collectionProgress: 'NOT APPLICABLE',
+  conceptId: 'C1200000100-MMT_2',
+  contactGroups: null,
+  contactPersons: null,
+  tagDefinitions: null,
+  dataCenters: [
+    {
+      roles: [
+        'ORIGINATOR'
+      ],
+      shortName: 'AAG',
+      longName: 'Association of American Geographers',
+      contactInformation: {
+        serviceHours: '8 to 6',
+        contactInstruction: 'Cell',
+        contactMechanisms: [
+          {
+            type: 'Mobile',
+            value: '555-555-1212'
+          }
+        ],
+        relatedUrls: [
+          {
+            urlContentType: 'DataCenterURL',
+            type: 'HOME PAGE',
+            url: 'http://www.aag.org/'
+          }
+        ]
+      },
+      contactPersons: [
+        {
+          roles: [
+            'Metadata Author'
+          ],
+          firstName: 'Mock',
+          lastName: 'Gray',
+          contactInformation: {
+            relatedUrls: [
+              {
+                urlContentType: 'DataContactURL',
+                type: 'HOME PAGE',
+                url: 'http://www.aag.org/'
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  dataDates: [
+    {
+      type: 'UPDATE',
+      date: '2024-01-23T00:00:00.000Z'
+    }
+  ],
+  directDistributionInformation: null,
+  doi: {
+    missingReason: 'Not Applicable'
+  },
+  isoTopicCategories: null,
+  locationKeywords: null,
+  metadataAssociations: null,
+  metadataDates: [
+    {
+      type: 'REVIEW',
+      date: '2025-06-17T00:00:00.000Z'
+    },
+    {
+      type: 'CREATE',
+      date: '2020-09-22T08:59:00.000Z'
+    },
+    {
+      type: 'UPDATE',
+      date: '2024-01-23T11:46:00.000Z'
+    }
+  ],
+  paleoTemporalCoverages: null,
+  platforms: [
+    {
+      type: 'Balloons',
+      shortName: 'MAXIS',
+      longName: 'MeV Auroral X-ray Imaging and Spectroscopy',
+      instruments: [
+        {
+          shortName: 'AAS',
+          longName: 'Atomic Absorption Spectrophotometry'
+        }
+      ]
+    }
+  ],
+  processingLevel: {
+    id: '1'
+  },
+  projects: null,
+  publicationReferences: null,
+  purpose: null,
+  quality: null,
+  relatedUrls: [
+    {
+      description: 'Test related URL',
+      urlContentType: 'DistributionURL',
+      type: 'USE SERVICE API',
+      url: 'amazon.com',
+      getService: {
+        format: 'ascii',
+        mimeType: 'application/json',
+        protocol: 'HTTPS',
+        fullName: 'Test Service',
+        dataId: 'Test ID',
+        dataType: 'Test type',
+        uri: [
+          'www.testingTest'
+        ]
+      }
+    }
+  ],
+  scienceKeywords: [
+    {
+      category: 'EARTH SCIENCE',
+      topic: 'BIOSPHERE',
+      term: 'VEGETATION',
+      variableLevel1: 'CARBON'
+    },
+    {
+      category: 'EARTH SCIENCE',
+      topic: 'LAND SURFACE',
+      term: 'FROZEN GROUND',
+      variableLevel1: 'ROCK GLACIERS'
+    },
+    {
+      category: 'EARTH SCIENCE',
+      topic: 'OCEANS',
+      term: 'OCEAN OPTICS'
+    }
+  ],
+  variables: null,
+  services: {
+    count: 0,
+    items: null,
+    __typename: 'ServiceList'
+  },
+  shortName: 'Mock Quick Test Services #2',
+  spatialExtent: {
+    spatialCoverageType: 'HORIZONTAL_VERTICAL',
+    horizontalSpatialDomain: {
+      geometry: {
+        coordinateSystem: 'GEODETIC',
+        boundingRectangles: [
+          {
+            northBoundingCoordinate: 90,
+            westBoundingCoordinate: -180,
+            eastBoundingCoordinate: 135,
+            southBoundingCoordinate: -75
+          }
+        ]
+      }
+    },
+    granuleSpatialRepresentation: 'CARTESIAN'
+  },
+  spatialInformation: {
+    spatialCoverageType: 'VERTICAL',
+    verticalCoordinateSystem: {
+      depthSystemDefinition: {
+        datumName: 'Test datum',
+        distanceUnits: 'Feet',
+        resolutions: [
+          0.5
+        ]
+      }
+    }
+  },
+  standardProduct: null,
+  tags: null,
+  temporalExtents: [
+    {
+      endsAtPresentFlag: true,
+      rangeDateTimes: [
+        {
+          beginningDateTime: '2020-02-01T00:00:00.000Z',
+          endingDateTime: '2020-05-20T00:00:00.000Z'
+        }
+      ]
+    }
+  ],
+  temporalKeywords: [
+    '1 second - < 1 minute'
+  ],
+  tilingIdentificationSystems: null,
+  title: 'Mock Test for Services Tab',
+  tools: {
+    count: 0,
+    items: null,
+    __typename: 'ToolList'
+  },
+  ummMetadata: {
+    AncillaryKeywords: [
+      'Test Ancillary keyword'
+    ],
+    CollectionCitations: [
+      {
+        Version: '1',
+        Title: 'Testing',
+        ReleaseDate: '2024-01-23T00:00:00.000Z'
+      }
+    ],
+    AdditionalAttributes: [
+      {
+        ParameterUnitsOfMeasure: 'meters',
+        DataType: 'STRING',
+        ParameterValueAccuracy: 'centimeter',
+        ValueAccuracyExplanation: 'Mock Text ',
+        Description: 'Lorem Ipsum',
+        UpdateDate: '2020-07-02T00:00:00.000Z',
+        MeasurementResolution: 'Measurement Resolution test',
+        Name: 'Mock additional attribute 1',
+        Group: 'Mock Test Group'
+      }
+    ],
+    SpatialExtent: {
+      SpatialCoverageType: 'HORIZONTAL_VERTICAL',
+      HorizontalSpatialDomain: {
+        Geometry: {
+          CoordinateSystem: 'GEODETIC',
+          BoundingRectangles: [
+            {
+              NorthBoundingCoordinate: 90,
+              WestBoundingCoordinate: -180,
+              EastBoundingCoordinate: 135,
+              SouthBoundingCoordinate: -75
+            }
+          ]
+        }
+      },
+      GranuleSpatialRepresentation: 'CARTESIAN'
+    },
+    CollectionProgress: 'NOT APPLICABLE',
+    ScienceKeywords: [
+      {
+        Category: 'EARTH SCIENCE',
+        Topic: 'BIOSPHERE',
+        Term: 'VEGETATION',
+        VariableLevel1: 'CARBON'
+      },
+      {
+        Category: 'EARTH SCIENCE',
+        Topic: 'LAND SURFACE',
+        Term: 'FROZEN GROUND',
+        VariableLevel1: 'ROCK GLACIERS'
+      },
+      {
+        Category: 'EARTH SCIENCE',
+        Topic: 'OCEANS',
+        Term: 'OCEAN OPTICS'
+      }
+    ],
+    TemporalExtents: [
+      {
+        EndsAtPresentFlag: true,
+        RangeDateTimes: [
+          {
+            BeginningDateTime: '2020-02-01T00:00:00.000Z',
+            EndingDateTime: '2020-05-20T00:00:00.000Z'
+          }
+        ]
+      }
+    ],
+    ProcessingLevel: {
+      Id: '1'
+    },
+    DOI: {
+      MissingReason: 'Not Applicable'
+    },
+    ShortName: 'Mock Quick Test Services #2',
+    EntryTitle: 'Mock Test for Services Tab',
+    MetadataLanguage: 'eng',
+    RelatedUrls: [
+      {
+        Description: 'Test related URL',
+        URLContentType: 'DistributionURL',
+        Type: 'USE SERVICE API',
+        URL: 'amazon.com',
+        GetService: {
+          Format: 'ascii',
+          MimeType: 'application/json',
+          Protocol: 'HTTPS',
+          FullName: 'Test Service',
+          DataID: 'Test ID',
+          DataType: 'Test type',
+          URI: [
+            'www.testingTest'
+          ]
+        }
+      }
+    ],
+    SpatialInformation: {
+      SpatialCoverageType: 'VERTICAL',
+      VerticalCoordinateSystem: {
+        DepthSystemDefinition: {
+          DatumName: 'Test datum',
+          DistanceUnits: 'Feet',
+          Resolutions: [
+            0.5
+          ]
+        }
+      }
+    },
+    DataDates: [
+      {
+        Type: 'UPDATE',
+        Date: '2024-01-23T00:00:00.000Z'
+      }
+    ],
+    Abstract: 'Mock Testing Collections',
+    MetadataDates: [
+      {
+        Type: 'REVIEW',
+        Date: '2025-06-17T00:00:00.000Z'
+      },
+      {
+        Type: 'CREATE',
+        Date: '2020-09-22T08:59:00.000Z'
+      },
+      {
+        Type: 'UPDATE',
+        Date: '2024-01-23T11:46:00.000Z'
+      }
+    ],
+    VersionDescription: 'Mock Test',
+    Version: '1',
+    AssociatedDOIs: [
+      {
+        DOI: 'TestDOI'
+      }
+    ],
+    DataCenters: [
+      {
+        Roles: [
+          'ORIGINATOR'
+        ],
+        ShortName: 'AAG',
+        LongName: 'Association of American Geographers',
+        ContactInformation: {
+          ServiceHours: '8 to 6',
+          ContactInstruction: 'Cell',
+          ContactMechanisms: [
+            {
+              Type: 'Mobile',
+              Value: '555-555-1212'
+            }
+          ],
+          RelatedUrls: [
+            {
+              URLContentType: 'DataCenterURL',
+              Type: 'HOME PAGE',
+              URL: 'http://www.aag.org/'
+            }
+          ]
+        },
+        ContactPersons: [
+          {
+            Roles: [
+              'Metadata Author'
+            ],
+            FirstName: 'Mock',
+            LastName: 'Gray',
+            ContactInformation: {
+              RelatedUrls: [
+                {
+                  URLContentType: 'DataContactURL',
+                  Type: 'HOME PAGE',
+                  URL: 'http://www.aag.org/'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    TemporalKeywords: [
+      '1 second - < 1 minute'
+    ],
+    Platforms: [
+      {
+        Type: 'Balloons',
+        ShortName: 'MAXIS',
+        LongName: 'MeV Auroral X-ray Imaging and Spectroscopy',
+        Instruments: [
+          {
+            ShortName: 'AAS',
+            LongName: 'Atomic Absorption Spectrophotometry'
+          }
+        ]
+      }
+    ],
+    MetadataSpecification: {
+      URL: 'https://cdn.earthdata.nasa.gov/umm/collection/v1.17.2',
+      Name: 'UMM-C',
+      Version: '1.17.2'
+    },
+    ArchiveAndDistributionInformation: {
+      FileArchiveInformation: [
+        {
+          Format: 'Test Archive',
+          FormatType: 'Supported',
+          AverageFileSize: 1,
+          AverageFileSizeUnit: 'TB',
+          TotalCollectionFileSize: 2,
+          TotalCollectionFileSizeUnit: 'TB',
+          Description: 'Lorem Ipsum'
+        }
+      ],
+      FileDistributionInformation: [
+        {
+          Format: 'Mock Very Long Text Mock Very Text Mock Very Long Text Mock Very',
+          Media: [
+            'Mock Very Long  Text Mock Very Text Mock Very Long Text MockVery'
+          ],
+          AverageFileSize: 10,
+          AverageFileSizeUnit: 'GB',
+          TotalCollectionFileSize: 10,
+          TotalCollectionFileSizeUnit: 'GB',
+          Description: 'Lorem Ipsum',
+          Fees: 'Lorem Ipsum'
+        }
+      ]
+    }
+  },
+  useConstraints: null,
+  '': {
+    count: 0,
+    items: null,
+    __typename: 'VariableList'
+  },
+  versionDescription: 'Mock Test',
+  versionId: '1',
+  __typename: 'Collection'
+}

--- a/static/src/js/hooks/__tests__/useSearchQuery.test.js
+++ b/static/src/js/hooks/__tests__/useSearchQuery.test.js
@@ -81,6 +81,15 @@ const setup = (overrideMocks) => {
                 granules: {
                   count: 3
                 },
+                tagDefinitions: {
+                  items: [{
+                    conceptId: 'C100000',
+                    description: 'Mock tag description',
+                    originatorId: 'test.user',
+                    revisionId: '1',
+                    tagKey: 'Mock tag key'
+                  }]
+                },
                 tags: { 'test.tag.one': { data: 'Some data' } },
                 revisionDate: '2023-11-30 00:00:00'
               },
@@ -95,6 +104,15 @@ const setup = (overrideMocks) => {
                 granules: {
                   count: 3
                 },
+                tagDefinitions: {
+                  items: [{
+                    conceptId: 'C100000',
+                    description: 'Mock tag description',
+                    originatorId: 'test.user',
+                    revisionId: '1',
+                    tagKey: 'Mock tag key'
+                  }]
+                },
                 tags: { 'test.tag.one': { data: 'Some data' } },
                 revisionDate: '2023-11-30 00:00:00'
               },
@@ -103,6 +121,7 @@ const setup = (overrideMocks) => {
                 shortName: 'Test Short Name 3',
                 revisionId: 1,
                 version: '3',
+                tagDefinitions: null,
                 title: 'Test Title 1',
                 provider: 'TESTPROV',
                 entryTitle: null,

--- a/static/src/js/operations/queries/getCollection.js
+++ b/static/src/js/operations/queries/getCollection.js
@@ -76,6 +76,15 @@ export const GET_COLLECTION = gql`
       spatialInformation
       standardProduct
       tags
+      tagDefinitions {
+        items {
+          conceptId
+          revisionId
+          tagKey
+          description
+          originatorId
+        }
+      }
       temporalExtents
       temporalKeywords
       tilingIdentificationSystems

--- a/static/src/js/operations/queries/getCollections.js
+++ b/static/src/js/operations/queries/getCollections.js
@@ -15,6 +15,15 @@ export const GET_COLLECTIONS = gql`
         granules {
           count
         }
+        tagDefinitions {
+          items {
+            conceptId
+            tagKey
+            revisionId
+            originatorId
+            description
+          }
+        }
         tags
         revisionDate
       }

--- a/static/src/js/pages/SearchPage/SearchPage.jsx
+++ b/static/src/js/pages/SearchPage/SearchPage.jsx
@@ -152,8 +152,9 @@ const SearchPage = ({ limit }) => {
   const buildTagCell = useCallback((cellData, rowData) => {
     if (!cellData) return <span className="p-1 d-block text-end w-100">0</span>
 
-    const tagKeys = Object.keys(cellData)
-    const tagCount = tagKeys.length
+    const { items: tagItems } = cellData
+
+    const tagCount = tagItems.length
 
     return (
       <Button
@@ -242,7 +243,7 @@ const SearchPage = ({ limit }) => {
           align: 'end'
         },
         {
-          dataKey: 'tags',
+          dataKey: 'tagDefinitions',
           title: 'Tags',
           className: 'col-auto text-nowrap',
           dataAccessorFn: buildTagCell,
@@ -406,13 +407,15 @@ const SearchPage = ({ limit }) => {
                 <ListGroup>
                   <For each={Object.keys(activeTagModalCollection.tags)}>
                     {
-                      (tagKey) => (
+                      (tagKey, index) => (
                         <ListGroupItem key={tagKey}>
                           <dl>
                             <dt>Tag Key:</dt>
                             <dd>{tagKey}</dd>
-                            <dt>Data:</dt>
-                            <dd>{activeTagModalCollection.tags[tagKey].data}</dd>
+                            <dt>Description:</dt>
+                            <dd>
+                              {activeTagModalCollection.tagDefinitions.items[index].description}
+                            </dd>
                           </dl>
                         </ListGroupItem>
                       )

--- a/static/src/js/pages/SearchPage/__tests__/SearchPage.test.js
+++ b/static/src/js/pages/SearchPage/__tests__/SearchPage.test.js
@@ -136,7 +136,7 @@ describe('SearchPage component', () => {
         expect(row2Cells[2].textContent).toBe('Collection Title 2')
         expect(row2Cells[3].textContent).toBe('MMT')
         expect(row2Cells[4].textContent).toBe('1234')
-        expect(row2Cells[5].textContent).toBe('2')
+        expect(row2Cells[5].textContent).toBe('1')
         expect(row2Cells[6].textContent).toBe('2023-11-31 00:00:00')
       })
     })
@@ -163,13 +163,13 @@ describe('SearchPage component', () => {
         expect(within(modal).queryByText('1 tag')).toBeInTheDocument()
         expect(within(modal).queryByText('Tag Key:')).toBeInTheDocument()
         expect(within(modal).queryByText('test.tag.one')).toBeInTheDocument()
-        expect(within(modal).queryByText('Data:')).toBeInTheDocument()
-        expect(within(modal).queryByText('Tag Data 1')).toBeInTheDocument()
+        expect(within(modal).queryByText('Description:')).toBeInTheDocument()
+        expect(within(modal).queryByText('Mock tag description')).toBeInTheDocument()
       })
     })
 
     describe('when clicking the close modal button', () => {
-      test.only('closes the modal', async () => {
+      test('closes the modal', async () => {
         const user = userEvent.setup()
 
         await waitFor(() => {

--- a/static/src/js/pages/SearchPage/__tests__/SearchPage.test.js
+++ b/static/src/js/pages/SearchPage/__tests__/SearchPage.test.js
@@ -169,7 +169,7 @@ describe('SearchPage component', () => {
     })
 
     describe('when clicking the close modal button', () => {
-      test('closes the modal', async () => {
+      test.only('closes the modal', async () => {
         const user = userEvent.setup()
 
         await waitFor(() => {

--- a/static/src/js/pages/SearchPage/__tests__/__mocks__/searchResults.js
+++ b/static/src/js/pages/SearchPage/__tests__/__mocks__/searchResults.js
@@ -37,6 +37,15 @@ export const singlePageCollectionSearch = {
                 data: 'Tag Data 1'
               }
             },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
             entryTitle: null,
             revisionDate: '2023-11-30 00:00:00'
           },
@@ -58,6 +67,15 @@ export const singlePageCollectionSearch = {
               'test.tag.two': {
                 data: 'Tag Data 2'
               }
+            },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description 2',
+                originatorId: 'test.user',
+                revisionId: '2',
+                tagKey: 'Mock tag key 2'
+              }]
             },
             revisionDate: '2023-11-31 00:00:00'
           }
@@ -101,6 +119,15 @@ export const multiPageCollectionSearchPage1 = {
                 data: 'Tag Data 1'
               }
             },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
             revisionDate: '2023-11-30 00:00:00'
           },
           {
@@ -122,6 +149,15 @@ export const multiPageCollectionSearchPage1 = {
                 data: 'Tag Data 2'
               }
             },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
             revisionDate: '2023-11-31 00:00:00'
           },
           {
@@ -139,6 +175,15 @@ export const multiPageCollectionSearchPage1 = {
               'test.tag.one': {
                 data: 'Tag Data 1'
               }
+            },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
             },
             revisionDate: '2023-11-30 00:00:00'
           }
@@ -185,6 +230,15 @@ export const multiPageCollectionSearchPage2 = {
                 data: 'Tag Data 2'
               }
             },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
             revisionDate: '2023-11-31 00:00:00'
           },
           {
@@ -203,6 +257,15 @@ export const multiPageCollectionSearchPage2 = {
                 data: 'Tag Data 1'
               }
             },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
             revisionDate: '2023-11-30 00:00:00'
           },
           {
@@ -217,6 +280,7 @@ export const multiPageCollectionSearchPage2 = {
               count: 1234
             },
             tags: null,
+            tagDefinitions: null,
             revisionDate: '2023-11-31 00:00:00'
           }
         ]
@@ -259,6 +323,15 @@ export const multiPageCollectionSearchPage1Asc = {
                 data: 'Tag Data 1'
               }
             },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
             revisionDate: '2023-11-30 00:00:00'
           },
           {
@@ -280,6 +353,15 @@ export const multiPageCollectionSearchPage1Asc = {
                 data: 'Tag Data 2'
               }
             },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
             revisionDate: '2023-11-31 00:00:00'
           },
           {
@@ -296,6 +378,15 @@ export const multiPageCollectionSearchPage1Asc = {
               'test.tag.one': {
                 data: 'Tag Data 1'
               }
+            },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
             },
             revisionDate: '2023-11-30 00:00:00',
             entryTitle: null
@@ -340,6 +431,15 @@ export const multiPageCollectionSearchPage1Desc = {
                 data: 'Tag Data 1'
               }
             },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
             revisionDate: '2023-11-30 00:00:00'
           },
           {
@@ -361,6 +461,15 @@ export const multiPageCollectionSearchPage1Desc = {
                 data: 'Tag Data 2'
               }
             },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
             revisionDate: '2023-11-31 00:00:00'
           },
           {
@@ -378,6 +487,15 @@ export const multiPageCollectionSearchPage1Desc = {
               'test.tag.one': {
                 data: 'Tag Data 1'
               }
+            },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
             },
             revisionDate: '2023-11-30 00:00:00'
           }
@@ -421,6 +539,15 @@ export const multiPageCollectionSearchPage1TitleAsc = {
                 data: 'Tag Data 1'
               }
             },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
             revisionDate: '2023-11-30 00:00:00'
           },
           {
@@ -442,6 +569,15 @@ export const multiPageCollectionSearchPage1TitleAsc = {
                 data: 'Tag Data 2'
               }
             },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
             revisionDate: '2023-11-31 00:00:00'
           },
           {
@@ -458,6 +594,15 @@ export const multiPageCollectionSearchPage1TitleAsc = {
               'test.tag.one': {
                 data: 'Tag Data 1'
               }
+            },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
             },
             revisionDate: '2023-11-30 00:00:00',
             entryTitle: null


### PR DESCRIPTION
Added support for Tag, if a collection record has a tag it will show the tag information in the collection search tag and for a individual collection page.

![image](https://github.com/nasa/mmt/assets/67551614/d26239de-b4f6-4f36-9440-0a2ccf88e99f)
![image](https://github.com/nasa/mmt/assets/67551614/0b490e9d-9f73-4fe2-8385-6939fb26ccf9)
![image](https://github.com/nasa/mmt/assets/67551614/3142b610-9d0d-4bcf-ad56-f77d0ffe7743)
