### PR TITLE
MMT-3726: Removed code that writes to .env as not needed and causing issues with writing password with special characters in it.

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -65,6 +65,7 @@ dockerRun() {
         -e "AWS_ACCESS_KEY_ID=$bamboo_AWS_ACCESS_KEY_ID" \
         -e "AWS_SECRET_ACCESS_KEY=$bamboo_AWS_SECRET_ACCESS_KEY" \
         -e "COOKIE_DOMAIN=$bamboo_COOKIE_DOMAIN" \
+        -e "EDL_PASSWORD='$bamboo_EDL_PASSWORD'" \
         -e "JWT_SECRET=$bamboo_JWT_SECRET" \
         -e "JWT_VALID_TIME=$bamboo_JWT_VALID_TIME" \
         -e "LAMBDA_TIMEOUT=$bamboo_LAMBDA_TIMEOUT" \

--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -65,7 +65,7 @@ dockerRun() {
         -e "AWS_ACCESS_KEY_ID=$bamboo_AWS_ACCESS_KEY_ID" \
         -e "AWS_SECRET_ACCESS_KEY=$bamboo_AWS_SECRET_ACCESS_KEY" \
         -e "COOKIE_DOMAIN=$bamboo_COOKIE_DOMAIN" \
-        -e "EDL_PASSWORD='$bamboo_EDL_PASSWORD'" \
+        -e "EDL_PASSWORD=$bamboo_EDL_PASSWORD" \
         -e "JWT_SECRET=$bamboo_JWT_SECRET" \
         -e "JWT_VALID_TIME=$bamboo_JWT_VALID_TIME" \
         -e "LAMBDA_TIMEOUT=$bamboo_LAMBDA_TIMEOUT" \

--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -34,7 +34,7 @@ config="`jq '.edl.uid = $newValue' --arg newValue $bamboo_EDL_UID <<< $config`"
 echo $config > tmp.$$.json && mv tmp.$$.json static.config.json
 
 # setup .env
-echo "EDL_PASSWORD=$bamboo_EDL_PASSWORD" > .env
+echo "EDL_PASSWORD='$bamboo_EDL_PASSWORD'" > .env
 
 # Set up Docker image
 #####################

--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -33,12 +33,6 @@ config="`jq '.edl.uid = $newValue' --arg newValue $bamboo_EDL_UID <<< $config`"
 # overwrite static.config.json with new values
 echo $config > tmp.$$.json && mv tmp.$$.json static.config.json
 
-# setup .env
-# Note: The single quotes are necessary to prevent the bamboo_EDL_PASSWORD from 
-# being interpolated.   This works well as long as there are no single quotes in
-# the password.
-echo "EDL_PASSWORD='$bamboo_EDL_PASSWORD'" > .env
-
 # Set up Docker image
 #####################
 

--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -34,6 +34,9 @@ config="`jq '.edl.uid = $newValue' --arg newValue $bamboo_EDL_UID <<< $config`"
 echo $config > tmp.$$.json && mv tmp.$$.json static.config.json
 
 # setup .env
+# Note: The single quotes are necessary to prevent the bamboo_EDL_PASSWORD from 
+# being interpolated.   This works well as long as there are no single quotes in
+# the password.
 echo "EDL_PASSWORD='$bamboo_EDL_PASSWORD'" > .env
 
 # Set up Docker image


### PR DESCRIPTION
# Overview

When deploying MMT to production, there were a few characters in the string that were being interpolated when writing EDL_PASSWORD to the .env file, as a result, it would base64 encode the wrong password used for EDL queries.

The EDL_PASSWORD should not be written to a .env file, but rather includes as a env parameters to docker.

### What areas of the application does this impact?

Deployments

# Testing

In prod, you should now be able to login.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings