### PR TITLE
MMT-3639: Rearrange useConstraints fields to be easier to use

### DIFF
--- a/static/src/js/components/FormNavigation/FormNavigation.jsx
+++ b/static/src/js/components/FormNavigation/FormNavigation.jsx
@@ -226,8 +226,7 @@ FormNavigation.propTypes = {
   onCancel: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
   schema: PropTypes.shape({}).isRequired,
-  setFocusField: PropTypes.func.isRequired,
-  uiSchema: PropTypes.shape({}).isRequired
+  setFocusField: PropTypes.func.isRequired
 }
 
 export default FormNavigation

--- a/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
+++ b/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
@@ -41,9 +41,6 @@ const setup = ({
     onSave: vi.fn(),
     schema: {},
     setFocusField: vi.fn(),
-    uiSchema: {
-      'section-1': {}
-    },
     validationErrors: [],
     visitedFields: [],
     ...overrideProps

--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -323,15 +323,13 @@ const MetadataForm = () => {
           <div className="metadata-form__navigation sticky-top p-0 ps-md-3 ps-lg-5 top-0 pt-md-3">
             <FormNavigation
               draft={ummMetadata}
-              fullSchema={schema}
               formSections={formSections}
               loading={ingestDraftLoading}
-              visitedFields={visitedFields}
-              onSave={handleSave}
               onCancel={handleCancel}
+              onSave={handleSave}
               schema={schema}
               setFocusField={setFocusField}
-              uiSchema={uiSchema}
+              visitedFields={visitedFields}
             />
           </div>
         </Col>

--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -93,13 +93,14 @@ const MetadataForm = () => {
   const [visitedFields, setVisitedFields] = useState([])
   const [focusField, setFocusField] = useState(null)
 
+  // On load, set the focused field and redirect if a field name was present
   useEffect(() => {
     // If fieldName was pulled from the URL, set it to the focusField
     if (fieldName) setFocusField(fieldName)
 
     // If a fieldName was pulled from the URL, then remove it from the URL. This will happen after the field is focused.
     if (fieldName && sectionName) navigate(`/drafts/${draftType}/${conceptId}/${sectionName}`, { replace: true })
-  }, []) // Should only do this redirect on page load
+  }, [])
 
   const [ingestDraftMutation, {
     loading: ingestDraftLoading

--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -80,8 +80,7 @@ const MetadataForm = () => {
   const {
     publishMutation,
     publishDraft,
-    error: publishDraftError,
-    loading: publishDraftLoading = true
+    error: publishDraftError
   } = usePublishMutation()
 
   useEffect(() => {
@@ -96,11 +95,11 @@ const MetadataForm = () => {
 
   useEffect(() => {
     // If fieldName was pulled from the URL, set it to the focusField
-    setFocusField(fieldName)
+    if (fieldName) setFocusField(fieldName)
 
     // If a fieldName was pulled from the URL, then remove it from the URL. This will happen after the field is focused.
     if (fieldName && sectionName) navigate(`/drafts/${draftType}/${conceptId}/${sectionName}`, { replace: true })
-  }, [fieldName])
+  }, []) // Should only do this redirect on page load
 
   const [ingestDraftMutation, {
     loading: ingestDraftLoading
@@ -276,7 +275,7 @@ const MetadataForm = () => {
 
       errorLogger(message, 'PublishMutation: publishMutation')
     }
-  }, [publishDraftLoading, publishDraftError])
+  }, [publishDraft, publishDraftError])
 
   // Handle the cancel button. Reset the form to the last time we fetched the draft from CMR
   const handleCancel = () => {

--- a/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
+++ b/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
@@ -429,9 +429,7 @@ describe('MetadataForm', () => {
       // Fill out a form field
       const nameField = screen.getByRole('textbox', { id: 'Name' })
       await user.type(nameField, 'Test Name')
-      await waitFor(async () => {
-        await nameField.blur()
-      })
+      await user.tab()
 
       expect(nameField).toHaveValue('Test Name')
       expect(FormNavigation).toHaveBeenCalledTimes(13)

--- a/static/src/js/components/TemplateForm/TemplateForm.jsx
+++ b/static/src/js/components/TemplateForm/TemplateForm.jsx
@@ -122,15 +122,16 @@ const TemplateForm = () => {
     formName: currentSection
   })
 
+  // On load, set the focused field and redirect if a field name was present
   useEffect(() => {
     // If fieldName was pulled from the URL, set it to the focusField
     if (fieldName) setFocusField(fieldName)
 
     // If a fieldName was pulled from the URL, then remove it from the URL. This will happen after the field is focused.
     if (fieldName && sectionName) navigate(`/templates/collections/${id}/${sectionName}`, { replace: true })
-  }, []) // Should only do this redirect on page load
+  }, [])
 
-  // Fetching collection template if ID is present and draft is not loaded
+  // On load, fetching collection template if ID is present and draft is not loaded
   useEffect(() => {
     const fetchTemplate = async () => {
       const { response, error: fetchTemplateError } = await getTemplate(mmtJwt, id)
@@ -155,7 +156,7 @@ const TemplateForm = () => {
       setLoading(true)
       fetchTemplate()
     }
-  }, []) // Should only fetch a template on page load
+  }, [])
 
   const handleSave = async (type) => {
     setSaveLoading(true)

--- a/static/src/js/components/TemplateForm/TemplateForm.jsx
+++ b/static/src/js/components/TemplateForm/TemplateForm.jsx
@@ -5,7 +5,7 @@ import Container from 'react-bootstrap/Container'
 import Row from 'react-bootstrap/Row'
 import Form from '@rjsf/core'
 import validator from '@rjsf/validator-ajv8'
-import { kebabCase } from 'lodash-es'
+import { isEmpty, kebabCase } from 'lodash-es'
 import crypto from 'crypto'
 
 import useAppContext from '@/js/hooks/useAppContext'
@@ -65,6 +65,7 @@ const TemplateForm = () => {
     originalDraft,
     providerId,
     setDraft,
+    setOriginalDraft,
     setProviderId
   } = useAppContext()
 
@@ -73,8 +74,7 @@ const TemplateForm = () => {
   const {
     ingestMutation,
     ingestDraft,
-    error: ingestDraftError,
-    loading: ingestLoading
+    error: ingestDraftError
   } = useIngestDraftMutation()
 
   const [visitedFields, setVisitedFields] = useState([])
@@ -124,16 +124,16 @@ const TemplateForm = () => {
 
   useEffect(() => {
     // If fieldName was pulled from the URL, set it to the focusField
-    setFocusField(fieldName)
+    if (fieldName) setFocusField(fieldName)
 
     // If a fieldName was pulled from the URL, then remove it from the URL. This will happen after the field is focused.
     if (fieldName && sectionName) navigate(`/templates/collections/${id}/${sectionName}`, { replace: true })
-  }, [fieldName])
+  }, []) // Should only do this redirect on page load
 
   // Fetching collection template if ID is present and draft is not loaded
   useEffect(() => {
     const fetchTemplate = async () => {
-      const { response, error: fetchTemplateError } = await getTemplate(providerId, mmtJwt, id)
+      const { response, error: fetchTemplateError } = await getTemplate(mmtJwt, id)
 
       if (response) {
         const { providerId: templateProviderId, template } = response
@@ -142,16 +142,20 @@ const TemplateForm = () => {
         setDraft({
           ummMetadata: template
         })
+
+        setOriginalDraft({
+          ummMetadata: template
+        })
       } else { setErrors(fetchTemplateError) }
 
       setLoading(false)
     }
 
-    if (id !== 'new' && !draft) {
+    if (id !== 'new' && isEmpty(draft)) {
       setLoading(true)
       fetchTemplate()
     }
-  }, [id])
+  }, []) // Should only fetch a template on page load
 
   const handleSave = async (type) => {
     setSaveLoading(true)
@@ -240,7 +244,7 @@ const TemplateForm = () => {
         variant: 'danger'
       })
     }
-  }, [ingestLoading])
+  }, [ingestDraft, ingestDraftError])
 
   // Handle the cancel button. Reset the form to the last time we fetched the draft from CMR
   const handleCancel = () => {

--- a/static/src/js/components/TemplateForm/TemplateForm.jsx
+++ b/static/src/js/components/TemplateForm/TemplateForm.jsx
@@ -331,15 +331,13 @@ const TemplateForm = () => {
             <div className="template-form__navigation sticky-top p-0 ps-md-3 ps-lg-5 top-0 pt-md-3">
               <FormNavigation
                 draft={ummMetadata}
-                fullSchema={ummCTemplateSchema}
                 formSections={collectionsTemplateConfiguration}
                 loading={saveLoading}
-                visitedFields={visitedFields}
-                onSave={handleSave}
                 onCancel={handleCancel}
+                onSave={handleSave}
                 schema={ummCTemplateSchema}
                 setFocusField={setFocusField}
-                uiSchema={collectionsUiSchema}
+                visitedFields={visitedFields}
               />
             </div>
           </Col>

--- a/static/src/js/components/TemplateForm/__tests__/TemplateForm.test.jsx
+++ b/static/src/js/components/TemplateForm/__tests__/TemplateForm.test.jsx
@@ -473,7 +473,6 @@ describe('TemplateForm', () => {
         }), {})
 
         vi.clearAllMocks()
-        console.log('mocks cleared')
 
         const cancelButton = await screen.findByRole('button', { name: 'Cancel' })
         await user.click(cancelButton)

--- a/static/src/js/components/TemplateForm/__tests__/TemplateForm.test.jsx
+++ b/static/src/js/components/TemplateForm/__tests__/TemplateForm.test.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import {
   render,
   screen,
-  waitFor,
   within
 } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
@@ -83,6 +82,7 @@ vi.mock('@rjsf/core', () => ({
 
             onChange({
               formData: {
+                ...formData,
                 Name: value
               }
             })
@@ -255,9 +255,9 @@ describe('TemplateForm', () => {
   })
 
   describe('when saving and navigating', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       FormNavigation.mockImplementation(
-        vi.importActual('@/js/components/FormNavigation/FormNavigation').default
+        await vi.importActual('@/js/components/FormNavigation/FormNavigation').default
       )
     })
 
@@ -436,41 +436,56 @@ describe('TemplateForm', () => {
 
     describe('when clicking on onCancel', () => {
       test('resets the form to the original values', async () => {
+        const originalDraft = {
+          TemplateName: 'Mock Template',
+          ShortName: 'Template Form Test',
+          Version: '1.0.0'
+        }
         getTemplate.mockReturnValue({
           response: {
-            TemplateName: 'Mock Template',
-            ShortName: 'Template Form Test',
-            Version: '1.0.0'
+            template: originalDraft,
+            providerId: 'MMT_2'
           }
         })
-
-        updateTemplate.mockReturnValue({ ok: true })
 
         const { user } = setup({ pageUrl: '/templates/collections/1234-abcd-5678-efgh/collection-information' })
 
         await waitForResponse()
 
         // Fill out a form field
-        const nameField = screen.getByRole('textbox', { id: 'Name' })
-        await user.type(nameField, 'Test Name')
-        await waitFor(async () => {
-          await nameField.blur()
-        })
+        const nameField = await screen.findByRole('textbox', { id: 'Name' })
+        await user.type(nameField, 'A')
 
-        expect(nameField).toHaveValue('Test Name')
-        expect(FormNavigation).toHaveBeenCalledTimes(12)
+        await user.tab()
+
+        expect(await screen.findByRole('textbox', {
+          id: 'Name',
+          value: 'A'
+        })).toBeInTheDocument()
+
+        expect(FormNavigation).toHaveBeenCalledTimes(4)
         expect(FormNavigation).toHaveBeenCalledWith(expect.objectContaining({
+          draft: {
+            ...originalDraft,
+            Name: 'A'
+          },
           visitedFields: ['mock-name']
         }), {})
 
         vi.clearAllMocks()
+        console.log('mocks cleared')
 
-        const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+        const cancelButton = await screen.findByRole('button', { name: 'Cancel' })
         await user.click(cancelButton)
 
-        expect(nameField).toHaveValue('')
+        expect(await screen.findByRole('textbox', {
+          id: 'Name',
+          value: ''
+        })).toBeInTheDocument()
+
         expect(FormNavigation).toHaveBeenCalledTimes(1)
         expect(FormNavigation).toHaveBeenCalledWith(expect.objectContaining({
+          draft: originalDraft,
           visitedFields: []
         }), {})
       })

--- a/static/src/js/schemas/uiSchemas/collections/dataIdentification.js
+++ b/static/src/js/schemas/uiSchemas/collections/dataIdentification.js
@@ -214,6 +214,26 @@ const dataIdentificationUiSchema = {
                   {
                     'ui:col': {
                       md: 12,
+                      children: ['LicenseURL']
+                    }
+                  }
+                ]
+              },
+              {
+                'ui:row': [
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['LicenseText']
+                    }
+                  }
+                ]
+              },
+              {
+                'ui:row': [
+                  {
+                    'ui:col': {
+                      md: 12,
                       children: ['Description']
                     }
                   }
@@ -235,26 +255,6 @@ const dataIdentificationUiSchema = {
                     'ui:col': {
                       md: 12,
                       children: ['EULAIdentifiers']
-                    }
-                  }
-                ]
-              },
-              {
-                'ui:row': [
-                  {
-                    'ui:col': {
-                      md: 12,
-                      children: ['LicenseURL']
-                    }
-                  }
-                ]
-              },
-              {
-                'ui:row': [
-                  {
-                    'ui:col': {
-                      md: 12,
-                      children: ['LicenseText']
                     }
                   }
                 ]


### PR DESCRIPTION
# Overview

### What is the feature?

The useConstraints field can be difficult to understand, as it selecting a type moves fields around.

### What is the Solution?

This PR moves the required fields to the top of the useConstraints section, so no matter which type option you select, the fields you are required to complete are the first fields you see.

### What areas of the application does this impact?

Collection form, Data Identification, useConstraints

# Testing

Create a new collection draft and navigate to the Data Identification form. Under Use Constraints select each of the options
* "Description without License URL or Text." will show the Description field as required directly under the select field.
* "License URL" will show the License URL field as required directly under the select field.
* "License Text" will show the License Text field as required directly under the select field.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings