### PR TITLE
MMT-3738: Fix provider selection bug

### DIFF
--- a/static/src/js/components/FormNavigation/FormNavigation.jsx
+++ b/static/src/js/components/FormNavigation/FormNavigation.jsx
@@ -58,8 +58,8 @@ const FormNavigation = ({
   const { errors } = validator.validateFormData(cleanedDraft, schema)
 
   const onSaveClick = (type) => {
-    // If there is no concept id for drafts or id for templates, open the modal
-    if (!conceptId && !id) {
+    // If there is no concept id for drafts or id for templates, or it is a new draft or template, open the modal
+    if ((!conceptId && !id) || conceptId === 'new') {
       setChooseProviderModalType(type)
       setChooseProviderModalOpen(true)
 

--- a/static/src/js/components/FormNavigation/FormNavigation.jsx
+++ b/static/src/js/components/FormNavigation/FormNavigation.jsx
@@ -50,16 +50,22 @@ const FormNavigation = ({
   // uiSchema,
   visitedFields
 }) => {
-  const { conceptId, id } = useParams()
+  // If the concept id or a template id are undefined, assume a new draft or template is being created
+  const { conceptId = 'new', id = 'new' } = useParams()
   const [chooseProviderModalOpen, setChooseProviderModalOpen] = useState(false)
   const [chooseProviderModalType, setChooseProviderModalType] = useState(null)
   const { templateType } = useParams()
   const cleanedDraft = cloneDeep(removeEmpty(draft))
   const { errors } = validator.validateFormData(cleanedDraft, schema)
 
+  const isTemplate = !!templateType
+
   const onSaveClick = (type) => {
-    // If there is no concept id for drafts or id for templates, or it is a new draft or template, open the modal
-    if ((!conceptId && !id) || conceptId === 'new') {
+    // If editing a new draft, open the provider selection modal
+    if (
+      (!isTemplate && conceptId === 'new')
+      || (isTemplate && id === 'new')
+    ) {
       setChooseProviderModalType(type)
       setChooseProviderModalOpen(true)
 
@@ -125,7 +131,7 @@ const FormNavigation = ({
             </Dropdown.Item>
 
             {
-              templateType && (
+              isTemplate && (
                 <Dropdown.Item
                   onClick={() => onSaveClick(saveTypes.saveAndCreateDraft)}
                 >
@@ -134,7 +140,7 @@ const FormNavigation = ({
               )
             }
             {
-              !templateType && (
+              !isTemplate && (
                 <Dropdown.Item
                   onClick={() => onSaveClick(saveTypes.saveAndPublish)}
                 >

--- a/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
+++ b/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
@@ -17,7 +17,6 @@ import NavigationItem from '@/js/components/NavigationItem/NavigationItem'
 
 import saveTypes from '@/js/constants/saveTypes'
 import useAvailableProviders from '@/js/hooks/useAvailableProviders'
-import { describe } from 'vitest'
 
 vi.mock('@/js/components/NavigationItem/NavigationItem')
 

--- a/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
+++ b/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
@@ -237,7 +237,6 @@ describe('FormNavigation', () => {
         await user.click(button)
 
         const modal = screen.getByRole('dialog')
-        console.log('🚀 ~ test ~ modal:', screen.debug(modal))
         const modalSubmit = within(modal).getByRole('button', { name: 'Save & Continue' })
 
         expect(modalSubmit).toBeInTheDocument()

--- a/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
+++ b/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
@@ -1,5 +1,9 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen,
+  within
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   MemoryRouter,
@@ -13,6 +17,7 @@ import NavigationItem from '@/js/components/NavigationItem/NavigationItem'
 
 import saveTypes from '@/js/constants/saveTypes'
 import useAvailableProviders from '@/js/hooks/useAvailableProviders'
+import { describe } from 'vitest'
 
 vi.mock('@/js/components/NavigationItem/NavigationItem')
 
@@ -56,7 +61,7 @@ const setup = ({
             path={overridePath || '/tool-drafts'}
           >
             <Route
-              path={overridePathName || ':conceptId/:sectionName'}
+              path={overridePathName || ':conceptId/:sectionName?'}
               element={<FormNavigation {...props} />}
             />
           </Route>
@@ -217,6 +222,43 @@ describe('FormNavigation', () => {
 
       expect(props.onSave).toHaveBeenCalledTimes(1)
       expect(props.onSave).toHaveBeenCalledWith(saveTypes.saveAndCreateDraft)
+    })
+  })
+
+  describe('when saving a new draft', () => {
+    describe('when on the default route', () => {
+      test('opens the choose provider modal', async () => {
+        const { user } = setup({
+          overrideInitialEntries: '/tool-drafts/new'
+        })
+
+        const button = screen.getByRole('button', { name: 'Save & Continue' })
+
+        await user.click(button)
+
+        const modal = screen.getByRole('dialog')
+        console.log('🚀 ~ test ~ modal:', screen.debug(modal))
+        const modalSubmit = within(modal).getByRole('button', { name: 'Save & Continue' })
+
+        expect(modalSubmit).toBeInTheDocument()
+      })
+
+      describe('when on a nested page', () => {
+        test('opens the choose provider modal', async () => {
+          const { user } = setup({
+            overrideInitialEntries: '/tool-drafts/new/mock-section-name'
+          })
+
+          const button = screen.getByRole('button', { name: 'Save & Continue' })
+
+          await user.click(button)
+
+          const modal = screen.getByRole('dialog')
+          const modalSubmit = within(modal).getByRole('button', { name: 'Save & Continue' })
+
+          expect(modalSubmit).toBeInTheDocument()
+        })
+      })
     })
   })
 })

--- a/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
+++ b/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
@@ -61,7 +61,7 @@ const setup = ({
             path={overridePath || '/tool-drafts'}
           >
             <Route
-              path={overridePathName || ':conceptId/:sectionName?'}
+              path={overridePathName || ':conceptId?/:sectionName?'}
               element={<FormNavigation {...props} />}
             />
           </Route>
@@ -246,6 +246,44 @@ describe('FormNavigation', () => {
         test('opens the choose provider modal', async () => {
           const { user } = setup({
             overrideInitialEntries: '/tool-drafts/new/mock-section-name'
+          })
+
+          const button = screen.getByRole('button', { name: 'Save & Continue' })
+
+          await user.click(button)
+
+          const modal = screen.getByRole('dialog')
+          const modalSubmit = within(modal).getByRole('button', { name: 'Save & Continue' })
+
+          expect(modalSubmit).toBeInTheDocument()
+        })
+      })
+    })
+  })
+
+  describe('when saving a new template', () => {
+    describe('when on the default route', () => {
+      test('opens the choose provider modal', async () => {
+        const { user } = setup({
+          overrideInitialEntries: '/templates/collections/new',
+          overridePath: '/templates/collections'
+        })
+
+        const button = screen.getByRole('button', { name: 'Save & Continue' })
+
+        await user.click(button)
+
+        const modal = screen.getByRole('dialog')
+        const modalSubmit = within(modal).getByRole('button', { name: 'Save & Continue' })
+
+        expect(modalSubmit).toBeInTheDocument()
+      })
+
+      describe('when on a nested page', () => {
+        test('opens the choose provider modal', async () => {
+          const { user } = setup({
+            overrideInitialEntries: '/templates/collections/new/mock-section-name',
+            overridePath: '/templates/collections'
           })
 
           const button = screen.getByRole('button', { name: 'Save & Continue' })

--- a/static/src/js/components/TemplateForm/TemplateForm.jsx
+++ b/static/src/js/components/TemplateForm/TemplateForm.jsx
@@ -61,12 +61,11 @@ const TemplateForm = () => {
   const navigate = useNavigate()
 
   const {
-    draft,
+    draft = {},
     originalDraft,
     providerId,
     setDraft,
-    setOriginalDraft,
-    setProviderId
+    setOriginalDraft
   } = useAppContext()
 
   const { mmtJwt } = useMMTCookie()
@@ -82,6 +81,7 @@ const TemplateForm = () => {
   const [error, setErrors] = useState()
   const [saveLoading, setSaveLoading] = useState(false)
   const [loading, setLoading] = useState()
+  const [templateProviderId, setTemplateProviderId] = useState()
 
   const { addNotification } = useNotificationsContext()
 
@@ -109,7 +109,7 @@ const TemplateForm = () => {
     FieldTemplate: CustomFieldTemplate,
     TitleFieldTemplate: CustomTitleFieldTemplate
   }
-  const { ummMetadata = {} } = draft || {}
+  const { ummMetadata = {} } = draft
 
   const [firstFormSection] = collectionsTemplateConfiguration
   const firstSectionName = kebabCase(firstFormSection.displayName)
@@ -133,13 +133,15 @@ const TemplateForm = () => {
 
   // On load, fetching collection template if ID is present and draft is not loaded
   useEffect(() => {
+    // SetDraft({})
+
     const fetchTemplate = async () => {
       const { response, error: fetchTemplateError } = await getTemplate(mmtJwt, id)
 
       if (response) {
-        const { providerId: templateProviderId, template } = response
+        const { template, providerId: fetchedProviderId } = response
 
-        setProviderId(templateProviderId)
+        setTemplateProviderId(fetchedProviderId)
         setDraft({
           ummMetadata: template
         })
@@ -160,6 +162,7 @@ const TemplateForm = () => {
 
   const handleSave = async (type) => {
     setSaveLoading(true)
+
     let savedId = null
     if (id === 'new') {
       const response = await createTemplate(providerId, mmtJwt, ummMetadata)
@@ -177,7 +180,7 @@ const TemplateForm = () => {
 
       setSaveLoading(false)
     } else {
-      const response = await updateTemplate(providerId, mmtJwt, ummMetadata, id)
+      const response = await updateTemplate(templateProviderId, mmtJwt, ummMetadata, id)
 
       if (response.ok) {
         addNotification({
@@ -215,7 +218,7 @@ const TemplateForm = () => {
 
       delete ummMetadata.TemplateName
 
-      ingestMutation('Collection', ummMetadata, nativeId, providerId)
+      ingestMutation('Collection', ummMetadata, nativeId, templateProviderId)
     }
 
     if (type === saveTypes.saveAndPreview) {
@@ -277,6 +280,7 @@ const TemplateForm = () => {
   const templateFormPageHeader = () => (
     <PageHeader
       title={pageTitle}
+      titleBadge={templateProviderId}
       breadcrumbs={
         [
           {

--- a/static/src/js/components/TemplateForm/TemplateForm.jsx
+++ b/static/src/js/components/TemplateForm/TemplateForm.jsx
@@ -133,8 +133,6 @@ const TemplateForm = () => {
 
   // On load, fetching collection template if ID is present and draft is not loaded
   useEffect(() => {
-    // SetDraft({})
-
     const fetchTemplate = async () => {
       const { response, error: fetchTemplateError } = await getTemplate(mmtJwt, id)
 

--- a/static/src/js/pages/MetadataFormPage/MetadataFormPage.jsx
+++ b/static/src/js/pages/MetadataFormPage/MetadataFormPage.jsx
@@ -45,7 +45,7 @@ const MetadataFormPageHeader = () => {
   })
 
   const { draft = {} } = data
-  const { previewMetadata = {} } = draft
+  const { previewMetadata = {}, providerId } = draft
   const { pageTitle } = previewMetadata
 
   const displayTitle = pageTitle || '<Blank Name>'
@@ -55,6 +55,7 @@ const MetadataFormPageHeader = () => {
   return (
     <PageHeader
       title={title}
+      titleBadge={providerId}
       pageType="secondary"
       breadcrumbs={
         [

--- a/static/src/js/utils/__tests__/updateTemplate.test.js
+++ b/static/src/js/utils/__tests__/updateTemplate.test.js
@@ -43,10 +43,7 @@ describe('updateTemplates', () => {
       const response = await updateTemplate(providerId, token, ummMetadata, id)
 
       expect(response).toEqual({
-        error: {
-          ok: false,
-          data: 'mock-error-data'
-        }
+        error: 'Error updating template'
       })
 
       expect(fetch).toHaveBeenCalledTimes(1)

--- a/static/src/js/utils/getTemplate.js
+++ b/static/src/js/utils/getTemplate.js
@@ -2,7 +2,6 @@ import { getApplicationConfig } from '../../../../sharedUtils/getConfig'
 
 /**
  * Calls /providers/{providerId}/template/{id} lambda to get a single template
- * @param {string} providerId A provider id that a given user is using
  * @param {Object} token A users token
  * @param {string} id An id for a collection template
  */

--- a/static/src/js/utils/updateTemplate.js
+++ b/static/src/js/utils/updateTemplate.js
@@ -20,13 +20,12 @@ const updateTemplate = async (providerId, token, ummMetadata, id) => {
         ...ummMetadata
       })
     })
-    const data = await response
 
     if (response.ok) {
-      return data
+      return response
     }
 
-    return { error: response }
+    throw new Error('Failed to update template')
   } catch (e) {
     return {
       error: 'Error updating template'


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes a bug where the provider selection modal would not appear when saving a new draft or template on nested form pages.

### What is the Solution?

Added a check for the conceptId of "new" on `if` statement wrapped around function that triggers the modal.

### What areas of the application does this impact?

New drafts/templates forms

# Testing

### Reproduction steps

- **Environment for testing:** N/A
- **Collection to test with:** N/A

1. Create a new draft
2. Click on a different form section
3. Confirm the modal appears
4. Save the draft
5. Confirm the provider selection modal applies the correct provider

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings