### PR TITLE
MMT-3609: Fixes issue with looping Apollo requests

### DIFF
--- a/static/src/js/providers/AppContextProvider/AppContextProvider.jsx
+++ b/static/src/js/providers/AppContextProvider/AppContextProvider.jsx
@@ -58,12 +58,12 @@ const AppContextProvider = ({ children }) => {
     setProviderIds,
     providerIds
   }), [
-    JSON.stringify(user),
-    JSON.stringify(draft),
-    JSON.stringify(originalDraft),
-    JSON.stringify(keywords),
-    JSON.stringify(savedDraft),
-    JSON.stringify(providerIds)
+    user,
+    draft,
+    originalDraft,
+    keywords,
+    savedDraft,
+    providerIds
   ])
 
   return (

--- a/static/src/js/providers/GraphQLProvider/GraphQLProvider.jsx
+++ b/static/src/js/providers/GraphQLProvider/GraphQLProvider.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import {
   ApolloClient,
@@ -35,29 +35,31 @@ const GraphQLProvider = ({ children }) => {
   const { token } = user
   const { tokenValue } = token || {}
 
-  const httpLink = createHttpLink({
-    uri: graphQlHost
-  })
+  const client = useMemo(() => {
+    const httpLink = createHttpLink({
+      uri: graphQlHost
+    })
 
-  const authLink = setContext((_, { headers }) => ({
-    headers: {
-      ...headers,
-      Authorization: tokenValue
-    }
-  }))
-
-  const client = new ApolloClient({
-    cache: new InMemoryCache(),
-    link: authLink.concat(httpLink),
-    defaultOptions: {
-      query: {
-        fetchPolicy: 'no-cache'
-      },
-      watchQuery: {
-        fetchPolicy: 'no-cache'
+    const authLink = setContext((_, { headers }) => ({
+      headers: {
+        ...headers,
+        Authorization: tokenValue
       }
-    }
-  })
+    }))
+
+    return new ApolloClient({
+      cache: new InMemoryCache(),
+      link: authLink.concat(httpLink),
+      defaultOptions: {
+        query: {
+          fetchPolicy: 'no-cache'
+        },
+        watchQuery: {
+          fetchPolicy: 'no-cache'
+        }
+      }
+    })
+  }, [tokenValue])
 
   return (
     <ApolloProvider client={client}>

--- a/static/src/js/providers/GraphQLProvider/__tests__/GraphQLProvider.test.js
+++ b/static/src/js/providers/GraphQLProvider/__tests__/GraphQLProvider.test.js
@@ -60,7 +60,7 @@ const defaultAuthContext = {
 }
 
 const setup = (authContextOverride) => {
-  render(
+  const { rerender } = render(
     <AuthContext.Provider value={
       {
         ...defaultAuthContext,
@@ -75,6 +75,10 @@ const setup = (authContextOverride) => {
       </AppContextProvider>
     </AuthContext.Provider>
   )
+
+  return {
+    rerender
+  }
 }
 
 describe('GraphQLProvider component', () => {
@@ -157,6 +161,75 @@ describe('GraphQLProvider component', () => {
           headers: { Authorization: undefined }
         }
       )
+    })
+  })
+
+  describe('when the component rerenders', () => {
+    describe('when the token does not change', () => {
+      test('does not reinitialize the ApolloClient', () => {
+        const { rerender } = setup()
+
+        expect(ApolloClient).toHaveBeenCalledTimes(1)
+
+        ApolloClient.mockReset()
+
+        rerender(
+          <AuthContext.Provider value={
+            {
+              ...defaultAuthContext,
+              user: {
+                ...defaultAuthContext.user,
+                name: 'New Name'
+              }
+            }
+          }
+          >
+            <AppContextProvider>
+              <GraphQLProvider>
+                <div />
+              </GraphQLProvider>
+            </AppContextProvider>
+          </AuthContext.Provider>
+        )
+
+        expect(ApolloClient).toHaveBeenCalledTimes(0)
+      })
+    })
+
+    describe('when the token does change', () => {
+      test('reinitializes the ApolloClient', () => {
+        const { rerender } = setup()
+
+        expect(ApolloClient).toHaveBeenCalledTimes(1)
+
+        ApolloClient.mockReset()
+
+        expect(ApolloClient).toHaveBeenCalledTimes(0)
+
+        rerender(
+          <AuthContext.Provider value={
+            {
+              ...defaultAuthContext,
+              user: {
+                ...defaultAuthContext.user,
+                token: {
+                  tokenValue: 'new_launchpad_token',
+                  tokenExp: 5678
+                }
+              }
+            }
+          }
+          >
+            <AppContextProvider>
+              <GraphQLProvider>
+                <div />
+              </GraphQLProvider>
+            </AppContextProvider>
+          </AuthContext.Provider>
+        )
+
+        expect(ApolloClient).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })


### PR DESCRIPTION
The request loop can be avoided by memoizing the creation of the ApolloClient, so that it is only initialized if the tokenValue changes. This prevents a new client from being created whenever the AppContext is changed.

When viewing the network tab, a request loop no longer occurs when loading drafts, searching for drafts, or when typing into the inputs on a form.

We might need to make improvements to the Contexts down the line but this should get us past the current issue and allow us some time to sort out how we would like to handle that.