### PR TITLE
MMT-3787: Adding production warning and environment badges

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -19,6 +19,7 @@ config="`jq '.application.cmrHost = $newValue' --arg newValue $bamboo_CMR_HOST <
 config="`jq '.application.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
 config="`jq '.application.gkrHost = $newValue' --arg newValue $bamboo_GKR_HOST <<< $config`"
 config="`jq '.application.cookieDomain = $newValue' --arg newValue $bamboo_COOKIE_DOMAIN <<< $config`"
+config="`jq '.application.displayProdWarning = $newValue' --arg newValue $bamboo_DISPLAY_PROD_WARNING <<< $config`"
 config="`jq '.application.tokenValidTime = $newValue' --arg newValue $bamboo_JWT_VALID_TIME <<< $config`"
 config="`jq '.saml.host = $newValue' --arg newValue $bamboo_SAML_HOST <<< $config`"
 config="`jq '.saml.callbackUrl = $newValue' --arg newValue $bamboo_SAML_CALLBACK_URL <<< $config`"
@@ -65,6 +66,7 @@ dockerRun() {
         -e "AWS_ACCESS_KEY_ID=$bamboo_AWS_ACCESS_KEY_ID" \
         -e "AWS_SECRET_ACCESS_KEY=$bamboo_AWS_SECRET_ACCESS_KEY" \
         -e "COOKIE_DOMAIN=$bamboo_COOKIE_DOMAIN" \
+        -e "DISPLAY_PROD_WARNING=$bamboo_DISPLAY_PROD_WARNING" \
         -e "EDL_PASSWORD=$bamboo_EDL_PASSWORD" \
         -e "JWT_SECRET=$bamboo_JWT_SECRET" \
         -e "JWT_VALID_TIME=$bamboo_JWT_VALID_TIME" \

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Metadata Management Tool</title>
     <link rel="stylesheet" type="text/css" href="/static/src/css/initial/index.scss">
-  <body class="h-100 flex flex-column is-loading">
+  <body class="h-100 d-flex flex-column is-loading">
     <div id="earthdata-tophat2" class="th-wrapper d-block w-100" style="height: 34px; background: #000;"></div>
     <div id="root" class="d-flex flex-grow-1 flex-shrink-1 align-items-stretch w-100 overflow-hidden"></div>
     <div class="app-loading-screen">

--- a/static.config.json
+++ b/static.config.json
@@ -14,7 +14,8 @@
       "Access-Control-Allow-Credentials": true
     },
     "cookieDomain": ".localhost",
-    "tokenValidTime": "900"
+    "tokenValidTime": "900",
+    "displayProdWarning": true
   },
   "ummVersions": {
     "ummC": "1.17.3",

--- a/static.config.json
+++ b/static.config.json
@@ -15,7 +15,7 @@
     },
     "cookieDomain": ".localhost",
     "tokenValidTime": "900",
-    "displayProdWarning": true
+    "displayProdWarning": "true"
   },
   "ummVersions": {
     "ummC": "1.17.3",

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -67,7 +67,7 @@ const Layout = ({ className, displayNav }) => {
         className="d-flex h-100 w-100 flex-grow-1 flex-column"
       >
         {
-          (env === 'production' && displayProdWarning) && (
+          (env === 'production' && displayProdWarning === 'true') && (
             <Alert className="mb-0 rounded-0 d-flex align-items-center justify-content-center p-3 flex-column flex-sm-row" variant="warning">
               <span className="d-inline-flex align-items-center gap-1 me-3">
                 <FaExclamationTriangle />
@@ -99,7 +99,7 @@ const Layout = ({ className, displayNav }) => {
                   <section className="position-relative d-flex w-100 flex-column overflow-y-auto flex-shrink-1">
                     {
                       env && env !== 'production' && (
-                        <Badge className="layout__env-badge position-absolute" bg="orange" data-testid="environment-badge">
+                        <Badge className="layout__env-badge position-absolute" bg="orange" data-testid="env-badge">
                           <span className="visually-hidden">Environment: </span>
                           {(env === 'development' ? 'dev' : env).toUpperCase()}
                         </Badge>

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -6,6 +6,7 @@ import Navbar from 'react-bootstrap/Navbar'
 import Dropdown from 'react-bootstrap/Dropdown'
 import {
   FaBook,
+  FaExclamationTriangle,
   FaExternalLinkAlt,
   FaList,
   FaQuestionCircle,
@@ -16,12 +17,13 @@ import {
 import useAuthContext from '@/js/hooks/useAuthContext'
 import usePermissions from '@/js/hooks/usePermissions'
 
+import { Alert, Badge } from 'react-bootstrap'
 import Button from '../Button/Button'
 import ErrorBoundary from '../ErrorBoundary/ErrorBoundary'
 import PrimaryNavigation from '../PrimaryNavigation/PrimaryNavigation'
 import AboutModal from '../AboutModal/AboutModal'
 
-import { getUmmVersionsConfig } from '../../../../../sharedUtils/getConfig'
+import { getApplicationConfig, getUmmVersionsConfig } from '../../../../../sharedUtils/getConfig'
 
 import './Layout.scss'
 
@@ -44,6 +46,8 @@ const Layout = ({ className, displayNav }) => {
     ummV
   } = getUmmVersionsConfig()
 
+  const { env, displayProdWarning } = getApplicationConfig()
+
   const { user } = useAuthContext()
 
   const { hasSystemGroup, loading } = usePermissions({
@@ -60,13 +64,26 @@ const Layout = ({ className, displayNav }) => {
   return (
     <>
       <div
-        className="flex w-100 flex-grow-0"
+        className="d-flex h-100 w-100 flex-grow-1 flex-column"
       >
+        {
+          (env === 'production' && displayProdWarning) && (
+            <Alert className="mb-0 rounded-0 d-flex align-items-center justify-content-center p-3 flex-column flex-sm-row" variant="warning">
+              <span className="d-inline-flex align-items-center gap-1 me-3">
+                <FaExclamationTriangle />
+                <strong>Caution</strong>
+              </span>
+              <span className="text-center">
+                You are currently viewing/editing the production CMR environment
+              </span>
+            </Alert>
+          )
+        }
         <ErrorBoundary>
           <main
             className={
               classNames([
-                'w-100 h-100 d-flex flex-column flex-grow-0 flex-md-row',
+                'w-100 d-flex flex-column flex-grow-1 flex-md-row overflow-hidden',
                 {
                   [className]: className
                 }
@@ -79,7 +96,15 @@ const Layout = ({ className, displayNav }) => {
                   className="layout__sidebar d-flex flex-column flex-md-row md-w-100 align-items-stretch flex-grow-0 md-flex-grow-1 flex-shrink-0 bg-light py-0"
                   expand="md"
                 >
-                  <section className="d-flex flex-column overflow-y-auto flex-shrink-1">
+                  <section className="position-relative d-flex w-100 flex-column overflow-y-auto flex-shrink-1">
+                    {
+                      env && env !== 'production' && (
+                        <Badge className="layout__env-badge position-absolute" bg="orange" data-testid="environment-badge">
+                          <span className="visually-hidden">Environment: </span>
+                          {(env === 'development' ? 'dev' : env).toUpperCase()}
+                        </Badge>
+                      )
+                    }
                     <div className="px-2 py-4 flex-shrink-0 flex-grow-0 d-flex flex-row justify-content-between">
                       <Navbar.Brand className="d-block nasa text-wrap text-dark" as={Link} to="/">
                         <span className="layout__brand-earthdata d-block text-uppercase">Earthdata</span>
@@ -195,7 +220,7 @@ const Layout = ({ className, displayNav }) => {
                         }
                       />
                       <div
-                        className="rounded p-2 border-top mt-auto"
+                        className="d-flex align-items-center justify-content-between p-2 pe-3 border-top mt-auto"
                       >
                         <Dropdown className="d-block text-secondary" drop="up">
                           <Dropdown.Toggle

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -2,8 +2,10 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { Link, Outlet } from 'react-router-dom'
 import classNames from 'classnames'
-import Navbar from 'react-bootstrap/Navbar'
+import Alert from 'react-bootstrap/Alert'
+import Badge from 'react-bootstrap/Badge'
 import Dropdown from 'react-bootstrap/Dropdown'
+import Navbar from 'react-bootstrap/Navbar'
 import {
   FaBook,
   FaExclamationTriangle,
@@ -17,7 +19,6 @@ import {
 import useAuthContext from '@/js/hooks/useAuthContext'
 import usePermissions from '@/js/hooks/usePermissions'
 
-import { Alert, Badge } from 'react-bootstrap'
 import Button from '../Button/Button'
 import ErrorBoundary from '../ErrorBoundary/ErrorBoundary'
 import PrimaryNavigation from '../PrimaryNavigation/PrimaryNavigation'
@@ -67,6 +68,8 @@ const Layout = ({ className, displayNav }) => {
         className="d-flex h-100 w-100 flex-grow-1 flex-column"
       >
         {
+          // eslint-disable-next-line capitalized-comments
+          // "displayProdWarning" is a string because it is a bamboo variable
           (env === 'production' && displayProdWarning === 'true') && (
             <Alert className="mb-0 rounded-0 d-flex align-items-center justify-content-center p-3 flex-column flex-sm-row" variant="warning">
               <span className="d-inline-flex align-items-center gap-1 me-3">

--- a/static/src/js/components/Layout/Layout.scss
+++ b/static/src/js/components/Layout/Layout.scss
@@ -33,4 +33,9 @@
       color: $gray-500;
     }
   }
+
+  &__env-badge {
+    top: 0.75rem;
+    right: 0.75rem;
+  }
 }

--- a/static/src/js/components/Layout/__tests__/Layout.test.jsx
+++ b/static/src/js/components/Layout/__tests__/Layout.test.jsx
@@ -337,8 +337,7 @@ describe('Layout component', () => {
     describe('when the prod warning is disabled', () => {
       test('does not display the warning', () => {
         vi.spyOn(getConfig, 'getApplicationConfig').mockImplementation(() => ({
-          env: 'production',
-          displayProdWarning: false
+          env: 'production'
         }))
 
         setup()
@@ -351,7 +350,7 @@ describe('Layout component', () => {
       test('displays the warning', () => {
         vi.spyOn(getConfig, 'getApplicationConfig').mockImplementation(() => ({
           env: 'production',
-          displayProdWarning: true
+          displayProdWarning: 'true'
         }))
 
         setup()

--- a/static/src/js/components/Layout/__tests__/Layout.test.jsx
+++ b/static/src/js/components/Layout/__tests__/Layout.test.jsx
@@ -322,4 +322,78 @@ describe('Layout component', () => {
       expect(screen.getByText('This is some content')).toBeInTheDocument()
     })
   })
+
+  describe('when in the production environment', () => {
+    test('does not display the badge', () => {
+      vi.spyOn(getConfig, 'getApplicationConfig').mockImplementation(() => ({
+        env: 'production'
+      }))
+
+      setup()
+
+      expect(screen.queryByTestId('env-badge')).not.toBeInTheDocument()
+    })
+
+    describe('when the prod warning is disabled', () => {
+      test('does not display the warning', () => {
+        vi.spyOn(getConfig, 'getApplicationConfig').mockImplementation(() => ({
+          env: 'production',
+          displayProdWarning: false
+        }))
+
+        setup()
+
+        expect(screen.queryByText('You are currently viewing/editing the production CMR environment')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('when the prod warning is enabled', () => {
+      test('displays the warning', () => {
+        vi.spyOn(getConfig, 'getApplicationConfig').mockImplementation(() => ({
+          env: 'production',
+          displayProdWarning: true
+        }))
+
+        setup()
+
+        expect(screen.getByText('You are currently viewing/editing the production CMR environment')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when in the SIT environment', () => {
+    test('displays the badge', () => {
+      vi.spyOn(getConfig, 'getApplicationConfig').mockImplementation(() => ({
+        env: 'sit'
+      }))
+
+      setup()
+
+      expect(screen.getByText('SIT')).toBeInTheDocument()
+    })
+  })
+
+  describe('when in the UAT environment', () => {
+    test('displays the badge', () => {
+      vi.spyOn(getConfig, 'getApplicationConfig').mockImplementation(() => ({
+        env: 'uat'
+      }))
+
+      setup()
+
+      expect(screen.getByText('UAT')).toBeInTheDocument()
+    })
+  })
+
+  describe('when in the development environment', () => {
+    test('displays the badge', () => {
+      vi.spyOn(getConfig, 'getApplicationConfig').mockImplementation(() => ({
+        env: 'development'
+      }))
+
+      setup()
+
+      expect(screen.getByText('DEV')).toBeInTheDocument()
+    })
+  })
 })

--- a/static/src/js/components/PageHeader/PageHeader.jsx
+++ b/static/src/js/components/PageHeader/PageHeader.jsx
@@ -114,7 +114,7 @@ const PageHeader = ({
         </Breadcrumb>
       )
     }
-    <div className="d-flex w-100 align-items-center justify-content-between">
+    <div className="d-flex w-100 align-items-center justify-content-between flex-wrap">
       <div className="d-flex align-items-center">
         <h2
           className="m-0 text-gray-200 fs-4"


### PR DESCRIPTION
# Overview

### What is the feature?

- Inform the user of their current environment
- Show a warning banner in the production environment

### What is the Solution?

- Added a banner at the top of the page when in production (based on a bamboo flag)
- Added a badge to the sidebar with the current environment for all envs except production
- Minor css changes

### What areas of the application does this impact?

- Layout.jsx

# Testing

### Reproduction steps

- **Environment for testing:** N/A
- **Collection to test with:** N/A

1. Verify the banner exists when in the production environment
2. Verify the badge exists when in dev, sit, and uat environments

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings