### PR TITLE
MMT-3680: Updated deploy_bamboo.sh to update launchpad host names.

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -22,7 +22,9 @@ config="`jq '.saml.callbackUrl = $newValue' --arg newValue $bamboo_SAML_CALLBACK
 config="`jq '.saml.keepAliveOrigin = $newValue' --arg newValue $bamboo_SAML_KEEP_ALIVE_ORIGIN <<< $config`"
 config="`jq '.saml.issuer = $newValue' --arg newValue $bamboo_SAML_ISSUER <<< $config`"
 config="`jq '.saml.cookieName = $newValue' --arg newValue $bamboo_SAML_COOKIE_NAME <<< $config`"
-
+config="`jq '.saml.entryPoint = $newValue' --arg newValue $bamboo_SAML_ENTRY_POINT <<< $config`"
+config="`jq '.saml.launchpadRoot = $newValue' --arg newValue $bamboo_SAML_LAUNCHPAD_ROOT <<< $config`"
+   
 # overwrite static.config.json with new values
 echo $config > tmp.$$.json && mv tmp.$$.json static.config.json
 


### PR DESCRIPTION
# Overview

Configuration used for launchpad host names are different for sandbox vs. production.   These changes allow these to be updated using bamboo variables.

### What is the feature?

The host names were set in `static.config.json` to `auth.launchpad-sbx.nasa.gov` and for production these need to be `auth.launchpad.nasa.gov`.  This change allows these host names to be updated in bamboo.

### What is the Solution?

Updated `deploy_bamboo.sh` to configure `static.config.json` with the proper launchpad host names.

### What areas of the application does this impact?

This impacts deployments, particuarly being able to deploy to UAT and eventually OPS.

# Testing

Currently, if you click Login with Launchpad button on https://mmt.uat.earthdatacloud.nasa.gov it will redirect to `auth.launchpad-sbx.nasa.gov`.  It should redirect to `auth.launchpad.nasa.gov`

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
