### PR TITLE
MMT-3778: Fixes bug when selecting data center short name

### DIFF
--- a/static/src/js/components/GridControlledField/GridControlledField.jsx
+++ b/static/src/js/components/GridControlledField/GridControlledField.jsx
@@ -242,7 +242,15 @@ const GridControlledField = (props) => {
             onChange(updatedFormData, null)
 
             if (onSelectValue) {
-              onSelectValue(name, selectValue, props, cmrKeywords)
+              onSelectValue(
+                name,
+                selectValue,
+                {
+                  ...props,
+                  formData: updatedFormData
+                },
+                cmrKeywords
+              )
             }
           }
         }

--- a/static/src/js/components/GridControlledField/__tests__/GridControlledField.test.jsx
+++ b/static/src/js/components/GridControlledField/__tests__/GridControlledField.test.jsx
@@ -401,7 +401,17 @@ describe('GridControlledField', () => {
           expect(props.onChange).toHaveBeenCalledWith({ URLContentType: 'DataCenterURL' }, null)
 
           expect(props.onSelectValue).toHaveBeenCalledTimes(1)
-          expect(props.onSelectValue).toHaveBeenCalledWith('URLContentType', 'DataCenterURL', props, relatedUrlsKeywords)
+          expect(props.onSelectValue).toHaveBeenCalledWith(
+            'URLContentType',
+            'DataCenterURL',
+            {
+              ...props,
+              formData: {
+                URLContentType: 'DataCenterURL'
+              }
+            },
+            relatedUrlsKeywords
+          )
         })
       })
     })


### PR DESCRIPTION
# Overview

### What is the feature?

Selecting a data center short name was populating the related url, but unselecting the short name/long name

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings