### PR TITLE
MMT-3673: Fixes 'Preview on Map' link

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -16,7 +16,7 @@ config="`jq '.application.graphQlHost = $newValue' --arg newValue $bamboo_GRAPHQ
 config="`jq '.application.mmtHost = $newValue' --arg newValue $bamboo_MMT_HOST <<< $config`"
 config="`jq '.application.apiHost = $newValue' --arg newValue $bamboo_API_HOST <<< $config`"
 config="`jq '.application.cmrHost = $newValue' --arg newValue $bamboo_CMR_HOST <<< $config`"
-config="`jq '.application.searchUrl = $newValue' --arg newValue $bamboo_CMR_HOST <<< $config`"
+config="`jq '.application.searchUrl = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
 config="`jq '.application.gkrHost = $newValue' --arg newValue $bamboo_GKR_HOST <<< $config`"
 config="`jq '.application.cookieDomain = $newValue' --arg newValue $bamboo_COOKIE_DOMAIN <<< $config`"
 config="`jq '.application.tokenValidTime = $newValue' --arg newValue $bamboo_JWT_VALID_TIME <<< $config`"


### PR DESCRIPTION
# Overview

### What is the feature?

The link for 'Preview on Map' was using the CMR_HOST in the deployment script. I added the correct values to the deployment system and updated the script to use the new value.
