### PR TITLE
MMT-3804: User cannot clone a collection record

### DIFF
--- a/static/src/js/components/PublishPreview/PublishPreview.jsx
+++ b/static/src/js/components/PublishPreview/PublishPreview.jsx
@@ -125,9 +125,9 @@ const PublishPreviewHeader = () => {
   const handleClone = () => {
     const cloneNativeId = `MMT_${crypto.randomUUID()}`
     // Removes the value from the metadata that has to be unique
-    removeMetadataKeys(ummMetadata, ['Name', 'LongName', 'ShortName'])
+    const modifiedMetadata = removeMetadataKeys(ummMetadata, ['Name', 'LongName', 'ShortName'])
 
-    ingestMutation(derivedConceptType, ummMetadata, cloneNativeId, providerId)
+    ingestMutation(derivedConceptType, modifiedMetadata, cloneNativeId, providerId)
   }
 
   // Handles the user selecting download record

--- a/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.jsx
+++ b/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.jsx
@@ -433,7 +433,6 @@ describe('PublishPreview', () => {
       expect(constructDownloadableFile).toHaveBeenCalledWith(
         JSON.stringify(mock.ummMetadata),
         'T1000000-MMT'
-
       )
     })
   })

--- a/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.jsx
+++ b/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.jsx
@@ -68,7 +68,7 @@ const mock = {
     name: 'UMM-T',
     version: '1.2.0'
   },
-  name: 'Testing tools for publiush asdfasfd',
+  name: 'Testing tools for publish Preview',
   organizations: [
     {
       roles: [
@@ -79,7 +79,7 @@ const mock = {
       urlValue: 'http://www.esa.org/education/'
     }
   ],
-  pageTitle: 'Testing tools for publiush asdfasfd',
+  pageTitle: 'Testing tools for publish Preview',
   providerId: 'MMT_2',
   potentialAction: null,
   quality: null,
@@ -104,7 +104,11 @@ const mock = {
     }
   ],
   type: 'Web User Interface',
-  ummMetadata: {},
+  ummMetadata: {
+    Name: 'Testing tools for publish Preview',
+    LongName: 'Mock Long Name',
+    Description: 'Mock description'
+  },
   url: {
     urlContentType: 'DistributionURL',
     type: 'DOWNLOAD SOFTWARE',
@@ -316,7 +320,11 @@ describe('PublishPreview', () => {
             query: INGEST_DRAFT,
             variables: {
               conceptType: 'Tool',
-              metadata: {},
+              metadata: {
+                Name: 'Testing tools for publish Preview',
+                LongName: 'Mock Long Name',
+                Description: 'Mock description'
+              },
               nativeId: 'MMT_PUBLISH_8b8a1965-67a5-415c-ae4c-8ecbafd84131',
               providerId: 'MMT_2',
               ummVersion: '1.2.0'
@@ -350,8 +358,12 @@ describe('PublishPreview', () => {
             query: INGEST_DRAFT,
             variables: {
               conceptType: 'Tool',
+              metadata: {
+                Name: 'Testing tools for publish Preview',
+                LongName: 'Mock Long Name',
+                Description: 'Mock description'
+              },
               nativeId: 'MMT_PUBLISH_8b8a1965-67a5-415c-ae4c-8ecbafd84131',
-              metadata: {},
               providerId: 'MMT_2',
               ummVersion: '1.2.0'
             }
@@ -380,7 +392,7 @@ describe('PublishPreview', () => {
             query: INGEST_DRAFT,
             variables: {
               conceptType: 'Tool',
-              metadata: {},
+              metadata: { Description: 'Mock description' },
               nativeId: 'MMT_mock-uuid',
               providerId: 'MMT_2',
               ummVersion: '1.2.0'
@@ -417,9 +429,11 @@ describe('PublishPreview', () => {
       await user.click(downloadButton)
 
       expect(constructDownloadableFile).toHaveBeenCalledTimes(1)
+
       expect(constructDownloadableFile).toHaveBeenCalledWith(
-        JSON.stringify(mock.ummMetadata, null, 2),
+        JSON.stringify(mock.ummMetadata),
         'T1000000-MMT'
+
       )
     })
   })

--- a/static/src/js/utils/removeMetadataKeys.js
+++ b/static/src/js/utils/removeMetadataKeys.js
@@ -1,3 +1,5 @@
+import { cloneDeep } from 'lodash-es'
+
 /**
  * Given a ummMetadata object, removes all the keys that are given in the
  * keys array.
@@ -5,7 +7,7 @@
  * @param {Array} keys An array that has all the keys that needs to be removed
  */
 const removeMetadataKeys = (metadata, keys) => {
-  const modifiedMetadata = metadata
+  const modifiedMetadata = cloneDeep(metadata)
 
   Object.keys(metadata).forEach((key) => {
     if (keys.includes(key)) {


### PR DESCRIPTION
# Overview

### What is the feature?

A user testing in UAT reported that they were unable to clone a Collection record. They were getting an error 

`Uncaught TypeError: property "ShortName" is non-configurable and can't be deleted`

The ummMetadata object that coming from graphql response is `non-configurable` because of this we cannot perform any modification on that object

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_delete

### What is the Solution?

The solution for this issue is to create a clone of the object which will allow us to modify the object and return the new object. 

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings