### PR TITLE
MMT-3623: Fixes enum fields in Related URLs

### DIFF
--- a/static/src/js/schemas/uiSchemas/collections/dataContacts.js
+++ b/static/src/js/schemas/uiSchemas/collections/dataContacts.js
@@ -1068,18 +1068,10 @@ const dataContactsUiSchema = {
                 ]
               },
               Format: {
-                'ui:widget': CustomSelectWidget,
-                'ui:controlled': {
-                  name: 'granule-data-format',
-                  controlName: 'short_name'
-                }
+                'ui:widget': CustomSelectWidget
               },
               MimeType: {
-                'ui:widget': CustomSelectWidget,
-                'ui:controlled': {
-                  name: 'mime-type',
-                  controlName: 'mime_type'
-                }
+                'ui:widget': CustomSelectWidget
               }
             }
           }


### PR DESCRIPTION
# Overview

### What is the feature?

Two of our enum fields were requesting controlled keywords from CMR instead of using the schema enum values. We have to use the schema enum fields in order for validation to succeed

### What areas of the application does this impact?

Collection Form

# Testing

Open a new draft, navigate to the Data Contacts form
Data Contacts -> Contacts Groups -> Contact Information -> Related URLs
* URL Content Type = “DistributionURL”
* Type = Use Service API
* Subtype = Opendap Data, 
* In the Get Service section, selecting any entry from the ‘Mime Type’ drop down list should not produce a validation error

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings