### PR TITLE
MMT-3682: Corrects checks related to messaging in permissions forms

### DIFF
--- a/static/src/js/components/ProviderPermissions/ProviderPermissions.jsx
+++ b/static/src/js/components/ProviderPermissions/ProviderPermissions.jsx
@@ -326,7 +326,7 @@ const ProviderPermissions = () => {
     const totalMutations = results.length
     const successfulMutations = results.filter((result) => {
       const { value = {} } = result
-      const { errors = [] } = value
+      const { errors } = value
 
       return errors == null
     })

--- a/static/src/js/components/ProviderPermissions/__tests__/ProviderPermissions.test.jsx
+++ b/static/src/js/components/ProviderPermissions/__tests__/ProviderPermissions.test.jsx
@@ -387,7 +387,7 @@ describe('ProviderPermissions', () => {
 
   describe('when adding permissions for a target that does not already have an Acl in CMR', () => {
     test('creates a new Acl in CMR', async () => {
-      const { user } = setup({
+      const { addNotificationMock, user } = setup({
         additionalMocks: [{
           request: {
             query: CREATE_ACL,
@@ -551,12 +551,18 @@ describe('ProviderPermissions', () => {
         name: 'delete group',
         checked: false
       })).toBeVisible()
+
+      expect(addNotificationMock).toHaveBeenCalledTimes(1)
+      expect(addNotificationMock).toHaveBeenCalledWith({
+        message: 'Provider permissions updated successfully.',
+        variant: 'success'
+      })
     })
   })
 
   describe('when adding permissions for a target that already has an Acl in CMR but doesnt include the selected group', () => {
     test('adds the selected group to the Acl in CMR', async () => {
-      const { user } = setup({
+      const { addNotificationMock, user } = setup({
         additionalMocks: [{
           request: {
             query: UPDATE_ACL,
@@ -731,12 +737,18 @@ describe('ProviderPermissions', () => {
         name: 'delete extended_service',
         checked: false
       })).toBeVisible()
+
+      expect(addNotificationMock).toHaveBeenCalledTimes(1)
+      expect(addNotificationMock).toHaveBeenCalledWith({
+        message: 'Provider permissions updated successfully.',
+        variant: 'success'
+      })
     })
   })
 
   describe('when updating permissions for a target that already has an Acl in CMR that includes the selected group', () => {
     test('updates the permissions for the selected group in the Acl in CMR', async () => {
-      const { user } = setup({
+      const { addNotificationMock, user } = setup({
         additionalMocks: [{
           request: {
             query: UPDATE_ACL,
@@ -906,12 +918,18 @@ describe('ProviderPermissions', () => {
         name: 'delete authenticator_definition',
         checked: true
       })).toBeVisible()
+
+      expect(addNotificationMock).toHaveBeenCalledTimes(1)
+      expect(addNotificationMock).toHaveBeenCalledWith({
+        message: 'Provider permissions updated successfully.',
+        variant: 'success'
+      })
     })
   })
 
   describe('when removing all permissions for a group that belongs to an Acl in CMR', () => {
     test('removes the selected group from the Acl in CMR', async () => {
-      const { user } = setup({
+      const { addNotificationMock, user } = setup({
         additionalMocks: [{
           request: {
             query: UPDATE_ACL,
@@ -1067,12 +1085,18 @@ describe('ProviderPermissions', () => {
         name: 'delete authenticator_definition',
         checked: false
       })).toBeVisible()
+
+      expect(addNotificationMock).toHaveBeenCalledTimes(1)
+      expect(addNotificationMock).toHaveBeenCalledWith({
+        message: 'Provider permissions updated successfully.',
+        variant: 'success'
+      })
     })
   })
 
   describe('when removing all permissions for a group that belongs to an Acl in CMR and its the last group in the Acl', () => {
     test('removes the Acl from CMR', async () => {
-      const { user } = setup({
+      const { addNotificationMock, user } = setup({
         additionalMocks: [{
           request: {
             query: DELETE_ACL,
@@ -1202,6 +1226,12 @@ describe('ProviderPermissions', () => {
         name: 'delete audit_report',
         checked: false
       })).toBeVisible()
+
+      expect(addNotificationMock).toHaveBeenCalledTimes(1)
+      expect(addNotificationMock).toHaveBeenCalledWith({
+        message: 'Provider permissions updated successfully.',
+        variant: 'success'
+      })
     })
   })
 })

--- a/static/src/js/components/SystemPermissions/SystemPermissions.jsx
+++ b/static/src/js/components/SystemPermissions/SystemPermissions.jsx
@@ -300,7 +300,7 @@ const SystemPermissions = () => {
     const totalMutations = results.length
     const successfulMutations = results.filter((result) => {
       const { value = {} } = result
-      const { errors = [] } = value
+      const { errors } = value
 
       return errors == null
     })

--- a/static/src/js/components/SystemPermissions/__tests__/SystemPermissions.test.jsx
+++ b/static/src/js/components/SystemPermissions/__tests__/SystemPermissions.test.jsx
@@ -347,7 +347,7 @@ describe('SystemPermissions', () => {
 
   describe('when adding permissions for a target that does not already have an Acl in CMR', () => {
     test('creates a new Acl in CMR', async () => {
-      const { user } = setup({
+      const { addNotificationMock, user } = setup({
         additionalMocks: [{
           request: {
             query: CREATE_ACL,
@@ -500,12 +500,18 @@ describe('SystemPermissions', () => {
         name: 'delete any_acl',
         checked: false
       })).toBeVisible()
+
+      expect(addNotificationMock).toHaveBeenCalledTimes(1)
+      expect(addNotificationMock).toHaveBeenCalledWith({
+        message: 'System permissions updated successfully.',
+        variant: 'success'
+      })
     })
   })
 
   describe('when adding permissions for a target that already has an Acl in CMR but doesnt include the selected group', () => {
     test('adds the selected group to the Acl in CMR', async () => {
-      const { user } = setup({
+      const { addNotificationMock, user } = setup({
         additionalMocks: [{
           request: {
             query: UPDATE_ACL,
@@ -669,12 +675,18 @@ describe('SystemPermissions', () => {
         name: 'delete tag_group',
         checked: false
       })).toBeVisible()
+
+      expect(addNotificationMock).toHaveBeenCalledTimes(1)
+      expect(addNotificationMock).toHaveBeenCalledWith({
+        message: 'System permissions updated successfully.',
+        variant: 'success'
+      })
     })
   })
 
   describe('when updating permissions for a target that already has an Acl in CMR that includes the selected group', () => {
     test('updates the permissions for the selected group in the Acl in CMR', async () => {
-      const { user } = setup({
+      const { addNotificationMock, user } = setup({
         additionalMocks: [{
           request: {
             query: UPDATE_ACL,
@@ -832,12 +844,18 @@ describe('SystemPermissions', () => {
         name: 'delete ingest_management_acl',
         checked: false
       })).toBeVisible()
+
+      expect(addNotificationMock).toHaveBeenCalledTimes(1)
+      expect(addNotificationMock).toHaveBeenCalledWith({
+        message: 'System permissions updated successfully.',
+        variant: 'success'
+      })
     })
   })
 
   describe('when removing all permissions for a group that belongs to an Acl in CMR', () => {
     test('removes the selected group from the Acl in CMR', async () => {
-      const { user } = setup({
+      const { addNotificationMock, user } = setup({
         additionalMocks: [{
           request: {
             query: UPDATE_ACL,
@@ -988,12 +1006,18 @@ describe('SystemPermissions', () => {
         name: 'delete ingest_management_acl',
         checked: false
       })).toBeVisible()
+
+      expect(addNotificationMock).toHaveBeenCalledTimes(1)
+      expect(addNotificationMock).toHaveBeenCalledWith({
+        message: 'System permissions updated successfully.',
+        variant: 'success'
+      })
     })
   })
 
   describe('when removing all permissions for a group that belongs to an Acl in CMR and its the last group in the Acl', () => {
     test('removes the Acl from CMR', async () => {
-      const { user } = setup({
+      const { addNotificationMock, user } = setup({
         additionalMocks: [{
           request: {
             query: DELETE_ACL,
@@ -1120,6 +1144,12 @@ describe('SystemPermissions', () => {
         name: 'delete dashboard_admin',
         checked: false
       })).toBeVisible()
+
+      expect(addNotificationMock).toHaveBeenCalledTimes(1)
+      expect(addNotificationMock).toHaveBeenCalledWith({
+        message: 'System permissions updated successfully.',
+        variant: 'success'
+      })
     })
   })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

There was a default causing incorrect messaging to appear on successful saves on permission forms.

### What is the Solution?

Removed the default, it wasn't necessary and was causing issues.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings