### PR TITLE
MMT-3673: Moves the search path out of the host parameter for Preview on Map logic

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -16,7 +16,7 @@ config="`jq '.application.graphQlHost = $newValue' --arg newValue $bamboo_GRAPHQ
 config="`jq '.application.mmtHost = $newValue' --arg newValue $bamboo_MMT_HOST <<< $config`"
 config="`jq '.application.apiHost = $newValue' --arg newValue $bamboo_API_HOST <<< $config`"
 config="`jq '.application.cmrHost = $newValue' --arg newValue $bamboo_CMR_HOST <<< $config`"
-config="`jq '.application.searchUrl = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
+config="`jq '.application.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
 config="`jq '.application.gkrHost = $newValue' --arg newValue $bamboo_GKR_HOST <<< $config`"
 config="`jq '.application.cookieDomain = $newValue' --arg newValue $bamboo_COOKIE_DOMAIN <<< $config`"
 config="`jq '.application.tokenValidTime = $newValue' --arg newValue $bamboo_JWT_VALID_TIME <<< $config`"

--- a/static.config.json
+++ b/static.config.json
@@ -6,7 +6,7 @@
     "gkrHost": "https://gkr.sit.earthdatacloud.nasa.gov",
     "graphQlHost": "http://localhost:3013/development/api",
     "mmtHost": "http://localhost:5173",
-    "searchUrl": "https://search.sit.earthdata.nasa.gov/search/map",
+    "edscHost": "https://search.sit.earthdata.nasa.gov",
     "version": "development",
     "defaultResponseHeaders": {
       "Access-Control-Allow-Origin": "*",

--- a/static/src/js/components/PreviewMapTemplate/PreviewMapTemplate.jsx
+++ b/static/src/js/components/PreviewMapTemplate/PreviewMapTemplate.jsx
@@ -13,7 +13,7 @@ import { getApplicationConfig } from '../../../../../sharedUtils/getConfig'
  * @param {PreviewMapTemplate} props
  */
 const PreviewMapTemplate = ({ type, formData }) => {
-  const { searchUrl } = getApplicationConfig()
+  const { edscHost } = getApplicationConfig()
 
   const [searchQuery, setSearchQuery] = useState()
 
@@ -54,7 +54,7 @@ const PreviewMapTemplate = ({ type, formData }) => {
   useEffect(() => {
     const query = getMapQuery()
     if (query) {
-      setSearchQuery(`${searchUrl}?${query}`)
+      setSearchQuery(`${edscHost}/search/map?${query}`)
     }
   }, [formData])
 

--- a/static/src/js/components/PreviewMapTemplate/__tests__/PreviewMapTemplate.test.jsx
+++ b/static/src/js/components/PreviewMapTemplate/__tests__/PreviewMapTemplate.test.jsx
@@ -1,7 +1,15 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+
 import PreviewMapTemplate from '../PreviewMapTemplate'
+
+vi.mock('../../../../../../sharedUtils/getConfig', async () => ({
+  ...await vi.importActual('../../../../../../sharedUtils/getConfig'),
+  getApplicationConfig: vi.fn(() => ({
+    edscHost: 'http://example.com'
+  }))
+}))
 
 const setup = ({ props }) => {
   const user = userEvent.setup()
@@ -29,7 +37,7 @@ describe('PreviewMapTemplate', () => {
 
       setup({ props })
 
-      expect(screen.getByRole('link')).toHaveAttribute('href', 'https://search.sit.earthdata.nasa.gov/search/map?sp=10%2C20')
+      expect(screen.getByRole('link')).toHaveAttribute('href', 'http://example.com/search/map?sp=10%2C20')
     })
   })
 
@@ -47,7 +55,7 @@ describe('PreviewMapTemplate', () => {
 
       setup({ props })
 
-      expect(screen.getByRole('link')).toHaveAttribute('href', 'https://search.sit.earthdata.nasa.gov/search/map?sb=-40%2C10%2C50%2C70')
+      expect(screen.getByRole('link')).toHaveAttribute('href', 'http://example.com/search/map?sb=-40%2C10%2C50%2C70')
     })
   })
 
@@ -81,7 +89,7 @@ describe('PreviewMapTemplate', () => {
 
       setup({ props })
 
-      expect(screen.getByRole('link')).toHaveAttribute('href', 'https://search.sit.earthdata.nasa.gov/search/map?polygon=-30%2C50%2C10%2C40%2C35%2C50%2C-30%2C50')
+      expect(screen.getByRole('link')).toHaveAttribute('href', 'http://example.com/search/map?polygon=-30%2C50%2C10%2C40%2C35%2C50%2C-30%2C50')
     })
   })
 


### PR DESCRIPTION
# Overview

### What is the feature?

The code expected the environment variable to include the correct path in EDSC to display the spatial area on the map, but all the other 'host' parameters we use are just the host. This PR adjusts that logic to only pull the `edscHost` from configs, and moves the path to where it is used.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings