### PR TITLE
MMT-3515: As a user, I can delete Order Option

### DIFF
--- a/static/src/js/components/OrderOption/OrderOption.jsx
+++ b/static/src/js/components/OrderOption/OrderOption.jsx
@@ -31,33 +31,18 @@ const OrderOption = () => {
   const {
     description,
     form,
+    deprecated,
     revisionDate
-    // Name
   } = orderOption
-
-  // UseEffect(() => {
-  //   setPageTitle(name)
-  // }, [name])
-
-  // UseEffect(() => {
-  //   const { revisionId: savedRevisionId } = savedDraft || {}
-  //   if (
-  //     (!orderOption && retries < 5)
-  //     || (savedRevisionId && orderOption.revisionId !== savedRevisionId)) {
-  //     refetch()
-  //     setRetries(retries + 1)
-  //   }
-
-  //   if (retries >= 5) {
-  //     errorLogger('Max retries allowed', 'OrderOptionPreview: getOrderOption Query')
-  //     setError('Order Option could not be loaded.')
-  //   }
-  // }, [orderOption, retries])
 
   return (
     <>
       <p className="text-muted">
-        {`Last updated ${moment(revisionDate).format('LLLL')}`}
+        {`Last updated: ${moment(revisionDate).format('LLLL')}`}
+      </p>
+
+      <p className="text-muted">
+        {`Deprecated: ${deprecated ? 'True' : 'False'}`}
       </p>
 
       <p>{description}</p>

--- a/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
+++ b/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
@@ -95,28 +95,37 @@ const OrderOptionForm = () => {
   })
 
   useEffect(() => {
-    const { orderOption: orderOptionData } = data || {}
-    const {
-      description,
-      form,
-      name,
-      sortKey,
-      nativeId: fetchedNativeId,
-      deprecated
-    } = orderOptionData || {}
+    if (data) {
+      const { orderOption: orderOptionData } = data
+      const {
+        deprecated,
+        description,
+        form,
+        name,
+        nativeId: fetchedNativeId,
+        sortKey
+      } = orderOptionData
 
-    const formData = {
-      description,
-      form,
-      name,
-      ...(sortKey ? { sortKey } : null),
-      deprecated
+      const formData = {
+        deprecated: false,
+        description,
+        form,
+        name
+      }
+
+      if (sortKey) {
+        formData.sortKey = sortKey
+      }
+
+      if (deprecated) {
+        formData.deprecated = deprecated
+      }
+
+      setNativeId(fetchedNativeId)
+
+      setDraft({ formData })
+      setOriginalDraft({ formData })
     }
-
-    setNativeId(fetchedNativeId)
-
-    setDraft({ formData })
-    setOriginalDraft({ formData })
   }, [data])
 
   useEffect(() => {

--- a/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
+++ b/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
@@ -70,7 +70,6 @@ const OrderOptionForm = () => {
   })
 
   const [nativeId, setNativeId] = useState()
-  const [deprecated, setDeprecated] = useState()
 
   const fields = {
     TitleField: CustomTitleField,
@@ -103,21 +102,18 @@ const OrderOptionForm = () => {
       name,
       sortKey,
       nativeId: fetchedNativeId,
-      deprecated: fetchedDeprecated
+      deprecated
     } = orderOptionData || {}
 
     const formData = {
       description,
       form,
-      name
-    }
-
-    if (sortKey) {
-      formData.sortKey = sortKey
+      name,
+      ...(sortKey ? { sortKey } : null),
+      deprecated
     }
 
     setNativeId(fetchedNativeId)
-    setDeprecated(fetchedDeprecated || false)
 
     setDraft({ formData })
     setOriginalDraft({ formData })
@@ -146,8 +142,7 @@ const OrderOptionForm = () => {
     const orderOptionVariables = {
       ...formData,
       scope: 'PROVIDER',
-      providerId,
-      deprecated
+      providerId
     }
 
     if (conceptId === 'new') {

--- a/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
+++ b/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
@@ -70,6 +70,7 @@ const OrderOptionForm = () => {
   })
 
   const [nativeId, setNativeId] = useState()
+  const [deprecated, setDeprecated] = useState()
 
   const fields = {
     TitleField: CustomTitleField,
@@ -101,7 +102,8 @@ const OrderOptionForm = () => {
       form,
       name,
       sortKey,
-      nativeId: fetchedNativeId
+      nativeId: fetchedNativeId,
+      deprecated: fetchedDeprecated
     } = orderOptionData || {}
 
     const formData = {
@@ -115,6 +117,7 @@ const OrderOptionForm = () => {
     }
 
     setNativeId(fetchedNativeId)
+    setDeprecated(fetchedDeprecated || false)
 
     setDraft({ formData })
     setOriginalDraft({ formData })
@@ -143,7 +146,8 @@ const OrderOptionForm = () => {
     const orderOptionVariables = {
       ...formData,
       scope: 'PROVIDER',
-      providerId
+      providerId,
+      deprecated
     }
 
     if (conceptId === 'new') {

--- a/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
+++ b/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
@@ -326,7 +326,7 @@ describe('OrderOptionForm', () => {
               data: {
                 orderOption: {
                   conceptId: 'OO1000000-MMT',
-                  deprecated: null,
+                  deprecated: true,
                   description: 'Test Description',
                   form: 'Test Form',
                   name: 'Test Name',
@@ -344,7 +344,7 @@ describe('OrderOptionForm', () => {
             request: {
               query: UPDATE_ORDER_OPTION,
               variables: {
-                deprecated: false,
+                deprecated: true,
                 description: 'Test Description',
                 form: 'Test Form',
                 name: 'Test NameUpdated Name',

--- a/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
+++ b/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
@@ -104,6 +104,7 @@ describe('OrderOptionForm', () => {
               request: {
                 query: CREATE_ORDER_OPTION,
                 variables: {
+                  deprecated: false,
                   name: 'Test Name',
                   description: 'Test Description',
                   form: 'Test Form',
@@ -123,7 +124,7 @@ describe('OrderOptionForm', () => {
               request: {
                 query: GET_ORDER_OPTION,
                 variables: {
-                  parmas: {
+                  params: {
                     conceptId: 'OO1000000-MMT'
                   }
                 }
@@ -166,6 +167,7 @@ describe('OrderOptionForm', () => {
               request: {
                 query: CREATE_ORDER_OPTION,
                 variables: {
+                  deprecated: false,
                   name: 'Test Name',
                   description: 'Test Description',
                   form: 'Test Form',
@@ -250,6 +252,7 @@ describe('OrderOptionForm', () => {
               request: {
                 query: UPDATE_ORDER_OPTION,
                 variables: {
+                  deprecated: false,
                   description: 'Test Description',
                   form: 'Test Form',
                   name: 'Test NameUpdated Name',
@@ -331,7 +334,7 @@ describe('OrderOptionForm', () => {
                   revisionId: '1',
                   revisionDate: '2024-04-23T15:03:34.399Z',
                   scope: 'PROVIDER',
-                  sortKey: 'Some Sort Key',
+                  sortKey: 'Sort',
                   __typename: 'OrderOption'
                 }
               }
@@ -341,10 +344,11 @@ describe('OrderOptionForm', () => {
             request: {
               query: UPDATE_ORDER_OPTION,
               variables: {
+                deprecated: false,
                 description: 'Test Description',
                 form: 'Test Form',
                 name: 'Test NameUpdated Name',
-                sortKey: 'Some Sort Key',
+                sortKey: 'Sort',
                 scope: 'PROVIDER',
                 providerId: 'MMT_2',
                 nativeId: 'dce1859e-774c-4561-9451-fc9d77906015'

--- a/static/src/js/components/OrderOptionList/OrderOptionList.jsx
+++ b/static/src/js/components/OrderOptionList/OrderOptionList.jsx
@@ -139,7 +139,7 @@ const OrderOptionList = () => {
           <Button
             className="d-flex"
             Icon={FaEdit}
-            iconTitle="Document with an arrow pointing down"
+            iconTitle="Edit Button"
             onClick={() => handleEdit(conceptId)}
             variant="primary"
             size="sm"
@@ -151,7 +151,7 @@ const OrderOptionList = () => {
           <Button
             className="d-flex"
             Icon={FaTrash}
-            iconTitle="Document with an arrow pointing down"
+            iconTitle="Delete Button"
             onClick={
               () => {
                 toggleShowDeleteModal(true)
@@ -243,7 +243,6 @@ const OrderOptionList = () => {
                       }
                     </Row>
                     <Table
-                      key={count}
                       id="order-option-table"
                       columns={columns}
                       generateCellKey={({ conceptId }, dataKey) => `column_${dataKey}_${conceptId}`}

--- a/static/src/js/components/OrderOptionList/OrderOptionList.jsx
+++ b/static/src/js/components/OrderOptionList/OrderOptionList.jsx
@@ -1,12 +1,8 @@
-import React, {
-  Suspense,
-  useCallback,
-  useState
-} from 'react'
+import React, { useCallback, useState } from 'react'
 import { useMutation, useSuspenseQuery } from '@apollo/client'
 import Col from 'react-bootstrap/Col'
 import Row from 'react-bootstrap/Row'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 import moment from 'moment'
 
 import { FaEdit, FaTrash } from 'react-icons/fa'
@@ -38,8 +34,6 @@ import errorLogger from '../../utils/errorLogger'
  */
 const OrderOptionList = () => {
   const { user } = useAppContext()
-
-  const navigate = useNavigate()
 
   const { addNotification } = useNotificationsContext()
 
@@ -86,10 +80,6 @@ const OrderOptionList = () => {
 
   const toggleShowDeleteModal = (nextState) => {
     setShowDeleteModal(nextState)
-  }
-
-  const handleEdit = (conceptId) => {
-    navigate(`/order-options/${conceptId}/edit`)
   }
 
   const handleDelete = () => {
@@ -140,7 +130,7 @@ const OrderOptionList = () => {
             className="d-flex"
             Icon={FaEdit}
             iconTitle="Edit Button"
-            onClick={() => handleEdit(conceptId)}
+            href={`order-options/${conceptId}/edit`}
             variant="primary"
             size="sm"
           >
@@ -203,98 +193,94 @@ const OrderOptionList = () => {
   const { count, items } = orderOptions
 
   return (
-    <Suspense>
+    <Row>
+      <Col sm={12}>
+        <ControlledPaginatedContent
+          activePage={activePage}
+          count={count}
+          limit={limit}
+          setPage={setPage}
+        >
+          {
+            ({
+              totalPages,
+              pagination,
+              firstResultPosition,
+              lastResultPosition
+            }) => {
+              const paginationMessage = count > 0
+                ? `Showing ${totalPages > 1 ? `${firstResultPosition}-${lastResultPosition} of` : ''} ${count} order options`
+                : 'No order option found'
 
-      <Row>
-        <Col sm={12}>
-          <ControlledPaginatedContent
-            activePage={activePage}
-            count={count}
-            limit={limit}
-            setPage={setPage}
-          >
-            {
-              ({
-                totalPages,
-                pagination,
-                firstResultPosition,
-                lastResultPosition
-              }) => {
-                const paginationMessage = count > 0
-                  ? `Showing ${totalPages > 1 ? `${firstResultPosition}-${lastResultPosition} of` : ''} ${count} order options`
-                  : 'No order option found'
-
-                return (
-                  <>
-                    <Row className="d-flex justify-content-between align-items-center">
-                      <Col className="mb-4 flex-grow-1" xs="auto">
-                        {
-                          (!!count) && (
-                            <span className="text-secondary fw-bolder">{paginationMessage}</span>
-                          )
-                        }
-                      </Col>
+              return (
+                <>
+                  <Row className="d-flex justify-content-between align-items-center">
+                    <Col className="mb-4 flex-grow-1" xs="auto">
                       {
-                        totalPages > 1 && (
-                          <Col xs="auto">
-                            {pagination}
-                          </Col>
+                        (!!count) && (
+                          <span className="text-secondary fw-bolder">{paginationMessage}</span>
                         )
                       }
-                    </Row>
-                    <Table
-                      id="order-option-table"
-                      columns={columns}
-                      generateCellKey={({ conceptId }, dataKey) => `column_${dataKey}_${conceptId}`}
-                      generateRowKey={({ conceptId }) => `row_${conceptId}`}
-                      data={items}
-                      noDataMessage="No order options found"
-                      count={count}
-                      setPage={setPage}
-                      limit={limit}
-                      offset={offset}
-                    />
-
+                    </Col>
                     {
                       totalPages > 1 && (
-                        <Row>
-                          <Col xs="12" className="pt-4 d-flex align-items-center justify-content-center">
-                            <div>
-                              {pagination}
-                            </div>
-                          </Col>
-                        </Row>
+                        <Col xs="auto">
+                          {pagination}
+                        </Col>
                       )
                     }
-                  </>
-                )
-              }
-            }
-          </ControlledPaginatedContent>
-        </Col>
-        <CustomModal
-          message="Are you sure you want to delete this order option?"
-          show={showDeleteModal}
-          size="lg"
-          toggleModal={toggleShowDeleteModal}
-          actions={
-            [
-              {
-                label: 'No',
-                variant: 'secondary',
-                onClick: () => { toggleShowDeleteModal(false) }
-              },
-              {
-                label: 'Yes',
-                variant: 'primary',
-                onClick: handleDelete
-              }
-            ]
-          }
-        />
-      </Row>
-    </Suspense>
+                  </Row>
+                  <Table
+                    id="order-option-table"
+                    columns={columns}
+                    generateCellKey={({ conceptId }, dataKey) => `column_${dataKey}_${conceptId}`}
+                    generateRowKey={({ conceptId }) => `row_${conceptId}`}
+                    data={items}
+                    noDataMessage="No order options found"
+                    count={count}
+                    setPage={setPage}
+                    limit={limit}
+                    offset={offset}
+                  />
 
+                  {
+                    totalPages > 1 && (
+                      <Row>
+                        <Col xs="12" className="pt-4 d-flex align-items-center justify-content-center">
+                          <div>
+                            {pagination}
+                          </div>
+                        </Col>
+                      </Row>
+                    )
+                  }
+                </>
+              )
+            }
+          }
+        </ControlledPaginatedContent>
+      </Col>
+      <CustomModal
+        message="Are you sure you want to delete this order option?"
+        show={showDeleteModal}
+        size="lg"
+        toggleModal={toggleShowDeleteModal}
+        actions={
+          [
+            {
+              label: 'No',
+              variant: 'secondary',
+              onClick: () => { toggleShowDeleteModal(false) }
+            },
+            {
+              label: 'Yes',
+              variant: 'primary',
+              onClick: handleDelete
+            }
+          ]
+        }
+      />
+    </Row>
   )
 }
 

--- a/static/src/js/components/OrderOptionList/__tests__/OrderOptionList.test.jsx
+++ b/static/src/js/components/OrderOptionList/__tests__/OrderOptionList.test.jsx
@@ -6,7 +6,6 @@ import {
   within
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import * as router from 'react-router'
 
 import { MockedProvider } from '@apollo/client/testing'
 import { BrowserRouter } from 'react-router-dom'
@@ -268,22 +267,6 @@ describe('OrderOptionList', () => {
         expect(screen.getByText('Showing 2 order options')).toBeInTheDocument()
         expect(screen.queryByText('Are you sure you want to delete this order option?')).not.toBeInTheDocument()
       })
-    })
-  })
-
-  describe('when clicking on edit button', () => {
-    test('should navigate to /order-options/id', async () => {
-      const navigateSpy = vi.fn()
-      vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
-      const { user } = setup({})
-
-      await waitForResponse()
-
-      const editButton = screen.getAllByRole('button', { name: 'Edit Button Edit' })
-      await user.click(editButton[0])
-
-      expect(navigateSpy).toHaveBeenCalledTimes(1)
-      expect(navigateSpy).toHaveBeenCalledWith('/order-options/OO1200000099-MMT_2/edit')
     })
   })
 

--- a/static/src/js/operations/mutations/deleteOrderOption.js
+++ b/static/src/js/operations/mutations/deleteOrderOption.js
@@ -1,0 +1,21 @@
+import { gql } from '@apollo/client'
+
+export const DELETE_ORDER_OPTION = gql`
+  mutation DeleteOrderOption (
+    $nativeId: String!
+    $providerId: String!
+  ) {
+    deleteOrderOption (
+      nativeId: $nativeId
+      providerId: $providerId
+    ) {
+      conceptId
+      revisionId
+    }
+  }
+`
+// Example Variables:
+// {
+//   "nativeId": "1234-abcd-5678-efgh",
+//   "providerId": MMT_2,
+// }

--- a/static/src/js/operations/queries/getOrderOptions.js
+++ b/static/src/js/operations/queries/getOrderOptions.js
@@ -5,7 +5,8 @@ export const GET_ORDER_OPTIONS = gql`
     orderOptions(params: $params) {
       count
       items {
-        description
+        description,
+        deprecated
         conceptId
         name
         form

--- a/static/src/js/pages/OrderOptionPage/OrderOptionPage.jsx
+++ b/static/src/js/pages/OrderOptionPage/OrderOptionPage.jsx
@@ -79,7 +79,7 @@ const OrderOptionPageHeader = () => {
           variant: 'success'
         })
 
-        navigate('/order-options', { replace: true })
+        navigate('/order-options')
       },
       onError: () => {
         addNotification({

--- a/static/src/js/pages/OrderOptionPage/OrderOptionPage.jsx
+++ b/static/src/js/pages/OrderOptionPage/OrderOptionPage.jsx
@@ -1,8 +1,8 @@
-import React, { Suspense } from 'react'
+import React, { Suspense, useState } from 'react'
 
-import { useSuspenseQuery } from '@apollo/client'
-import { useParams } from 'react-router'
-import { FaEdit } from 'react-icons/fa'
+import { useMutation, useSuspenseQuery } from '@apollo/client'
+import { useNavigate, useParams } from 'react-router'
+import { FaEdit, FaTrash } from 'react-icons/fa'
 
 import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary'
 import OrderOption from '../../components/OrderOption/OrderOption'
@@ -10,6 +10,12 @@ import Page from '../../components/Page/Page'
 import PageHeader from '../../components/PageHeader/PageHeader'
 
 import { GET_ORDER_OPTION } from '../../operations/queries/getOrderOption'
+import { DELETE_ORDER_OPTION } from '../../operations/mutations/deleteOrderOption'
+import useAppContext from '../../hooks/useAppContext'
+import CustomModal from '../../components/CustomModal/CustomModal'
+import useNotificationsContext from '../../hooks/useNotificationsContext'
+import errorLogger from '../../utils/errorLogger'
+import { GET_ORDER_OPTIONS } from '../../operations/queries/getOrderOptions'
 
 /**
  * Renders a OrderOptionPageHeader component
@@ -21,7 +27,27 @@ import { GET_ORDER_OPTION } from '../../operations/queries/getOrderOption'
  * )
  */
 const OrderOptionPageHeader = () => {
+  const { user } = useAppContext()
+  const { providerId } = user
+
+  const navigate = useNavigate()
+
+  const { addNotification } = useNotificationsContext()
+
   const { conceptId } = useParams()
+
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+
+  const [deleteOrderOptionMutation] = useMutation(DELETE_ORDER_OPTION, {
+    refetchQueries: [{
+      query: GET_ORDER_OPTIONS,
+      variables: {
+        params: {
+          providerId
+        }
+      }
+    }]
+  })
 
   const { data } = useSuspenseQuery(GET_ORDER_OPTION, {
     variables: {
@@ -31,35 +57,100 @@ const OrderOptionPageHeader = () => {
     }
   })
 
+  const toggleShowDeleteModal = (nextState) => {
+    setShowDeleteModal(nextState)
+  }
+
   const { orderOption = {} } = data
-  const { name } = orderOption
+  const {
+    name,
+    nativeId
+  } = orderOption
+
+  const handleDelete = () => {
+    deleteOrderOptionMutation({
+      variables: {
+        nativeId,
+        providerId
+      },
+      onCompleted: () => {
+        addNotification({
+          message: 'Order Option was successfully deleted.',
+          variant: 'success'
+        })
+
+        navigate('/order-options', { replace: true })
+      },
+      onError: () => {
+        addNotification({
+          message: 'Error deleting order option',
+          variant: 'danger'
+        })
+
+        errorLogger('Unable delete order option', 'Order Option Page: deleteOrderOption Mutation')
+
+        setShowDeleteModal(false)
+      }
+    })
+  }
 
   return (
-    <PageHeader
-      title={name}
-      breadcrumbs={
-        [
-          {
-            label: 'Order Options',
-            to: '/order-options'
-          },
-          {
-            label: name,
-            active: true
-          }
-        ]
-      }
-      pageType="secondary"
-      primaryActions={
-        [{
-          icon: FaEdit,
-          to: 'edit',
-          title: 'Edit',
-          iconTitle: 'A edit icon',
-          variant: 'primary'
-        }]
-      }
-    />
+    <>
+      <PageHeader
+        title={name}
+        breadcrumbs={
+          [
+            {
+              label: 'Order Options',
+              to: '/order-options'
+            },
+            {
+              label: name,
+              active: true
+            }
+          ]
+        }
+        pageType="secondary"
+        primaryActions={
+          [
+            {
+              icon: FaEdit,
+              to: 'edit',
+              title: 'Edit',
+              iconTitle: 'A edit icon',
+              variant: 'primary'
+            },
+            {
+              icon: FaTrash,
+              onClick: () => toggleShowDeleteModal(true),
+              title: 'Delete',
+              iconTitle: 'A trash can icon',
+              variant: 'danger'
+            }
+          ]
+        }
+      />
+      <CustomModal
+        message="Are you sure you want to delete this order option?"
+        show={showDeleteModal}
+        size="lg"
+        toggleModal={toggleShowDeleteModal}
+        actions={
+          [
+            {
+              label: 'No',
+              variant: 'secondary',
+              onClick: () => { toggleShowDeleteModal(false) }
+            },
+            {
+              label: 'Yes',
+              variant: 'primary',
+              onClick: handleDelete
+            }
+          ]
+        }
+      />
+    </>
   )
 }
 

--- a/static/src/js/pages/OrderOptionPage/__tests__/OrderOptionPage.test.jsx
+++ b/static/src/js/pages/OrderOptionPage/__tests__/OrderOptionPage.test.jsx
@@ -5,6 +5,8 @@ import {
   waitFor
 } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
+import * as router from 'react-router'
+
 import {
   MemoryRouter,
   Route,
@@ -12,12 +14,22 @@ import {
 } from 'react-router'
 import userEvent from '@testing-library/user-event'
 import { GraphQLError } from 'graphql'
-import { GET_ORDER_OPTION } from '../../../operations/queries/getOrderOption'
-import AppContext from '../../../context/AppContext'
 import OrderOptionPage from '../OrderOptionPage'
 import ErrorBoundary from '../../../components/ErrorBoundary/ErrorBoundary'
 
-const setup = ({ overrideMocks = false }) => {
+import AppContext from '../../../context/AppContext'
+import NotificationsContext from '../../../context/NotificationsContext'
+
+import { DELETE_ORDER_OPTION } from '../../../operations/mutations/deleteOrderOption'
+import { GET_ORDER_OPTION } from '../../../operations/queries/getOrderOption'
+import { GET_ORDER_OPTIONS } from '../../../operations/queries/getOrderOptions'
+
+vi.mock('../../../utils/errorLogger')
+
+const setup = ({
+  additionalMocks = [],
+  overrideMocks = false
+}) => {
   const mockOrderOption = {
     conceptId: 'OO1200000099-MMT_2',
     deprecated: true,
@@ -31,6 +43,7 @@ const setup = ({ overrideMocks = false }) => {
     sortKey: 'Mock',
     __typename: 'OrderOption'
   }
+
   const mocks = [{
     request: {
       query: GET_ORDER_OPTION,
@@ -45,7 +58,11 @@ const setup = ({ overrideMocks = false }) => {
         orderOption: mockOrderOption
       }
     }
-  }]
+  }, ...additionalMocks]
+
+  const notificationContext = {
+    addNotification: vi.fn()
+  }
   render(
     <AppContext.Provider value={
       {
@@ -55,30 +72,32 @@ const setup = ({ overrideMocks = false }) => {
       }
     }
     >
-      <MockedProvider
-        mocks={overrideMocks || mocks}
-      >
-        <MemoryRouter initialEntries={['/order-options/OO12000000-MMT_2']}>
-          <Routes>
-            <Route
-              path="/order-options"
-            >
+      <NotificationsContext.Provider value={notificationContext}>
+        <MockedProvider
+          mocks={overrideMocks || mocks}
+        >
+          <MemoryRouter initialEntries={['/order-options/OO12000000-MMT_2']}>
+            <Routes>
               <Route
-                path=":conceptId"
-                element={
-                  (
-                    <ErrorBoundary>
-                      <Suspense>
-                        <OrderOptionPage />
-                      </Suspense>
-                    </ErrorBoundary>
-                  )
-                }
-              />
-            </Route>
-          </Routes>
-        </MemoryRouter>
-      </MockedProvider>
+                path="/order-options"
+              >
+                <Route
+                  path=":conceptId"
+                  element={
+                    (
+                      <ErrorBoundary>
+                        <Suspense>
+                          <OrderOptionPage />
+                        </Suspense>
+                      </ErrorBoundary>
+                    )
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </MockedProvider>
+      </NotificationsContext.Provider>
     </AppContext.Provider>
   )
 
@@ -99,7 +118,7 @@ describe('OrderOptionPage', () => {
   })
 
   describe('when the api throws an error ', () => {
-    test.skip('renders an error', async () => {
+    test('renders an error', async () => {
       setup({
         overrideMocks: [
           {
@@ -126,6 +145,134 @@ describe('OrderOptionPage', () => {
       await waitFor(() => {
         expect(screen.queryByText('Sorry!')).toBeInTheDocument()
         expect(screen.queryByText('An error occurred')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when clicking the delete button', () => {
+    describe('when clicking Yes on the delete modal results in a success', () => {
+      test('deletes the order option and hides the modal', async () => {
+        const navigateSpy = vi.fn()
+        vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+
+        const { user } = setup({
+          additionalMocks: [
+            {
+              request: {
+                query: DELETE_ORDER_OPTION,
+                variables: {
+                  nativeId: '1234-abcd-5678-efgh',
+                  providerId: 'MMT_2'
+                }
+              },
+              result: {
+                data: {
+                  deleteOrderOption: {
+                    conceptId: 'TD1000000-MMT',
+                    revisionId: '3'
+                  }
+                }
+              }
+            },
+            {
+              request: {
+                query: GET_ORDER_OPTIONS,
+                variables: {
+                  params: {
+                    providerId: 'MMT_2'
+                  }
+                }
+              },
+              result: {
+                data: {
+                  orderOptions: {
+                    count: 1,
+                    items: [
+                      {
+                        description: 'This is a test record',
+                        deprecated: false,
+                        conceptId: 'OO1200000099-MMT_2',
+                        name: 'Test order option 1',
+                        form: 'some form',
+                        nativeId: 'Test-Native-Id-1',
+                        scope: 'PROVIDER',
+                        sortKey: '',
+                        associationDetails: null,
+                        revisionDate: '2024-04-16T18:20:12.124Z',
+                        __typename: 'OrderOption'
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        })
+        await waitForResponse()
+
+        const deleteLink = screen.getByRole('button', { name: 'A trash can icon Delete' })
+        await user.click(deleteLink)
+
+        expect(screen.getByText('Are you sure you want to delete this order option?')).toBeInTheDocument()
+
+        const yesButton = screen.getByRole('button', { name: 'Yes' })
+
+        await user.click(yesButton)
+
+        await waitForResponse()
+
+        expect(navigateSpy).toHaveBeenCalledTimes(1)
+        expect(navigateSpy).toHaveBeenCalledWith('/order-options')
+      })
+    })
+
+    describe('when clicking Yes on the delete modal results in a failure', () => {
+      test('does not delete the order option', async () => {
+        const { user } = setup({
+          additionalMocks: [
+            {
+              request: {
+                query: DELETE_ORDER_OPTION,
+                variables: {
+                  nativeId: '1234-abcd-5678-efgh',
+                  providerId: 'MMT_2'
+                }
+              },
+              error: new Error('An error occurred')
+            }
+          ]
+        })
+        await waitForResponse()
+
+        const deleteLink = screen.getByRole('button', { name: 'A trash can icon Delete' })
+        await user.click(deleteLink)
+
+        expect(screen.getByText('Are you sure you want to delete this order option?')).toBeInTheDocument()
+
+        const yesButton = screen.getByRole('button', { name: 'Yes' })
+        await user.click(yesButton)
+
+        await waitForResponse()
+
+        expect(screen.queryByText('Are you sure you want to delete this order option?')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('when clicking No on the delete modal', () => {
+      test('hides delete modal', async () => {
+        const { user } = setup({})
+
+        await waitForResponse()
+
+        const deleteLink = screen.getByRole('button', { name: 'A trash can icon Delete' })
+        await user.click(deleteLink)
+
+        expect(screen.getByText('Are you sure you want to delete this order option?')).toBeInTheDocument()
+
+        const noButton = screen.getByRole('button', { name: 'No' })
+        await user.click(noButton)
+
+        expect(screen.queryByText('Are you sure you want to delete this order option?')).not.toBeInTheDocument()
       })
     })
   })

--- a/static/src/js/schemas/orderOption.js
+++ b/static/src/js/schemas/orderOption.js
@@ -22,6 +22,11 @@ const orderOption = {
       minLength: 1,
       maxLength: 1024
     },
+    deprecated: {
+      description: 'Deprecated flag of the order option.',
+      type: 'boolean',
+      default: false
+    },
     form: {
       description: 'The XML of the order option.',
       type: 'string',

--- a/static/src/js/schemas/orderOption.js
+++ b/static/src/js/schemas/orderOption.js
@@ -14,7 +14,7 @@ const orderOption = {
       description: 'The sort key of the order option.',
       type: 'string',
       minLength: 1,
-      maxLength: 85
+      maxLength: 5
     },
     description: {
       description: 'The description of the order option.',

--- a/static/src/js/schemas/uiSchemas/OrderOption.js
+++ b/static/src/js/schemas/uiSchemas/OrderOption.js
@@ -1,3 +1,5 @@
+import CustomRadioWidget from '../../components/CustomRadioWidget/CustomRadioWidget'
+
 const orderOptionUiSchema = {
   'ui:submitButtonOptions': {
     norender: true
@@ -44,6 +46,16 @@ const orderOptionUiSchema = {
                   }
                 }
               ]
+            },
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 2,
+                    children: ['deprecated']
+                  }
+                }
+              ]
             }
           ]
         }
@@ -52,6 +64,12 @@ const orderOptionUiSchema = {
   },
   description: {
     'ui:widget': 'textarea'
+  },
+  deprecated: {
+    'ui:widget': CustomRadioWidget,
+    'ui:options': {
+      showClear: false
+    }
   },
   form: {
     'ui:title': 'Form XML',


### PR DESCRIPTION
# Overview

### What is the feature?

Adding the ability to delete and deprecate an order option

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings