### PR TITLE
MMT-3778: Fixes saving changes to a newly created template

### DIFF
--- a/static/src/js/components/TemplateForm/TemplateForm.jsx
+++ b/static/src/js/components/TemplateForm/TemplateForm.jsx
@@ -165,6 +165,9 @@ const TemplateForm = () => {
     if (id === 'new') {
       const response = await createTemplate(providerId, mmtJwt, ummMetadata)
 
+      // Set the providerId into state so saving the template again will have the correct providerId
+      setTemplateProviderId(providerId)
+
       if (response.id) {
         savedId = response.id
       } else {


### PR DESCRIPTION
# Overview

### What is the feature?

Updating a template relies on retrieving the providerId from the saved template, but for a newly created template that provider isn't available. This PR saves that selected providerId into the state where the update function is expecting it

### What areas of the application does this impact?

Templates

# Testing

Create a new collection template with the save or save & continue option. After it successfully saves, click save again, ensure that second save is successful

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings