### PR TITLE
MMT-3741: Updates to gems and node modules.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "3.0.6"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 # We have not investigated the cost of moving to rails 6, but expect it to make
 # more breaking changes.  Rails 5 is still supported.
-gem 'rails', '~> 6.1'
+gem 'rails', '~> 6.1.7.7'
 # Rails currently limits all of the action*/active* gems
 # activesupport limits tzinfo
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
+    base64 (0.2.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
@@ -221,27 +222,27 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.3)
+    marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.6)
-    minitest (5.22.3)
+    minitest (5.23.1)
     momentjs-rails (2.29.4.1)
       railties (>= 3.1)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
-    net-imap (0.4.10)
+    net-imap (0.4.11)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0.1)
+    net-smtp (0.5.0)
       net-protocol
-    nio4r (2.7.0)
+    nio4r (2.7.3)
     nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -259,7 +260,7 @@ GEM
     public_suffix (5.0.1)
     pundit (2.3.0)
       activesupport (>= 3.0.0)
-    racc (1.7.3)
+    racc (1.8.0)
     rack (2.2.9)
     rack-proxy (0.7.6)
       rack
@@ -311,7 +312,8 @@ GEM
       railties (>= 3.2)
       tilt
     regexp_parser (2.8.0)
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rouge (4.2.1)
     rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
@@ -376,7 +378,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sprockets (3.7.2)
+    sprockets (3.7.3)
+      base64
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)
@@ -387,6 +390,7 @@ GEM
       mini_portile2 (~> 2.8.0)
     sqlite3 (1.6.1-arm64-darwin)
     sqlite3 (1.6.1-x86_64-darwin)
+    strscan (3.1.0)
     tdiff (0.3.4)
     thor (1.3.1)
     tilt (2.1.0)
@@ -418,7 +422,7 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.13)
+    zeitwerk (2.6.15)
 
 PLATFORMS
   arm64-darwin-21
@@ -465,7 +469,7 @@ DEPENDENCIES
   pg (< 1.3)
   pundit
   rack_session_access
-  rails (~> 6.1)
+  rails (~> 6.1.7.7)
   rails-controller-testing
   react-rails (= 2.6)
   rspec-rails

--- a/package.json
+++ b/package.json
@@ -138,7 +138,9 @@
     "shakapacker": "^6.5.0",
     "typescript": "^4.7.4",
     "webpack-dev-server": "^4.11.1",
-    "serialize-javascript": "^6.0.2"
+    "serialize-javascript": "^6.0.2",
+    "braces": "^3.0.3",
+    "micromatch":"^4.0.6"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
# Overview

### What is the feature?

Update package.json and Gemfile to fix vulnerabilities.

### What is the Solution?

Rails side:
Updated to the latest 6.1 minor version of rails (6.1.7.7)
Did not update "rack", upgrade path is beta, so since medium vulnerability, will wait on this one.
Updated rexml gem to the latest version.
actionable means going to rails 7, also medium vulnerability so not updating.

React side:
Upgraded braces and micro match to their respective patch versions.

### What areas of the application does this impact?

Rails MMT

# Testing

yarn audit should be clean
bundle-audit check --update should be clean

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings