### PR TITLE
MMT-3604: Clean up cookies

### DIFF
--- a/serverless/src/samlCallback/handler.js
+++ b/serverless/src/samlCallback/handler.js
@@ -38,7 +38,7 @@ const samlCallback = async (event) => {
 
   // There appears to be a limitation in AWS to only allow sending 1 cookie, so we are sending
   // 1 cookie with multiple values in a base 64 encoded json string.
-  let setCookie = `launchpadToken=${launchpadToken}; Secure; Path=/; Domain=.earthdatacloud.nasa.gov; Max-Age=2147483647`
+  let setCookie = `launchpadToken=${launchpadToken}; Secure; Path=/; Domain=.earthdatacloud.nasa.gov`
 
   if (version === 'development') {
     setCookie = `launchpadToken=${launchpadToken}; Path=/`

--- a/static/src/js/components/AuthCallbackContainer/AuthCallbackContainer.jsx
+++ b/static/src/js/components/AuthCallbackContainer/AuthCallbackContainer.jsx
@@ -12,17 +12,16 @@ import useAppContext from '../../hooks/useAppContext'
 export const AuthCallbackContainer = () => {
   const [searchParams] = useSearchParams()
   const { updateLoginInfo, user } = useAppContext()
-
   const path = searchParams.get('target')
   const auid = searchParams.get('auid')
 
   const navigate = useNavigate()
 
   useEffect(() => {
-    updateLoginInfo(auid)
-
     if (!isEmpty(user)) {
       navigate(path, { replace: true })
+    } else {
+      updateLoginInfo(auid)
     }
   }, [user])
 

--- a/static/src/js/components/AuthCallbackContainer/__tests__/AuthCallbackContainer.test.js
+++ b/static/src/js/components/AuthCallbackContainer/__tests__/AuthCallbackContainer.test.js
@@ -73,7 +73,7 @@ describe('AuthCallbackContainer component', () => {
     jest.useRealTimers()
   })
 
-  test('sets the user and redirects', async () => {
+  test('sets the user and calls updateLoginInfo', async () => {
     const navigateSpy = jest.fn()
     jest.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
 
@@ -81,10 +81,21 @@ describe('AuthCallbackContainer component', () => {
     expires.setMinutes(expires.getMinutes() + 15)
     expires = new Date(expires)
 
-    const context = setup()
+    const context = setup({})
 
     expect(context.updateLoginInfo).toHaveBeenCalledTimes(1)
     expect(context.updateLoginInfo).toHaveBeenCalledWith('mock_user')
+  })
+
+  test('if we have user, navigate', async () => {
+    const navigateSpy = jest.fn()
+    jest.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+
+    let expires = new Date()
+    expires.setMinutes(expires.getMinutes() + 15)
+    expires = new Date(expires)
+
+    setup()
     expect(navigateSpy).toHaveBeenCalledWith('/manage/services', { replace: true })
   })
 

--- a/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
+++ b/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
@@ -58,9 +58,9 @@ const AuthContextProvider = ({ children }) => {
       secure: true
     })
 
-    // Remove this code after about 2 months, prior versions used data and we
-    // just need to clean up that cookie for users, as it was causing
-    // header size issues.
+    // Todo: https://bugs.earthdata.nasa.gov/browse/MMT-3612
+    // Remove this code after about 2 months, prior versions used data and we just need 
+    // to clean up that cookie for users, as it was causing header size issues.
     removeCookie('data', {
       path: '/',
       domain: '.earthdatacloud.nasa.gov',

--- a/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
+++ b/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
@@ -29,7 +29,7 @@ const { apiHost } = getApplicationConfig()
  * )
  */
 const AuthContextProvider = ({ children }) => {
-  const [cookies, setCookie] = useCookies(['loginInfo', 'launchpadToken'])
+  const [cookies, setCookie, removeCookie] = useCookies(['loginInfo', 'launchpadToken', 'data'])
   const { loginInfo = {}, launchpadToken } = cookies
 
   const setUser = (info) => {
@@ -37,6 +37,7 @@ const AuthContextProvider = ({ children }) => {
   }
 
   const updateLoginInfo = (auid) => {
+    console.log('updating login info')
     let expires = new Date()
     expires.setMinutes(expires.getMinutes() + 15)
     expires = new Date(expires)
@@ -49,6 +50,22 @@ const AuthContextProvider = ({ children }) => {
       }
     }
     setUser(info)
+
+    // We've moved the launchpad token into the loginInfo, so no need to store it twice.
+    removeCookie('launchpadToken', {
+      path: '/',
+      domain: '.earthdatacloud.nasa.gov',
+      secure: true
+    })
+
+    // Remove this code after about 2 months, prior versions used data and we
+    // just need to clean up that cookie for users, as it was causing
+    // header size issues.
+    removeCookie('data', {
+      path: '/',
+      domain: '.earthdatacloud.nasa.gov',
+      secure: true
+    })
   }
 
   useEffect(() => {

--- a/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
+++ b/static/src/js/providers/AuthContextProvider/AuthContextProvider.jsx
@@ -59,7 +59,7 @@ const AuthContextProvider = ({ children }) => {
     })
 
     // Todo: https://bugs.earthdata.nasa.gov/browse/MMT-3612
-    // Remove this code after about 2 months, prior versions used data and we just need 
+    // Remove this code after about 2 months, prior versions used data and we just need
     // to clean up that cookie for users, as it was causing header size issues.
     removeCookie('data', {
       path: '/',


### PR DESCRIPTION
This PR removes the max-age on the launchpad token, so it will clear on browser close.  It also really isn't needed once the loginInfo cookie is set, as the launchpad token gets assigned into that object with an expiration, so I'm now removing the launchpadToken cookie altogether once loginInfo cookie is set.  Earlier versions of the code also had a 'data' cookie, this caused issues with header length size because it was so large, so I'm also removing that cookie if it exists.   