### PR TITLE
MMT-3529: As a user, I can view all collection permissions

### DIFF
--- a/static/src/js/components/PermissionList/PermissionList.jsx
+++ b/static/src/js/components/PermissionList/PermissionList.jsx
@@ -30,10 +30,15 @@ const PermissionList = () => {
   const { count, items } = acls
 
   const permissionList = items.map((item) => {
-    const { catalogItemIdentity, name } = item
+    const {
+      catalogItemIdentity,
+      conceptId,
+      name
+    } = item
     const { providerId } = catalogItemIdentity
 
     return {
+      conceptId,
       name,
       providerId
     }


### PR DESCRIPTION
# Overview

When testing collection permission in SIT, noticed that clicking on a permission was navigating /undefined

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings