### PR TITLE
MMT-3749: Updates CORS settings for token refreshing

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -71,6 +71,7 @@ dockerRun() {
         -e "JWT_SECRET=$bamboo_JWT_SECRET" \
         -e "JWT_VALID_TIME=$bamboo_JWT_VALID_TIME" \
         -e "LAMBDA_TIMEOUT=$bamboo_LAMBDA_TIMEOUT" \
+        -e "MMT_HOST=$bamboo_MMT_HOST" \
         -e "NODE_ENV=production" \
         -e "NODE_OPTIONS=--max_old_space_size=4096" \
         -e "SUBNET_ID_A=$bamboo_SUBNET_ID_A" \

--- a/serverless-configs/aws-cors-configuration.yml
+++ b/serverless-configs/aws-cors-configuration.yml
@@ -1,9 +1,10 @@
-origin: '*'
+origin: 'https://mmt.sit.earthdatacloud.nasa.gov'
 headers:
+  - Access-Control-Allow-Origin
+  - Access-Control-Allow-Credentials
   - Access-Control-Request-Headers
   - Access-Control-Request-Methods
   - Authorization
   - Origin
   - User-Agent
-  - token
-  - expires
+allowCredentials: true

--- a/serverless-configs/aws-cors-configuration.yml
+++ b/serverless-configs/aws-cors-configuration.yml
@@ -1,4 +1,4 @@
-origin: 'https://mmt.sit.earthdatacloud.nasa.gov'
+origin: ${env:MMT_HOST, 'http://localhost:5173'}
 headers:
   - Access-Control-Allow-Origin
   - Access-Control-Allow-Credentials

--- a/serverless/src/samlRefreshToken/handler.js
+++ b/serverless/src/samlRefreshToken/handler.js
@@ -4,7 +4,7 @@ import cookie from 'cookie'
 import createCookie from '../utils/createCookie'
 import createJwt from '../utils/createJwt'
 
-import { getSamlConfig } from '../../../sharedUtils/getConfig'
+import { getApplicationConfig, getSamlConfig } from '../../../sharedUtils/getConfig'
 import { downcaseKeys } from '../utils/downcaseKeys'
 
 /**
@@ -32,7 +32,11 @@ const findLaunchpadTokenInHeaders = (headers) => {
  * @param {Object} event Details about the HTTP request that it received
  */
 const samlRefreshToken = async (event) => {
-  const { IS_OFFLINE, JWT_SECRET } = process.env
+  const {
+    IS_OFFLINE,
+    JWT_SECRET
+  } = process.env
+  const { mmtHost } = getApplicationConfig()
 
   const { headers } = event
   const { authorization: token = '' } = downcaseKeys(headers)
@@ -52,10 +56,9 @@ const samlRefreshToken = async (event) => {
       statusCode: 200,
       headers: {
         'Set-Cookie': createCookie(newJwt),
-        'Access-Control-Expose-Headers': 'token',
-        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Origin': mmtHost,
         'Access-Control-Allow-Headers': '*',
-        'Access-Control-Allow-Methods': 'GET, POST',
+        'Access-Control-Allow-Methods': 'POST',
         'Access-Control-Allow-Credentials': true
       }
     }
@@ -87,10 +90,9 @@ const samlRefreshToken = async (event) => {
       statusCode: 200,
       headers: {
         'Set-Cookie': createCookie(newJwt),
-        'Access-Control-Expose-Headers': 'token',
-        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Origin': mmtHost,
         'Access-Control-Allow-Headers': '*',
-        'Access-Control-Allow-Methods': 'GET, POST',
+        'Access-Control-Allow-Methods': 'POST',
         'Access-Control-Allow-Credentials': true
       }
     }

--- a/static/src/js/providers/GraphQLProvider/__tests__/GraphQLProvider.test.jsx
+++ b/static/src/js/providers/GraphQLProvider/__tests__/GraphQLProvider.test.jsx
@@ -1,10 +1,6 @@
 import React, { createContext } from 'react'
 import { render } from '@testing-library/react'
-import {
-  ApolloClient,
-  ApolloLink,
-  createHttpLink
-} from '@apollo/client'
+import { ApolloClient, ApolloLink } from '@apollo/client'
 import { setContext } from '@apollo/client/link/context'
 
 import GraphQLProvider from '../GraphQLProvider'
@@ -100,12 +96,6 @@ describe('GraphQLProvider component', () => {
         )
       )
 
-      // Check that createHttpLink is called properly
-      expect(createHttpLink).toHaveBeenCalledTimes(1)
-      expect(createHttpLink).toHaveBeenCalledWith({
-        uri: 'http://graphqlhost.com/dev/api'
-      })
-
       // Check that the authLink is called properly
       expect(setContext).toHaveBeenCalledTimes(1)
       expect(setContext.mock.calls[0][0](null, {})).toEqual({
@@ -133,12 +123,6 @@ describe('GraphQLProvider component', () => {
           }
         )
       )
-
-      // Check that createHttpLink is called properly
-      expect(createHttpLink).toHaveBeenCalledTimes(1)
-      expect(createHttpLink).toHaveBeenCalledWith({
-        uri: 'http://graphqlhost.com/dev/api'
-      })
 
       // Check that the authLink is called properly
       expect(setContext).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
# Overview

### What is the feature?

If the user has been active during the lifespan of their token, we want to auto-refresh the token for them so they don't have to be redirected. If they have been idle throughout their token, they will still be redirected to login again.

### What areas of the application does this impact?

Refreshing tokens

# Testing

Login, wait for 14 minutes and you will see a call to `saml-refresh-token` in dev tools. If you wait another 14 minutes you will see a console log of "LOG OUT WARNING", which means your token will expire in 60 seconds. 

Any interaction with the website will reset your 'idle' state (mouse moves, keystrokes, etc.) and keep you logged in

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings