### PR TITLE
MMT-3776: Issues found testing collection permissions

### DIFF
--- a/static/src/js/components/CollectionSelector/CollectionSelector.jsx
+++ b/static/src/js/components/CollectionSelector/CollectionSelector.jsx
@@ -272,6 +272,7 @@ const CollectionSelector = ({ onChange, formData }) => {
           <Form.Control
             className="mb-3"
             onChange={handleAvailableSearchChange}
+            onKeyDown={(event) => { if (event.key === 'Enter') event.preventDefault() }}
             placeholder="Search Available..."
             type="text"
             value={searchAvailable}
@@ -403,11 +404,12 @@ const CollectionSelector = ({ onChange, formData }) => {
         <div className="border rounded p-3 h-100">
           <h5 className="text-center mb-3">Selected Collections</h5>
           <Form.Control
-            type="text"
-            placeholder="Search Selected..."
-            value={searchSelected}
-            onChange={(e) => setSearchSelected(e.target.value)}
             className="mb-3"
+            onChange={(e) => setSearchSelected(e.target.value)}
+            onKeyDown={(event) => { if (event.key === 'Enter') event.preventDefault() }}
+            placeholder="Search Selected..."
+            type="text"
+            value={searchSelected}
           />
           <div className="collection-selector__list-group d-block w-100 overflow-y-scroll border rounded">
 

--- a/static/src/js/components/CollectionSelector/__tests__/CollectionSelector.test.jsx
+++ b/static/src/js/components/CollectionSelector/__tests__/CollectionSelector.test.jsx
@@ -270,6 +270,24 @@ describe('CollectionSelector', () => {
     })
   })
 
+  describe('when the user presses enter key', () => {
+    test('prevents Enter key default action in search input', async () => {
+      const { user } = setup({})
+
+      const availableSearchField = await screen.findByPlaceholderText('Search Available...')
+
+      await user.type(availableSearchField, '{enter}')
+
+      expect(availableSearchField).toHaveValue('')
+
+      const selectedSearchField = await screen.findByPlaceholderText('Search Selected...')
+
+      await user.type(selectedSearchField, '{enter}')
+
+      expect(selectedSearchField).toHaveValue('')
+    })
+  })
+
   describe('when searching for selected collection', () => {
     test('should call cmr with filtered data', async () => {
       const { user } = setup({


### PR DESCRIPTION
# Overview

### What is the feature?

During SIT testing, Francell found that pressing enter for the Collection Selector search was submitting the form.

### What is the Solution?

For the search I have disabled the Enter keyDown by using `event.preventDefault()`

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings