### PR TITLE
MMT-3631: Fixes cache of available providers

### DIFF
--- a/static/src/js/components/AuthRequiredLayout/AuthRequiredLayout.jsx
+++ b/static/src/js/components/AuthRequiredLayout/AuthRequiredLayout.jsx
@@ -22,7 +22,6 @@ const AuthRequiredLayout = () => {
   }
 
   const isExpired = isTokenExpired(tokenExpires)
-  console.log('🚀 ~ AuthRequiredLayout ~ isExpired:', isExpired)
 
   // If we have a token value that has expired, redirect to login the user again
   if (isExpired) {

--- a/static/src/js/operations/queries/getAvailableProviders.js
+++ b/static/src/js/operations/queries/getAvailableProviders.js
@@ -5,6 +5,7 @@ export const GET_AVAILABLE_PROVIDERS = gql`
   query GetAvailableProviders($params: AclsInput) {
     acls(params: $params) {
       items {
+        conceptId
         providerIdentity
       }
     }


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes the GraphQLProvider cache keys for the getAvailableProviders query, by requesting the conceptId of the acl to be returned

### What areas of the application does this impact?

/providers page, ChooseProviderModal

# Testing

Navigate to /providers, ensure that the same provider isn't listed for every list item

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings