### PR TITLE
MMT-3696: Add pull request template to MMT repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Before contributing to this project, please review [Contribution.md](https://github.com/nasa/mmt/blob/master/CONTRIBUTING.md).
+
+### Description
+A clear and concise description of what the bug is.
+
+**Reproduction Steps**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**System Information (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+### Additional context
+Add any other context about the problem here.
+
+### Acceptance Criteria
+Steps to produce expected behavior.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,18 @@
+---
+name: Custom issue template
+about: Template for general tasks and improvements
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Please review [Contribution.md](https://github.com/nasa/mmt/blob/master/CONTRIBUTING.md) before contributing to this project.
+
+### Description
+Describe the purpose of the issue
+
+### Files
+Attach any relevant images or files
+
+### Acceptance Criteria

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+# Overview
+
+### What is the feature?
+
+Please summarize the feature or fix.
+
+### What is the Solution?
+
+Summarize what you changed.
+
+### What areas of the application does this impact?
+
+List impacted areas.
+
+# Testing
+
+### Reproduction steps
+
+- **Environment for testing:**
+- **Collection to test with:**
+
+1. Step 1
+2. Step 2...
+
+### Attachments
+
+Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.
+
+# Checklist
+
+- [ ] I have added automated tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings


### PR DESCRIPTION
# Overview

### What is the feature?

This should be how PRs for this repository look from now on. These files exist in MMT-3390 so we are just moving them to the master branch in the hopes this template will start to show up. 

### What is the Solution?

Added .github file from MMT-3390 to master branch. 

### What areas of the application does this impact?

All future PRs

# Testing

### Reproduction steps

Not sure how to test this without merging it first. Open to suggestions!

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works. N/A
- [x] New and existing unit tests pass locally with my changes. N/A
- [x] I have performed a self-review of my own code. 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings