### PR TITLE
MMT-3776: Issues found testing collection permissions

### DIFF
--- a/static/src/js/components/PermissionForm/PermissionForm.jsx
+++ b/static/src/js/components/PermissionForm/PermissionForm.jsx
@@ -496,54 +496,62 @@ const PermissionForm = () => {
     // Extract permissions from groupPermissions
     const { searchGroup, searchAndOrderGroup } = groupPermissions
 
-    const searchGroupPermissions = searchGroup?.map((item) => {
-      const { value } = item
-      // Handle special cases for guest and registered users
-      if (value === 'all-guest-user') {
+    let searchGroupPermissions = []
+
+    let searchAndOrderGroupPermissions = []
+
+    if (searchGroup) {
+      searchGroupPermissions = searchGroup.map((item) => {
+        const { value } = item
+        // Handle special cases for guest and registered users
+        if (value === 'all-guest-user') {
+          return {
+            permissions: ['read'],
+            userType: 'guest'
+          }
+        }
+
+        if (value === 'all-registered-user') {
+          return {
+            permissions: ['read'],
+            userType: 'registered'
+          }
+        }
+
         return {
           permissions: ['read'],
-          userType: 'guest'
+          groupId: value
         }
-      }
+      })
+    }
 
-      if (value === 'all-registered-user') {
-        return {
-          permissions: ['read'],
-          userType: 'registered'
+    if (searchAndOrderGroup) {
+      searchAndOrderGroupPermissions = searchAndOrderGroup?.map((item) => {
+        const { value } = item
+
+        if (value === 'all-guest-user') {
+          return {
+            permissions: ['read', 'order'],
+            userType: 'guest'
+          }
         }
-      }
 
-      return {
-        permissions: ['read'],
-        groupId: value
-      }
-    })
-
-    const searchAndOrderGroupPermissions = searchAndOrderGroup?.map((item) => {
-      const { value } = item
-
-      if (value === 'all-guest-user') {
-        return {
-          permissions: ['read', 'order'],
-          userType: 'guest'
+        if (value === 'all-registered-user') {
+          return {
+            permissions: ['read', 'order'],
+            userType: 'registered'
+          }
         }
-      }
 
-      if (value === 'all-registered-user') {
         return {
           permissions: ['read', 'order'],
-          userType: 'registered'
+          groupId: value
         }
-      }
-
-      return {
-        permissions: ['read', 'order'],
-        groupId: value
-      }
-    })
+      })
+    }
 
     // Combine searchGroupPermissions and searchAndOrderGroupPermissions into permissions array
-    const permissions = searchGroupPermissions?.concat(searchAndOrderGroupPermissions)
+    const permissions = searchGroupPermissions.concat(searchAndOrderGroupPermissions)
 
     // Construct catalogItemIdentity object
     const catalogItemIdentity = {


### PR DESCRIPTION
# Overview

### What is the feature?

During SIT testing, Francell found when only filling out `Search, Order, and S3 (If Available)` in the form was causing an error when saving the form.

### What is the Solution?

There was a error in the logic where if searchGroup was empty it was not concating the permission array correctly and sending empty array to CMR

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings