### PR TITLE
MMT-3526: Implements the Provider Permissions form for groups.

### DIFF
--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -16,6 +16,7 @@ import MetadataFormPage from './pages/MetadataFormPage/MetadataFormPage'
 import OrderOptionFormPage from './pages/OrderOptionFormPage/OrderOptionFormPage'
 import OrderOptionListPage from './pages/OrderOptionListPage/OrderOptionListPage'
 import OrderOptionPage from './pages/OrderOptionPage/OrderOptionPage'
+import ProviderPermissionsPage from './pages/ProviderPermissionsPage/ProviderPermissionsPage'
 import RevisionListPage from './pages/RevisionListPage/RevisionListPage'
 import SearchPage from './pages/SearchPage/SearchPage'
 
@@ -40,7 +41,6 @@ import useNotificationsContext from './hooks/useNotificationsContext'
 import { GET_ACLS } from './operations/queries/getAcls'
 
 import withProviders from './providers/withProviders/withProviders'
-import ProviderPermissionsPage from './pages/ProviderPermissionsPage/ProviderPermissionsPage'
 
 import '../css/index.scss'
 
@@ -72,6 +72,7 @@ export const App = () => {
   const [getProviders] = useLazyQuery(GET_ACLS, {
     variables: {
       params: {
+        limit: 500,
         permittedUser,
         target: 'PROVIDER_CONTEXT'
       }

--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -40,6 +40,7 @@ import useNotificationsContext from './hooks/useNotificationsContext'
 import { GET_ACLS } from './operations/queries/getAcls'
 
 import withProviders from './providers/withProviders/withProviders'
+import ProviderPermissionsPage from './pages/ProviderPermissionsPage/ProviderPermissionsPage'
 
 import '../css/index.scss'
 
@@ -225,6 +226,10 @@ export const App = () => {
             {
               path: '/groups/:id',
               element: <GroupPage />
+            },
+            {
+              path: '/groups/:id/permissions',
+              element: <ProviderPermissionsPage />
             },
             {
               path: 'templates/:templateType',

--- a/static/src/js/__tests__/App.test.jsx
+++ b/static/src/js/__tests__/App.test.jsx
@@ -80,6 +80,7 @@ const setup = (overrideMocks, overrideAppContext) => {
         query: GET_ACLS,
         variables: {
           params: {
+            limit: 500,
             permittedUser: 'typical',
             target: 'PROVIDER_CONTEXT'
           }
@@ -279,6 +280,7 @@ describe('App component', () => {
               query: GET_ACLS,
               variables: {
                 params: {
+                  limit: 500,
                   permittedUser: 'typical',
                   target: 'PROVIDER_CONTEXT'
                 }
@@ -310,6 +312,7 @@ describe('App component', () => {
                 query: GET_ACLS,
                 variables: {
                   params: {
+                    limit: 500,
                     permittedUser: 'typical',
                     target: 'PROVIDER_CONTEXT'
                   }
@@ -343,6 +346,7 @@ describe('App component', () => {
               query: GET_ACLS,
               variables: {
                 params: {
+                  limit: 500,
                   permittedUser: 'typical',
                   target: 'PROVIDER_CONTEXT'
                 }
@@ -379,6 +383,7 @@ describe('App component', () => {
               query: GET_ACLS,
               variables: {
                 params: {
+                  limit: 500,
                   permittedUser: 'typical',
                   target: 'PROVIDER_CONTEXT'
                 }
@@ -411,6 +416,7 @@ describe('App component', () => {
             query: GET_ACLS,
             variables: {
               params: {
+                limit: 500,
                 permittedUser: 'typical',
                 target: 'PROVIDER_CONTEXT'
               }

--- a/static/src/js/components/Group/Group.jsx
+++ b/static/src/js/components/Group/Group.jsx
@@ -65,8 +65,6 @@ const Group = () => {
 
       <p>Associated Collection Permissions - TBD</p>
 
-      <p>Manage Provider Object Permissions - TBD</p>
-
       <Table
         id="member-table"
         columns={columns}

--- a/static/src/js/components/ProviderPermissions/ProviderPermissions.jsx
+++ b/static/src/js/components/ProviderPermissions/ProviderPermissions.jsx
@@ -1,0 +1,141 @@
+import React, { useCallback } from 'react'
+
+import { Row } from 'react-bootstrap'
+import { useParams } from 'react-router-dom'
+import { useSuspenseQuery } from '@apollo/client'
+
+import Table from '@/js/components/Table/Table'
+
+import providerIdentityPermissions from '@/js/constants/providerIdentityPermissions'
+
+import {
+  GET_PROVIDER_IDENTITY_PERMISSIONS
+} from '@/js/operations/queries/getProviderIdentityPermissions'
+
+/**
+ * Renders a ProviderPermissions component
+ *
+ * @component
+ * @example <caption>Render a ProviderPermissions</caption>
+ * return (
+ *   <ProviderPermissions />
+ * )
+ */
+const ProviderPermissions = () => {
+  const { id } = useParams()
+
+  const { data } = useSuspenseQuery(GET_PROVIDER_IDENTITY_PERMISSIONS, {
+    variables: {
+      params: {
+        identityType: 'provider',
+        limit: 50
+      }
+    }
+  })
+
+  const { acls } = data
+  const { items } = acls
+
+  const tableItems = Object.entries(providerIdentityPermissions).map((permission) => {
+    const [key, value] = permission
+
+    const { title, permissions } = value
+
+    return {
+      key,
+      title,
+      permissions
+    }
+  })
+
+  /**
+   * Determine if a group has a permission for a target
+   * @param {String} target The target identity of the Acl
+   * @param {String} permission One of create, read, update or delete
+   * @returns Whether or not the group has the permission
+   */
+  const checkAclPermission = (target, permission) => {
+    const acl = items
+      .filter((item) => item.groupPermissions.some((gp) => gp.group_id === id))
+      .find((item) => item.providerIdentity.target === target)
+
+    if (acl == null) {
+      return false
+    }
+
+    const { groupPermissions = [] } = acl
+
+    const { permissions = [] } = groupPermissions.find((gp) => gp.group_id === id)
+
+    return permissions.includes(permission)
+  }
+
+  const buildCheckboxCell = useCallback((cellData, rowData) => {
+    const {
+      key,
+      permissions
+    } = rowData
+
+    return (
+      <input
+        checked={checkAclPermission(key, cellData)}
+        disabled={!permissions.includes(cellData)}
+        name={`${key.toLowerCase()}_${cellData}`}
+        onChange={() => {}}
+        type="checkbox"
+      />
+    )
+  }, [])
+
+  const columns = [
+    {
+      dataKey: 'title',
+      title: 'Title',
+      className: 'col-auto'
+    },
+    {
+      dataKey: 'create',
+      title: 'Create',
+      className: 'col-auto',
+      align: 'center',
+      dataAccessorFn: (cellData, rowData) => buildCheckboxCell('create', rowData)
+    },
+    {
+      dataKey: 'read',
+      title: 'Read',
+      className: 'col-auto',
+      align: 'center',
+      dataAccessorFn: (cellData, rowData) => buildCheckboxCell('read', rowData)
+    },
+    {
+      dataKey: 'update',
+      title: 'Update',
+      className: 'col-auto',
+      align: 'center',
+      dataAccessorFn: (cellData, rowData) => buildCheckboxCell('update', rowData)
+    },
+    {
+      dataKey: 'delete',
+      title: 'Delete',
+      className: 'col-auto',
+      align: 'center',
+      dataAccessorFn: (cellData, rowData) => buildCheckboxCell('delete', rowData)
+    }
+  ]
+
+  return (
+    <Row>
+      <Table
+        className="m-5"
+        columns={columns}
+        data={tableItems}
+        generateCellKey={({ key }, dataKey) => `column_${dataKey}_${key}`}
+        generateRowKey={({ key }) => `row_${key}`}
+        id="provider-permissions-table"
+        limit={Object.keys(providerIdentityPermissions).length}
+      />
+    </Row>
+  )
+}
+
+export default ProviderPermissions

--- a/static/src/js/components/ProviderPermissions/ProviderPermissions.jsx
+++ b/static/src/js/components/ProviderPermissions/ProviderPermissions.jsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useState } from 'react'
 
-import {
-  Col,
-  Container,
-  FormLabel,
-  Row
-} from 'react-bootstrap'
+import Col from 'react-bootstrap/Col'
+import Container from 'react-bootstrap/Container'
+import FormLabel from 'react-bootstrap/FormLabel'
+import Row from 'react-bootstrap/Row'
+
 import { useLazyQuery, useSuspenseQuery } from '@apollo/client'
 import { useParams } from 'react-router-dom'
 import Select from 'react-select'

--- a/static/src/js/components/ProviderPermissions/__tests__/ProviderPermissions.test.jsx
+++ b/static/src/js/components/ProviderPermissions/__tests__/ProviderPermissions.test.jsx
@@ -1,0 +1,210 @@
+import React, { Suspense } from 'react'
+import { render, screen } from '@testing-library/react'
+import { Cookies } from 'react-cookie'
+import { MockedProvider } from '@apollo/client/testing'
+import {
+  MemoryRouter,
+  Route,
+  Routes
+} from 'react-router'
+import userEvent from '@testing-library/user-event'
+import { describe } from 'vitest'
+
+import {
+  GET_PROVIDER_IDENTITY_PERMISSIONS
+} from '@/js/operations/queries/getProviderIdentityPermissions'
+
+import { GET_GROUP } from '../../../operations/queries/getGroup'
+
+import ProviderPermissions from '../ProviderPermissions'
+import ErrorBoundary from '../../ErrorBoundary/ErrorBoundary'
+
+let expires = new Date()
+expires.setMinutes(expires.getMinutes() + 15)
+expires = new Date(expires)
+
+const cookie = new Cookies(
+  {
+    loginInfo: ({
+      providerId: 'MMT_2',
+      name: 'User Name',
+      token: {
+        tokenValue: 'ABC-1',
+        tokenExp: expires.valueOf()
+      }
+    })
+  }
+)
+cookie.HAS_DOCUMENT_COOKIE = false
+
+const setup = ({
+  additionalMocks = [],
+  overrideMocks = false
+}) => {
+  const mockGroup = {
+    id: '1234-abcd-5678-efgh',
+    description: 'Mock group description',
+    members: {
+      count: 1,
+      items: [{
+        id: 'test.user',
+        firstName: 'Test',
+        lastName: 'User',
+        emailAddress: 'test@example.com',
+        __typename: 'GroupMember'
+      }]
+    },
+    name: 'Mock group',
+    tag: 'MMT_2'
+  }
+
+  const mocks = [{
+    request: {
+      query: GET_GROUP,
+      variables: {
+        params: {
+          id: '1234-abcd-5678-efgh'
+        }
+      }
+    },
+    result: {
+      data: {
+        group: mockGroup
+      }
+    }
+  }, {
+    request: {
+      query: GET_PROVIDER_IDENTITY_PERMISSIONS,
+      variables: {
+        params: {
+          identityType: 'provider',
+          limit: 50
+        }
+      }
+    },
+    result: {
+      data: {
+        acls: {
+          count: 30,
+          cursor: 'eyJqc29uIjoiW1wicHJvdmlkZXIgLSBtbXRfMSAtIHByb3ZpZGVyX2luZm9ybWF0aW9uXCIsXCJBQ0wxMjAwMjE1Nzg5LUNNUlwiXSJ9',
+          items: [
+            {
+              providerIdentity: {
+                target: 'AUDIT_REPORT',
+                provider_id: 'MMT_1'
+              },
+              identityType: 'Provider',
+              groupPermissions: [
+                {
+                  permissions: [
+                    'read'
+                  ],
+                  group_id: '1234-abcd-5678-efgh'
+                },
+                {
+                  permissions: [
+                    'read'
+                  ],
+                  group_id: 'fc9f3eab-97d5-4c99-8ba1-f2ae0eca42ee'
+                }
+              ],
+              conceptId: 'ACL1200216198-CMR'
+            },
+            {
+              providerIdentity: {
+                target: 'AUTHENTICATOR_DEFINITION',
+                provider_id: 'MMT_1'
+              },
+              identityType: 'Provider',
+              groupPermissions: [
+                {
+                  permissions: [],
+                  group_id: '3a07720d-2ac4-4ea5-a0fb-a32dd7c7435f'
+                },
+                {
+                  permissions: [
+                    'delete',
+                    'create'
+                  ],
+                  group_id: '1234-abcd-5678-efgh'
+                }
+              ],
+              conceptId: 'ACL1200216108-CMR'
+            },
+            {
+              providerIdentity: {
+                target: 'CATALOG_ITEM_ACL',
+                provider_id: 'MMT_1'
+              },
+              identityType: 'Provider',
+              groupPermissions: [
+                {
+                  permissions: [],
+                  user_type: 'registered'
+                },
+                {
+                  permissions: [],
+                  user_type: 'guest'
+                }
+              ],
+              conceptId: 'ACL1200216192-CMR'
+            }
+          ]
+        }
+      }
+    }
+  },
+  ...additionalMocks]
+
+  render(
+
+    <MockedProvider
+      mocks={overrideMocks || mocks}
+    >
+      <MemoryRouter initialEntries={['/groups/1234-abcd-5678-efgh']}>
+        <Routes>
+          <Route
+            path="/groups"
+          >
+            <Route
+              path=":id"
+              element={
+                (
+                  <ErrorBoundary>
+                    <Suspense>
+                      <ProviderPermissions />
+                    </Suspense>
+                  </ErrorBoundary>
+                )
+              }
+            />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </MockedProvider>
+  )
+
+  return {
+    user: userEvent.setup()
+  }
+}
+
+describe('ProviderPermissions', () => {
+  describe('when showing the list of permissions for the groups provider permissions', () => {
+    test('renders the full table of checkboxes with correct options checked', async () => {
+      setup({})
+
+      await waitForResponse()
+
+      expect(screen.queryByText('Audit Reports')).toBeInTheDocument()
+      expect(screen.queryByText('Authenticator Definitions')).toBeInTheDocument()
+
+      const checkboxes = screen.getAllByRole('checkbox', { checked: true })
+      expect(checkboxes.length).toBe(3)
+
+      expect(checkboxes[0]).toHaveAttribute('name', 'audit_report_read')
+      expect(checkboxes[1]).toHaveAttribute('name', 'authenticator_definition_create')
+      expect(checkboxes[2]).toHaveAttribute('name', 'authenticator_definition_delete')
+    })
+  })
+})

--- a/static/src/js/constants/providerIdentityPermissions.js
+++ b/static/src/js/constants/providerIdentityPermissions.js
@@ -4,119 +4,119 @@
 const providerIdentityPermissions = {
   AUDIT_REPORT: {
     title: 'Audit Reports',
-    permissions: ['read']
+    permittedPermissions: ['read']
   },
   AUTHENTICATOR_DEFINITION: {
     title: 'Authenticator Definitions',
-    permissions: ['create', 'delete']
+    permittedPermissions: ['create', 'delete']
   },
   CATALOG_ITEM_ACL: {
     title: 'Catalog Item ACLs',
-    permissions: ['create', 'read', 'update', 'delete']
+    permittedPermissions: ['create', 'read', 'update', 'delete']
   },
   DASHBOARD_DAAC_CURATOR: {
     title: 'CMR Dashboard DAAC Curator',
-    permissions: ['create', 'read', 'update', 'delete']
+    permittedPermissions: ['create', 'read', 'update', 'delete']
   },
   DATA_QUALITY_SUMMARY_ASSIGNMENT: {
     title: 'Data Quality Summary Assignments',
-    permissions: ['create', 'delete']
+    permittedPermissions: ['create', 'delete']
   },
   DATA_QUALITY_SUMMARY_DEFINITION: {
     title: 'Data Quality Summary Definitions',
-    permissions: ['create', 'update', 'delete']
+    permittedPermissions: ['create', 'update', 'delete']
   },
   DATASET_INFORMATION: {
     title: 'Dataset Information',
-    permissions: ['read']
+    permittedPermissions: ['read']
   },
   SUBSCRIPTION_MANAGEMENT: {
     title: 'Subscription Management',
-    permissions: ['read', 'update']
+    permittedPermissions: ['read', 'update']
   },
   EXTENDED_SERVICE: {
     title: 'Extended Services',
-    permissions: ['create', 'update', 'delete']
+    permittedPermissions: ['create', 'update', 'delete']
   },
   GROUP: {
     title: 'Groups',
-    permissions: ['create', 'read']
+    permittedPermissions: ['create', 'read']
   },
   INGEST_MANAGEMENT_ACL: {
     title: 'Ingest Operations',
-    permissions: ['read', 'update']
+    permittedPermissions: ['read', 'update']
   },
   NON_NASA_DRAFT_APPROVER: {
     title: 'Non-NASA Draft MMT Approver',
-    permissions: ['create', 'read', 'update', 'delete']
+    permittedPermissions: ['create', 'read', 'update', 'delete']
   },
   NON_NASA_DRAFT_USER: {
     title: 'Non-NASA Draft MMT User',
-    permissions: ['create', 'read', 'update', 'delete']
+    permittedPermissions: ['create', 'read', 'update', 'delete']
   },
   OPTION_ASSIGNMENT: {
     title: 'Option Assignments',
-    permissions: ['create', 'read', 'delete']
+    permittedPermissions: ['create', 'read', 'delete']
   },
   OPTION_DEFINITION: {
     title: 'Option Definition Deprecations',
-    permissions: ['create', 'delete']
+    permittedPermissions: ['create', 'delete']
   },
   OPTION_DEFINITION_DEPRECATION: {
     title: 'Option Definitions',
-    permissions: ['create']
+    permittedPermissions: ['create']
   },
   PROVIDER_CALENDAR_EVENT: {
     title: 'Provider Calendar Event',
-    permissions: ['create', 'update', 'delete']
+    permittedPermissions: ['create', 'update', 'delete']
   },
   PROVIDER_CONTEXT: {
     title: 'Provider Context',
-    permissions: ['read']
+    permittedPermissions: ['read']
   },
   PROVIDER_HOLDINGS: {
     title: 'Provider Holdings',
-    permissions: ['read']
+    permittedPermissions: ['read']
   },
   PROVIDER_INFORMATION: {
     title: 'Provider Information',
-    permissions: ['update']
+    permittedPermissions: ['update']
   },
   PROVIDER_OBJECT_ACL: {
     title: 'Provider Object ACLs',
-    permissions: ['create', 'read', 'update', 'delete']
+    permittedPermissions: ['create', 'read', 'update', 'delete']
   },
   PROVIDER_ORDER_ACCEPTANCE: {
     title: 'Provider Order Acceptances',
-    permissions: ['create']
+    permittedPermissions: ['create']
   },
   PROVIDER_ORDER_CLOSURE: {
     title: 'Provider Order Closures',
-    permissions: ['create']
+    permittedPermissions: ['create']
   },
   PROVIDER_ORDER_REJECTION: {
     title: 'Provider Order Rejections',
-    permissions: ['create']
+    permittedPermissions: ['create']
   },
   PROVIDER_ORDER_RESUBMISSION: {
     title: 'Provider Order Resubmissions',
-    permissions: ['create']
+    permittedPermissions: ['create']
   },
   PROVIDER_ORDER_TRACKING_ID: {
     title: 'Provider Order Tracking IDs',
-    permissions: ['update']
+    permittedPermissions: ['update']
   },
   PROVIDER_ORDER: {
     title: 'Provider Orders',
-    permissions: ['read']
+    permittedPermissions: ['read']
   },
   PROVIDER_POLICIES: {
     title: 'Provider Policies',
-    permissions: ['read', 'update', 'delete']
+    permittedPermissions: ['read', 'update', 'delete']
   },
   USER: {
     title: 'Users',
-    permissions: ['read']
+    permittedPermissions: ['read']
   }
 }
 

--- a/static/src/js/constants/providerIdentityPermissions.js
+++ b/static/src/js/constants/providerIdentityPermissions.js
@@ -1,0 +1,123 @@
+/**
+ * Permissions for the Provider Identities and Provider Identity ACLs
+ */
+const providerIdentityPermissions = {
+  AUDIT_REPORT: {
+    title: 'Audit Reports',
+    permissions: ['read']
+  },
+  AUTHENTICATOR_DEFINITION: {
+    title: 'Authenticator Definitions',
+    permissions: ['create', 'delete']
+  },
+  CATALOG_ITEM_ACL: {
+    title: 'Catalog Item ACLs',
+    permissions: ['create', 'read', 'update', 'delete']
+  },
+  DASHBOARD_DAAC_CURATOR: {
+    title: 'CMR Dashboard DAAC Curator',
+    permissions: ['create', 'read', 'update', 'delete']
+  },
+  DATA_QUALITY_SUMMARY_ASSIGNMENT: {
+    title: 'Data Quality Summary Assignments',
+    permissions: ['create', 'delete']
+  },
+  DATA_QUALITY_SUMMARY_DEFINITION: {
+    title: 'Data Quality Summary Definitions',
+    permissions: ['create', 'update', 'delete']
+  },
+  DATASET_INFORMATION: {
+    title: 'Dataset Information',
+    permissions: ['read']
+  },
+  SUBSCRIPTION_MANAGEMENT: {
+    title: 'Subscription Management',
+    permissions: ['read', 'update']
+  },
+  EXTENDED_SERVICE: {
+    title: 'Extended Services',
+    permissions: ['create', 'update', 'delete']
+  },
+  GROUP: {
+    title: 'Groups',
+    permissions: ['create', 'read']
+  },
+  INGEST_MANAGEMENT_ACL: {
+    title: 'Ingest Operations',
+    permissions: ['read', 'update']
+  },
+  NON_NASA_DRAFT_APPROVER: {
+    title: 'Non-NASA Draft MMT Approver',
+    permissions: ['create', 'read', 'update', 'delete']
+  },
+  NON_NASA_DRAFT_USER: {
+    title: 'Non-NASA Draft MMT User',
+    permissions: ['create', 'read', 'update', 'delete']
+  },
+  OPTION_ASSIGNMENT: {
+    title: 'Option Assignments',
+    permissions: ['create', 'read', 'delete']
+  },
+  OPTION_DEFINITION: {
+    title: 'Option Definition Deprecations',
+    permissions: ['create', 'delete']
+  },
+  OPTION_DEFINITION_DEPRECATION: {
+    title: 'Option Definitions',
+    permissions: ['create']
+  },
+  PROVIDER_CALENDAR_EVENT: {
+    title: 'Provider Calendar Event',
+    permissions: ['create', 'update', 'delete']
+  },
+  PROVIDER_CONTEXT: {
+    title: 'Provider Context',
+    permissions: ['read']
+  },
+  PROVIDER_HOLDINGS: {
+    title: 'Provider Holdings',
+    permissions: ['read']
+  },
+  PROVIDER_INFORMATION: {
+    title: 'Provider Information',
+    permissions: ['update']
+  },
+  PROVIDER_OBJECT_ACL: {
+    title: 'Provider Object ACLs',
+    permissions: ['create', 'read', 'update', 'delete']
+  },
+  PROVIDER_ORDER_ACCEPTANCE: {
+    title: 'Provider Order Acceptances',
+    permissions: ['create']
+  },
+  PROVIDER_ORDER_CLOSURE: {
+    title: 'Provider Order Closures',
+    permissions: ['create']
+  },
+  PROVIDER_ORDER_REJECTION: {
+    title: 'Provider Order Rejections',
+    permissions: ['create']
+  },
+  PROVIDER_ORDER_RESUBMISSION: {
+    title: 'Provider Order Resubmissions',
+    permissions: ['create']
+  },
+  PROVIDER_ORDER_TRACKING_ID: {
+    title: 'Provider Order Tracking IDs',
+    permissions: ['update']
+  },
+  PROVIDER_ORDER: {
+    title: 'Provider Orders',
+    permissions: ['read']
+  },
+  PROVIDER_POLICIES: {
+    title: 'Provider Policies',
+    permissions: ['read', 'update', 'delete']
+  },
+  USER: {
+    title: 'Users',
+    permissions: ['read']
+  }
+}
+
+export default providerIdentityPermissions

--- a/static/src/js/constants/systemIdentityPermissions.js
+++ b/static/src/js/constants/systemIdentityPermissions.js
@@ -1,0 +1,111 @@
+/**
+ * Permissions for the System Identities and System Identity ACLs
+ */
+const systemIdentityPermissions = {
+  ANY_ACL: {
+    title: 'Any ACL',
+    permissions: ['create', 'read', 'update', 'delete']
+  },
+  ARCHIVE_RECORD: {
+    title: 'Archive Records',
+    permissions: ['delete']
+  },
+  DASHBOARD_ADMIN: {
+    title: 'CMR Dashboard Admin',
+    permissions: ['create', 'read', 'update', 'delete']
+  },
+  DASHBOARD_ARC_CURATOR: {
+    title: 'CMR Dashboard ARC Curator',
+    permissions: ['create', 'read', 'update', 'delete']
+  },
+  DASHBOARD_MDQ_CURATOR: {
+    title: 'CMR Dashboard MDQ Curator',
+    permissions: ['create', 'read', 'update', 'delete']
+  },
+  ERROR_MESSAGE: {
+    title: 'Error Messages',
+    permissions: ['update']
+  },
+  EVENT_NOTIFICATION: {
+    title: 'Event Notifications',
+    permissions: ['delete']
+  },
+  EXTENDED_SERVICE_ACTIVATION: {
+    title: 'Extended Service Activation',
+    permissions: ['create']
+  },
+  EXTENDED_SERVICE: {
+    title: 'Extended Services',
+    permissions: ['delete']
+  },
+  GROUP: {
+    title: 'Groups',
+    permissions: ['create', 'read']
+  },
+  INGEST_MANAGEMENT_ACL: {
+    title: 'Ingest Operations',
+    permissions: ['read', 'update']
+  },
+  METRIC_DATA_POINT_SAMPLE: {
+    title: 'Metric Data Point Samples',
+    permissions: ['read']
+  },
+  ORDER_AND_ORDER_ITEMS: {
+    title: 'Orders and Order Items',
+    permissions: ['read', 'delete']
+  },
+  PROVIDER: {
+    title: 'Providers',
+    permissions: ['create', 'delete']
+  },
+  SYSTEM_AUDIT_REPORT: {
+    title: 'System Audit Reports',
+    permissions: ['read']
+  },
+  SYSTEM_CALENDAR_EVENT: {
+    title: 'System Calendar Event',
+    permissions: ['create', 'update', 'delete']
+  },
+  SYSTEM_INITIALIZER: {
+    title: 'System Initializer',
+    permissions: ['create']
+  },
+  SYSTEM_OPTION_DEFINITION_DEPRECATION: {
+    title: 'System Option Definition Deprecations',
+    permissions: ['create']
+  },
+  SYSTEM_OPTION_DEFINITION: {
+    title: 'System Option Definitions',
+    permissions: ['create', 'delete']
+  },
+  TAG_GROUP: {
+    title: 'Tags and Tag Groups',
+    permissions: ['create', 'update', 'delete']
+  },
+  TAXONOMY: {
+    title: 'Taxonomies',
+    permissions: ['create']
+  },
+  TAXONOMY_ENTRY: {
+    title: 'Taxonomy Entries',
+    permissions: ['create']
+  },
+  TOKEN_REVOCATION: {
+    title: 'Token Revocations',
+    permissions: ['create']
+  },
+  TOKEN: {
+    title: 'Tokens',
+    permissions: ['read', 'delete']
+  },
+  USER_CONTEXT: {
+    title: 'User Context',
+    permissions: ['read']
+  },
+  USER: {
+    title: 'Users',
+    permissions: ['read', 'update', 'delete']
+  }
+}
+
+export default systemIdentityPermissions

--- a/static/src/js/operations/queries/getAcls.js
+++ b/static/src/js/operations/queries/getAcls.js
@@ -6,6 +6,8 @@ export const GET_ACLS = gql`
     acls(params: $params) {
       items {
         acl
+        groupPermissions
+        providerIdentity
       }
     }
   }

--- a/static/src/js/operations/queries/getProviderIdentityPermissions.js
+++ b/static/src/js/operations/queries/getProviderIdentityPermissions.js
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client'
+
+export const GET_PROVIDER_IDENTITY_PERMISSIONS = gql`
+  query GetProviderIdentityPermissions($params: AclsInput) {
+    acls(params: $params) {
+      items {
+        providerIdentity
+        groupPermissions
+        conceptId
+      }
+    }
+  }
+`

--- a/static/src/js/pages/GroupPage/GroupPage.jsx
+++ b/static/src/js/pages/GroupPage/GroupPage.jsx
@@ -1,7 +1,11 @@
 import React, { Suspense, useState } from 'react'
 import { useMutation, useSuspenseQuery } from '@apollo/client'
 import { useNavigate, useParams } from 'react-router'
-import { FaEdit, FaTrash } from 'react-icons/fa'
+import {
+  FaEdit,
+  FaKey,
+  FaTrash
+} from 'react-icons/fa'
 
 import CustomModal from '../../components/CustomModal/CustomModal'
 import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary'
@@ -127,6 +131,13 @@ const GroupPageHeader = () => {
               variant: 'danger',
               disabled: count > 0,
               disabledTooltipText: count > 0 ? 'Can\'t delete groups that have members.' : null
+            },
+            {
+              icon: FaKey,
+              to: 'permissions',
+              title: 'Provider Permissions',
+              iconTitle: 'A key icon',
+              variant: 'light-dark'
             }
           ]
         }

--- a/static/src/js/pages/ProviderPermissionsPage/ProviderPermissionsPage.jsx
+++ b/static/src/js/pages/ProviderPermissionsPage/ProviderPermissionsPage.jsx
@@ -1,0 +1,82 @@
+import React, { Suspense } from 'react'
+import { useSuspenseQuery } from '@apollo/client'
+import { useParams } from 'react-router'
+
+import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+import LoadingTable from '@/js/components/LoadingTable/LoadingTable'
+import Page from '@/js/components/Page/Page'
+import PageHeader from '@/js/components/PageHeader/PageHeader'
+import ProviderPermissions from '@/js/components/ProviderPermissions/ProviderPermissions'
+
+import { GET_GROUP } from '@/js/operations/queries/getGroup'
+
+/**
+ * Renders a ProviderPermissionHeader component
+ *
+ * @component
+ * @example <caption>Render a ProviderPermissionHeader</caption>
+ * return (
+ *   <ProviderPermissionHeader />
+ * )
+ */
+const ProviderPermissionHeader = () => {
+  const { id } = useParams()
+
+  const { data } = useSuspenseQuery(GET_GROUP, {
+    variables: {
+      params: {
+        id
+      }
+    }
+  })
+
+  const { group = {} } = data
+  const { name } = group
+
+  return (
+    <PageHeader
+      title={`${name} Provider Permissions`}
+      breadcrumbs={
+        [
+          {
+            label: 'Groups',
+            to: '/groups'
+          },
+          {
+            label: name,
+            to: `/groups/${id}`
+          },
+          {
+            label: 'Provider Permissions',
+            active: true
+          }
+        ]
+      }
+      pageType="secondary"
+    />
+  )
+}
+
+/**
+ * Renders a ProviderPermissionsPage component
+ *
+ * @component
+ * @example <caption>Render a ProviderPermissionsPage</caption>
+ * return (
+ *   <ProviderPermissionsPage />
+ * )
+ */
+const ProviderPermissionsPage = () => (
+  <Page
+    pageType="secondary"
+    header={<ProviderPermissionHeader />}
+  >
+    <ErrorBoundary>
+      <Suspense fallback={<LoadingTable />}>
+        <ProviderPermissions />
+      </Suspense>
+    </ErrorBoundary>
+  </Page>
+)
+
+export default ProviderPermissionsPage

--- a/static/src/js/pages/ProviderPermissionsPage/__tests__/ProviderPermissionPage.test.jsx
+++ b/static/src/js/pages/ProviderPermissionsPage/__tests__/ProviderPermissionPage.test.jsx
@@ -8,7 +8,6 @@ import {
   Routes
 } from 'react-router'
 import userEvent from '@testing-library/user-event'
-import { describe } from 'vitest'
 
 import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
 

--- a/static/src/js/pages/ProviderPermissionsPage/__tests__/ProviderPermissionPage.test.jsx
+++ b/static/src/js/pages/ProviderPermissionsPage/__tests__/ProviderPermissionPage.test.jsx
@@ -1,0 +1,215 @@
+import React, { Suspense } from 'react'
+import { render, screen } from '@testing-library/react'
+import { Cookies } from 'react-cookie'
+import { MockedProvider } from '@apollo/client/testing'
+import {
+  MemoryRouter,
+  Route,
+  Routes
+} from 'react-router'
+import userEvent from '@testing-library/user-event'
+import { describe } from 'vitest'
+
+import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+
+import {
+  GET_PROVIDER_IDENTITY_PERMISSIONS
+} from '@/js/operations/queries/getProviderIdentityPermissions'
+import { GET_GROUP } from '@/js/operations/queries/getGroup'
+
+import ProviderPermissionsPage from '@/js/pages/ProviderPermissionsPage/ProviderPermissionsPage'
+
+vi.mock('@/js/components/ProviderPermissions/ProviderPermissions', () => ({
+  default: vi.fn(() => (
+    <div data-testid="mock-provider-permissions">Provider Permissions</div>
+  ))
+}))
+
+let expires = new Date()
+expires.setMinutes(expires.getMinutes() + 15)
+expires = new Date(expires)
+
+const cookie = new Cookies(
+  {
+    loginInfo: ({
+      providerId: 'MMT_2',
+      name: 'User Name',
+      token: {
+        tokenValue: 'ABC-1',
+        tokenExp: expires.valueOf()
+      }
+    })
+  }
+)
+cookie.HAS_DOCUMENT_COOKIE = false
+
+const setup = ({
+  additionalMocks = [],
+  overrideMocks = false
+}) => {
+  const mockGroup = {
+    id: '1234-abcd-5678-efgh',
+    description: 'Mock group description',
+    members: {
+      count: 1,
+      items: [{
+        id: 'test.user',
+        firstName: 'Test',
+        lastName: 'User',
+        emailAddress: 'test@example.com',
+        __typename: 'GroupMember'
+      }]
+    },
+    name: 'Mock group',
+    tag: 'MMT_2'
+  }
+
+  const mocks = [{
+    request: {
+      query: GET_GROUP,
+      variables: {
+        params: {
+          id: '1234-abcd-5678-efgh'
+        }
+      }
+    },
+    result: {
+      data: {
+        group: mockGroup
+      }
+    }
+  }, {
+    request: {
+      query: GET_PROVIDER_IDENTITY_PERMISSIONS,
+      variables: {
+        params: {
+          identityType: 'provider',
+          limit: 50
+        }
+      }
+    },
+    result: {
+      data: {
+        acls: {
+          count: 30,
+          cursor: 'eyJqc29uIjoiW1wicHJvdmlkZXIgLSBtbXRfMSAtIHByb3ZpZGVyX2luZm9ybWF0aW9uXCIsXCJBQ0wxMjAwMjE1Nzg5LUNNUlwiXSJ9',
+          items: [
+            {
+              providerIdentity: {
+                target: 'AUDIT_REPORT',
+                provider_id: 'MMT_1'
+              },
+              identityType: 'Provider',
+              groupPermissions: [
+                {
+                  permissions: [
+                    'read'
+                  ],
+                  group_id: '1234-abcd-5678-efgh'
+                },
+                {
+                  permissions: [
+                    'read'
+                  ],
+                  group_id: 'fc9f3eab-97d5-4c99-8ba1-f2ae0eca42ee'
+                }
+              ],
+              conceptId: 'ACL1200216198-CMR'
+            },
+            {
+              providerIdentity: {
+                target: 'AUTHENTICATOR_DEFINITION',
+                provider_id: 'MMT_1'
+              },
+              identityType: 'Provider',
+              groupPermissions: [
+                {
+                  permissions: [],
+                  group_id: '3a07720d-2ac4-4ea5-a0fb-a32dd7c7435f'
+                },
+                {
+                  permissions: [
+                    'delete',
+                    'create'
+                  ],
+                  group_id: '1234-abcd-5678-efgh'
+                }
+              ],
+              conceptId: 'ACL1200216108-CMR'
+            },
+            {
+              providerIdentity: {
+                target: 'CATALOG_ITEM_ACL',
+                provider_id: 'MMT_1'
+              },
+              identityType: 'Provider',
+              groupPermissions: [
+                {
+                  permissions: [],
+                  user_type: 'registered'
+                },
+                {
+                  permissions: [],
+                  user_type: 'guest'
+                }
+              ],
+              conceptId: 'ACL1200216192-CMR'
+            }
+          ]
+        }
+      }
+    }
+  },
+  ...additionalMocks]
+
+  render(
+
+    <MockedProvider
+      mocks={overrideMocks || mocks}
+    >
+      <MemoryRouter initialEntries={['/groups/1234-abcd-5678-efgh']}>
+        <Routes>
+          <Route
+            path="/groups"
+          >
+            <Route
+              path=":id"
+              element={
+                (
+                  <ErrorBoundary>
+                    <Suspense>
+                      <ProviderPermissionsPage />
+                    </Suspense>
+                  </ErrorBoundary>
+                )
+              }
+            />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </MockedProvider>
+  )
+
+  return {
+    user: userEvent.setup()
+  }
+}
+
+describe('ProviderPermissionPage', () => {
+  describe('when showing the list of permissions for the groups provider permissions', () => {
+    test('renders the full table of checkboxes with correct options checked', async () => {
+      setup({})
+
+      await waitForResponse()
+
+      expect(screen.getByRole('link', { name: 'Groups' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Groups' })).toHaveAttribute('href', '/groups')
+      expect(screen.getByRole('link', { name: 'Mock group' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Mock group' })).toHaveAttribute('href', '/groups/1234-abcd-5678-efgh')
+
+      expect(screen.queryByText('Mock group Provider Permissions')).toBeInTheDocument()
+
+      expect(screen.getByTestId('mock-provider-permissions')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
# Overview

### What is the feature?

Adds the permissions form for Provider lever permissions that apply to a group.

### What is the Solution?

Added the checkbox table / form that _shows_ the permissions and which permissions are selected for a given group.

### What areas of the application does this impact?

Group Provider level permissions.

# Testing

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings