### PR TITLE
MMT-3558: As a user, I can see how many granules are associated with my collection

### DIFF
--- a/static/src/js/components/PublishPreview/PublishPreview.jsx
+++ b/static/src/js/components/PublishPreview/PublishPreview.jsx
@@ -2,6 +2,7 @@ import { useLazyQuery, useMutation } from '@apollo/client'
 import pluralize from 'pluralize'
 import React, { useState, useEffect } from 'react'
 import {
+  Badge,
   Button,
   Col,
   ListGroup,
@@ -330,9 +331,14 @@ const PublishPreview = () => {
                     }
                   }
                 >
-                  Tags (
-                  { tagCount }
-                  )
+                  Tags
+                  <Badge
+                    className="m-1"
+                    bg="secondary"
+                    pill
+                  >
+                    { tagCount }
+                  </Badge>
                 </Button>
                 <Button
                   className="btn btn-link"
@@ -340,9 +346,15 @@ const PublishPreview = () => {
                   variant="link"
                   disabled
                 >
-                  Granules (
-                  { granuleCount }
-                  )
+                  Granules
+                  <Badge
+                    className="m-1"
+                    bg="secondary"
+                    pill
+                  >
+                    { granuleCount }
+                  </Badge>
+
                 </Button>
                 <Button
                   className="btn btn-link"

--- a/static/src/js/components/PublishPreview/PublishPreview.jsx
+++ b/static/src/js/components/PublishPreview/PublishPreview.jsx
@@ -235,10 +235,13 @@ const PublishPreview = () => {
   }
 
   let tagCount = 0
+  let granuleCount = 0
   if (derivedConceptType === conceptTypes.Collection) {
-    const { tagDefinitions } = previewMetadata || {}
+    const { tagDefinitions, granules } = previewMetadata || {}
+    const { count } = granules || {}
 
     tagCount = getTagCount(tagDefinitions)
+    granuleCount = count
   }
 
   if (error) {
@@ -329,6 +332,16 @@ const PublishPreview = () => {
                 >
                   Tags (
                   { tagCount }
+                  )
+                </Button>
+                <Button
+                  className="btn btn-link"
+                  type="button"
+                  variant="link"
+                  disabled
+                >
+                  Granules (
+                  { granuleCount }
                   )
                 </Button>
                 <Button

--- a/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.js
+++ b/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.js
@@ -641,7 +641,7 @@ describe('PublishPreview', () => {
 
           await waitForResponse()
 
-          const tagBtn = screen.getByRole('button', { name: 'Tags (1)' })
+          const tagBtn = screen.getByRole('button', { name: 'Tags 1' })
           await user.click(tagBtn)
 
           const modal = screen.queryByRole('dialog')
@@ -688,7 +688,7 @@ describe('PublishPreview', () => {
 
           await waitForResponse()
 
-          const tagBtn = screen.getByRole('button', { name: 'Tags (0)' })
+          const tagBtn = screen.getByRole('button', { name: 'Tags 0' })
           await user.click(tagBtn)
 
           const modal = screen.queryByRole('dialog')
@@ -727,7 +727,7 @@ describe('PublishPreview', () => {
           })
 
           await waitForResponse()
-          expect(screen.getByRole('button', { name: 'Granules (1)' }))
+          expect(screen.getByRole('button', { name: 'Granules 1' }))
         })
       })
 
@@ -758,7 +758,7 @@ describe('PublishPreview', () => {
           })
 
           await waitForResponse()
-          expect(screen.getByRole('button', { name: 'Granules (0)' }))
+          expect(screen.getByRole('button', { name: 'Granules 0' }))
         })
       })
     })

--- a/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.js
+++ b/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.js
@@ -23,7 +23,7 @@ import constructDownloadableFile from '../../../utils/constructDownloadableFile'
 import { GET_TOOL } from '../../../operations/queries/getTool'
 import { DELETE_TOOL } from '../../../operations/mutations/deleteTool'
 import { INGEST_DRAFT } from '../../../operations/mutations/ingestDraft'
-import { noTagsCollection, publishCollectionRecord } from './__mocks__/publishPreview'
+import { noTagsOrGranulesCollection, publishCollectionRecord } from './__mocks__/publishPreview'
 
 jest.mock('../../../utils/constructDownloadableFile')
 jest.mock('../../MetadataPreview/MetadataPreview')
@@ -635,34 +635,6 @@ describe('PublishPreview', () => {
                     collection: publishCollectionRecord
                   }
                 }
-              },
-              {
-                request: {
-                  query: INGEST_DRAFT,
-                  variables: {
-                    conceptType: 'Variable',
-                    metadata: {
-                      _private: {
-                        CollectionAssociation: {
-                          collectionConceptId: 'C1200000100-MMT_2',
-                          shortName: 'Mock Quick Test Services #2',
-                          version: '1'
-                        }
-                      }
-                    },
-                    nativeId: 'MMT_mock-uuid',
-                    providerId: 'MMT_2',
-                    ummVersion: '1.9.0'
-                  }
-                },
-                result: {
-                  data: {
-                    ingestDraft: {
-                      conceptId: 'VD1000000-MMT',
-                      revisionId: '1'
-                    }
-                  }
-                }
               }
             ]
           })
@@ -707,7 +679,7 @@ describe('PublishPreview', () => {
                 },
                 result: {
                   data: {
-                    collection: noTagsCollection
+                    collection: noTagsOrGranulesCollection
                   }
                 }
               }
@@ -723,6 +695,70 @@ describe('PublishPreview', () => {
 
           expect(modal).toBeInTheDocument()
           expect(within(modal).queryByText('There are no tags associated with this collection')).toBeInTheDocument()
+        })
+      })
+    })
+
+    describe('Granules', () => {
+      describe('when the collection has granules', () => {
+        test('should display the granule count', async () => {
+          setup({
+            overrideInitialEntries: ['/collections/C1000000-MMT/1'],
+            overridePath: '/collections',
+            overrideMocks: [
+              {
+                request: {
+                  query: conceptTypeQueries.Collection,
+
+                  variables: {
+                    params: {
+                      conceptId: 'C1000000-MMT',
+                      includeTags: '*'
+                    }
+                  }
+                },
+                result: {
+                  data: {
+                    collection: publishCollectionRecord
+                  }
+                }
+              }
+            ]
+          })
+
+          await waitForResponse()
+          expect(screen.getByRole('button', { name: 'Granules (1)' }))
+        })
+      })
+
+      describe('when the collection has no granules', () => {
+        test('should display the granule count with 0', async () => {
+          setup({
+            overrideInitialEntries: ['/collections/C1000000-MMT/1'],
+            overridePath: '/collections',
+            overrideMocks: [
+              {
+                request: {
+                  query: conceptTypeQueries.Collection,
+
+                  variables: {
+                    params: {
+                      conceptId: 'C1000000-MMT',
+                      includeTags: '*'
+                    }
+                  }
+                },
+                result: {
+                  data: {
+                    collection: noTagsOrGranulesCollection
+                  }
+                }
+              }
+            ]
+          })
+
+          await waitForResponse()
+          expect(screen.getByRole('button', { name: 'Granules (0)' }))
         })
       })
     })

--- a/static/src/js/components/PublishPreview/__tests__/__mocks__/publishPreview.js
+++ b/static/src/js/components/PublishPreview/__tests__/__mocks__/publishPreview.js
@@ -124,6 +124,9 @@ export const publishCollectionRecord = {
   doi: {
     missingReason: 'Not Applicable'
   },
+  granules: {
+    count: 1
+  },
   isoTopicCategories: null,
   locationKeywords: null,
   metadataAssociations: null,
@@ -503,7 +506,7 @@ export const publishCollectionRecord = {
   __typename: 'Collection'
 }
 
-export const noTagsCollection = {
+export const noTagsOrGranulesCollection = {
   relatedCollections: null,
   abstract: 'Mock Testing Collections',
   accessConstraints: null,
@@ -620,6 +623,9 @@ export const noTagsCollection = {
   directDistributionInformation: null,
   doi: {
     missingReason: 'Not Applicable'
+  },
+  granules: {
+    count: 0
   },
   isoTopicCategories: null,
   locationKeywords: null,

--- a/static/src/js/operations/queries/getCollection.js
+++ b/static/src/js/operations/queries/getCollection.js
@@ -18,6 +18,9 @@ export const GET_COLLECTION = gql`
       dataDates
       directDistributionInformation
       doi
+      granules {
+        count
+      }
       isoTopicCategories
       locationKeywords
       metadataAssociations


### PR DESCRIPTION
# Overview
Added granule count for a given collection on Preview Preview page.

## When a collection has no granules
![image](https://github.com/nasa/mmt/assets/67551614/a938204e-e757-4b56-829f-181c01feed1a)

## When a collection has a granules
![image](https://github.com/nasa/mmt/assets/67551614/91c99845-25a2-4b28-8c08-b13e37b55d18)
