### PR TITLE
MMT-3536: As a user, I can delete a collection permission

### DIFF
--- a/static/src/js/components/PermissionList/PermissionList.jsx
+++ b/static/src/js/components/PermissionList/PermissionList.jsx
@@ -5,15 +5,13 @@ import { useSearchParams } from 'react-router-dom'
 import Col from 'react-bootstrap/Col'
 import Row from 'react-bootstrap/Row'
 
-import { FaEdit } from 'react-icons/fa'
+import { FaEdit, FaTrash } from 'react-icons/fa'
 
 import ControlledPaginatedContent from '@/js/components/ControlledPaginatedContent/ControlledPaginatedContent'
 import EllipsisLink from '@/js/components/EllipsisLink/EllipsisLink'
 import Table from '@/js/components/Table/Table'
 
 import { GET_COLLECTION_PERMISSIONS } from '@/js/operations/queries/getCollectionPermissions'
-
-import { FaEdit, FaTrash } from 'react-icons/fa'
 
 import { DELETE_ACL } from '@/js/operations/mutations/deleteAcl'
 

--- a/static/src/js/components/PermissionList/PermissionList.jsx
+++ b/static/src/js/components/PermissionList/PermissionList.jsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from 'react'
-import { useSuspenseQuery } from '@apollo/client'
+import React, { useCallback, useState } from 'react'
+import { useMutation, useSuspenseQuery } from '@apollo/client'
 import { useSearchParams } from 'react-router-dom'
 
 import Col from 'react-bootstrap/Col'
@@ -13,16 +13,34 @@ import Table from '@/js/components/Table/Table'
 
 import { GET_COLLECTION_PERMISSIONS } from '@/js/operations/queries/getCollectionPermissions'
 
+import { FaEdit, FaTrash } from 'react-icons/fa'
+
+import { DELETE_ACL } from '@/js/operations/mutations/deleteAcl'
+
+import useNotificationsContext from '@/js/hooks/useNotificationsContext'
+
+import errorLogger from '@/js/utils/errorLogger'
+
 import Button from '../Button/Button'
+import CustomModal from '../CustomModal/CustomModal'
 
 const PermissionList = () => {
+  const { addNotification } = useNotificationsContext()
+
   const [searchParams, setSearchParams] = useSearchParams()
+
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [selectedPermission, setSelectedPermission] = useState(false)
 
   const activePage = parseInt(searchParams.get('page'), 10) || 1
   const limit = 20
   const offset = (activePage - 1) * limit
 
-  const { data } = useSuspenseQuery(GET_COLLECTION_PERMISSIONS, {
+  const toggleShowDeleteModal = (nextState) => {
+    setShowDeleteModal(nextState)
+  }
+
+  const { data, refetch } = useSuspenseQuery(GET_COLLECTION_PERMISSIONS, {
     variables: {
       params: {
         identityType: 'catalog_item',
@@ -85,6 +103,23 @@ const PermissionList = () => {
             Edit
           </Button>
         </Col>
+        <Col className="col-auto">
+          <Button
+            className="d-flex"
+            Icon={FaTrash}
+            iconTitle="Delete Button"
+            onClick={
+              () => {
+                setSelectedPermission(rowData)
+                toggleShowDeleteModal(true)
+              }
+            }
+            variant="danger"
+            size="sm"
+          >
+            Delete
+          </Button>
+        </Col>
       </Row>
     )
   }, [])
@@ -107,6 +142,37 @@ const PermissionList = () => {
       dataAccessorFn: buildActionsCell
     }
   ]
+
+  const [deleteAclMutation] = useMutation(DELETE_ACL)
+
+  const handleDelete = () => {
+    const { conceptId } = selectedPermission
+    deleteAclMutation({
+      variables: {
+        conceptId
+      },
+      onCompleted: () => {
+        addNotification({
+          message: 'Collection permission was successfully deleted.',
+          variant: 'success'
+        })
+
+        refetch()
+      },
+      onError: () => {
+        addNotification({
+          message: 'Error deleting collection permission',
+          variant: 'danger'
+        })
+
+        errorLogger('Unable delete collection permission', 'Permission List: deleteAcl Mutation')
+
+        setShowDeleteModal(false)
+      }
+    })
+
+    setShowDeleteModal(false)
+  }
 
   return (
     <Row>
@@ -176,6 +242,26 @@ const PermissionList = () => {
           }
         </ControlledPaginatedContent>
       </Col>
+      <CustomModal
+        message="Are you sure you want to delete this collection permission?"
+        show={showDeleteModal}
+        size="lg"
+        toggleModal={toggleShowDeleteModal}
+        actions={
+          [
+            {
+              label: 'No',
+              variant: 'secondary',
+              onClick: () => { toggleShowDeleteModal(false) }
+            },
+            {
+              label: 'Yes',
+              variant: 'primary',
+              onClick: handleDelete
+            }
+          ]
+        }
+      />
     </Row>
   )
 }

--- a/static/src/js/components/PermissionList/__tests__/PermissionList.test.jsx
+++ b/static/src/js/components/PermissionList/__tests__/PermissionList.test.jsx
@@ -2,6 +2,7 @@ import { MockedProvider } from '@apollo/client/testing'
 import {
   render,
   screen,
+  waitFor,
   within
 } from '@testing-library/react'
 import React, { Suspense } from 'react'
@@ -163,6 +164,10 @@ const setup = ({
       }
     }
   }]
+
+  const notificationContext = {
+    addNotification: vi.fn()
+  }
 
   const user = userEvent.setup()
 

--- a/static/src/js/components/PermissionList/__tests__/PermissionList.test.jsx
+++ b/static/src/js/components/PermissionList/__tests__/PermissionList.test.jsx
@@ -5,7 +5,7 @@ import {
   within
 } from '@testing-library/react'
 import React, { Suspense } from 'react'
-import { BrowserRouter } from 'react-router-dom'
+
 import userEvent from '@testing-library/user-event'
 
 import { DELETE_ACL } from '@/js/operations/mutations/deleteAcl'
@@ -15,6 +15,7 @@ import NotificationsContext from '@/js/context/NotificationsContext'
 
 import errorLogger from '@/js/utils/errorLogger'
 
+import { MemoryRouter } from 'react-router'
 import PermissionList from '../PermissionList'
 
 vi.mock('../../../utils/errorLogger')
@@ -168,11 +169,11 @@ const setup = ({
   render(
     <NotificationsContext.Provider value={notificationContext}>
       <MockedProvider mocks={overrideMocks || mocks}>
-        <BrowserRouter initialEntries="">
+        <MemoryRouter>
           <Suspense>
             <PermissionList />
           </Suspense>
-        </BrowserRouter>
+        </MemoryRouter>
       </MockedProvider>
     </NotificationsContext.Provider>
   )
@@ -328,7 +329,7 @@ describe('PermissionList', () => {
                     params: {
                       identityType: 'catalog_item',
                       limit: 20,
-                      offset: 20
+                      offset: 0
                     }
                   }
                 },
@@ -376,7 +377,7 @@ describe('PermissionList', () => {
                     params: {
                       identityType: 'catalog_item',
                       limit: 20,
-                      offset: 20
+                      offset: 0
                     }
                   }
                 },
@@ -418,7 +419,7 @@ describe('PermissionList', () => {
                     params: {
                       identityType: 'catalog_item',
                       limit: 20,
-                      offset: 20
+                      offset: 0
                     }
                   }
                 },
@@ -484,7 +485,7 @@ describe('PermissionList', () => {
                     params: {
                       identityType: 'catalog_item',
                       limit: 20,
-                      offset: 20
+                      offset: 0
                     }
                   }
                 },

--- a/static/src/js/components/PermissionList/__tests__/PermissionList.test.jsx
+++ b/static/src/js/components/PermissionList/__tests__/PermissionList.test.jsx
@@ -8,8 +8,16 @@ import React, { Suspense } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 
+import { DELETE_ACL } from '@/js/operations/mutations/deleteAcl'
 import { GET_COLLECTION_PERMISSIONS } from '@/js/operations/queries/getCollectionPermissions'
+
+import NotificationsContext from '@/js/context/NotificationsContext'
+
+import errorLogger from '@/js/utils/errorLogger'
+
 import PermissionList from '../PermissionList'
+
+vi.mock('../../../utils/errorLogger')
 
 const setup = ({
   overrideMocks = false
@@ -158,13 +166,15 @@ const setup = ({
   const user = userEvent.setup()
 
   render(
-    <MockedProvider mocks={overrideMocks || mocks}>
-      <BrowserRouter initialEntries="">
-        <Suspense>
-          <PermissionList />
-        </Suspense>
-      </BrowserRouter>
-    </MockedProvider>
+    <NotificationsContext.Provider value={notificationContext}>
+      <MockedProvider mocks={overrideMocks || mocks}>
+        <BrowserRouter initialEntries="">
+          <Suspense>
+            <PermissionList />
+          </Suspense>
+        </BrowserRouter>
+      </MockedProvider>
+    </NotificationsContext.Provider>
   )
 
   return {
@@ -299,9 +309,223 @@ describe('PermissionList', () => {
 
       await user.click(paginationButton)
 
-      const paginationLinks = await screen.findAllByRole('cell')
+      await waitFor(() => {
+        expect(screen.queryAllByRole('cell')[0].textContent).toContain('Page 2 All Collection')
+      })
+    })
+  })
 
-      expect(paginationLinks[0].textContent).toContain('Page 2 All Collection')
+  describe('when clicking delete button', () => {
+    describe('when clicking yes on the delete modal', () => {
+      test('deletes collection permission and hides the modal', async () => {
+        const { user } = setup(
+          {
+            overrideMocks: [
+              {
+                request: {
+                  query: GET_COLLECTION_PERMISSIONS,
+                  variables: {
+                    params: {
+                      identityType: 'catalog_item',
+                      limit: 20,
+                      offset: 20
+                    }
+                  }
+                },
+                result: {
+                  data: {
+                    acls: {
+                      __typename: 'AclList',
+                      count: 1,
+                      items: [
+                        {
+                          __typename: 'Acl',
+                          conceptId: 'ACL1200216197-CMR',
+                          name: 'All Collections',
+                          providerIdentity: null,
+                          catalogItemIdentity: {
+                            name: 'All Collections',
+                            providerId: 'MMT_2',
+                            granuleApplicable: false,
+                            collectionApplicable: true
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                request: {
+                  query: DELETE_ACL,
+                  variables: { conceptId: 'ACL1200216197-CMR' }
+                },
+                result: {
+                  data: {
+                    deleteAcl: {
+                      conceptId: 'ACL1200216197-CMR',
+                      revisionId: '1'
+                    }
+                  }
+                }
+              },
+              {
+                request: {
+                  query: GET_COLLECTION_PERMISSIONS,
+                  variables: {
+                    params: {
+                      identityType: 'catalog_item',
+                      limit: 20,
+                      offset: 20
+                    }
+                  }
+                },
+                result: {
+                  data: {
+                    acls: {
+                      __typename: 'AclList',
+                      count: 0,
+                      items: []
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        )
+
+        const deleteLink = await screen.findByRole('button', { name: 'Delete Button Delete' })
+        await user.click(deleteLink)
+
+        expect(screen.getByText('Are you sure you want to delete this collection permission?')).toBeInTheDocument()
+
+        const yesButton = screen.getByRole('button', { name: 'Yes' })
+        await user.click(yesButton)
+
+        expect(await screen.findByText('No permissions found')).toBeInTheDocument()
+      })
+    })
+
+    describe('when clicking Yes on the delete modal results in a failure', () => {
+      test('should not delete the permission and calls errorLogger', async () => {
+        const { user } = setup(
+          {
+            overrideMocks: [
+              {
+                request: {
+                  query: GET_COLLECTION_PERMISSIONS,
+                  variables: {
+                    params: {
+                      identityType: 'catalog_item',
+                      limit: 20,
+                      offset: 20
+                    }
+                  }
+                },
+                result: {
+                  data: {
+                    acls: {
+                      __typename: 'AclList',
+                      count: 1,
+                      items: [
+                        {
+                          __typename: 'Acl',
+                          conceptId: 'ACL1200216197-CMR',
+                          name: 'All Collections',
+                          providerIdentity: null,
+                          catalogItemIdentity: {
+                            name: 'All Collections',
+                            providerId: 'MMT_2',
+                            granuleApplicable: false,
+                            collectionApplicable: true
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                request: {
+                  query: DELETE_ACL,
+                  variables: { conceptId: 'ACL1200216197-CMR' }
+                },
+                error: new Error('An error occurred')
+              }
+            ]
+          }
+        )
+        const deleteLink = await screen.findByRole('button', { name: 'Delete Button Delete' })
+        await user.click(deleteLink)
+
+        expect(screen.getByText('Are you sure you want to delete this collection permission?')).toBeInTheDocument()
+
+        const yesButton = screen.getByRole('button', { name: 'Yes' })
+        await user.click(yesButton)
+
+        expect(errorLogger).toHaveBeenCalledTimes(1)
+
+        expect(errorLogger).toHaveBeenCalledWith(
+          'Unable delete collection permission',
+          'Permission List: deleteAcl Mutation'
+        )
+      })
+    })
+
+    describe('when clicking no on the delete modal', () => {
+      test('should hide the modal and should not delete the permission', async () => {
+        const { user } = setup(
+          {
+            overrideMocks: [
+              {
+                request: {
+                  query: GET_COLLECTION_PERMISSIONS,
+                  variables: {
+                    params: {
+                      identityType: 'catalog_item',
+                      limit: 20,
+                      offset: 20
+                    }
+                  }
+                },
+                result: {
+                  data: {
+                    acls: {
+                      __typename: 'AclList',
+                      count: 1,
+                      items: [
+                        {
+                          __typename: 'Acl',
+                          conceptId: 'ACL1200216197-CMR',
+                          name: 'All Collections',
+                          providerIdentity: null,
+                          catalogItemIdentity: {
+                            name: 'All Collections',
+                            providerId: 'MMT_2',
+                            granuleApplicable: false,
+                            collectionApplicable: true
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        )
+
+        const deleteLink = await screen.findByRole('button', { name: 'Delete Button Delete' })
+        await user.click(deleteLink)
+
+        expect(screen.getByText('Are you sure you want to delete this collection permission?')).toBeInTheDocument()
+
+        const noButton = screen.getByRole('button', { name: 'No' })
+        await user.click(noButton)
+
+        expect(screen.getByText('Showing 1 permissions')).toBeInTheDocument()
+        expect(screen.queryByText('Are you sure you want to delete this collection permission?')).not.toBeInTheDocument()
+      })
     })
   })
 })

--- a/static/src/js/pages/PermissionPage/PermissionPage.jsx
+++ b/static/src/js/pages/PermissionPage/PermissionPage.jsx
@@ -69,7 +69,7 @@ const PermissionPageHeader = () => {
       },
       onCompleted: () => {
         addNotification({
-          message: 'Order Option was successfully deleted.',
+          message: 'Collection permission was successfully deleted.',
           variant: 'success'
         })
 
@@ -77,7 +77,7 @@ const PermissionPageHeader = () => {
       },
       onError: () => {
         addNotification({
-          message: 'Error deleting order option',
+          message: 'Error deleting collection permission',
           variant: 'danger'
         })
 

--- a/static/src/js/pages/PermissionPage/PermissionPage.jsx
+++ b/static/src/js/pages/PermissionPage/PermissionPage.jsx
@@ -1,18 +1,24 @@
-import { useSuspenseQuery } from '@apollo/client'
+import { useMutation, useSuspenseQuery } from '@apollo/client'
 
-import React, { Suspense } from 'react'
+import React, { Suspense, useState } from 'react'
 
-import { FaEdit } from 'react-icons/fa'
+import { useNavigate, useParams } from 'react-router'
 
-import { useParams } from 'react-router'
-
+import CustomModal from '@/js/components/CustomModal/CustomModal'
 import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
 import LoadingTable from '@/js/components/LoadingTable/LoadingTable'
 import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
 import Permission from '@/js/components/Permission/Permission'
 
+import { DELETE_ACL } from '@/js/operations/mutations/deleteAcl'
 import { GET_COLLECTION_PERMISSION } from '@/js/operations/queries/getCollectionPermission'
+
+import { FaEdit, FaTrash } from 'react-icons/fa'
+
+import useNotificationsContext from '@/js/hooks/useNotificationsContext'
+
+import errorLogger from '@/js/utils/errorLogger'
 
 /**
  * Renders a PermissionListPageHeader component
@@ -26,6 +32,18 @@ import { GET_COLLECTION_PERMISSION } from '@/js/operations/queries/getCollection
 const PermissionPageHeader = () => {
   const { conceptId } = useParams()
 
+  const { addNotification } = useNotificationsContext()
+
+  const navigate = useNavigate()
+
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+
+  const toggleShowDeleteModal = (nextState) => {
+    setShowDeleteModal(nextState)
+  }
+
+  const [deleteAclMutation] = useMutation(DELETE_ACL)
+
   const { data } = useSuspenseQuery(GET_COLLECTION_PERMISSION, {
     variables: {
       conceptId
@@ -35,34 +53,89 @@ const PermissionPageHeader = () => {
   const { acl } = data
   const { name } = acl
 
+  const handleDelete = () => {
+    deleteAclMutation({
+      variables: {
+        conceptId
+      },
+      onCompleted: () => {
+        addNotification({
+          message: 'Order Option was successfully deleted.',
+          variant: 'success'
+        })
+
+        navigate('/permissions')
+      },
+      onError: () => {
+        addNotification({
+          message: 'Error deleting order option',
+          variant: 'danger'
+        })
+
+        errorLogger('Unable delete collection permission', 'Permission Page: deleteAcl Mutation')
+
+        setShowDeleteModal(false)
+      }
+    })
+  }
+
   return (
-    <PageHeader
-      breadcrumbs={
-        [
-          {
-            label: 'Collection Permissions',
-            to: '/permissions'
-          },
-          {
-            label: name,
-            active: true
-          }
-        ]
-      }
-      pageType="secondary"
-      title={name}
-      primaryActions={
-        [
-          {
-            icon: FaEdit,
-            to: 'edit',
-            title: 'Edit',
-            iconTitle: 'A edit icon',
-            variant: 'primary'
-          }
-        ]
-      }
-    />
+    <>
+      <PageHeader
+        breadcrumbs={
+          [
+            {
+              label: 'Collection Permissions',
+              to: '/permissions'
+            },
+            {
+              label: name,
+              active: true
+            }
+          ]
+        }
+        pageType="secondary"
+        title={name}
+        primaryActions={
+          [
+            {
+              icon: FaEdit,
+              to: 'edit',
+              title: 'Edit',
+              iconTitle: 'A edit icon',
+              variant: 'primary'
+            },
+            {
+              icon: FaTrash,
+              onClick: () => toggleShowDeleteModal(true),
+              title: 'Delete',
+              iconTitle: 'A trash can icon',
+              variant: 'danger'
+            }
+          ]
+        }
+      />
+      <CustomModal
+        message="Are you sure you want to delete this collection permission?"
+        show={showDeleteModal}
+        size="lg"
+        toggleModal={toggleShowDeleteModal}
+        actions={
+          [
+            {
+              label: 'No',
+              variant: 'secondary',
+              onClick: () => { toggleShowDeleteModal(false) }
+            },
+            {
+              label: 'Yes',
+              variant: 'primary',
+              onClick: handleDelete
+            }
+          ]
+        }
+      />
+    </>
   )
 }
 

--- a/static/src/js/pages/PermissionPage/PermissionPage.jsx
+++ b/static/src/js/pages/PermissionPage/PermissionPage.jsx
@@ -4,6 +4,8 @@ import React, { Suspense, useState } from 'react'
 
 import { useNavigate, useParams } from 'react-router'
 
+import { FaEdit, FaTrash } from 'react-icons/fa'
+
 import CustomModal from '@/js/components/CustomModal/CustomModal'
 import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
 import LoadingTable from '@/js/components/LoadingTable/LoadingTable'
@@ -13,8 +15,6 @@ import Permission from '@/js/components/Permission/Permission'
 
 import { DELETE_ACL } from '@/js/operations/mutations/deleteAcl'
 import { GET_COLLECTION_PERMISSION } from '@/js/operations/queries/getCollectionPermission'
-
-import { FaEdit, FaTrash } from 'react-icons/fa'
 
 import useNotificationsContext from '@/js/hooks/useNotificationsContext'
 
@@ -42,7 +42,16 @@ const PermissionPageHeader = () => {
     setShowDeleteModal(nextState)
   }
 
-  const [deleteAclMutation] = useMutation(DELETE_ACL)
+  const [deleteAclMutation] = useMutation(DELETE_ACL, {
+    update: (cache) => {
+      cache.modify({
+        fields: {
+          // Remove the list of permissions from the cache. This ensures that if the user returns to the list page they will see the correct data.
+          permissions: () => {}
+        }
+      })
+    }
+  })
 
   const { data } = useSuspenseQuery(GET_COLLECTION_PERMISSION, {
     variables: {

--- a/static/src/js/pages/PermissionPage/__tests__/PermissionPage.test.jsx
+++ b/static/src/js/pages/PermissionPage/__tests__/PermissionPage.test.jsx
@@ -8,17 +8,24 @@ import {
 } from 'react-router'
 import userEvent from '@testing-library/user-event'
 
+import * as router from 'react-router'
+
+import { DELETE_ACL } from '@/js/operations/mutations/deleteAcl'
 import { GET_COLLECTION_PERMISSION } from '@/js/operations/queries/getCollectionPermission'
 
 import NotificationsContext from '@/js/context/NotificationsContext'
 
 import Permission from '@/js/components/Permission/Permission'
 
+import errorLogger from '@/js/utils/errorLogger'
+
 import PermissionPage from '../PermissionPage'
 
 vi.mock('../../../components/Permission/Permission')
+vi.mock('../../../utils/errorLogger')
 
 const setup = ({
+  additionalMocks = [],
   overrideMocks = false
 }) => {
   const mockPermission = {
@@ -45,7 +52,7 @@ const setup = ({
         acl: mockPermission
       }
     }
-  }]
+  }, ...additionalMocks]
 
   const notificationContext = {
     addNotification: vi.fn()
@@ -95,6 +102,96 @@ describe('PermissionPage', () => {
       expect(pageContent[0]).toBeInTheDocument()
 
       expect(Permission).toHaveBeenCalled(1)
+    })
+  })
+
+  describe('when clicking the delete button', () => {
+    describe('when clicking Yes on the delete modal results in a success', () => {
+      test('should delete the permission and hides the modal', async () => {
+        const navigateSpy = vi.fn()
+        vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+
+        const { user } = setup({
+          additionalMocks: [
+            {
+              request: {
+                query: DELETE_ACL,
+                variables: { conceptId: 'ACL00000-CMR' }
+              },
+              result: {
+                data: {
+                  deleteAcl: {
+                    conceptId: 'ACL1200216197-CMR',
+                    revisionId: '1'
+                  }
+                }
+              }
+            }
+          ]
+        })
+
+        const deleteLink = await screen.findByRole('button', { name: 'A trash can icon Delete' })
+        await user.click(deleteLink)
+
+        expect(screen.getByText('Are you sure you want to delete this collection permission?')).toBeInTheDocument()
+
+        const yesButton = screen.getByRole('button', { name: 'Yes' })
+        await user.click(yesButton)
+
+        expect(navigateSpy).toHaveBeenCalledTimes(1)
+        expect(navigateSpy).toHaveBeenCalledWith('/permissions')
+      })
+    })
+
+    describe('when clicking Yes on the delete modal results in a failure', () => {
+      test('does not delete the collection permission and calls errorLogger', async () => {
+        const { user } = setup({
+          additionalMocks: [
+            {
+              request: {
+                query: DELETE_ACL,
+                variables: { conceptId: 'ACL00000-CMR' }
+              },
+              error: new Error('An error occurred')
+            }
+          ]
+        })
+
+        const deleteLink = await screen.findByRole('button', { name: 'A trash can icon Delete' })
+        await user.click(deleteLink)
+
+        expect(screen.getByText('Are you sure you want to delete this collection permission?')).toBeInTheDocument()
+
+        const yesButton = screen.getByRole('button', { name: 'Yes' })
+        await user.click(yesButton)
+
+        expect(errorLogger).toHaveBeenCalledTimes(1)
+
+        expect(errorLogger).toHaveBeenCalledWith(
+          'Unable delete collection permission',
+          'Permission Page: deleteAcl Mutation'
+        )
+      })
+    })
+  })
+
+  describe('when clicking no on the delete modal', () => {
+    test('should hide the modal and should not delete the permission', async () => {
+      const navigateSpy = vi.fn()
+      vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+
+      const { user } = setup({})
+
+      const deleteLink = await screen.findByRole('button', { name: 'A trash can icon Delete' })
+      await user.click(deleteLink)
+
+      expect(screen.getByText('Are you sure you want to delete this collection permission?')).toBeInTheDocument()
+
+      const noButton = screen.getByRole('button', { name: 'No' })
+      await user.click(noButton)
+
+      expect(navigateSpy).toHaveBeenCalledTimes(0)
+      expect(screen.queryByText('Are you sure you want to delete this collection permission?')).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

Adding support for deleting a collection permission

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings