### PR TITLE
MMT-3738: Remove provider context selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,41 @@
 ![Build Status](https://github.com/nasa/mmt/workflows/CI/badge.svg?branch=MMT-3390)
 [![codecov](https://codecov.io/gh/nasa/mmt/graph/badge.svg?token=B8Qspgsjou)](https://codecov.io/gh/nasa/mmt)
 
-The Metadata Management Tool (MMT) and Draft Metadata Management Tool (dMMT) are web applications designed to assist users in managing metadata and interfacing with the CMR. The user’s guide for MMT can be found [here](https://wiki.earthdata.nasa.gov/display/ED/Metadata+Management+Tool+%28MMT%29+User%27s+Guide "MMT User Guide") and the user’s guide for dMMT can be found [here](https://wiki.earthdata.nasa.gov/display/ED/Draft+MMT+%28dMMT%29+User%27s+Guide "dMMT User Guide"). Release notes for these applications can be found [here](https://wiki.earthdata.nasa.gov/display/ED/MMT+Release+Notes "Release Notes").
+The Metadata Management Tool (MMT) and Draft Metadata Management Tool (dMMT) are web applications designed to assist users in managing metadata and interfacing with the CMR.
+
+### Links
+
+- [MMT Users Guide](https://wiki.earthdata.nasa.gov/display/ED/Metadata+Management+Tool+%28MMT%29+User%27s+Guide)
+- [Draft MMT Users Guide](https://wiki.earthdata.nasa.gov/display/ED/Draft+MMT+%28dMMT%29+User%27s+Guide)
+- [Release Notes](https://wiki.earthdata.nasa.gov/display/ED/MMT+Release+Notes)
 
 ## Getting Started
 
 ### Requirements
 
-* [Node](https://nodejs.org/) (check .nvmrc for correct version)
-  * [nvm](https://github.com/nvm-sh/nvm) is highly recommended
-* [Docker](https://www.docker.com/get-started/)
-* Java 17
-  * `brew install openjdk@17`
+- [Node](https://nodejs.org/) (check .nvmrc for correct version)
+  - [nvm](https://github.com/nvm-sh/nvm) is highly recommended
+- [Docker](https://www.docker.com/get-started/)
+- Java 17
+  - `brew install openjdk@17`
 
 ### Setup
 
-Type the following command to install the necessary components:
+To install the necessary components, run:
 
+```bash
     npm install
+```
 
 ### Usage
 
-In order to run MMT locally, you first need to setup a local CMR, cmr-graphql, and GraphDB
+In order to run MMT locally, you first need to setup a local CMR, cmr-graphql, and GraphDB.
 
 #### Running a local CMR
 
 In order to use a local copy of the CMR you will need to download the latest file, set an environment variable, and run a rake task to set required permissions and ingest some data.
 
-##### 1. Downloading the CMR file
+##### Downloading the CMR file
 
 Download the CMR JAR file [here](https://ci.earthdata.nasa.gov/artifact/CN2-CSN2/shared/build-latest/cmr-dev-system-uberjar.jar/cmr-dev-system-0.1.0-SNAPSHOT-standalone.jar). Ensure you save the file as `cmr-dev-system-0.1.0-SNAPSHOT-standalone.jar`
 
@@ -40,93 +48,122 @@ In your root directory for MMT, create a folder named `cmr`. Place the `cmr-dev-
 
 Before running a local copy of the CMR, you will need to set a required environment variable. Add this line into your `.bash_profile` (or `.zsh_profile`):
 
+```bash
     export CMR_URS_PASSWORD=mock-urs-password
+```
 
-After adding the line and saving the file, don't forget to source the file
+After adding the line and saving the file, don't forget to source the file by running:
 
+```bash
     source ~/.bash_profile
+```
 
 ##### 3. Setting up local redis for CMR
 
-CMR comes with redis in the jar, but it is not compiled to run on Macs.  If you need to run the CMR on a Mac, install redis with homebrew
+CMR comes with redis in the jar, but it is not compiled to run on Macs.  If you need to run the CMR on a Mac, install redis with homebrew by running:
 
+```bash
     brew update
     brew install redis
     brew services start redis
+```
 
-For more information, see one of these links
+For more information, see:
 
-    https://www.devglan.com/blog/install-redis-windows-and-mac
-    https://gist.github.com/tomysmile/1b8a321e7c58499ef9f9441b2faa0aa8
+ - [https://www.devglan.com/blog/install-redis-windows-and-mac](https://www.devglan.com/blog/install-redis-windows-and-mac)
+ - [https://gist.github.com/tomysmile/1b8a321e7c58499ef9f9441b2faa0aa8](https://gist.github.com/tomysmile/1b8a321e7c58499ef9f9441b2faa0aa8)
 
 ##### 4. Running the CMR npm scripts
 
-To start the local CMR and load the test data:
+To start the local CMR and load the test data, run:
+
 _Note: This command can be ran as two separate commands if needed:_
 
+```bash
     npm run cmr:start_and_setup
+```
 
-    < or >
+< or >
 
+```bash
     npm run cmr:start
     npm run cmr:setup
+```
 
-After you see "Done!", you can load the app in your browser and use the local CMR. After you have started CMR, to just reload the data:
+After you see "Done!", you can load the app in your browser and use the local CMR. After you have started CMR, to just reload the data, run:
 
+```bash
     npm run cmr:reset
     npm run cmr:setup
+```
 
-To stop the locally running CMR, run this command:
+To stop the locally running CMR, run:
 
+```bash
     npm run cmr:stop
+```
 
 You will need to stop the CMR before upgrading to a new CMR version. Note: stopping the running CMR for any reason will delete all data from the CMR. You will have to load the data again when you start it.
 
 ### Running a local CMR GraphQL
 
-To setup cmr-graphql, follow the readme on the repo [here](https://github.com/nasa/cmr-graphql)
+To setup cmr-graphql, follow the [https://github.com/nasa/cmr-graphql](readme).
 
-After you have cmr-graphql set up, run this command (within the cmr-graphql repo) to start it and point it to your local CMR
+After you have set up cmr-graphql, to start it and point it to your local CMR, run:
 
+```bash
     CMR_ROOT_URL=http://localhost:4000 npm start
+```
+
+_Note: This should be run from within the mmt directory._
 
 ### Running a local CMR proxy
 
-The local CMR uses ports instead of the routes you see in production. So you also need to start the graphql proxy found within this repo for the local cmr-graphql to successfully talk to local CMR.
+The local CMR uses ports instead of the routes you see in production. So you also need to start the graphql proxy found within this repo to connect to local cmr-graphql to local CMR.
 
-After opening a new terminal within the MMT repo, run this command:
+To start the proxy, run:
 
+```bash
     npm run start:proxy
+```
 
 ### Running a local GraphDB
 
-To run GraphDB in docker, run this script
+To run GraphDB in docker, run:
 
+```bash
     npm run start:graphdb
+```
 
 #### Running Serverless Offline (API Gateway/Lambdas)
 
-In order to run serverless-offline, which is used for mimicking API Gateway to call lambda functions, run this command:
+In order to run serverless-offline, which is used for mimicking API Gateway to call lambda functions, run:
 
+```bash
     EDL_PASSWORD=<password here> npm run offline
+```
 
-Note: The EDL_PASSWORD environment variable is required for group member queries to function.
+_Note: The EDL_PASSWORD environment variable is required for group member queries to function._
 
 #### Running MMT
 
-After starting the local CMR, cmr-graphql and GraphDB, run the start command
+After starting the local CMR, cmr-graphql and GraphDB, run:
 
+```bash
     npm start
+```
 
 ### UMM JSON-Schema
 
-You can view/download the latest UMM JSON-Schema here, https://git.earthdata.nasa.gov/projects/CMR/repos/cmr/browse/umm-spec-lib/resources/json-schemas
+You can view/download the latest UMM JSON-Schema [here](https://git.earthdata.nasa.gov/projects/CMR/repos/cmr/browse/umm-spec-lib/resources/json-schemas).
 
 ## Local Testing
 
-To run the tests:
+To run the test suite, run:
 
+```bash
     npm run test
+```
 
 ## UI
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To setup cmr-graphql, follow the [https://github.com/nasa/cmr-graphql](readme).
 After you have set up cmr-graphql, to start it and point it to your local CMR, run:
 
 ```bash
-    CMR_ROOT_URL=http://localhost:4000 EDL_PASSWORD=<password here> npm start
+    CMR_ROOT_URL=http://localhost:4000 EDL_CLIENT_ID=<client id> EDL_PASSWORD=<password> npm start
 ```
 
 _Note: This should be run from within the mmt directory._
@@ -140,7 +140,7 @@ To run GraphDB in docker, run:
 In order to run serverless-offline, which is used for mimicking API Gateway to call lambda functions, run:
 
 ```bash
-    EDL_PASSWORD=<password here> npm run offline
+    EDL_PASSWORD=<password> npm run offline
 ```
 
 _Note: The EDL_PASSWORD environment variable is required for group member queries to function._

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 The Metadata Management Tool (MMT) and Draft Metadata Management Tool (dMMT) are web applications designed to assist users in managing metadata and interfacing with the CMR.
 
-### Links
+## Links
 
 - [MMT Users Guide](https://wiki.earthdata.nasa.gov/display/ED/Metadata+Management+Tool+%28MMT%29+User%27s+Guide)
 - [Draft MMT Users Guide](https://wiki.earthdata.nasa.gov/display/ED/Draft+MMT+%28dMMT%29+User%27s+Guide)
@@ -70,8 +70,8 @@ CMR comes with redis in the jar, but it is not compiled to run on Macs.  If you 
 
 For more information, see:
 
- - [https://www.devglan.com/blog/install-redis-windows-and-mac](https://www.devglan.com/blog/install-redis-windows-and-mac)
- - [https://gist.github.com/tomysmile/1b8a321e7c58499ef9f9441b2faa0aa8](https://gist.github.com/tomysmile/1b8a321e7c58499ef9f9441b2faa0aa8)
+- [https://www.devglan.com/blog/install-redis-windows-and-mac](https://www.devglan.com/blog/install-redis-windows-and-mac)
+- [https://gist.github.com/tomysmile/1b8a321e7c58499ef9f9441b2faa0aa8](https://gist.github.com/tomysmile/1b8a321e7c58499ef9f9441b2faa0aa8)
 
 ##### 4. Running the CMR npm scripts
 
@@ -112,7 +112,7 @@ To setup cmr-graphql, follow the [https://github.com/nasa/cmr-graphql](readme).
 After you have set up cmr-graphql, to start it and point it to your local CMR, run:
 
 ```bash
-    CMR_ROOT_URL=http://localhost:4000 npm start
+    CMR_ROOT_URL=http://localhost:4000 EDL_PASSWORD=<password here> npm start
 ```
 
 _Note: This should be run from within the mmt directory._
@@ -171,29 +171,29 @@ To run the test suite, run:
 
 CSS should follow the following guidelines:
 
-* Prefer [Bootstrap](https://getbootstrap.com/docs/5.0/) styles when writing custom components
-* If the desired look can not be achieved with Bootstrap, additional styling should be accomplished by:
-  * Creating a scss file for the custom component
-    * Classes should be defined on the elements following the [BEM methodology](https://getbem.com/)
-    * Sass should be written take advantage of nesting to prevent repetition of the blocks and elements
+- Prefer [Bootstrap](https://getbootstrap.com/docs/5.0/) styles when writing custom components
+- If the desired look can not be achieved with Bootstrap, additional styling should be accomplished by:
+  - Creating a scss file for the custom component
+    - Classes should be defined on the elements following the [BEM methodology](https://getbem.com/)
+    - Sass should be written take advantage of nesting to prevent repetition of the blocks and elements
 
 #### Things to keep in mind
 
 These will help create more maintainable css:
 
-* Use Bootstrap variables where possible
-  * Bootstrap provides css variables for things like colors, sizes, etc which should be used when possible.
-    * Bootstrap variables are used with the `var()` syntax in css
-* Aim to keep specificity low
-  * Most elements should only require a single class name
-  * Avoid chaining selectors, descendant selectors, or other ways of increasing specificity
-* Use consistent modifier class names, starting with `--is`. Add more to the list below as new states are required.
-  * `--is-active`,
-  * `--is-complete`
-  * `--is-errored`
+- Use Bootstrap variables where possible
+  - Bootstrap provides css variables for things like colors, sizes, etc which should be used when possible.
+    - Bootstrap variables are used with the `var()` syntax in css
+- Aim to keep specificity low
+  - Most elements should only require a single class name
+  - Avoid chaining selectors, descendant selectors, or other ways of increasing specificity
+- Use consistent modifier class names, starting with `--is`. Add more to the list below as new states are required.
+  - `--is-active`,
+  - `--is-complete`
+  - `--is-errored`
 
 ### Helpful links
 
-* [Bootstrap Docs](https://getbootstrap.com/docs/5.0/)
-* [BEM methodology](https://getbem.com/)
-* [Specificity MDN Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity)
+- [Bootstrap Docs](https://getbootstrap.com/docs/5.0/)
+- [BEM methodology](https://getbem.com/)
+- [Specificity MDN Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity)

--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -119,7 +119,7 @@ getTemplates:
     - http:
         method: get
         cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
-        path: providers/{providerId}/templates
+        path: templates
         authorizer:
           name: edlAuthorizer
           type: request
@@ -133,7 +133,7 @@ getTemplate:
     - http:
         method: get
         cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
-        path: providers/{providerId}/templates/{id}
+        path: templates/{id}
         authorizer:
           name: edlAuthorizer
           type: request

--- a/serverless/src/getTemplate/__tests__/handler.test.js
+++ b/serverless/src/getTemplate/__tests__/handler.test.js
@@ -15,7 +15,7 @@ describe('getTemplate', () => {
   describe('when the object is found', () => {
     test('returns the template from s3', async () => {
       const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects').mockResolvedValue([{
-        Key: 'mock-key'
+        Key: 'MMT-1/mock-id'
       }])
 
       const mockBody = new Blob([JSON.stringify({ Mock: 'Template' })])
@@ -35,18 +35,23 @@ describe('getTemplate', () => {
 
       const event = {
         pathParameters: {
-          id: 'mock-id',
-          providerId: 'MMT-1'
+          id: 'mock-id'
         }
       }
 
       const response = await getTemplate(event)
+      const result = JSON.parse(response.body)
 
       expect(response.statusCode).toBe(200)
-      expect(response.body).toBe(JSON.stringify({ Mock: 'Template' }))
+
+      expect(result.template).toEqual(expect.objectContaining({
+        Mock: 'Template'
+      }))
+
+      expect(result.providerId).toEqual('MMT-1')
 
       expect(listObjectsMock).toHaveBeenCalledTimes(1)
-      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT-1/mock-id')
+      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object))
     })
   })
 
@@ -57,8 +62,7 @@ describe('getTemplate', () => {
 
       const event = {
         pathParameters: {
-          id: 'mock-id',
-          providerId: 'MMT-1'
+          id: 'mock-id'
         }
       }
 
@@ -67,7 +71,7 @@ describe('getTemplate', () => {
       expect(response.statusCode).toBe(404)
 
       expect(listObjectsMock).toHaveBeenCalledTimes(1)
-      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT-1/mock-id')
+      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object))
 
       expect(consoleMock).toHaveBeenCalledTimes(1)
       expect(consoleMock).toHaveBeenCalledWith('getTemplate Error:', expect.any(Object))

--- a/serverless/src/getTemplate/handler.js
+++ b/serverless/src/getTemplate/handler.js
@@ -30,9 +30,14 @@ const getTemplate = async (event) => {
     const object = objectList.find(({ Key }) => {
       const [objectProviderId, guid] = Key.split('/')
 
-      providerId = objectProviderId
+      // Set the providerId when the guid and id match so it can be returned with the response.
+      if (guid === id) {
+        providerId = objectProviderId
 
-      return guid === id
+        return true
+      }
+
+      return false
     })
 
     const { Key: key } = object

--- a/serverless/src/getTemplate/handler.js
+++ b/serverless/src/getTemplate/handler.js
@@ -18,14 +18,23 @@ const getTemplate = async (event) => {
   }
 
   const { pathParameters } = event
-  const { id, providerId } = pathParameters
-  const prefix = `${providerId}/${id}`
+  const { id } = pathParameters
 
   try {
     // We only know the provider and the id, but we need the full filename to retrieve the contents
     // Use the provider and id to find the correct file
-    const objectList = await s3ListObjects(s3Client, prefix)
-    const [object] = objectList
+    const objectList = await s3ListObjects(s3Client)
+
+    let providerId
+
+    const object = objectList.find(({ Key }) => {
+      const [objectProviderId, guid] = Key.split('/')
+
+      providerId = objectProviderId
+
+      return guid === id
+    })
+
     const { Key: key } = object
 
     // Retrieve the file from S3
@@ -38,14 +47,19 @@ const getTemplate = async (event) => {
     const response = await s3Client.send(getCommand)
 
     const { $metadata: metadata } = response
+
     const { httpStatusCode: statusCode } = metadata
 
     // Transform the body into a string to return
-    const { Body: body } = response
-    const strBody = await body.transformToString()
+    const { Body: responseBody } = response
+
+    const body = {
+      template: JSON.parse(await responseBody.transformToString()),
+      providerId
+    }
 
     return {
-      body: strBody,
+      body: JSON.stringify(body),
       statusCode,
       headers: defaultResponseHeaders
     }

--- a/serverless/src/getTemplates/__tests__/handler.test.js
+++ b/serverless/src/getTemplates/__tests__/handler.test.js
@@ -47,18 +47,23 @@ describe('getTemplates', () => {
       const response = await getTemplates(event)
 
       expect(response.statusCode).toBe(200)
-      expect(response.body).toBe(JSON.stringify([{
+
+      expect(JSON.parse(response.body)[0]).toEqual(expect.objectContaining({
         id: '460bfd33-cad3-46f8-9eee-47664f98038c',
         name: 'Test Template 1',
-        lastModified: '2024-04-02T19:18:11.000Z'
-      }, {
+        lastModified: '2024-04-02T19:18:11.000Z',
+        providerId: 'MMT-1'
+      }))
+
+      expect(JSON.parse(response.body)[1]).toEqual(expect.objectContaining({
         id: '34a25a4d-da4e-4ffd-b374-beae7978f689',
         name: 'Test Template 2',
-        lastModified: '2024-04-01T19:18:11.000Z'
-      }]))
+        lastModified: '2024-04-01T19:18:11.000Z',
+        providerId: 'MMT-1'
+      }))
 
       expect(listObjectsMock).toHaveBeenCalledTimes(1)
-      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT-1/')
+      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object))
     })
   })
 
@@ -78,7 +83,7 @@ describe('getTemplates', () => {
       expect(response.body).toBe(JSON.stringify([]))
 
       expect(listObjectsMock).toHaveBeenCalledTimes(1)
-      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT-1/')
+      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object))
     })
   })
 })

--- a/serverless/src/getTemplates/handler.js
+++ b/serverless/src/getTemplates/handler.js
@@ -8,28 +8,26 @@ let s3Client
  * Retrieve a list of templates from S3
  * @param {Object} event Details about the HTTP request that it received
  */
-const getTemplates = async (event) => {
+const getTemplates = async () => {
   const { defaultResponseHeaders } = getApplicationConfig()
 
   if (s3Client == null) {
     s3Client = getS3Client()
   }
 
-  const { pathParameters } = event
-  const { providerId } = pathParameters
-  const prefix = `${providerId}/`
-
   try {
-    const objectList = await s3ListObjects(s3Client, prefix)
+    const objectList = await s3ListObjects(s3Client)
 
     const body = objectList.map((object) => {
-      const [guid, hashedName] = object.Key.replace(prefix, '').split('/')
+      const [providerId, guid, hashedName] = object.Key.split('/')
+
       const name = Buffer.from(hashedName, 'base64').toString()
 
       return {
         id: guid,
+        lastModified: object.LastModified,
         name,
-        lastModified: object.LastModified
+        providerId
       }
     })
 

--- a/setup/setupCmr.js
+++ b/setup/setupCmr.js
@@ -312,6 +312,31 @@ const createAcls = async (groupConceptIds) => {
       console.log('ANY_ACL CRUD access for Administrators_2 and read for registered users:', jsonData)
     })
 
+  // ACL for admin and typical user to have provider context for MMT_1
+  await fetch('http://localhost:3011/acls', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: systemToken
+    },
+    body: JSON.stringify({
+      group_permissions: [{
+        group_id: groupConceptIds.MMT_1,
+        permissions: ['read']
+      }, {
+        group_id: groupConceptIds.Administrators_2,
+        permissions: ['read']
+      }],
+      provider_identity: {
+        target: 'PROVIDER_CONTEXT',
+        provider_id: 'MMT_1'
+      }
+    })
+  }).then((response) => response.json())
+    .then((jsonData) => {
+      console.log('ACL for admin and typical user to read PROVIDER_CONTEXT for MMT_1:', jsonData)
+    })
+
   // ACL for admin and typical user to have provider context for MMT_2
   await fetch('http://localhost:3011/acls', {
     method: 'POST',

--- a/static/src/js/components/Button/Button.jsx
+++ b/static/src/js/components/Button/Button.jsx
@@ -112,7 +112,7 @@ const Button = React.forwardRef(({
             'd-flex': !inline,
             'd-inline-flex p-0': inline,
             'button--naked': naked,
-            'px-2': iconOnly,
+            'px-2': iconOnly && !inline,
             [className]: className
           }
         ])

--- a/static/src/js/components/ChooseProviderModal/ChooseProviderModal.jsx
+++ b/static/src/js/components/ChooseProviderModal/ChooseProviderModal.jsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Form from 'react-bootstrap/Form'
+import FormSelect from 'react-bootstrap/FormSelect'
+
+import useAppContext from '@/js/hooks/useAppContext'
+
+import CustomModal from '@/js/components/CustomModal/CustomModal'
+import For from '@/js/components/For/For'
+
+/**
+ * @typedef {Object} ChooseProviderModalProps
+ * @property {String} show Boolean that displays or hides the modal.
+ * @property {Function} toggleModal A callback function called when the modal is closed with a boolean representing its next state.
+ * @property {String} type A string used in the body of the modal to designate the item type being saved.
+ * @property {Function} onSubmit A callback function called when the user submits the selection.
+ * @property {String} primaryActionType The text for the submit button.
+ */
+
+/*
+ * Renders a `ChooseProviderModal` component.
+ *
+ * The component is renders a button, optionally displaying an icon
+ *
+ * @param {ChooseProviderModalProps} props
+ *
+ * @component
+ * @example <caption>Render a button with an icon</caption>
+ * return (
+ *   <ChooseProviderModal
+ *      show
+ *      toggleModal={setModalShow}
+ *      type="draft"
+ *      onSubmit={doAThing}
+ *      primaryActionType="Save & Continue"
+ *   />
+ * )
+ */
+const ChooseProviderModal = ({
+  show,
+  toggleModal,
+  type,
+  onSubmit,
+  primaryActionType
+}) => {
+  const { providerIds, setProviderId, user: { providerId } } = useAppContext()
+
+  return (
+    <CustomModal
+      show={show}
+      toggleModal={toggleModal}
+      header="Choose a provider"
+      message={
+        (
+          <>
+            <p>
+              {`Choose a provider before saving${type && ` your ${type}`}.`}
+            </p>
+            <Form className="mb-3">
+              <label className="visually-hidden" htmlFor="select_provider">Select a provider</label>
+              <FormSelect
+                id="select_provider"
+                value={providerId}
+                onChange={
+                  (e) => {
+                    setProviderId(e.target.value)
+                  }
+                }
+              >
+                {
+                  providerIds && providerIds.length > 0 && (
+                    <For each={providerIds}>
+                      {
+                        (id) => (
+                          <option key={id} value={id}>{id}</option>
+                        )
+                      }
+                    </For>
+                  )
+                }
+              </FormSelect>
+            </Form>
+          </>
+        )
+      }
+      actions={
+        [
+          {
+            label: `${primaryActionType}`,
+            variant: 'success',
+            onClick: () => {
+              onSubmit()
+              toggleModal(false)
+            }
+          },
+          {
+            label: 'Cancel',
+            variant: 'light-dark',
+            onClick: () => toggleModal(false)
+          }
+        ]
+      }
+    />
+  )
+}
+
+ChooseProviderModal.defaultProps = {
+  primaryActionType: null
+}
+
+ChooseProviderModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  toggleModal: PropTypes.func.isRequired,
+  type: PropTypes.string.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  primaryActionType: PropTypes.string
+}
+
+export default ChooseProviderModal

--- a/static/src/js/components/ChooseProviderModal/ChooseProviderModal.jsx
+++ b/static/src/js/components/ChooseProviderModal/ChooseProviderModal.jsx
@@ -43,7 +43,13 @@ const ChooseProviderModal = ({
   onSubmit,
   primaryActionType
 }) => {
-  const { providerIds, setProviderId, user: { providerId } } = useAppContext()
+  const {
+    providerIds,
+    setProviderId,
+    user = {}
+  } = useAppContext()
+
+  const { providerId } = user
 
   return (
     <CustomModal

--- a/static/src/js/components/ChooseProviderModal/__tests__/ChooseProviderModal.test.jsx
+++ b/static/src/js/components/ChooseProviderModal/__tests__/ChooseProviderModal.test.jsx
@@ -3,6 +3,8 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { describe } from 'vitest'
+import saveTypesToHumanizedStringMap from '@/js/constants/saveTypesToHumanizedStringMap'
+import saveTypes from '@/js/constants/saveTypes'
 import AppContext from '../../../context/AppContext'
 import ChooseProviderModal from '../ChooseProviderModal'
 
@@ -20,12 +22,14 @@ const setup = ({
   overrideProps = {},
   overrideContext = {}
 } = {}) => {
+  const user = userEvent.setup()
+
   const props = {
     show: false,
     toggleModal: () => {},
     type: 'draft',
     onSubmit: () => {},
-    primaryActionType: 'Save',
+    primaryActionType: saveTypesToHumanizedStringMap[saveTypes.save],
     ...overrideProps
   }
   const context = {
@@ -46,7 +50,7 @@ const setup = ({
   return {
     container,
     context,
-    user: userEvent.setup()
+    user
   }
 }
 
@@ -78,7 +82,7 @@ describe('ChooseProviderModal component', () => {
       expect(screen.getByRole('button', { name: /Close/i })).toBeDefined()
       expect(screen.getByRole('combobox', { name: 'Select a provider' })).toBeDefined()
       expect(screen.getByRole('combobox', { name: 'Select a provider' })).toHaveValue('MMT-2')
-      expect(screen.getByRole('button', { name: 'Save' })).toBeDefined()
+      expect(screen.getByRole('button', { name: saveTypesToHumanizedStringMap[saveTypes.save] })).toBeDefined()
       expect(screen.getByRole('button', { name: 'Cancel' })).toBeDefined()
     })
   })
@@ -164,7 +168,7 @@ describe('ChooseProviderModal component', () => {
         }
       })
 
-      const button = screen.getByRole('button', { name: 'Save' })
+      const button = screen.getByRole('button', { name: saveTypesToHumanizedStringMap[saveTypes.save] })
 
       await user.click(button)
 

--- a/static/src/js/components/ChooseProviderModal/__tests__/ChooseProviderModal.test.jsx
+++ b/static/src/js/components/ChooseProviderModal/__tests__/ChooseProviderModal.test.jsx
@@ -1,0 +1,177 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { describe } from 'vitest'
+import AppContext from '../../../context/AppContext'
+import ChooseProviderModal from '../ChooseProviderModal'
+
+vi.mock('react-router-dom', async () => ({
+  ...await vi.importActual('react-router-dom'),
+  useNavigate: vi.fn()
+}))
+
+const defaultUser = {
+  name: 'User Name',
+  providerId: 'MMT-2'
+}
+
+const setup = ({
+  overrideProps = {},
+  overrideContext = {}
+} = {}) => {
+  const props = {
+    show: false,
+    toggleModal: () => {},
+    type: 'draft',
+    onSubmit: () => {},
+    primaryActionType: 'Save',
+    ...overrideProps
+  }
+  const context = {
+    user: defaultUser,
+    login: vi.fn(),
+    logout: vi.fn(),
+    providerIds: [],
+    setProviderId: vi.fn(),
+    ...overrideContext
+  }
+
+  const { container } = render(
+    <AppContext.Provider value={context}>
+      <ChooseProviderModal {...props} />
+    </AppContext.Provider>
+  )
+
+  return {
+    container,
+    context,
+    user: userEvent.setup()
+  }
+}
+
+describe('ChooseProviderModal component', () => {
+  describe('when show is false', () => {
+    test('does not render the modal', () => {
+      const { container } = setup()
+
+      expect(container).toBeEmptyDOMElement()
+    })
+  })
+
+  describe('when show is true', () => {
+    test('renders the modal correctly', () => {
+      setup({
+        overrideProps: {
+          show: true
+        },
+        overrideContext: {
+          providerIds: [
+            'MMT-1',
+            'MMT-2'
+          ]
+        }
+      })
+
+      expect(screen.getByText('Choose a provider')).toBeDefined()
+      expect(screen.getByText('Choose a provider before saving your draft.')).toBeDefined()
+      expect(screen.getByRole('button', { name: /Close/i })).toBeDefined()
+      expect(screen.getByRole('combobox', { name: 'Select a provider' })).toBeDefined()
+      expect(screen.getByRole('combobox', { name: 'Select a provider' })).toHaveValue('MMT-2')
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDefined()
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDefined()
+    })
+  })
+
+  describe('when the select is changed', () => {
+    test('sets the provider', async () => {
+      const toggleModalMock = vi.fn()
+
+      const { user, context } = setup({
+        overrideProps: {
+          show: true,
+          toggleModal: toggleModalMock
+        },
+        overrideContext: {
+          providerIds: [
+            'MMT-1',
+            'MMT-2'
+          ]
+        }
+      })
+
+      const select = screen.getByRole('combobox', { name: 'Select a provider' })
+
+      expect(select).toHaveValue('MMT-2')
+
+      await user.selectOptions(select, 'MMT-1')
+
+      expect(context.setProviderId).toHaveBeenCalledTimes(1)
+      expect(context.setProviderId).toHaveBeenCalledWith('MMT-1')
+    })
+  })
+
+  describe('when the close button is clicked', () => {
+    test('calls the toggleModal callback with false', async () => {
+      const toggleModalMock = vi.fn()
+
+      const { user } = setup({
+        overrideProps: {
+          show: true,
+          toggleModal: toggleModalMock
+        }
+      })
+
+      const button = screen.getByRole('button', { name: /Close/i })
+
+      await user.click(button)
+
+      expect(toggleModalMock).toHaveBeenCalledTimes(1)
+      expect(toggleModalMock).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('when the cancel button is clicked', () => {
+    test('calls the toggleModal callback with false', async () => {
+      const toggleModalMock = vi.fn()
+
+      const { user } = setup({
+        overrideProps: {
+          show: true,
+          toggleModal: toggleModalMock
+        }
+      })
+
+      const button = screen.getByRole('button', { name: 'Cancel' })
+
+      await user.click(button)
+
+      expect(toggleModalMock).toHaveBeenCalledTimes(1)
+      expect(toggleModalMock).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('when the cancel button is clicked', () => {
+    test('calls the toggleModal callback with false', async () => {
+      const toggleModalMock = vi.fn()
+      const onSubmitMock = vi.fn()
+
+      const { user } = setup({
+        overrideProps: {
+          show: true,
+          toggleModal: toggleModalMock,
+          onSubmit: onSubmitMock
+        }
+      })
+
+      const button = screen.getByRole('button', { name: 'Save' })
+
+      await user.click(button)
+
+      expect(onSubmitMock).toHaveBeenCalledTimes(1)
+      expect(onSubmitMock).toHaveBeenCalledWith()
+      expect(toggleModalMock).toHaveBeenCalledTimes(1)
+      expect(toggleModalMock).toHaveBeenCalledWith(false)
+    })
+  })
+})

--- a/static/src/js/components/CustomModal/CustomModal.jsx
+++ b/static/src/js/components/CustomModal/CustomModal.jsx
@@ -58,7 +58,11 @@ const CustomModal = ({
   >
     <Modal.Header>
       <div>
-        {header}
+        {
+          header && (
+            <Modal.Title>{header}</Modal.Title>
+          )
+        }
       </div>
       <Button
         className="text-secondary p-0"

--- a/static/src/js/components/CustomModal/CustomModal.jsx
+++ b/static/src/js/components/CustomModal/CustomModal.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import Modal from 'react-bootstrap/Modal'
 import { FaTimes } from 'react-icons/fa'
 
-import Button from '../Button/Button'
+import Button from '@/js/components/Button/Button'
 
 /**
  * @typedef {Object} CustomModalActionDef
@@ -53,52 +53,57 @@ const CustomModal = ({
     show={show}
     size={size}
     centered
+    backdrop
     onHide={() => toggleModal(false)}
   >
+    <Modal.Header>
+      <div>
+        {header}
+      </div>
+      <Button
+        className="text-secondary p-0"
+        naked
+        variant="link"
+        onClick={
+          () => {
+            toggleModal(false)
+          }
+        }
+        Icon={FaTimes}
+        iconTitle="X icon"
+        iconOnly
+        inline
+      >
+        Close
+      </Button>
+    </Modal.Header>
+    <Modal.Body>{message}</Modal.Body>
     {
-      !!header && (
-        <Modal.Header>
-          <div>{header}</div>
-          <Button
-            className="text-secondary"
-            naked
-            variant="link"
-            onClick={
-              () => {
-                toggleModal(false)
-              }
-            }
-            Icon={FaTimes}
-            iconTitle="X icon"
-            iconOnly
-          >
-            Close
-          </Button>
-        </Modal.Header>
+      actions && (
+        <Modal.Footer>
+          {
+            actions.map((item) => {
+              const { label, variant, onClick } = item
+
+              return (
+                <Button
+                  key={label}
+                  variant={variant}
+                  onClick={onClick}
+                >
+                  {label}
+                </Button>
+              )
+            })
+          }
+        </Modal.Footer>
       )
     }
-    <Modal.Body>{message}</Modal.Body>
-    <Modal.Footer>
-      {
-        actions.map((item) => {
-          const { label, variant, onClick } = item
-
-          return (
-            <Button
-              key={label}
-              variant={variant}
-              onClick={onClick}
-            >
-              {label}
-            </Button>
-          )
-        })
-      }
-    </Modal.Footer>
   </Modal>
 )
 
 CustomModal.defaultProps = {
+  actions: null,
   header: null,
   message: null,
   size: null
@@ -109,7 +114,7 @@ CustomModal.propTypes = {
     label: PropTypes.string.isRequired,
     variant: PropTypes.string.isRequired,
     onClick: PropTypes.func.isRequired
-  })).isRequired,
+  })),
   header: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.node

--- a/static/src/js/components/CustomModal/__tests__/CustomModal.test.jsx
+++ b/static/src/js/components/CustomModal/__tests__/CustomModal.test.jsx
@@ -19,10 +19,12 @@ const setup = (overrideProps) => {
     ...overrideProps
   }
 
-  render(<CustomModal {...props} />)
+  const { container } = render(<CustomModal {...props} />)
 
   return {
-    props
+    container,
+    props,
+    user: userEvent.setup()
   }
 }
 
@@ -60,6 +62,52 @@ describe('CustomModal', () => {
       })
 
       expect(screen.getByRole('button', { name: 'X icon Close' })).toBeInTheDocument()
+    })
+  })
+
+  describe('when no actions are provided', () => {
+    test('does not render the footer', () => {
+      const { container } = setup({
+        actions: null
+      })
+
+      expect(container.querySelector('.modal-footer')).toEqual(null)
+    })
+  })
+
+  describe('when the close button is clicked', () => {
+    test('calls the toggleModal callback', async () => {
+      const toggleModalMock = vi.fn()
+
+      const { user } = setup({
+        actions: null,
+        toggleModal: toggleModalMock
+      })
+
+      const button = screen.getByRole('button', { name: /Close/i })
+
+      await user.click(button)
+
+      expect(toggleModalMock).toHaveBeenCalledTimes(1)
+      expect(toggleModalMock).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('when the backdrop is clicked', () => {
+    test('calls the toggleModal callback', async () => {
+      const toggleModalMock = vi.fn()
+
+      const { user } = setup({
+        actions: null,
+        toggleModal: toggleModalMock
+      })
+
+      const dialog = screen.getByRole('dialog')
+
+      await user.click(dialog)
+
+      expect(toggleModalMock).toHaveBeenCalledTimes(1)
+      expect(toggleModalMock).toHaveBeenCalledWith(false)
     })
   })
 })

--- a/static/src/js/components/CustomModal/__tests__/CustomModal.test.jsx
+++ b/static/src/js/components/CustomModal/__tests__/CustomModal.test.jsx
@@ -4,7 +4,9 @@ import React from 'react'
 import CustomModal from '../CustomModal'
 
 const setup = (overrideProps) => {
+  const user = userEvent.setup()
   const onClick = vi.fn()
+
   const props = {
     show: true,
     message: 'Mock message',
@@ -24,7 +26,7 @@ const setup = (overrideProps) => {
   return {
     container,
     props,
-    user: userEvent.setup()
+    user
   }
 }
 

--- a/static/src/js/components/DraftList/DraftList.jsx
+++ b/static/src/js/components/DraftList/DraftList.jsx
@@ -4,32 +4,27 @@ import React, {
   useState
 } from 'react'
 
+import { FaFileDownload } from 'react-icons/fa'
 import { useParams } from 'react-router-dom'
 import { useSuspenseQuery } from '@apollo/client'
-import { FaFileDownload } from 'react-icons/fa'
+import moment from 'moment'
+import pluralize from 'pluralize'
 import Col from 'react-bootstrap/Col'
 import Row from 'react-bootstrap/Row'
-import pluralize from 'pluralize'
 
-import moment from 'moment'
-import useAppContext from '../../hooks/useAppContext'
-import constructDownloadableFile from '../../utils/constructDownloadableFile'
+import { DATE_FORMAT } from '@/js/constants/dateFormat'
+import conceptIdTypes from '@/js/constants/conceptIdTypes'
+import conceptTypeDraftsQueries from '@/js/constants/conceptTypeDraftsQueries'
+import constructDownloadableFile from '@/js/utils/constructDownloadableFile'
+import urlValueTypeToConceptTypeMap from '@/js/constants/urlValueToConceptTypeMap'
 
-import Table from '../Table/Table'
-import Button from '../Button/Button'
-
-import conceptIdTypes from '../../constants/conceptIdTypes'
-import EllipsisLink from '../EllipsisLink/EllipsisLink'
-import EllipsisText from '../EllipsisText/EllipsisText'
-import ControlledPaginatedContent from '../ControlledPaginatedContent/ControlledPaginatedContent'
-import urlValueTypeToConceptTypeMap from '../../constants/urlValueToConceptTypeMap'
-import conceptTypeDraftsQueries from '../../constants/conceptTypeDraftsQueries'
-import { DATE_FORMAT } from '../../constants/dateFormat'
+import Button from '@/js/components/Button/Button'
+import ControlledPaginatedContent from '@/js/components/ControlledPaginatedContent/ControlledPaginatedContent'
+import EllipsisLink from '@/js/components/EllipsisLink/EllipsisLink'
+import EllipsisText from '@/js/components/EllipsisText/EllipsisText'
+import Table from '@/js/components/Table/Table'
 
 const DraftList = () => {
-  const { user } = useAppContext()
-  const { providerId } = user
-
   const { draftType: paramDraftType } = useParams()
 
   const draftType = urlValueTypeToConceptTypeMap[paramDraftType]
@@ -42,7 +37,6 @@ const DraftList = () => {
   const { data } = useSuspenseQuery(conceptTypeDraftsQueries[draftType], {
     variables: {
       params: {
-        provider: providerId,
         conceptType: draftType,
         limit,
         offset,
@@ -111,6 +105,11 @@ const DraftList = () => {
   }, [])
 
   const [columns, setColumns] = useState([
+    {
+      dataKey: 'providerId',
+      className: 'col-auto',
+      title: 'Provider'
+    },
     {
       dataKey: 'revisionDate',
       title: 'Last Modified (UTC)',
@@ -209,7 +208,7 @@ const DraftList = () => {
                     generateCellKey={({ conceptId }, dataKey) => `column_${dataKey}_${conceptId}`}
                     generateRowKey={({ conceptId }) => `row_${conceptId}`}
                     data={items}
-                    noDataMessage={`No ${draftType} drafts exist for the provider ${providerId}`}
+                    noDataMessage={`No ${draftType} drafts exist`}
                     count={count}
                     setPage={setPage}
                     limit={limit}

--- a/static/src/js/components/DraftList/DraftList.jsx
+++ b/static/src/js/components/DraftList/DraftList.jsx
@@ -16,7 +16,7 @@ import { DATE_FORMAT } from '@/js/constants/dateFormat'
 import conceptIdTypes from '@/js/constants/conceptIdTypes'
 import conceptTypeDraftsQueries from '@/js/constants/conceptTypeDraftsQueries'
 import constructDownloadableFile from '@/js/utils/constructDownloadableFile'
-import urlValueTypeToConceptTypeMap from '@/js/constants/urlValueToConceptTypeMap'
+import urlValueTypeToConceptTypeStringMap from '@/js/constants/urlValueToConceptStringMap'
 
 import Button from '@/js/components/Button/Button'
 import ControlledPaginatedContent from '@/js/components/ControlledPaginatedContent/ControlledPaginatedContent'
@@ -27,7 +27,7 @@ import Table from '@/js/components/Table/Table'
 const DraftList = () => {
   const { draftType: paramDraftType } = useParams()
 
-  const draftType = urlValueTypeToConceptTypeMap[paramDraftType]
+  const draftType = urlValueTypeToConceptTypeStringMap[paramDraftType]
 
   const [activePage, setActivePage] = useState(1)
 

--- a/static/src/js/components/DraftList/__tests__/DraftList.test.jsx
+++ b/static/src/js/components/DraftList/__tests__/DraftList.test.jsx
@@ -44,6 +44,7 @@ const mockDraft = {
         longName: 'Tool TD1200000092 long name',
         __typename: 'Tool'
       },
+      providerId: 'MMT_2',
       __typename: 'Draft'
     },
     {
@@ -55,6 +56,7 @@ const mockDraft = {
         longName: null,
         __typename: 'Tool'
       },
+      providerId: 'MMT_2',
       __typename: 'Draft'
     },
     {
@@ -69,6 +71,7 @@ const mockDraft = {
         longName: null,
         __typename: 'Tool'
       },
+      providerId: 'MMT_2',
       __typename: 'Draft'
     }
   ],
@@ -81,7 +84,6 @@ const setup = ({ overrideMocks = false }) => {
       query: GET_TOOL_DRAFTS,
       variables: {
         params: {
-          provider: 'MMT_2',
           conceptType: 'Tool',
           limit: 20,
           offset: 0,
@@ -161,7 +163,6 @@ describe('DraftList', () => {
             query: GET_TOOL_DRAFTS,
             variables: {
               params: {
-                provider: 'MMT_2',
                 conceptType: 'Tool',
                 limit: 20,
                 offset: 0,
@@ -187,7 +188,7 @@ describe('DraftList', () => {
       const rows = screen.getAllByRole('row')
 
       expect(within(rows[1]).getByRole('cell', {
-        name: 'No Tool drafts exist for the provider MMT_2'
+        name: 'No Tool drafts exist'
       })).toBeInTheDocument()
     })
   })

--- a/static/src/js/components/FormNavigation/FormNavigation.jsx
+++ b/static/src/js/components/FormNavigation/FormNavigation.jsx
@@ -10,6 +10,7 @@ import ListGroup from 'react-bootstrap/ListGroup'
 import Spinner from 'react-bootstrap/Spinner'
 
 import saveTypes from '@/js/constants/saveTypes'
+import saveTypesToHumanizedStringMap from '@/js/constants/saveTypesToHumanizedStringMap'
 
 import removeEmpty from '@/js/utils/removeEmpty'
 
@@ -18,14 +19,6 @@ import For from '@/js/components/For/For'
 import NavigationItem from '@/js/components/NavigationItem/NavigationItem'
 
 import './FormNavigation.scss'
-
-const humanizedSaveTypes = {
-  [saveTypes.save]: 'Save',
-  [saveTypes.saveAndContinue]: 'Save & Continue',
-  [saveTypes.saveAndCreateDraft]: 'Save & Create Draft',
-  [saveTypes.saveAndPreview]: 'Save & Preview',
-  [saveTypes.saveAndPublish]: 'Save & Publish'
-}
 
 /**
  * FormNavigation
@@ -67,7 +60,7 @@ const FormNavigation = ({
   const onSaveClick = (type) => {
     // If there is no concept id for drafts or id for templates, open the modal
     if (!conceptId && !id) {
-      setChooseProviderModalType(humanizedSaveTypes[type])
+      setChooseProviderModalType(saveTypesToHumanizedStringMap[type])
       setChooseProviderModalOpen(true)
 
       return
@@ -101,7 +94,7 @@ const FormNavigation = ({
               {
                 loading
                   ? 'Saving draft...'
-                  : humanizedSaveTypes[saveTypes.saveAndContinue]
+                  : saveTypesToHumanizedStringMap[saveTypes.saveAndContinue]
               }
             </span>
           </Button>
@@ -119,7 +112,7 @@ const FormNavigation = ({
               onClick={() => onSaveClick(saveTypes.save)}
             >
               <span>
-                {humanizedSaveTypes[saveTypes.save]}
+                {saveTypesToHumanizedStringMap[saveTypes.save]}
               </span>
             </Dropdown.Item>
 
@@ -127,7 +120,7 @@ const FormNavigation = ({
               onClick={() => onSaveClick(saveTypes.saveAndContinue)}
             >
               <span>
-                {humanizedSaveTypes[saveTypes.saveAndContinue]}
+                {saveTypesToHumanizedStringMap[saveTypes.saveAndContinue]}
               </span>
             </Dropdown.Item>
 
@@ -136,7 +129,7 @@ const FormNavigation = ({
                 <Dropdown.Item
                   onClick={() => onSaveClick(saveTypes.saveAndCreateDraft)}
                 >
-                  {humanizedSaveTypes[saveTypes.saveAndCreateDraft]}
+                  {saveTypesToHumanizedStringMap[saveTypes.saveAndCreateDraft]}
                 </Dropdown.Item>
               )
             }
@@ -145,7 +138,7 @@ const FormNavigation = ({
                 <Dropdown.Item
                   onClick={() => onSaveClick(saveTypes.saveAndPublish)}
                 >
-                  {humanizedSaveTypes[saveTypes.saveAndPublish]}
+                  {saveTypesToHumanizedStringMap[saveTypes.saveAndPublish]}
                 </Dropdown.Item>
 
               )
@@ -155,7 +148,7 @@ const FormNavigation = ({
               onClick={() => onSaveClick(saveTypes.saveAndPreview)}
             >
               <span>
-                {humanizedSaveTypes[saveTypes.saveAndPreview]}
+                {saveTypesToHumanizedStringMap[saveTypes.saveAndPreview]}
               </span>
             </Dropdown.Item>
           </Dropdown.Menu>
@@ -210,7 +203,6 @@ const FormNavigation = ({
         onSubmit={
           () => {
             onSave(chooseProviderModalType)
-            setChooseProviderModalOpen(false)
           }
         }
       />

--- a/static/src/js/components/FormNavigation/FormNavigation.jsx
+++ b/static/src/js/components/FormNavigation/FormNavigation.jsx
@@ -1,22 +1,31 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import { useParams } from 'react-router'
+import validator from '@rjsf/validator-ajv8'
+import { cloneDeep } from 'lodash-es'
 import Button from 'react-bootstrap/Button'
 import ButtonGroup from 'react-bootstrap/ButtonGroup'
 import Dropdown from 'react-bootstrap/Dropdown'
 import ListGroup from 'react-bootstrap/ListGroup'
 import Spinner from 'react-bootstrap/Spinner'
-import validator from '@rjsf/validator-ajv8'
-import { cloneDeep } from 'lodash-es'
 
-import { useParams } from 'react-router'
-import NavigationItem from '../NavigationItem/NavigationItem'
-import For from '../For/For'
+import saveTypes from '@/js/constants/saveTypes'
 
-import saveTypes from '../../constants/saveTypes'
+import removeEmpty from '@/js/utils/removeEmpty'
 
-import removeEmpty from '../../utils/removeEmpty'
+import ChooseProviderModal from '@/js/components/ChooseProviderModal/ChooseProviderModal'
+import For from '@/js/components/For/For'
+import NavigationItem from '@/js/components/NavigationItem/NavigationItem'
 
 import './FormNavigation.scss'
+
+const humanizedSaveTypes = {
+  [saveTypes.save]: 'Save',
+  [saveTypes.saveAndContinue]: 'Save & Continue',
+  [saveTypes.saveAndCreateDraft]: 'Save & Create Draft',
+  [saveTypes.saveAndPreview]: 'Save & Preview',
+  [saveTypes.saveAndPublish]: 'Save & Publish'
+}
 
 /**
  * FormNavigation
@@ -48,9 +57,24 @@ const FormNavigation = ({
   // uiSchema,
   visitedFields
 }) => {
+  const { conceptId, id } = useParams()
+  const [chooseProviderModalOpen, setChooseProviderModalOpen] = useState(false)
+  const [chooseProviderModalType, setChooseProviderModalType] = useState(null)
   const { templateType } = useParams()
   const cleanedDraft = cloneDeep(removeEmpty(draft))
   const { errors } = validator.validateFormData(cleanedDraft, schema)
+
+  const onSaveClick = (type) => {
+    // If there is no concept id for drafts or id for templates, open the modal
+    if (!conceptId && !id) {
+      setChooseProviderModalType(humanizedSaveTypes[type])
+      setChooseProviderModalOpen(true)
+
+      return
+    }
+
+    onSave(type)
+  }
 
   return (
     <>
@@ -59,7 +83,7 @@ const FormNavigation = ({
           <Button
             className="text-white"
             disabled={loading}
-            onClick={() => onSave(saveTypes.saveAndContinue)}
+            onClick={() => onSaveClick(saveTypes.saveAndContinue)}
             variant="success"
           >
             {
@@ -77,7 +101,7 @@ const FormNavigation = ({
               {
                 loading
                   ? 'Saving draft...'
-                  : 'Save & Continue'
+                  : humanizedSaveTypes[saveTypes.saveAndContinue]
               }
             </span>
           </Button>
@@ -92,46 +116,46 @@ const FormNavigation = ({
 
           <Dropdown.Menu>
             <Dropdown.Item
-              onClick={() => onSave(saveTypes.save)}
+              onClick={() => onSaveClick(saveTypes.save)}
             >
               <span>
-                Save
+                {humanizedSaveTypes[saveTypes.save]}
               </span>
             </Dropdown.Item>
 
             <Dropdown.Item
-              onClick={() => onSave(saveTypes.saveAndContinue)}
+              onClick={() => onSaveClick(saveTypes.saveAndContinue)}
             >
               <span>
-                Save &amp; Continue
+                {humanizedSaveTypes[saveTypes.saveAndContinue]}
               </span>
             </Dropdown.Item>
 
             {
               templateType && (
                 <Dropdown.Item
-                  onClick={() => onSave(saveTypes.saveAndCreateDraft)}
+                  onClick={() => onSaveClick(saveTypes.saveAndCreateDraft)}
                 >
-                  Save &amp; Create Draft
+                  {humanizedSaveTypes[saveTypes.saveAndCreateDraft]}
                 </Dropdown.Item>
               )
             }
             {
               !templateType && (
                 <Dropdown.Item
-                  onClick={() => onSave(saveTypes.saveAndPublish)}
+                  onClick={() => onSaveClick(saveTypes.saveAndPublish)}
                 >
-                  Save &amp; Publish
+                  {humanizedSaveTypes[saveTypes.saveAndPublish]}
                 </Dropdown.Item>
 
               )
             }
 
             <Dropdown.Item
-              onClick={() => onSave(saveTypes.saveAndPreview)}
+              onClick={() => onSaveClick(saveTypes.saveAndPreview)}
             >
               <span>
-                Save &amp; Preview
+                {humanizedSaveTypes[saveTypes.saveAndPreview]}
               </span>
             </Dropdown.Item>
           </Dropdown.Menu>
@@ -173,6 +197,23 @@ const FormNavigation = ({
           }
         </For>
       </ListGroup>
+
+      <ChooseProviderModal
+        show={chooseProviderModalOpen}
+        primaryActionType={chooseProviderModalType}
+        toggleModal={
+          () => {
+            setChooseProviderModalOpen(false)
+          }
+        }
+        type={!templateType ? 'draft' : 'template'}
+        onSubmit={
+          () => {
+            onSave(chooseProviderModalType)
+            setChooseProviderModalOpen(false)
+          }
+        }
+      />
     </>
   )
 }

--- a/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
+++ b/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
@@ -8,12 +8,12 @@ import {
 } from 'react-router'
 
 import Providers from '@/js/providers/Providers/Providers'
-import FormNavigation from '../FormNavigation'
-import NavigationItem from '../../NavigationItem/NavigationItem'
+import FormNavigation from '@/js/components/FormNavigation/FormNavigation'
+import NavigationItem from '@/js/components/NavigationItem/NavigationItem'
 
-import saveTypes from '../../../constants/saveTypes'
+import saveTypes from '@/js/constants/saveTypes'
 
-vi.mock('../../NavigationItem/NavigationItem')
+vi.mock('@/js/components/NavigationItem/NavigationItem')
 
 const setup = ({
   overrideProps = {},

--- a/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
+++ b/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
@@ -7,6 +7,7 @@ import {
   Routes
 } from 'react-router'
 
+import Providers from '@/js/providers/Providers/Providers'
 import FormNavigation from '../FormNavigation'
 import NavigationItem from '../../NavigationItem/NavigationItem'
 
@@ -43,18 +44,20 @@ const setup = ({
   }
 
   render(
-    <MemoryRouter initialEntries={[overrideInitialEntries || '/tool-drafts/TD1000000-MMT/mock-section-name']}>
-      <Routes>
-        <Route
-          path={overridePath || '/tool-drafts'}
-        >
+    <Providers>
+      <MemoryRouter initialEntries={[overrideInitialEntries || '/tool-drafts/TD1000000-MMT/mock-section-name']}>
+        <Routes>
           <Route
-            path={overridePathName || ':conceptId/:sectionName'}
-            element={<FormNavigation {...props} />}
-          />
-        </Route>
-      </Routes>
-    </MemoryRouter>
+            path={overridePath || '/tool-drafts'}
+          >
+            <Route
+              path={overridePathName || ':conceptId/:sectionName'}
+              element={<FormNavigation {...props} />}
+            />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </Providers>
   )
 
   return {

--- a/static/src/js/components/GroupForm/GroupForm.jsx
+++ b/static/src/js/components/GroupForm/GroupForm.jsx
@@ -36,6 +36,8 @@ import CustomTextareaWidget from '@/js/components/CustomTextareaWidget/CustomTex
 import CustomTextWidget from '@/js/components/CustomTextWidget/CustomTextWidget'
 import CustomTitleField from '@/js/components/CustomTitleField/CustomTitleField'
 import GridLayout from '@/js/components/GridLayout/GridLayout'
+import saveTypes from '@/js/constants/saveTypes'
+import saveTypesToHumanizedStringMap from '@/js/constants/saveTypesToHumanizedStringMap'
 
 /**
  * Renders a GroupForm component
@@ -66,6 +68,7 @@ const GroupForm = ({ isAdminPage }) => {
   const [chooseProviderModalOpen, setChooseProviderModalOpen] = useState(false)
 
   const [createGroupMutation] = useMutation(CREATE_GROUP)
+
   const [updateGroupMutation] = useMutation(UPDATE_GROUP, {
     refetchQueries: [{
       query: GET_GROUP,
@@ -277,7 +280,7 @@ const GroupForm = ({ isAdminPage }) => {
             >
               <div className="d-flex gap-2">
                 <Button type="submit">
-                  Submit
+                  {saveTypesToHumanizedStringMap[saveTypes.submit]}
                 </Button>
                 <Button
                   onClick={handleClear}
@@ -292,13 +295,13 @@ const GroupForm = ({ isAdminPage }) => {
       </Container>
       <ChooseProviderModal
         show={chooseProviderModalOpen}
-        primaryActionType="Submit"
+        primaryActionType={saveTypesToHumanizedStringMap[saveTypes.submit]}
         toggleModal={
           () => {
             setChooseProviderModalOpen(false)
           }
         }
-        type="Group"
+        type="group"
         onSubmit={
           () => {
             handleSubmit()

--- a/static/src/js/components/GroupForm/GroupForm.jsx
+++ b/static/src/js/components/GroupForm/GroupForm.jsx
@@ -28,13 +28,14 @@ import getPermittedUser from '@/js/utils/getPermittedUser'
 import errorLogger from '@/js/utils/errorLogger'
 import removeEmpty from '@/js/utils/removeEmpty'
 
-import CustomArrayFieldTemplate from '../CustomArrayFieldTemplate/CustomArrayFieldTemplate'
-import CustomFieldTemplate from '../CustomFieldTemplate/CustomFieldTemplate'
-import CustomSelectWidget from '../CustomSelectWidget/CustomSelectWidget'
-import CustomTextareaWidget from '../CustomTextareaWidget/CustomTextareaWidget'
-import CustomTextWidget from '../CustomTextWidget/CustomTextWidget'
-import CustomTitleField from '../CustomTitleField/CustomTitleField'
-import GridLayout from '../GridLayout/GridLayout'
+import ChooseProviderModal from '@/js/components/ChooseProviderModal/ChooseProviderModal'
+import CustomArrayFieldTemplate from '@/js/components/CustomArrayFieldTemplate/CustomArrayFieldTemplate'
+import CustomFieldTemplate from '@/js/components/CustomFieldTemplate/CustomFieldTemplate'
+import CustomSelectWidget from '@/js/components/CustomSelectWidget/CustomSelectWidget'
+import CustomTextareaWidget from '@/js/components/CustomTextareaWidget/CustomTextareaWidget'
+import CustomTextWidget from '@/js/components/CustomTextWidget/CustomTextWidget'
+import CustomTitleField from '@/js/components/CustomTitleField/CustomTitleField'
+import GridLayout from '@/js/components/GridLayout/GridLayout'
 
 /**
  * Renders a GroupForm component
@@ -62,6 +63,7 @@ const GroupForm = ({ isAdminPage }) => {
   const { addNotification } = useNotificationsContext()
 
   const [focusField, setFocusField] = useState(null)
+  const [chooseProviderModalOpen, setChooseProviderModalOpen] = useState(false)
 
   const [createGroupMutation] = useMutation(CREATE_GROUP)
   const [updateGroupMutation] = useMutation(UPDATE_GROUP, {
@@ -232,6 +234,16 @@ const GroupForm = ({ isAdminPage }) => {
     }
   }
 
+  const handleSetProviderOrSubmit = () => {
+    if (id === 'new' && !isAdminPage) {
+      setChooseProviderModalOpen(true)
+
+      return
+    }
+
+    handleSubmit()
+  }
+
   const handleClear = () => {
     setDraft(originalDraft)
     addNotification({
@@ -241,42 +253,60 @@ const GroupForm = ({ isAdminPage }) => {
   }
 
   return (
-    <Container className="group-form__container mx-0" fluid>
-      <Row>
-        <Col>
-          <Form
-            fields={fields}
-            formContext={
-              {
-                focusField,
-                setFocusField
+    <>
+      <Container className="group-form__container mx-0" fluid>
+        <Row>
+          <Col>
+            <Form
+              fields={fields}
+              formContext={
+                {
+                  focusField,
+                  setFocusField
+                }
               }
-            }
-            widgets={widgets}
-            schema={updatedGroupSchema}
-            validator={validator}
-            templates={templates}
-            uiSchema={isAdminPage ? systemGroupUiSchema : groupUiSchema}
-            onChange={handleChange}
-            formData={formData}
-            onSubmit={handleSubmit}
-            showErrorList="false"
-          >
-            <div className="d-flex gap-2">
-              <Button type="submit">
-                Submit
-              </Button>
-              <Button
-                onClick={handleClear}
-                variant="secondary"
-              >
-                Clear
-              </Button>
-            </div>
-          </Form>
-        </Col>
-      </Row>
-    </Container>
+              widgets={widgets}
+              schema={updatedGroupSchema}
+              validator={validator}
+              templates={templates}
+              uiSchema={isAdminPage ? systemGroupUiSchema : groupUiSchema}
+              onChange={handleChange}
+              formData={formData}
+              onSubmit={handleSetProviderOrSubmit}
+              showErrorList="false"
+            >
+              <div className="d-flex gap-2">
+                <Button type="submit">
+                  Submit
+                </Button>
+                <Button
+                  onClick={handleClear}
+                  variant="secondary"
+                >
+                  Clear
+                </Button>
+              </div>
+            </Form>
+          </Col>
+        </Row>
+      </Container>
+      <ChooseProviderModal
+        show={chooseProviderModalOpen}
+        primaryActionType="Submit"
+        toggleModal={
+          () => {
+            setChooseProviderModalOpen(false)
+          }
+        }
+        type="Group"
+        onSubmit={
+          () => {
+            handleSubmit()
+            setChooseProviderModalOpen(false)
+          }
+        }
+      />
+    </>
   )
 }
 

--- a/static/src/js/components/GroupForm/__tests__/GroupForm.test.jsx
+++ b/static/src/js/components/GroupForm/__tests__/GroupForm.test.jsx
@@ -1,5 +1,9 @@
 import React, { Suspense } from 'react'
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen,
+  within
+} from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import {
   MemoryRouter,
@@ -232,6 +236,10 @@ describe('GroupForm', () => {
         const submitButton = screen.getByRole('button', { name: 'Submit' })
         await user.click(submitButton)
 
+        const modal = screen.getByRole('dialog')
+        const modalSubmit = within(modal).getByRole('button', { name: 'Submit' })
+        await user.click(modalSubmit)
+
         expect(navigateSpy).toHaveBeenCalledTimes(1)
         expect(navigateSpy).toHaveBeenCalledWith('/groups/1234-abcd-5678-efgh')
       })
@@ -353,6 +361,10 @@ describe('GroupForm', () => {
 
         const submitButton = screen.getByRole('button', { name: 'Submit' })
         await user.click(submitButton)
+
+        const modal = screen.getByRole('dialog')
+        const modalSubmit = within(modal).getByRole('button', { name: 'Submit' })
+        await user.click(modalSubmit)
 
         expect(errorLogger).toHaveBeenCalledTimes(1)
         expect(errorLogger).toHaveBeenCalledWith('Error creating group', 'GroupForm: createGroupMutation')

--- a/static/src/js/components/Header/Header.jsx
+++ b/static/src/js/components/Header/Header.jsx
@@ -30,7 +30,6 @@ import InputGroup from 'react-bootstrap/InputGroup'
 import Navbar from 'react-bootstrap/Navbar'
 import Spinner from 'react-bootstrap/Spinner'
 import {
-  FaCheck,
   FaExclamationCircle,
   FaExternalLinkAlt,
   FaQuestionCircle,
@@ -39,14 +38,14 @@ import {
   FaSignOutAlt
 } from 'react-icons/fa'
 
-import { GET_PROVIDERS } from '../../operations/queries/getProviders'
+import { GET_PROVIDERS } from '@/js/operations/queries/getProviders'
 
-import useAppContext from '../../hooks/useAppContext'
+import useAppContext from '@/js/hooks/useAppContext'
 
-import Button from '../Button/Button'
-import For from '../For/For'
+import isTokenExpired from '@/js/utils/isTokenExpired'
 
-import isTokenExpired from '../../utils/isTokenExpired'
+import Button from '@/js/components/Button/Button'
+import For from '@/js/components/For/For'
 
 import './Header.scss'
 
@@ -63,9 +62,7 @@ const Header = () => {
   const {
     user,
     login,
-    logout,
-    providerIds,
-    setProviderId
+    logout
   } = useAppContext()
   const navigate = useNavigate()
 
@@ -184,7 +181,7 @@ const Header = () => {
                     id="user-dropdown"
                     as={Badge}
                     bg={null}
-                    className="header__user-dropdown-toggle pointer me-1"
+                    className="header__user-dropdown-toggle pointer"
                     role="button"
                   >
                     {`${user.name} `}
@@ -214,54 +211,6 @@ const Header = () => {
                       <FaSignOutAlt className="me-2" />
                       Logout
                     </Dropdown.Item>
-                  </Dropdown.Menu>
-                </Dropdown>
-
-                <Dropdown align="end">
-                  <Dropdown.Toggle
-                    id="provider-dropdown"
-                    as={Badge}
-                    bg={null}
-                    className="header__prov-dropdown-toggle pointer"
-                    role="button"
-                  >
-                    {user.providerId}
-                  </Dropdown.Toggle>
-
-                  <Dropdown.Menu
-                    className="header__prov-dropdown bg-blue-light border-blue-light shadow text-white"
-                  >
-                    {
-                      providerIds?.length > 0 && (
-                        <>
-                          <span className="header__prov-dropdown-header d-block px-3 my-2 fw-bold">Choose a provider context</span>
-                          <div className="header__prov-dropdown-items-wrapper">
-                            <For each={providerIds}>
-                              {
-                                (providerId) => (
-                                  <Dropdown.Item
-                                    key={providerId}
-                                    className="header__prov-dropdown-item d-flex align-items-center justify-content-between text-white"
-                                    active={providerId === user.providerId}
-                                    onClick={() => setProviderId(providerId)}
-                                  >
-                                    {providerId}
-                                    {
-                                      providerId === user.providerId && (
-                                        <Badge className="ms-2 d-flex align-items-center" bg="indigo">
-                                          <FaCheck className="me-1" />
-                                          {' Selected'}
-                                        </Badge>
-                                      )
-                                    }
-                                  </Dropdown.Item>
-                                )
-                              }
-                            </For>
-                          </div>
-                        </>
-                      )
-                    }
                   </Dropdown.Menu>
                 </Dropdown>
               </div>

--- a/static/src/js/components/Header/__tests__/Header.test.jsx
+++ b/static/src/js/components/Header/__tests__/Header.test.jsx
@@ -195,64 +195,6 @@ describe('Header component', () => {
       expect(screen.getByText('Search Collections')).not.toHaveClass('show')
     })
 
-    test('displays the provider dropdown', () => {
-      setup({
-        overrideContext: {
-          user: {
-            name: 'User Name',
-            token: {
-              tokenValue: 'ABC-1',
-              tokenExp: expires.valueOf()
-            },
-            providerId: 'MMT_2'
-          },
-          login: vi.fn(),
-          logout: vi.fn()
-        }
-      })
-
-      expect(screen.getByRole('button', { name: 'MMT_2' })).toBeInTheDocument()
-    })
-
-    describe('when a provider is selected from the dropdown', () => {
-      test('updates the selected provider in the state', async () => {
-        const { context } = setup({
-          overrideContext: {
-            user: {
-              name: 'User Name',
-              token: {
-                tokenValue: 'ABC-1',
-                tokenExp: expires.valueOf()
-              },
-              providerId: 'MMT_2'
-            },
-            providerIds: [
-              'MMT_TEST',
-              'MMT_3'
-            ],
-            login: vi.fn(),
-            logout: vi.fn()
-          }
-        })
-
-        const providerDropdownButton = screen.getByRole('button', { name: 'MMT_2' })
-        await userEvent.click(providerDropdownButton)
-
-        await waitFor(() => {
-          expect(providerDropdownButton).toHaveAttribute('aria-expanded', 'true')
-        })
-
-        const providerOption = await screen.findByText('MMT_TEST')
-
-        await userEvent.click(providerOption)
-
-        await waitFor(() => {
-          expect(context.setProviderId).toHaveBeenCalledTimes(1)
-          expect(context.setProviderId).toHaveBeenCalledWith('MMT_TEST')
-        })
-      })
-    })
-
     describe('when the search submit dropdown button is clicked', () => {
       test('displays the search submit button', async () => {
         const user = userEvent.setup()

--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -31,7 +31,7 @@ import formConfigurations from '../../schemas/uiForms'
 
 import conceptTypeDraftQueries from '../../constants/conceptTypeDraftQueries'
 import saveTypes from '../../constants/saveTypes'
-import urlValueTypeToConceptTypeMap from '../../constants/urlValueToConceptTypeMap'
+import urlValueTypeToConceptTypeStringMap from '../../constants/urlValueToConceptStringMap'
 
 import useAppContext from '../../hooks/useAppContext'
 import useNotificationsContext from '../../hooks/useNotificationsContext'
@@ -75,7 +75,7 @@ const MetadataForm = () => {
   if (conceptId !== 'new') {
     derivedConceptType = getConceptTypeByDraftConceptId(conceptId)
   } else {
-    derivedConceptType = urlValueTypeToConceptTypeMap[draftType]
+    derivedConceptType = urlValueTypeToConceptTypeStringMap[draftType]
   }
 
   const {

--- a/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
+++ b/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
@@ -28,6 +28,8 @@ import CustomTextareaWidget from '@/js/components/CustomTextareaWidget/CustomTex
 import CustomTextWidget from '@/js/components/CustomTextWidget/CustomTextWidget'
 import CustomTitleField from '@/js/components/CustomTitleField/CustomTitleField'
 import GridLayout from '@/js/components/GridLayout/GridLayout'
+import saveTypesToHumanizedStringMap from '@/js/constants/saveTypesToHumanizedStringMap'
+import saveTypes from '@/js/constants/saveTypes'
 
 /**
  * Renders a OrderOptionForm component
@@ -253,7 +255,7 @@ const OrderOptionForm = () => {
             >
               <div className="d-flex gap-2">
                 <Button type="submit">
-                  Submit
+                  {saveTypesToHumanizedStringMap[saveTypes.submit]}
                 </Button>
                 <Button
                   onClick={handleClear}
@@ -268,7 +270,7 @@ const OrderOptionForm = () => {
       </Container>
       <ChooseProviderModal
         show={chooseProviderModalOpen}
-        primaryActionType="Submit"
+        primaryActionType={saveTypesToHumanizedStringMap[saveTypes.submit]}
         toggleModal={
           () => {
             setChooseProviderModalOpen(false)

--- a/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
+++ b/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
@@ -9,24 +9,25 @@ import validator from '@rjsf/validator-ajv8'
 
 import { useMutation, useSuspenseQuery } from '@apollo/client'
 
-import CustomFieldTemplate from '../CustomFieldTemplate/CustomFieldTemplate'
-import CustomTextareaWidget from '../CustomTextareaWidget/CustomTextareaWidget'
-import CustomTextWidget from '../CustomTextWidget/CustomTextWidget'
-import CustomTitleField from '../CustomTitleField/CustomTitleField'
-import GridLayout from '../GridLayout/GridLayout'
+import orderOption from '@/js/schemas/orderOption'
+import orderOptionUiSchema from '@/js/schemas/uiSchemas/OrderOption'
 
-import orderOption from '../../schemas/orderOption'
-import orderOptionUiSchema from '../../schemas/uiSchemas/OrderOption'
+import { CREATE_ORDER_OPTION } from '@/js/operations/mutations/createOrderOption'
+import { GET_ORDER_OPTION } from '@/js/operations/queries/getOrderOption'
+import { UPDATE_ORDER_OPTION } from '@/js/operations/mutations/updateOrderOption'
 
-import { CREATE_ORDER_OPTION } from '../../operations/mutations/createOrderOption'
-import { GET_ORDER_OPTION } from '../../operations/queries/getOrderOption'
-import { UPDATE_ORDER_OPTION } from '../../operations/mutations/updateOrderOption'
+import useNotificationsContext from '@/js/hooks/useNotificationsContext'
+import useAppContext from '@/js/hooks/useAppContext'
 
-import useNotificationsContext from '../../hooks/useNotificationsContext'
-import useAppContext from '../../hooks/useAppContext'
+import errorLogger from '@/js/utils/errorLogger'
+import removeEmpty from '@/js/utils/removeEmpty'
 
-import errorLogger from '../../utils/errorLogger'
-import removeEmpty from '../../utils/removeEmpty'
+import ChooseProviderModal from '@/js/components/ChooseProviderModal/ChooseProviderModal'
+import CustomFieldTemplate from '@/js/components/CustomFieldTemplate/CustomFieldTemplate'
+import CustomTextareaWidget from '@/js/components/CustomTextareaWidget/CustomTextareaWidget'
+import CustomTextWidget from '@/js/components/CustomTextWidget/CustomTextWidget'
+import CustomTitleField from '@/js/components/CustomTitleField/CustomTitleField'
+import GridLayout from '@/js/components/GridLayout/GridLayout'
 
 /**
  * Renders a OrderOptionForm component
@@ -70,6 +71,7 @@ const OrderOptionForm = () => {
   })
 
   const [nativeId, setNativeId] = useState()
+  const [chooseProviderModalOpen, setChooseProviderModalOpen] = useState(false)
 
   const fields = {
     TitleField: CustomTitleField,
@@ -208,6 +210,16 @@ const OrderOptionForm = () => {
     }
   }
 
+  const handleSetProviderOrSubmit = () => {
+    if (conceptId === 'new') {
+      setChooseProviderModalOpen(true)
+
+      return
+    }
+
+    handleSubmit()
+  }
+
   const handleClear = () => {
     setDraft(originalDraft)
     addNotification({
@@ -217,42 +229,60 @@ const OrderOptionForm = () => {
   }
 
   return (
-    <Container className="order-option-form__container mx-0" fluid>
-      <Row>
-        <Col>
-          <Form
-            fields={fields}
-            formContext={
-              {
-                focusField,
-                setFocusField
+    <>
+      <Container className="order-option-form__container mx-0" fluid>
+        <Row>
+          <Col>
+            <Form
+              fields={fields}
+              formContext={
+                {
+                  focusField,
+                  setFocusField
+                }
               }
-            }
-            widgets={widgets}
-            schema={orderOption}
-            validator={validator}
-            templates={templates}
-            uiSchema={orderOptionUiSchema}
-            onChange={handleChange}
-            formData={formData}
-            onSubmit={handleSubmit}
-            showErrorList="false"
-          >
-            <div className="d-flex gap-2">
-              <Button type="submit">
-                Submit
-              </Button>
-              <Button
-                onClick={handleClear}
-                variant="secondary"
-              >
-                Clear
-              </Button>
-            </div>
-          </Form>
-        </Col>
-      </Row>
-    </Container>
+              widgets={widgets}
+              schema={orderOption}
+              validator={validator}
+              templates={templates}
+              uiSchema={orderOptionUiSchema}
+              onChange={handleChange}
+              formData={formData}
+              onSubmit={handleSetProviderOrSubmit}
+              showErrorList="false"
+            >
+              <div className="d-flex gap-2">
+                <Button type="submit">
+                  Submit
+                </Button>
+                <Button
+                  onClick={handleClear}
+                  variant="secondary"
+                >
+                  Clear
+                </Button>
+              </div>
+            </Form>
+          </Col>
+        </Row>
+      </Container>
+      <ChooseProviderModal
+        show={chooseProviderModalOpen}
+        primaryActionType="Submit"
+        toggleModal={
+          () => {
+            setChooseProviderModalOpen(false)
+          }
+        }
+        type="order option"
+        onSubmit={
+          () => {
+            handleSubmit()
+            setChooseProviderModalOpen(false)
+          }
+        }
+      />
+    </>
   )
 }
 

--- a/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
+++ b/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
@@ -1,5 +1,9 @@
 import React, { Suspense } from 'react'
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen,
+  within
+} from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import {
   MemoryRouter,
@@ -28,35 +32,26 @@ let expires = new Date()
 expires.setMinutes(expires.getMinutes() + 15)
 expires = new Date(expires)
 
-const cookie = new Cookies(
-  {
-    loginInfo: ({
-      providerId: 'MMT_2',
-      name: 'User Name',
-      token: {
-        tokenValue: 'ABC-1',
-        tokenExp: expires.valueOf()
-      }
-    })
+const cookie = new Cookies({
+  loginInfo: {
+    providerId: 'MMT_2',
+    name: 'User Name',
+    token: {
+      tokenValue: 'ABC-1',
+      tokenExp: expires.valueOf()
+    }
   }
-)
+})
 cookie.HAS_DOCUMENT_COOKIE = false
 
-const setup = ({
-  mocks,
-  pageUrl
-}) => {
+const setup = ({ mocks, pageUrl }) => {
   render(
     <CookiesProvider defaultSetOptions={{ path: '/' }} cookies={cookie}>
       <Providers>
-        <MockedProvider
-          mocks={mocks}
-        >
+        <MockedProvider mocks={mocks}>
           <MemoryRouter initialEntries={[pageUrl]}>
             <Routes>
-              <Route
-                path="/order-options"
-              >
+              <Route path="/order-options">
                 <Route
                   element={
                     (
@@ -120,7 +115,8 @@ describe('OrderOptionForm', () => {
                   }
                 }
               }
-            }, {
+            },
+            {
               request: {
                 query: GET_ORDER_OPTION,
                 variables: {
@@ -152,6 +148,12 @@ describe('OrderOptionForm', () => {
 
         const submitButton = screen.getByRole('button', { name: 'Submit' })
         await user.click(submitButton)
+
+        const modal = screen.getByRole('dialog')
+        const modalButton = within(modal).getByRole('button', {
+          name: 'Submit'
+        })
+        await user.click(modalButton)
 
         expect(navigateSpy).toHaveBeenCalledTimes(1)
         expect(navigateSpy).toHaveBeenCalledWith('/order-options/OO1000000-MMT')
@@ -193,8 +195,15 @@ describe('OrderOptionForm', () => {
         const submitButton = screen.getByRole('button', { name: 'Submit' })
         await user.click(submitButton)
 
+        const modal = screen.getByRole('dialog')
+        const modalButton = within(modal).getByRole('button', { name: 'Submit' })
+        await user.click(modalButton)
+
         expect(errorLogger).toHaveBeenCalledTimes(1)
-        expect(errorLogger).toHaveBeenCalledWith('Error creating order option', 'OrderOptionForm: createOrderOptionMutation')
+        expect(errorLogger).toHaveBeenCalledWith(
+          'Error creating order option',
+          'OrderOptionForm: createOrderOptionMutation'
+        )
       })
     })
 
@@ -304,8 +313,7 @@ describe('OrderOptionForm', () => {
                   }
                 }
               }
-            }
-            ]
+            }]
           }
         )
 
@@ -373,8 +381,7 @@ describe('OrderOptionForm', () => {
               }
             },
             error: new Error('An error occurred')
-          }
-          ]
+          }]
         })
 
         await waitForResponse()
@@ -386,7 +393,10 @@ describe('OrderOptionForm', () => {
         await user.click(submitButton)
 
         expect(errorLogger).toHaveBeenCalledTimes(1)
-        expect(errorLogger).toHaveBeenCalledWith('Error updating order option', 'OrderOptionForm: updateOrderOptionMutation')
+        expect(errorLogger).toHaveBeenCalledWith(
+          'Error updating order option',
+          'OrderOptionForm: updateOrderOptionMutation'
+        )
       })
     })
   })

--- a/static/src/js/components/OrderOptionList/OrderOptionList.jsx
+++ b/static/src/js/components/OrderOptionList/OrderOptionList.jsx
@@ -6,21 +6,20 @@ import { useSearchParams } from 'react-router-dom'
 import moment from 'moment'
 import { FaEdit, FaTrash } from 'react-icons/fa'
 
-import Button from '../Button/Button'
-import ControlledPaginatedContent from '../ControlledPaginatedContent/ControlledPaginatedContent'
-import CustomModal from '../CustomModal/CustomModal'
-import EllipsisLink from '../EllipsisLink/EllipsisLink'
-import Table from '../Table/Table'
+import Button from '@/js/components/Button/Button'
+import ControlledPaginatedContent from '@/js/components/ControlledPaginatedContent/ControlledPaginatedContent'
+import CustomModal from '@/js/components/CustomModal/CustomModal'
+import EllipsisLink from '@/js/components/EllipsisLink/EllipsisLink'
+import Table from '@/js/components/Table/Table'
 
-import { DELETE_ORDER_OPTION } from '../../operations/mutations/deleteOrderOption'
-import { GET_ORDER_OPTIONS } from '../../operations/queries/getOrderOptions'
+import { DELETE_ORDER_OPTION } from '@/js/operations/mutations/deleteOrderOption'
+import { GET_ORDER_OPTIONS } from '@/js/operations/queries/getOrderOptions'
 
-import { DATE_FORMAT } from '../../constants/dateFormat'
+import { DATE_FORMAT } from '@/js/constants/dateFormat'
 
-import useAppContext from '../../hooks/useAppContext'
-import useNotificationsContext from '../../hooks/useNotificationsContext'
+import useNotificationsContext from '@/js/hooks/useNotificationsContext'
 
-import errorLogger from '../../utils/errorLogger'
+import errorLogger from '@/js/utils/errorLogger'
 
 /**
  * Renders a OrderOptionList component
@@ -32,11 +31,7 @@ import errorLogger from '../../utils/errorLogger'
  * )
  */
 const OrderOptionList = () => {
-  const { user } = useAppContext()
-
   const { addNotification } = useNotificationsContext()
-
-  const { providerId } = user
 
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [selectedOrderOption, setSelectedOrderOption] = useState(false)
@@ -59,7 +54,6 @@ const OrderOptionList = () => {
   const { data, refetch } = useSuspenseQuery(GET_ORDER_OPTIONS, {
     variables: {
       params: {
-        providerId,
         limit,
         offset
       }
@@ -68,12 +62,7 @@ const OrderOptionList = () => {
 
   const [deleteOrderOptionMutation] = useMutation(DELETE_ORDER_OPTION, {
     refetchQueries: [{
-      query: GET_ORDER_OPTIONS,
-      variables: {
-        params: {
-          providerId
-        }
-      }
+      query: GET_ORDER_OPTIONS
     }]
   })
 
@@ -82,7 +71,7 @@ const OrderOptionList = () => {
   }
 
   const handleDelete = () => {
-    const { nativeId } = selectedOrderOption
+    const { nativeId, providerId } = selectedOrderOption
     deleteOrderOptionMutation({
       variables: {
         nativeId,

--- a/static/src/js/components/OrderOptionList/OrderOptionList.jsx
+++ b/static/src/js/components/OrderOptionList/OrderOptionList.jsx
@@ -132,8 +132,8 @@ const OrderOptionList = () => {
             iconTitle="Delete Button"
             onClick={
               () => {
-                toggleShowDeleteModal(true)
                 setSelectedOrderOption(rowData)
+                toggleShowDeleteModal(true)
               }
             }
             variant="danger"
@@ -158,6 +158,12 @@ const OrderOptionList = () => {
       dataKey: 'scope',
       title: 'Scope',
       className: 'col-auto'
+    },
+    {
+      dataKey: 'providerId',
+      title: 'Provider',
+      className: 'col-auto',
+      center: true
     },
     {
       dataKey: 'deprecated',

--- a/static/src/js/components/OrderOptionList/__tests__/OrderOptionList.test.jsx
+++ b/static/src/js/components/OrderOptionList/__tests__/OrderOptionList.test.jsx
@@ -116,6 +116,16 @@ describe('OrderOptionList', () => {
     })
   })
 
+  describe('when getting list of order options results in a success', () => {
+    test('render a table with 2 order options', async () => {
+      setup({})
+
+      await waitForResponse()
+
+      expect(screen.getAllByText('MMT_2')).toHaveLength(2)
+    })
+  })
+
   describe('when clicking the delete button', () => {
     describe('when clicking Yes on the delete modal results in a success', () => {
       test('deletes the order option and hides the modal', async () => {

--- a/static/src/js/components/OrderOptionList/__tests__/OrderOptionList.test.jsx
+++ b/static/src/js/components/OrderOptionList/__tests__/OrderOptionList.test.jsx
@@ -33,6 +33,7 @@ const setup = ({
         name: 'Test order option 1',
         form: 'some form',
         nativeId: 'Test-Native-Id-1',
+        providerId: 'MMT_2',
         scope: 'PROVIDER',
         sortKey: '',
         associationDetails: null,
@@ -46,6 +47,7 @@ const setup = ({
         name: 'Test order option 2',
         form: 'some form',
         nativeId: 'Test-Native-Id',
+        providerId: 'MMT_2',
         scope: 'PROVIDER',
         sortKey: '',
         associationDetails: null,
@@ -59,7 +61,6 @@ const setup = ({
       query: GET_ORDER_OPTIONS,
       variables: {
         params: {
-          providerId: 'MMT_2',
           limit: 20,
           offset: 0
         }
@@ -140,11 +141,7 @@ describe('OrderOptionList', () => {
             {
               request: {
                 query: GET_ORDER_OPTIONS,
-                variables: {
-                  params: {
-                    providerId: 'MMT_2'
-                  }
-                }
+                variables: {}
               },
               result: {
                 data: {
@@ -158,6 +155,7 @@ describe('OrderOptionList', () => {
                         name: 'Test order option 1',
                         form: 'some form',
                         nativeId: 'Test-Native-Id-1',
+                        providerId: 'MMT_2',
                         scope: 'PROVIDER',
                         sortKey: '',
                         associationDetails: null,
@@ -174,7 +172,6 @@ describe('OrderOptionList', () => {
                 query: GET_ORDER_OPTIONS,
                 variables: {
                   params: {
-                    providerId: 'MMT_2',
                     limit: 20,
                     offset: 0
                   }
@@ -192,6 +189,7 @@ describe('OrderOptionList', () => {
                         name: 'Test order option 1',
                         form: 'some form',
                         nativeId: 'Test-Native-Id-1',
+                        providerId: 'MMT_2',
                         scope: 'PROVIDER',
                         sortKey: '',
                         associationDetails: null,
@@ -279,7 +277,6 @@ describe('OrderOptionList', () => {
               query: GET_ORDER_OPTIONS,
               variables: {
                 params: {
-                  providerId: 'MMT_2',
                   limit: 20,
                   offset: 0
                 }
@@ -312,7 +309,6 @@ describe('OrderOptionList', () => {
               query: GET_ORDER_OPTIONS,
               variables: {
                 params: {
-                  providerId: 'MMT_2',
                   limit: 20,
                   offset: 0
                 }
@@ -330,6 +326,7 @@ describe('OrderOptionList', () => {
                       name: 'Test order option 1',
                       form: 'some form',
                       nativeId: 'Test-Native-Id-1',
+                      providerId: 'MMT_2',
                       scope: 'PROVIDER',
                       sortKey: '',
                       associationDetails: null,
@@ -343,6 +340,7 @@ describe('OrderOptionList', () => {
                       name: 'Test order option 2',
                       form: 'some form',
                       nativeId: 'Test-Native-Id',
+                      providerId: 'MMT_2',
                       scope: 'PROVIDER',
                       sortKey: '',
                       associationDetails: null,
@@ -359,7 +357,6 @@ describe('OrderOptionList', () => {
               query: GET_ORDER_OPTIONS,
               variables: {
                 params: {
-                  providerId: 'MMT_2',
                   limit: 20,
                   offset: 20
                 }
@@ -377,6 +374,7 @@ describe('OrderOptionList', () => {
                       name: 'Test order option 1',
                       form: 'some form',
                       nativeId: 'Test-Native-Id-1',
+                      providerId: 'MMT_2',
                       scope: 'PROVIDER',
                       sortKey: '',
                       associationDetails: null,
@@ -390,6 +388,7 @@ describe('OrderOptionList', () => {
                       name: 'Test order option 2',
                       form: 'some form',
                       nativeId: 'Test-Native-Id',
+                      providerId: 'MMT_2',
                       scope: 'PROVIDER',
                       sortKey: '',
                       associationDetails: null,

--- a/static/src/js/components/Page/Page.jsx
+++ b/static/src/js/components/Page/Page.jsx
@@ -6,7 +6,7 @@ import Container from 'react-bootstrap/Container'
 import Row from 'react-bootstrap/Row'
 import Placeholder from 'react-bootstrap/Placeholder'
 
-import LoadingBanner from '../LoadingBanner/LoadingBanner'
+import LoadingBanner from '@/js/components/LoadingBanner/LoadingBanner'
 
 import './Page.scss'
 
@@ -17,7 +17,7 @@ const PageHeaderPlaceholder = () => (
       <Placeholder style={
         {
           width: '25rem',
-          height: '2rem'
+          height: '1.5rem'
         }
       }
       />

--- a/static/src/js/components/PageHeader/PageHeader.jsx
+++ b/static/src/js/components/PageHeader/PageHeader.jsx
@@ -10,10 +10,10 @@ import DropdownMenu from 'react-bootstrap/DropdownMenu'
 import DropdownToggle from 'react-bootstrap/DropdownToggle'
 import { Link } from 'react-router-dom'
 
-import Button from '../Button/Button'
-import CustomMenu from '../CustomMenu/CustomMenu'
-import CustomToggle from '../CustomToggle/CustomToggle'
-import For from '../For/For'
+import Button from '@/js/components/Button/Button'
+import CustomMenu from '@/js/components/CustomMenu/CustomMenu'
+import CustomToggle from '@/js/components/CustomToggle/CustomToggle'
+import For from '@/js/components/For/For'
 
 /**
  * @typedef {Object} PrimaryAction
@@ -42,12 +42,39 @@ import For from '../For/For'
  * @property {Boolean} active A boolean flag to trigger the active state
  */
 
+/**
+ * @typedef {Object} PageHeaderProps
+ * @property {AdditionalAction[]} additionalActions An array of objects that configure the additional actions.
+ * @property {Breadcrumb[]} breadcrumbs An array of objects that configure the breadcrumbs.
+ * @property {String} pageType A string that defines the page type.
+ * @property {PrimaryAction[]} primaryActions An array of objects that configure the primary actions.
+ * @property {String} title The text for the title.
+ * @property {String} titleBadge The text for a title badge.
+ */
+
+/*
+ * Renders a `PageHeader` component.
+ *
+ * The component is renders a button, optionally displaying an icon
+ *
+ * @param {PageHeaderProps} props
+ *
+ * @component
+ * @example <caption>Render a button with an icon</caption>
+ * return (
+ *   <PageHeader
+ *      pageType="primary"
+ *      title="This is the page title"
+ *   />
+ * )
+ */
 const PageHeader = ({
   additionalActions,
   breadcrumbs,
   pageType,
   primaryActions,
-  title
+  title,
+  titleBadge
 }) => (
   <header
     className={
@@ -87,17 +114,20 @@ const PageHeader = ({
       )
     }
     <div className="d-flex w-100 align-items-center justify-content-between">
-      <h2
-        className="m-0 text-gray-200 fs-2"
-        style={
-          {
-            fontWeight: 700,
-            letterSpacing: '-0.015rem'
+      <div className="d-flex align-items-center">
+        <h2
+          className="m-0 text-gray-200 fs-4"
+          style={
+            {
+              fontWeight: 700,
+              letterSpacing: '-0.015rem'
+            }
           }
-        }
-      >
-        {title}
-      </h2>
+        >
+          {title}
+        </h2>
+        {titleBadge && <Badge className="ms-2" bg="light-dark text-secondary" size="sm">{titleBadge}</Badge>}
+      </div>
       {
         primaryActions && (
           <div className="d-flex flex-row">
@@ -243,7 +273,8 @@ PageHeader.defaultProps = {
   additionalActions: null,
   breadcrumbs: [],
   pageType: 'primary',
-  primaryActions: []
+  primaryActions: [],
+  titleBadge: null
 }
 
 PageHeader.propTypes = {
@@ -275,7 +306,8 @@ PageHeader.propTypes = {
       variant: PropTypes.string.isRequired
     }).isRequired
   ),
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  titleBadge: PropTypes.string
 }
 
 export default PageHeader

--- a/static/src/js/components/TemplateForm/TemplateForm.jsx
+++ b/static/src/js/components/TemplateForm/TemplateForm.jsx
@@ -132,8 +132,6 @@ const TemplateForm = () => {
       const { response, error: fetchTemplateError } = await getTemplate(providerId, token, id)
 
       if (response) {
-        delete response.pathParameters
-
         setDraft({
           ummMetadata: response
         })

--- a/static/src/js/components/TemplateForm/__tests__/TemplateForm.test.jsx
+++ b/static/src/js/components/TemplateForm/__tests__/TemplateForm.test.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import {
   render,
   screen,
-  waitFor
+  waitFor,
+  within
 } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import {
@@ -347,6 +348,10 @@ describe('TemplateForm', () => {
 
         const button = screen.getByRole('button', { name: 'Save & Continue' })
         await user.click(button)
+
+        const modal = screen.getByRole('dialog')
+        const modalButton = within(modal).getByRole('button', { name: 'Save & Continue' })
+        await user.click(modalButton)
 
         await waitForResponse()
 

--- a/static/src/js/components/TemplateList/TemplateList.jsx
+++ b/static/src/js/components/TemplateList/TemplateList.jsx
@@ -3,28 +3,29 @@ import React, {
   useEffect,
   useState
 } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import Col from 'react-bootstrap/Col'
 import Row from 'react-bootstrap/Row'
 import moment from 'moment'
 import { FaPlus } from 'react-icons/fa'
 
-import deleteTemplate from '../../utils/deleteTemplate'
-import errorLogger from '../../utils/errorLogger'
-import getTemplates from '../../utils/getTemplates'
+import urlValueTypeToConceptTypeMap from '@/js/constants/urlValueToConceptTypeMap'
+import deleteTemplate from '@/js/utils/deleteTemplate'
+import errorLogger from '@/js/utils/errorLogger'
+import getTemplates from '@/js/utils/getTemplates'
 
-import useAppContext from '../../hooks/useAppContext'
-import useNotificationsContext from '../../hooks/useNotificationsContext'
+import useAppContext from '@/js/hooks/useAppContext'
+import useNotificationsContext from '@/js/hooks/useNotificationsContext'
 
-import { DATE_FORMAT } from '../../constants/dateFormat'
+import { DATE_FORMAT } from '@/js/constants/dateFormat'
 
-import Button from '../Button/Button'
-import CustomModal from '../CustomModal/CustomModal'
-import EllipsisLink from '../EllipsisLink/EllipsisLink'
-import ErrorBanner from '../ErrorBanner/ErrorBanner'
-import Page from '../Page/Page'
-import PageHeader from '../PageHeader/PageHeader'
-import Table from '../Table/Table'
+import Button from '@/js/components/Button/Button'
+import CustomModal from '@/js/components/CustomModal/CustomModal'
+import EllipsisLink from '@/js/components/EllipsisLink/EllipsisLink'
+import ErrorBanner from '@/js/components/ErrorBanner/ErrorBanner'
+import Page from '@/js/components/Page/Page'
+import PageHeader from '@/js/components/PageHeader/PageHeader'
+import Table from '@/js/components/Table/Table'
 
 /**
  * Renders a TemplateList component
@@ -36,6 +37,7 @@ import Table from '../Table/Table'
  * )
  */
 const TemplateList = () => {
+  const { templateType } = useParams()
   const { user } = useAppContext()
   const { token } = user
 
@@ -50,7 +52,7 @@ const TemplateList = () => {
   const { addNotification } = useNotificationsContext()
 
   const fetchTemplates = async () => {
-    const { response, error } = await getTemplates(providerId, token)
+    const { response, error } = await getTemplates(token)
     setErrors(error)
     setTemplateList(response)
     setLoading(false)
@@ -138,6 +140,12 @@ const TemplateList = () => {
       dataAccessorFn: buildEllipsisLinkCell
     },
     {
+      dataKey: 'providerId',
+      title: 'Provider',
+      className: 'col-auto',
+      align: 'center'
+    },
+    {
       dataKey: 'lastModified',
       title: 'Last Modified (UTC)',
       className: 'col-auto',
@@ -150,12 +158,14 @@ const TemplateList = () => {
     }
   ]
 
+  const conceptType = urlValueTypeToConceptTypeMap[templateType]
+
   const templateListHeader = () => (
     <PageHeader
       breadcrumbs={
         [
           {
-            label: 'Templates',
+            label: `${conceptType} Templates`,
             active: true
           }
         ]
@@ -170,7 +180,7 @@ const TemplateList = () => {
           variant: 'success'
         }]
       }
-      title={`${providerId} Template`}
+      title={`${conceptType} Templates`}
     />
   )
 

--- a/static/src/js/components/TemplateList/TemplateList.jsx
+++ b/static/src/js/components/TemplateList/TemplateList.jsx
@@ -9,7 +9,7 @@ import Row from 'react-bootstrap/Row'
 import moment from 'moment'
 import { FaPlus } from 'react-icons/fa'
 
-import urlValueTypeToConceptTypeMap from '@/js/constants/urlValueToConceptTypeMap'
+import urlValueTypeToConceptTypeStringMap from '@/js/constants/urlValueToConceptStringMap'
 import deleteTemplate from '@/js/utils/deleteTemplate'
 import errorLogger from '@/js/utils/errorLogger'
 import getTemplates from '@/js/utils/getTemplates'
@@ -158,7 +158,7 @@ const TemplateList = () => {
     }
   ]
 
-  const conceptType = urlValueTypeToConceptTypeMap[templateType]
+  const conceptType = urlValueTypeToConceptTypeStringMap[templateType]
 
   const templateListHeader = () => (
     <PageHeader

--- a/static/src/js/components/TemplatePreview/TemplatePreview.jsx
+++ b/static/src/js/components/TemplatePreview/TemplatePreview.jsx
@@ -6,27 +6,27 @@ import Row from 'react-bootstrap/Row'
 import validator from '@rjsf/validator-ajv8'
 import camelcaseKeys from 'camelcase-keys'
 import { FaCopy, FaTrash } from 'react-icons/fa'
-
 import { CollectionPreview } from '@edsc/metadata-preview'
-import collectionsTemplateConfiguration from '../../schemas/uiForms/collectionTemplatesConfiguration.'
-import ummCTemplateSchema from '../../schemas/umm/ummCTemplateSchema'
 
-import CustomModal from '../CustomModal/CustomModal'
-import ErrorBanner from '../ErrorBanner/ErrorBanner'
-import Page from '../Page/Page'
-import PageHeader from '../PageHeader/PageHeader'
-import PreviewProgress from '../PreviewProgress/PreviewProgress'
+import collectionsTemplateConfiguration from '@/js/schemas/uiForms/collectionTemplatesConfiguration.'
+import ummCTemplateSchema from '@/js/schemas/umm/ummCTemplateSchema'
 
-import delateTemplate from '../../utils/deleteTemplate'
-import errorLogger from '../../utils/errorLogger'
-import getTemplate from '../../utils/getTemplate'
-import parseError from '../../utils/parseError'
+import delateTemplate from '@/js/utils/deleteTemplate'
+import errorLogger from '@/js/utils/errorLogger'
+import getTemplate from '@/js/utils/getTemplate'
+import parseError from '@/js/utils/parseError'
 
-import useAppContext from '../../hooks/useAppContext'
-import useIngestDraftMutation from '../../hooks/useIngestDraftMutation'
-import useNotificationsContext from '../../hooks/useNotificationsContext'
-import DraftPreviewPlaceholder from '../DraftPreviewPlaceholder/DraftPreviewPlaceholder'
-import MetadataPreviewPlaceholder from '../MetadataPreviewPlaceholder/MetadataPreviewPlaceholder'
+import useAppContext from '@/js/hooks/useAppContext'
+import useIngestDraftMutation from '@/js/hooks/useIngestDraftMutation'
+import useNotificationsContext from '@/js/hooks/useNotificationsContext'
+
+import CustomModal from '@/js/components/CustomModal/CustomModal'
+import DraftPreviewPlaceholder from '@/js/components/DraftPreviewPlaceholder/DraftPreviewPlaceholder'
+import ErrorBanner from '@/js/components/ErrorBanner/ErrorBanner'
+import MetadataPreviewPlaceholder from '@/js/components/MetadataPreviewPlaceholder/MetadataPreviewPlaceholder'
+import Page from '@/js/components/Page/Page'
+import PageHeader from '@/js/components/PageHeader/PageHeader'
+import PreviewProgress from '@/js/components/PreviewProgress/PreviewProgress'
 
 import './TemplatePreview.scss'
 
@@ -65,11 +65,12 @@ const TemplatePreview = () => {
   const { addNotification } = useNotificationsContext()
   const { id } = useParams()
 
-  const { token, providerId } = user
+  const { token } = user
 
-  const [loading, setLoading] = useState()
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState()
   const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [providerId, setProviderId] = useState()
 
   const {
     ingestMutation,
@@ -83,14 +84,14 @@ const TemplatePreview = () => {
   }
 
   useEffect(() => {
-    const fetchTemplates = async () => {
-      const { response, error: fetchTemplateError } = await getTemplate(providerId, token, id)
-
+    const fetchTemplate = async () => {
+      const { response, error: fetchTemplateError } = await getTemplate(token, id)
       if (response) {
-        delete response.pathParameters
+        const { providerId: templateProviderId, template } = response
 
+        setProviderId(templateProviderId)
         setDraft({
-          ummMetadata: { ...response }
+          ummMetadata: { ...template }
         })
       } else {
         setError(fetchTemplateError)
@@ -100,7 +101,7 @@ const TemplatePreview = () => {
     }
 
     setLoading(true)
-    fetchTemplates()
+    fetchTemplate()
   }, [])
 
   const handleCreateCollectionDraft = () => {
@@ -164,6 +165,7 @@ const TemplatePreview = () => {
   const templatePreviewPageHeader = () => (
     <PageHeader
       title={templateName}
+      titleBadge={providerId}
       pageType="secondary"
       breadcrumbs={
         [
@@ -199,7 +201,6 @@ const TemplatePreview = () => {
   )
 
   const pageHeader = templatePreviewPageHeader()
-
   if (loading) {
     return (
       <Page

--- a/static/src/js/components/TemplatePreview/__tests__/TemplatePreview.test.jsx
+++ b/static/src/js/components/TemplatePreview/__tests__/TemplatePreview.test.jsx
@@ -77,16 +77,19 @@ describe('TemplatePreview', () => {
     test('render a template preview', async () => {
       getTemplate.mockReturnValue({
         response: {
-          TemplateName: 'Mock Template',
-          ShortName: 'Template Form Test',
-          Version: '1.0.0'
+          template: {
+            TemplateName: 'Mock Template',
+            ShortName: 'Template Form Test',
+            Version: '1.0.0'
+          },
+          providerId: 'MMT-1'
         }
       })
 
       setup()
       await waitForResponse()
 
-      expect(PreviewProgress).toHaveBeenCalledTimes(2)
+      expect(PreviewProgress).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -249,9 +252,12 @@ describe('TemplatePreview', () => {
     beforeEach(() => {
       getTemplate.mockReturnValue({
         response: {
-          TemplateName: 'Mock Template',
-          ShortName: 'Template Form Test',
-          Version: '1.0.0'
+          template: {
+            TemplateName: 'Mock Template',
+            ShortName: 'Template Form Test',
+            Version: '1.0.0'
+          },
+          providerId: 'MMT_2'
         }
       })
     })

--- a/static/src/js/constants/saveTypes.js
+++ b/static/src/js/constants/saveTypes.js
@@ -3,7 +3,8 @@ const saveTypes = {
   saveAndContinue: 'SAVE_AND_CONTINUE',
   saveAndPreview: 'SAVE_AND_PREVIEW',
   saveAndPublish: 'SAVE_AND_PUBLISH',
-  saveAndCreateDraft: 'SAVE_AND_CREATE_DRAFT'
+  saveAndCreateDraft: 'SAVE_AND_CREATE_DRAFT',
+  submit: 'SUBMIT'
 }
 
 export default saveTypes

--- a/static/src/js/constants/saveTypesToHumanizedStringMap.js
+++ b/static/src/js/constants/saveTypesToHumanizedStringMap.js
@@ -1,0 +1,12 @@
+import saveTypes from '@/js/constants/saveTypes'
+
+const saveTypesToHumanizedStringMap = {
+  [saveTypes.save]: 'Save',
+  [saveTypes.saveAndContinue]: 'Save & Continue',
+  [saveTypes.saveAndCreateDraft]: 'Save & Create Draft',
+  [saveTypes.saveAndPreview]: 'Save & Preview',
+  [saveTypes.saveAndPublish]: 'Save & Publish',
+  [saveTypes.submit]: 'Submit'
+}
+
+export default saveTypesToHumanizedStringMap

--- a/static/src/js/constants/typeParamToHumanizedStringMap.js
+++ b/static/src/js/constants/typeParamToHumanizedStringMap.js
@@ -1,8 +1,8 @@
-const typeParamToHumanizedNameMap = {
+const typeParamToHumanizedStringMap = {
   collections: 'collection',
   services: 'service',
   tools: 'tool',
   variables: 'variable'
 }
 
-export default typeParamToHumanizedNameMap
+export default typeParamToHumanizedStringMap

--- a/static/src/js/constants/urlValueToConceptStringMap.js
+++ b/static/src/js/constants/urlValueToConceptStringMap.js
@@ -1,4 +1,4 @@
-const urlValueTypeToConceptTypeMap = {
+const urlValueTypeToConceptTypeStringMap = {
   variables: 'Variable',
   collections: 'Collection',
   tools: 'Tool',
@@ -6,4 +6,4 @@ const urlValueTypeToConceptTypeMap = {
   cmr: 'CMR'
 }
 
-export default urlValueTypeToConceptTypeMap
+export default urlValueTypeToConceptTypeStringMap

--- a/static/src/js/operations/queries/getCollection.js
+++ b/static/src/js/operations/queries/getCollection.js
@@ -33,35 +33,35 @@ export const GET_COLLECTION = gql`
       publicationReferences
       purpose
       quality
-      # relatedCollections (
-      #   limit: 10
-      # ) {
-      #   count
-      #   items {
-      #     id
-      #     doi
-      #     title
-      #     relationships {
-      #       relationshipType
+      relatedCollections (
+        limit: 10
+      ) {
+        count
+        items {
+          id
+          doi
+          title
+          relationships {
+            relationshipType
 
-      #       ... on GraphDbRelatedUrl {
-      #         description
-      #         subtype
-      #         type
-      #         url
-      #       }
+            ... on GraphDbRelatedUrl {
+              description
+              subtype
+              type
+              url
+            }
 
-      #       ... on GraphDbProject {
-      #         name
-      #       }
+            ... on GraphDbProject {
+              name
+            }
 
-      #       ... on GraphDbPlatformInstrument {
-      #         instrument
-      #         platform
-      #       }
-      #     }
-      #   }
-      # }
+            ... on GraphDbPlatformInstrument {
+              instrument
+              platform
+            }
+          }
+        }
+      }
       relatedUrls
       revisionDate
       revisionId

--- a/static/src/js/operations/queries/getCollection.js
+++ b/static/src/js/operations/queries/getCollection.js
@@ -33,35 +33,35 @@ export const GET_COLLECTION = gql`
       publicationReferences
       purpose
       quality
-      relatedCollections (
-        limit: 10
-      ) {
-        count
-        items {
-          id
-          doi
-          title
-          relationships {
-            relationshipType
+      # relatedCollections (
+      #   limit: 10
+      # ) {
+      #   count
+      #   items {
+      #     id
+      #     doi
+      #     title
+      #     relationships {
+      #       relationshipType
 
-            ... on GraphDbRelatedUrl {
-              description
-              subtype
-              type
-              url
-            }
+      #       ... on GraphDbRelatedUrl {
+      #         description
+      #         subtype
+      #         type
+      #         url
+      #       }
 
-            ... on GraphDbProject {
-              name
-            }
+      #       ... on GraphDbProject {
+      #         name
+      #       }
 
-            ... on GraphDbPlatformInstrument {
-              instrument
-              platform
-            }
-          }
-        }
-      }
+      #       ... on GraphDbPlatformInstrument {
+      #         instrument
+      #         platform
+      #       }
+      #     }
+      #   }
+      # }
       relatedUrls
       revisionDate
       revisionId

--- a/static/src/js/operations/queries/getCollectionDrafts.js
+++ b/static/src/js/operations/queries/getCollectionDrafts.js
@@ -6,6 +6,7 @@ export const GET_COLLECTION_DRAFTS = gql`
     drafts(params: $params) {
       count
       items {
+        providerId
         conceptId
         revisionDate
         ummMetadata

--- a/static/src/js/operations/queries/getOrderOptions.js
+++ b/static/src/js/operations/queries/getOrderOptions.js
@@ -5,12 +5,13 @@ export const GET_ORDER_OPTIONS = gql`
     orderOptions(params: $params) {
       count
       items {
-        description,
+        description
         deprecated
         conceptId
         name
         form
         nativeId
+        providerId
         scope
         sortKey
         associationDetails

--- a/static/src/js/operations/queries/getServiceDrafts.js
+++ b/static/src/js/operations/queries/getServiceDrafts.js
@@ -7,6 +7,7 @@ export const GET_SERVICE_DRAFTS = gql`
       count
       items {
         conceptId
+        providerId
         revisionDate
         ummMetadata
         previewMetadata {

--- a/static/src/js/operations/queries/getToolDrafts.js
+++ b/static/src/js/operations/queries/getToolDrafts.js
@@ -7,6 +7,7 @@ export const GET_TOOL_DRAFTS = gql`
       count
       items {
         conceptId
+        providerId
         revisionDate
         ummMetadata
         previewMetadata {

--- a/static/src/js/operations/queries/getVariableDrafts.js
+++ b/static/src/js/operations/queries/getVariableDrafts.js
@@ -7,6 +7,7 @@ export const GET_VARIABLE_DRAFTS = gql`
       count
       items {
         conceptId
+        providerId
         revisionDate
         ummMetadata
         previewMetadata {

--- a/static/src/js/pages/DraftListPage/DraftListPage.jsx
+++ b/static/src/js/pages/DraftListPage/DraftListPage.jsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react'
 import { useParams } from 'react-router'
 import { FaPlus } from 'react-icons/fa'
 
-import urlValueTypeToConceptTypeMap from '@/js/constants/urlValueToConceptTypeMap'
+import urlValueTypeToConceptTypeStringMap from '@/js/constants/urlValueToConceptStringMap'
 
 import DraftList from '@/js/components/DraftList/DraftList'
 import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
@@ -22,7 +22,7 @@ import PageHeader from '@/js/components/PageHeader/PageHeader'
 const DraftListPageHeader = () => {
   const { draftType } = useParams()
 
-  const conceptType = urlValueTypeToConceptTypeMap[draftType]
+  const conceptType = urlValueTypeToConceptTypeStringMap[draftType]
 
   return (
     <PageHeader

--- a/static/src/js/pages/DraftListPage/DraftListPage.jsx
+++ b/static/src/js/pages/DraftListPage/DraftListPage.jsx
@@ -1,16 +1,14 @@
 import React, { Suspense } from 'react'
-
+import { useParams } from 'react-router'
 import { FaPlus } from 'react-icons/fa'
 
-import { useParams } from 'react-router'
-import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary'
-import LoadingTable from '../../components/LoadingTable/LoadingTable'
-import DraftList from '../../components/DraftList/DraftList'
-import Page from '../../components/Page/Page'
-import PageHeader from '../../components/PageHeader/PageHeader'
+import urlValueTypeToConceptTypeMap from '@/js/constants/urlValueToConceptTypeMap'
 
-import useAppContext from '../../hooks/useAppContext'
-import urlValueTypeToConceptTypeMap from '../../constants/urlValueToConceptTypeMap'
+import DraftList from '@/js/components/DraftList/DraftList'
+import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+import LoadingTable from '@/js/components/LoadingTable/LoadingTable'
+import Page from '@/js/components/Page/Page'
+import PageHeader from '@/js/components/PageHeader/PageHeader'
 
 /**
  * Renders a DraftPageHeader component
@@ -24,14 +22,11 @@ import urlValueTypeToConceptTypeMap from '../../constants/urlValueToConceptTypeM
 const DraftListPageHeader = () => {
   const { draftType } = useParams()
 
-  const { user } = useAppContext()
-  const { providerId } = user
-
   const conceptType = urlValueTypeToConceptTypeMap[draftType]
 
   return (
     <PageHeader
-      title={`${providerId} ${conceptType} Drafts`}
+      title={`${conceptType} Drafts`}
       breadcrumbs={
         [
           {

--- a/static/src/js/pages/DraftListPage/__tests__/DraftListPage.test.jsx
+++ b/static/src/js/pages/DraftListPage/__tests__/DraftListPage.test.jsx
@@ -4,7 +4,11 @@ import {
   Route,
   Routes
 } from 'react-router-dom'
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen,
+  within
+} from '@testing-library/react'
 import AppContext from '../../../context/AppContext'
 import DraftListPage from '../DraftListPage'
 import ErrorBoundary from '../../../components/ErrorBoundary/ErrorBoundary'
@@ -61,7 +65,8 @@ describe('DraftListPage', () => {
 
       expect(screen.getByText('New Draft')).toBeInTheDocument()
       expect(screen.getByText('A plus icon')).toBeInTheDocument()
-      expect(screen.getByText('MMT_2 Tool Drafts')).toBeInTheDocument()
+      expect(within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByText('Tool Drafts')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Tool Drafts' })).toBeInTheDocument()
     })
   })
 })

--- a/static/src/js/pages/DraftPage/DraftPage.jsx
+++ b/static/src/js/pages/DraftPage/DraftPage.jsx
@@ -13,26 +13,26 @@ import {
   FaTrash
 } from 'react-icons/fa'
 
-import CustomModal from '../../components/CustomModal/CustomModal'
-import DraftPreview from '../../components/DraftPreview/DraftPreview'
-import DraftPreviewPlaceholder from '../../components/DraftPreviewPlaceholder/DraftPreviewPlaceholder'
-import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary'
-import MetadataPreviewPlaceholder from '../../components/MetadataPreviewPlaceholder/MetadataPreviewPlaceholder'
-import Page from '../../components/Page/Page'
-import PageHeader from '../../components/PageHeader/PageHeader'
+import getConceptTypeByDraftConceptId from '@/js/utils/getConceptTypeByDraftConceptId'
+import createTemplate from '@/js/utils/createTemplate'
+import errorLogger from '@/js/utils/errorLogger'
 
-import getConceptTypeByDraftConceptId from '../../utils/getConceptTypeByDraftConceptId'
-import createTemplate from '../../utils/createTemplate'
-import errorLogger from '../../utils/errorLogger'
+import useNotificationsContext from '@/js/hooks/useNotificationsContext'
+import usePublishMutation from '@/js/hooks/usePublishMutation'
+import useAppContext from '@/js/hooks/useAppContext'
 
-import useNotificationsContext from '../../hooks/useNotificationsContext'
-import usePublishMutation from '../../hooks/usePublishMutation'
-import useAppContext from '../../hooks/useAppContext'
+import conceptTypeDraftQueries from '@/js/constants/conceptTypeDraftQueries'
+import conceptTypes from '@/js/constants/conceptTypes'
 
-import conceptTypeDraftQueries from '../../constants/conceptTypeDraftQueries'
-import conceptTypes from '../../constants/conceptTypes'
+import { DELETE_DRAFT } from '@/js/operations/mutations/deleteDraft'
 
-import { DELETE_DRAFT } from '../../operations/mutations/deleteDraft'
+import CustomModal from '@/js/components/CustomModal/CustomModal'
+import DraftPreview from '@/js/components/DraftPreview/DraftPreview'
+import DraftPreviewPlaceholder from '@/js/components/DraftPreviewPlaceholder/DraftPreviewPlaceholder'
+import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+import MetadataPreviewPlaceholder from '@/js/components/MetadataPreviewPlaceholder/MetadataPreviewPlaceholder'
+import Page from '@/js/components/Page/Page'
+import PageHeader from '@/js/components/PageHeader/PageHeader'
 
 /**
  * Renders a DraftPageHeader component
@@ -169,7 +169,8 @@ const DraftPageHeader = () => {
   return (
     <>
       <PageHeader
-        title={data?.draft?.pageTitle || '<Blank Name>'}
+        title={data?.draft?.previewMetadata?.pageTitle || '<Blank Name>'}
+        titleBadge={providerId}
         pageType="secondary"
         breadcrumbs={
           [
@@ -178,7 +179,7 @@ const DraftPageHeader = () => {
               to: `/drafts/${derivedConceptType.toLowerCase()}s`
             },
             {
-              label: data?.draft?.pageTitle || '<Blank Name>',
+              label: data?.draft?.previewMetadata?.pageTitle || '<Blank Name>',
               active: true
             }
           ]

--- a/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
+++ b/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
@@ -153,6 +153,15 @@ describe('DraftPreview', () => {
     expect(breadcrumbTwo).toHaveClass('active')
   })
 
+  test('renders the provider id in a badge', async () => {
+    setup({})
+
+    await waitForResponse()
+
+    expect(screen.getByText('MMT_2')).toBeInTheDocument()
+    expect(screen.getByText('MMT_2')).toHaveClass('badge')
+  })
+
   describe('when clicking the Delete button', () => {
     test('shows the DeleteDraftModal', async () => {
       const { user } = setup({})

--- a/static/src/js/pages/GroupFormPage/GroupFormPage.jsx
+++ b/static/src/js/pages/GroupFormPage/GroupFormPage.jsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types'
 import { useParams } from 'react-router'
 import { useSuspenseQuery } from '@apollo/client'
 
+import { GET_GROUP } from '@/js/operations/queries/getGroup'
+
 import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
 import GroupForm from '@/js/components/GroupForm/GroupForm'
 import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
-
-import { GET_GROUP } from '@/js/operations/queries/getGroup'
 
 /**
  * Renders a GroupFormPageHeader component
@@ -32,7 +32,7 @@ const GroupFormPageHeader = ({ isAdminPage }) => {
   })
 
   const { group } = data || {}
-  const { name } = group || {}
+  const { name, tag: providerId } = group || {}
 
   const newTitle = `New ${isAdminPage ? 'System ' : ''}Group`
   const pageTitle = id === 'new' ? newTitle : `Edit ${name}`
@@ -41,6 +41,7 @@ const GroupFormPageHeader = ({ isAdminPage }) => {
   return (
     <PageHeader
       title={pageTitle}
+      titleBadge={providerId}
       breadcrumbs={
         [
           {

--- a/static/src/js/pages/GroupFormPage/__tests__/GroupFormPage.test.jsx
+++ b/static/src/js/pages/GroupFormPage/__tests__/GroupFormPage.test.jsx
@@ -199,4 +199,36 @@ describe('GroupFormPage', () => {
       expect(screen.getByRole('heading', { value: 'Edit Test Name' })).toBeInTheDocument()
     })
   })
+
+  describe('when showing the header for a system group with name', () => {
+    test('show render the header with name', async () => {
+      setup({
+        pageUrl: '/admin/groups/dce1859e-774c-4561-9451-fc9d77906015/edit',
+        mocks: [{
+          request: {
+            query: GET_GROUP,
+            variables: { params: { id: 'dce1859e-774c-4561-9451-fc9d77906015' } }
+          },
+          result: {
+            data: {
+              group: {
+                id: 'dce1859e-774c-4561-9451-fc9d77906015',
+                description: 'Test Description',
+                name: 'Test Name',
+                members: {
+                  count: 0,
+                  items: []
+                },
+                tag: 'CMR'
+              }
+            }
+          }
+        }]
+      })
+
+      await waitForResponse()
+
+      expect(screen.getByText('CMR')).toBeInTheDocument()
+    })
+  })
 })

--- a/static/src/js/pages/GroupListPage/GroupListPage.jsx
+++ b/static/src/js/pages/GroupListPage/GroupListPage.jsx
@@ -32,7 +32,8 @@ const GroupListPageHeader = ({ isAdminPage }) => {
         [
           {
             label: title,
-            to: `${isAdminPage ? '/admin' : ''}/groups`
+            to: `${isAdminPage ? '/admin' : ''}/groups`,
+            active: true
           }
         ]
       }

--- a/static/src/js/pages/GroupPage/GroupPage.jsx
+++ b/static/src/js/pages/GroupPage/GroupPage.jsx
@@ -70,7 +70,7 @@ const GroupPageHeader = ({ isAdminPage }) => {
   }
 
   const { group = {} } = data
-  const { members, name } = group
+  const { members, name, tag: providerId } = group
   const { count } = members
 
   const handleDelete = () => {
@@ -105,6 +105,7 @@ const GroupPageHeader = ({ isAdminPage }) => {
     <>
       <PageHeader
         title={name}
+        titleBadge={providerId}
         breadcrumbs={
           [
             {

--- a/static/src/js/pages/GroupPage/GroupPage.jsx
+++ b/static/src/js/pages/GroupPage/GroupPage.jsx
@@ -70,7 +70,11 @@ const GroupPageHeader = ({ isAdminPage }) => {
   }
 
   const { group = {} } = data
-  const { members, name, tag: providerId } = group
+  const {
+    members,
+    name,
+    tag: providerId
+  } = group
   const { count } = members
 
   const handleDelete = () => {

--- a/static/src/js/pages/GroupPage/__tests__/GroupPage.test.jsx
+++ b/static/src/js/pages/GroupPage/__tests__/GroupPage.test.jsx
@@ -141,6 +141,7 @@ describe('GroupPage', () => {
       await waitForResponse()
 
       expect(screen.queryByText('Groups')).toBeInTheDocument()
+      expect(screen.queryByText('MMT_2')).toBeInTheDocument()
       expect(screen.getByRole('heading', { value: 'Mock group' })).toBeInTheDocument()
     })
   })

--- a/static/src/js/pages/MetadataFormPage/MetadataFormPage.jsx
+++ b/static/src/js/pages/MetadataFormPage/MetadataFormPage.jsx
@@ -6,13 +6,13 @@ import Col from 'react-bootstrap/Col'
 import Placeholder from 'react-bootstrap/Placeholder'
 import Row from 'react-bootstrap/Row'
 
-import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary'
-import MetadataForm from '../../components/MetadataForm/MetadataForm'
-import Page from '../../components/Page/Page'
-import PageHeader from '../../components/PageHeader/PageHeader'
-import getConceptTypeByDraftConceptId from '../../utils/getConceptTypeByDraftConceptId'
-import urlValueTypeToConceptTypeMap from '../../constants/urlValueToConceptTypeMap'
-import conceptTypeDraftQueries from '../../constants/conceptTypeDraftQueries'
+import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+import MetadataForm from '@/js/components/MetadataForm/MetadataForm'
+import Page from '@/js/components/Page/Page'
+import PageHeader from '@/js/components/PageHeader/PageHeader'
+import getConceptTypeByDraftConceptId from '@/js/utils/getConceptTypeByDraftConceptId'
+import urlValueTypeToConceptTypeMap from '@/js/constants/urlValueToConceptTypeMap'
+import conceptTypeDraftQueries from '@/js/constants/conceptTypeDraftQueries'
 
 /**
  * Renders a MetadataFormPageHeader component

--- a/static/src/js/pages/MetadataFormPage/MetadataFormPage.jsx
+++ b/static/src/js/pages/MetadataFormPage/MetadataFormPage.jsx
@@ -11,7 +11,7 @@ import MetadataForm from '@/js/components/MetadataForm/MetadataForm'
 import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
 import getConceptTypeByDraftConceptId from '@/js/utils/getConceptTypeByDraftConceptId'
-import urlValueTypeToConceptTypeMap from '@/js/constants/urlValueToConceptTypeMap'
+import urlValueTypeToConceptTypeStringMap from '@/js/constants/urlValueToConceptStringMap'
 import conceptTypeDraftQueries from '@/js/constants/conceptTypeDraftQueries'
 
 /**
@@ -31,7 +31,7 @@ const MetadataFormPageHeader = () => {
   if (conceptId !== 'new') {
     derivedConceptType = getConceptTypeByDraftConceptId(conceptId)
   } else {
-    derivedConceptType = urlValueTypeToConceptTypeMap[draftType]
+    derivedConceptType = urlValueTypeToConceptTypeStringMap[draftType]
   }
 
   const { data = {} } = useSuspenseQuery(conceptTypeDraftQueries[derivedConceptType], {

--- a/static/src/js/pages/OrderOptionListPage/OrderOptionListPage.jsx
+++ b/static/src/js/pages/OrderOptionListPage/OrderOptionListPage.jsx
@@ -2,13 +2,11 @@ import React, { Suspense } from 'react'
 
 import { FaPlus } from 'react-icons/fa'
 
-import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary'
-import LoadingTable from '../../components/LoadingTable/LoadingTable'
-import OrderOptionList from '../../components/OrderOptionList/OrderOptionList'
-import Page from '../../components/Page/Page'
-import PageHeader from '../../components/PageHeader/PageHeader'
-
-import useAppContext from '../../hooks/useAppContext'
+import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+import LoadingTable from '@/js/components/LoadingTable/LoadingTable'
+import OrderOptionList from '@/js/components/OrderOptionList/OrderOptionList'
+import Page from '@/js/components/Page/Page'
+import PageHeader from '@/js/components/PageHeader/PageHeader'
 
 /**
  * Renders a OrderOptionPageHeader component
@@ -19,34 +17,29 @@ import useAppContext from '../../hooks/useAppContext'
  *   <OrderOptionPageHeader />
  * )
  */
-const OrderOptionListPageHeader = () => {
-  const { user } = useAppContext()
-  const { providerId } = user
-
-  return (
-    <PageHeader
-      breadcrumbs={
-        [
-          {
-            label: 'Order Options',
-            to: '/order-options'
-          }
-        ]
-      }
-      pageType="secondary"
-      primaryActions={
-        [{
-          icon: FaPlus,
-          iconTitle: 'A plus icon',
-          title: 'New Order Option',
-          to: 'new',
-          variant: 'success'
-        }]
-      }
-      title={`${providerId} Order Options`}
-    />
-  )
-}
+const OrderOptionListPageHeader = () => (
+  <PageHeader
+    breadcrumbs={
+      [
+        {
+          label: 'Order Options',
+          to: '/order-options'
+        }
+      ]
+    }
+    pageType="secondary"
+    primaryActions={
+      [{
+        icon: FaPlus,
+        iconTitle: 'A plus icon',
+        title: 'New Order Option',
+        to: 'new',
+        variant: 'success'
+      }]
+    }
+    title="Order Options"
+  />
+)
 
 /**
  * Renders a OrderOptionListPage component

--- a/static/src/js/pages/OrderOptionListPage/__tests__/OrderOptionListPage.test.jsx
+++ b/static/src/js/pages/OrderOptionListPage/__tests__/OrderOptionListPage.test.jsx
@@ -31,7 +31,8 @@ describe('OrderOptionListPage', () => {
     test('render the page and calls OrderOptionList', async () => {
       setup()
 
-      expect(screen.getByText('MMT_2 Order Options')).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Order Options' })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Order Options' })).toBeInTheDocument()
       expect(OrderOptionList).toHaveBeenCalled(1)
     })
   })

--- a/static/src/js/pages/OrderOptionPage/OrderOptionPage.jsx
+++ b/static/src/js/pages/OrderOptionPage/OrderOptionPage.jsx
@@ -18,18 +18,18 @@ import { DELETE_ORDER_OPTION } from '@/js/operations/mutations/deleteOrderOption
 import { GET_ORDER_OPTION } from '@/js/operations/queries/getOrderOption'
 import { GET_ORDER_OPTIONS } from '@/js/operations/queries/getOrderOptions'
 
-import CustomModal from '@/js/components/CustomModal/CustomModal'
-import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
-import OrderOption from '@/js/components/OrderOption/OrderOption'
-import Page from '@/js/components/Page/Page'
-import PageHeader from '@/js/components/PageHeader/PageHeader'
-
 import useAppContext from '@/js/hooks/useAppContext'
 import useNotificationsContext from '@/js/hooks/useNotificationsContext'
 
 import errorLogger from '@/js/utils/errorLogger'
 import getConceptTypeByConceptId from '@/js/utils/getConceptTypeByConceptId'
 import toKebabCase from '@/js/utils/toKebabCase'
+
+import CustomModal from '@/js/components/CustomModal/CustomModal'
+import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+import OrderOption from '@/js/components/OrderOption/OrderOption'
+import Page from '@/js/components/Page/Page'
+import PageHeader from '@/js/components/PageHeader/PageHeader'
 
 /**
  * Renders a OrderOptionPageHeader component
@@ -123,6 +123,7 @@ const OrderOptionPageHeader = () => {
           ]
         }
         title={name}
+        titleBadge={providerId}
         breadcrumbs={
           [
             {

--- a/static/src/js/pages/OrderOptionPage/__tests__/OrderOptionPage.test.jsx
+++ b/static/src/js/pages/OrderOptionPage/__tests__/OrderOptionPage.test.jsx
@@ -119,6 +119,7 @@ describe('OrderOptionPage', () => {
       await waitForResponse()
 
       expect(screen.queryByText('Order Options')).toBeInTheDocument()
+      expect(screen.queryByText('MMT_2')).toBeInTheDocument()
       expect(screen.queryByText('Mock form')).toBeInTheDocument()
     })
   })

--- a/static/src/js/pages/SearchList/SearchList.jsx
+++ b/static/src/js/pages/SearchList/SearchList.jsx
@@ -28,7 +28,7 @@ import EllipsisText from '../../components/EllipsisText/EllipsisText'
 import EllipsisLink from '../../components/EllipsisLink/EllipsisLink'
 import getTagCount from '../../utils/getTagCount'
 import ControlledPaginatedContent from '../../components/ControlledPaginatedContent/ControlledPaginatedContent'
-import typeParamToHumanizedNameMap from '../../constants/typeParamToHumanizedNameMap'
+import typeParamToHumanizedStringMap from '../../constants/typeParamToHumanizedStringMap'
 import conceptTypeQueries from '../../constants/conceptTypeQueries'
 import { DATE_FORMAT } from '../../constants/dateFormat'
 
@@ -54,7 +54,7 @@ const SearchList = ({ limit }) => {
   const activePage = parseInt(searchParams.get('page'), 10) || 1
   const offset = (activePage - 1) * limit
 
-  if (!typeParamToHumanizedNameMap[conceptType]) {
+  if (!typeParamToHumanizedStringMap[conceptType]) {
     return (
       <Navigate to="/404" replace />
     )

--- a/static/src/js/utils/createTemplate.js
+++ b/static/src/js/utils/createTemplate.js
@@ -16,9 +16,6 @@ const createTemplate = async (providerId, token, ummMetadata) => {
       Authorization: `Bearer ${tokenValue}`
     },
     body: JSON.stringify({
-      pathParameters: {
-        providerId
-      },
       ...ummMetadata
     })
   })

--- a/static/src/js/utils/getHumanizedNameFromTypeParam.js
+++ b/static/src/js/utils/getHumanizedNameFromTypeParam.js
@@ -1,4 +1,4 @@
-import typeParamToHumanizedNameMap from '../constants/typeParamToHumanizedNameMap'
+import typeParamToHumanizedStringMap from '../constants/typeParamToHumanizedStringMap'
 
 /**
  * Takes a type from the url and returns a humanized singular or plural version
@@ -7,7 +7,7 @@ import typeParamToHumanizedNameMap from '../constants/typeParamToHumanizedNameMa
  */
 
 const getHumanizedNameFromTypeParam = (type, plural) => {
-  const humanizedName = typeParamToHumanizedNameMap[type]
+  const humanizedName = typeParamToHumanizedStringMap[type]
 
   return plural ? `${humanizedName}s` : humanizedName
 }

--- a/static/src/js/utils/getTemplate.js
+++ b/static/src/js/utils/getTemplate.js
@@ -6,12 +6,12 @@ import { getApplicationConfig } from '../../../../sharedUtils/getConfig'
  * @param {Object} token A users token
  * @param {string} id An id for a collection template
  */
-const getTemplate = async (providerId, token, id) => {
+const getTemplate = async (token, id) => {
   const { apiHost } = getApplicationConfig()
   const { tokenValue } = token
 
   try {
-    const response = await fetch(`${apiHost}/providers/${providerId}/templates/${id}`, {
+    const response = await fetch(`${apiHost}/templates/${id}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${tokenValue}`

--- a/static/src/js/utils/getTemplates.js
+++ b/static/src/js/utils/getTemplates.js
@@ -1,17 +1,15 @@
 import { getApplicationConfig } from '../../../../sharedUtils/getConfig'
 
 /**
- * Calls /providers/{providerId}/templates lambda to get list of templates
- * for a given provider
- * @param {string} providerId A provider id that a given user is using
+ * Calls /templates lambda to get list of all templates
  * @param {Object} token A users token
  */
-const getTemplates = async (providerId, token) => {
+const getTemplates = async (token) => {
   const { apiHost } = getApplicationConfig()
   const { tokenValue } = token
 
   try {
-    const response = await fetch(`${apiHost}/providers/${providerId}/templates`, {
+    const response = await fetch(`${apiHost}/templates`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${tokenValue}`

--- a/static/src/js/utils/updateTemplate.js
+++ b/static/src/js/utils/updateTemplate.js
@@ -18,9 +18,6 @@ const updateTemplate = async (providerId, token, ummMetadata, id) => {
         Authorization: `Bearer ${tokenValue}`
       },
       body: JSON.stringify({
-        pathParameters: {
-          providerId
-        },
         ...ummMetadata
       })
     })


### PR DESCRIPTION
# Overview

### What is the feature?

Removes the global provider context selection.

### What is the Solution?

Remove the global provider context selection and add a modal to select providers before creating new concepts.

### What areas of the application does this impact?

- The menu was removed from the header
- A modal was created to select providers when creating new concepts.
- The index pages for each concept type was modified to remove the provider
  - Provider id was added as a column for types where it was not included
- The provider id was added to the edit and show pages for the different types

# Testing

### Reproduction steps

- **Environment for testing:** N/A
- **Collection to test with:** N/A

1. Confirm all concepts require the user to select a provider id
2. Confirm the provider id is listed in all list pages
3. Confirm the provider id is listed on all show pages
4. Confirm the last provider the user selected is chosen by default when the modal opens

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings