### PR TITLE
MMT-3624: umm_c's Spatial Information Bounding Rectangle boxes are missing i-icons, page is being rolled when using mouse roll to increase/decrease number in these boxes.

### DIFF
--- a/static/src/css/initial/index.scss
+++ b/static/src/css/initial/index.scss
@@ -83,3 +83,17 @@ body {
     opacity: 1;
   }
 }
+
+/* Removes scrollbar for input fields with type Number */
+/* stylelint-disable property-no-vendor-prefix */
+input[type='number']::-webkit-outer-spin-button,
+input[type='number']::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+}
+
+/* Firefox */
+input[type='number'] {
+  -moz-appearance: textfield;
+    appearance: textfield;
+}

--- a/static/src/js/components/BoundingRectangleField/BoundingRectangleField.jsx
+++ b/static/src/js/components/BoundingRectangleField/BoundingRectangleField.jsx
@@ -2,13 +2,16 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import Button from 'react-bootstrap/Button'
 
-import './BoundingRectangleField.scss'
 import CustomWidgetWrapper from '../CustomWidgetWrapper/CustomWidgetWrapper'
+
+import './BoundingRectangleField.scss'
 
 /**
  * BoundingRectangleField
  * @property {Object} formData Saved draft.
+ * @property {String} name String BoundingRectangle--0, etc.
  * @property {Function} onChange A callback function triggered when the user inputs a text.
+ * @property {Object} schema The UMM Schema for this custom widget.
  */
 
 /**
@@ -16,17 +19,19 @@ import CustomWidgetWrapper from '../CustomWidgetWrapper/CustomWidgetWrapper'
  * @param {BoundingRectangleField} props
  */
 const BoundingRectangleField = ({
-  name,
   formData,
+  name,
   onChange,
   schema
 }) => {
   const { properties } = schema
-  const { EastBoundingCoordinate: EBoundingCoordinate } = properties
-  const { NorthBoundingCoordinate: NBoundingCoordinate } = properties
-  const { description: latitudeDescription } = EBoundingCoordinate
-  const { description: longitudeDescription } = NBoundingCoordinate
-  
+  const {
+    EastBoundingCoordinate: eBoundingCoordinate,
+    NorthBoundingCoordinate: nBoundingCoordinate
+  } = properties
+  const { description: latitudeDescription } = eBoundingCoordinate
+  const { description: longitudeDescription } = nBoundingCoordinate
+
   // Creates state object from given coordinates
   const createStateObject = (object) => {
     const {
@@ -104,11 +109,12 @@ const BoundingRectangleField = ({
           <div className="bounding-rectangle-coordinate-label">
             <CustomWidgetWrapper
               id={name}
-              title='North'
+              title="North"
               description={longitudeDescription}
               centered
             >
               <input
+                aria-label="North"
                 className="form-control bounding-rectangle-coordinate"
                 type="number"
                 step="any"
@@ -129,11 +135,12 @@ const BoundingRectangleField = ({
             <div className="bounding-rectangle-coordinate-label">
               <CustomWidgetWrapper
                 id={name}
-                title='West'
+                title="West"
                 description={latitudeDescription}
                 centered
               >
                 <input
+                  aria-label="West"
                   className="form-control bounding-rectangle-coordinate"
                   type="number"
                   step="any"
@@ -153,11 +160,12 @@ const BoundingRectangleField = ({
             <div className="bounding-rectangle-coordinate-label">
               <CustomWidgetWrapper
                 id={name}
-                title='East'
+                title="East"
                 description={latitudeDescription}
                 centered
               >
                 <input
+                  aria-label="East"
                   className="form-control bounding-rectangle-coordinate"
                   type="number"
                   step="any"
@@ -178,11 +186,12 @@ const BoundingRectangleField = ({
           <div className="bounding-rectangle-coordinate-label">
             <CustomWidgetWrapper
               id={name}
-              title='South'
+              title="South"
               description={longitudeDescription}
               centered
             >
               <input
+                aria-label="South"
                 className="form-control bounding-rectangle-coordinate"
                 type="number"
                 step="any"
@@ -204,7 +213,6 @@ const BoundingRectangleField = ({
 }
 
 BoundingRectangleField.propTypes = {
-  name: PropTypes.string.isRequired,
   formData: PropTypes.shape({
     NorthBoundingCoordinate: PropTypes.number,
     SouthBoundingCoordinate: PropTypes.number,
@@ -212,6 +220,7 @@ BoundingRectangleField.propTypes = {
     WestBoundingCoordinate: PropTypes.number
   }).isRequired,
   onChange: PropTypes.func.isRequired,
+  name: PropTypes.string.isRequired,
   schema: PropTypes.shape({
     properties: PropTypes.shape({
       NorthBoundingCoordinate: PropTypes.shape({
@@ -221,7 +230,7 @@ BoundingRectangleField.propTypes = {
         description: PropTypes.string.isRequired
       })
     })
-  })
+  }).isRequired
 }
 
 export default BoundingRectangleField

--- a/static/src/js/components/BoundingRectangleField/BoundingRectangleField.jsx
+++ b/static/src/js/components/BoundingRectangleField/BoundingRectangleField.jsx
@@ -9,7 +9,6 @@ import './BoundingRectangleField.scss'
 /**
  * BoundingRectangleField
  * @property {Object} formData Saved draft.
- * @property {String} name String BoundingRectangle--0, etc.
  * @property {Function} onChange A callback function triggered when the user inputs a text.
  * @property {Object} schema The UMM Schema for this custom widget.
  */
@@ -20,7 +19,6 @@ import './BoundingRectangleField.scss'
  */
 const BoundingRectangleField = ({
   formData,
-  name,
   onChange,
   schema
 }) => {
@@ -216,7 +214,6 @@ BoundingRectangleField.propTypes = {
     WestBoundingCoordinate: PropTypes.number
   }).isRequired,
   onChange: PropTypes.func.isRequired,
-  name: PropTypes.string.isRequired,
   schema: PropTypes.shape({
     properties: PropTypes.shape({
       NorthBoundingCoordinate: PropTypes.shape({

--- a/static/src/js/components/BoundingRectangleField/BoundingRectangleField.jsx
+++ b/static/src/js/components/BoundingRectangleField/BoundingRectangleField.jsx
@@ -108,13 +108,12 @@ const BoundingRectangleField = ({
         <div className="bounding-rectangle-north-row">
           <div className="bounding-rectangle-coordinate-label">
             <CustomWidgetWrapper
-              id={name}
+              id="north-coordinate"
               title="North"
               description={longitudeDescription}
               centered
             >
               <input
-                aria-label="North"
                 className="form-control bounding-rectangle-coordinate"
                 type="number"
                 step="any"
@@ -134,13 +133,12 @@ const BoundingRectangleField = ({
           <div>
             <div className="bounding-rectangle-coordinate-label">
               <CustomWidgetWrapper
-                id={name}
+                id="west-coordinate"
                 title="West"
                 description={latitudeDescription}
                 centered
               >
                 <input
-                  aria-label="West"
                   className="form-control bounding-rectangle-coordinate"
                   type="number"
                   step="any"
@@ -159,13 +157,12 @@ const BoundingRectangleField = ({
           <div>
             <div className="bounding-rectangle-coordinate-label">
               <CustomWidgetWrapper
-                id={name}
+                id="east-coordinate"
                 title="East"
                 description={latitudeDescription}
                 centered
               >
                 <input
-                  aria-label="East"
                   className="form-control bounding-rectangle-coordinate"
                   type="number"
                   step="any"
@@ -185,13 +182,12 @@ const BoundingRectangleField = ({
         <div className="bounding-rectangle-south-row">
           <div className="bounding-rectangle-coordinate-label">
             <CustomWidgetWrapper
-              id={name}
+              id="south-coordinate"
               title="South"
               description={longitudeDescription}
               centered
             >
               <input
-                aria-label="South"
                 className="form-control bounding-rectangle-coordinate"
                 type="number"
                 step="any"

--- a/static/src/js/components/BoundingRectangleField/BoundingRectangleField.jsx
+++ b/static/src/js/components/BoundingRectangleField/BoundingRectangleField.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import Button from 'react-bootstrap/Button'
 
 import './BoundingRectangleField.scss'
+import CustomWidgetWrapper from '../CustomWidgetWrapper/CustomWidgetWrapper'
 
 /**
  * BoundingRectangleField
@@ -15,9 +16,17 @@ import './BoundingRectangleField.scss'
  * @param {BoundingRectangleField} props
  */
 const BoundingRectangleField = ({
+  name,
   formData,
-  onChange
+  onChange,
+  schema
 }) => {
+  const { properties } = schema
+  const { EastBoundingCoordinate: EBoundingCoordinate } = properties
+  const { NorthBoundingCoordinate: NBoundingCoordinate } = properties
+  const { description: latitudeDescription } = EBoundingCoordinate
+  const { description: longitudeDescription } = NBoundingCoordinate
+  
   // Creates state object from given coordinates
   const createStateObject = (object) => {
     const {
@@ -93,78 +102,100 @@ const BoundingRectangleField = ({
       <div className="bounding-rectangle-container">
         <div className="bounding-rectangle-north-row">
           <div className="bounding-rectangle-coordinate-label">
-            <label htmlFor="north-coordinate">North</label>
-            <input
-              className="form-control bounding-rectangle-coordinate"
-              type="number"
-              step="any"
-              id="north-coordinate"
-              onChange={
-                (event) => {
-                  handleChange('NorthBoundingCoordinate', event)
+            <CustomWidgetWrapper
+              id={name}
+              title='North'
+              description={longitudeDescription}
+              centered
+            >
+              <input
+                className="form-control bounding-rectangle-coordinate"
+                type="number"
+                step="any"
+                id="north-coordinate"
+                onChange={
+                  (event) => {
+                    handleChange('NorthBoundingCoordinate', event)
+                  }
                 }
-              }
-              value={NorthBoundingCoordinate}
-            />
+                value={NorthBoundingCoordinate}
+              />
+            </CustomWidgetWrapper>
           </div>
         </div>
 
         <div className="bounding-rectangle-east-west-row">
           <div>
             <div className="bounding-rectangle-coordinate-label">
-              <label htmlFor="west-coordinate">West</label>
+              <CustomWidgetWrapper
+                id={name}
+                title='West'
+                description={latitudeDescription}
+                centered
+              >
+                <input
+                  className="form-control bounding-rectangle-coordinate"
+                  type="number"
+                  step="any"
+                  id="west-coordinate"
+                  onChange={
+                    (event) => {
+                      handleChange('WestBoundingCoordinate', event)
+                    }
+                  }
+                  value={WestBoundingCoordinate}
+                />
+              </CustomWidgetWrapper>
             </div>
-
-            <input
-              className="form-control bounding-rectangle-coordinate"
-              type="number"
-              step="any"
-              id="west-coordinate"
-              onChange={
-                (event) => {
-                  handleChange('WestBoundingCoordinate', event)
-                }
-              }
-              value={WestBoundingCoordinate}
-            />
           </div>
 
           <div>
             <div className="bounding-rectangle-coordinate-label">
-              <label htmlFor="east-coordinate">East</label>
+              <CustomWidgetWrapper
+                id={name}
+                title='East'
+                description={latitudeDescription}
+                centered
+              >
+                <input
+                  className="form-control bounding-rectangle-coordinate"
+                  type="number"
+                  step="any"
+                  id="east-coordinate"
+                  onChange={
+                    (event) => {
+                      handleChange('EastBoundingCoordinate', event)
+                    }
+                  }
+                  value={EastBoundingCoordinate}
+                />
+              </CustomWidgetWrapper>
             </div>
-
-            <input
-              className="form-control bounding-rectangle-coordinate"
-              type="number"
-              step="any"
-              id="east-coordinate"
-              onChange={
-                (event) => {
-                  handleChange('EastBoundingCoordinate', event)
-                }
-              }
-              value={EastBoundingCoordinate}
-            />
           </div>
         </div>
 
         <div className="bounding-rectangle-south-row">
           <div className="bounding-rectangle-coordinate-label">
-            <label htmlFor="south-coordinate">South</label>
-            <input
-              className="form-control bounding-rectangle-coordinate"
-              type="number"
-              step="any"
-              id="south-coordinate"
-              width="100px"
-              onChange={
-                (event) => {
-                  handleChange('SouthBoundingCoordinate', event)
+            <CustomWidgetWrapper
+              id={name}
+              title='South'
+              description={longitudeDescription}
+              centered
+            >
+              <input
+                className="form-control bounding-rectangle-coordinate"
+                type="number"
+                step="any"
+                id="south-coordinate"
+                width="100px"
+                onChange={
+                  (event) => {
+                    handleChange('SouthBoundingCoordinate', event)
+                  }
                 }
-              }
-              value={SouthBoundingCoordinate}
-            />
+                value={SouthBoundingCoordinate}
+              />
+            </CustomWidgetWrapper>
           </div>
         </div>
       </div>
@@ -173,13 +204,24 @@ const BoundingRectangleField = ({
 }
 
 BoundingRectangleField.propTypes = {
+  name: PropTypes.string.isRequired,
   formData: PropTypes.shape({
     NorthBoundingCoordinate: PropTypes.number,
     SouthBoundingCoordinate: PropTypes.number,
     EastBoundingCoordinate: PropTypes.number,
     WestBoundingCoordinate: PropTypes.number
   }).isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  schema: PropTypes.shape({
+    properties: PropTypes.shape({
+      NorthBoundingCoordinate: PropTypes.shape({
+        description: PropTypes.string.isRequired
+      }),
+      EastBoundingCoordinate: PropTypes.shape({
+        description: PropTypes.string.isRequired
+      })
+    })
+  })
 }
 
 export default BoundingRectangleField

--- a/static/src/js/components/BoundingRectangleField/BoundingRectangleField.scss
+++ b/static/src/js/components/BoundingRectangleField/BoundingRectangleField.scss
@@ -22,3 +22,4 @@
     text-align: center;
   }
 }
+

--- a/static/src/js/components/BoundingRectangleField/BoundingRectangleField.scss
+++ b/static/src/js/components/BoundingRectangleField/BoundingRectangleField.scss
@@ -21,5 +21,10 @@
     width: 200px;  
     text-align: center;
   }
-}
 
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+}

--- a/static/src/js/components/BoundingRectangleField/BoundingRectangleField.scss
+++ b/static/src/js/components/BoundingRectangleField/BoundingRectangleField.scss
@@ -21,10 +21,4 @@
     width: 200px;  
     text-align: center;
   }
-
-  input::-webkit-outer-spin-button,
-  input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
 }

--- a/static/src/js/components/BoundingRectangleField/__tests__/BoundingRectangleField.test.jsx
+++ b/static/src/js/components/BoundingRectangleField/__tests__/BoundingRectangleField.test.jsx
@@ -42,18 +42,16 @@ describe('BoundingRectangleField', () => {
     test('renders the fields', () => {
       setup()
 
-      const spinbuttons = screen.getAllByRole('spinbutton')
-
-      const north = spinbuttons[0]
+      const north = screen.getByRole('spinbutton', { name: 'North' })
       expect(north).toHaveValue(89)
 
-      const west = spinbuttons[1]
+      const west = screen.getByRole('spinbutton', { name: 'West' })
       expect(west).toHaveValue(-179)
 
-      const east = spinbuttons[2]
+      const east = screen.getByRole('spinbutton', { name: 'East' })
       expect(east).toHaveValue(179)
 
-      const south = spinbuttons[3]
+      const south = screen.getByRole('spinbutton', { name: 'South' })
       expect(south).toHaveValue(-89)
     })
   })
@@ -64,18 +62,16 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const spinbuttons = screen.getAllByRole('spinbutton')
-
-      const north = spinbuttons[0]
+      const north = screen.getByRole('spinbutton', { name: 'North' })
       expect(north).toHaveValue(null)
 
-      const west = spinbuttons[1]
+      const west = screen.getByRole('spinbutton', { name: 'West' })
       expect(west).toHaveValue(null)
 
-      const east = spinbuttons[2]
+      const east = screen.getByRole('spinbutton', { name: 'East' })
       expect(east).toHaveValue(null)
 
-      const south = spinbuttons[3]
+      const south = screen.getByRole('spinbutton', { name: 'South' })
       expect(south).toHaveValue(null)
     })
   })
@@ -88,18 +84,16 @@ describe('BoundingRectangleField', () => {
 
       await user.click(screen.getByRole('button', { name: 'Apply Global Spatial Coverage' }))
 
-      const spinbuttons = screen.getAllByRole('spinbutton')
-
-      const north = spinbuttons[0]
+      const north = screen.getByRole('spinbutton', { name: 'North' })
       expect(north).toHaveValue(90)
 
-      const west = spinbuttons[1]
+      const west = screen.getByRole('spinbutton', { name: 'West' })
       expect(west).toHaveValue(-180)
 
-      const east = spinbuttons[2]
+      const east = screen.getByRole('spinbutton', { name: 'East' })
       expect(east).toHaveValue(180)
 
-      const south = spinbuttons[3]
+      const south = screen.getByRole('spinbutton', { name: 'South' })
       expect(south).toHaveValue(-90)
     })
   })
@@ -113,9 +107,7 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const spinbuttons = screen.getAllByRole('spinbutton')
-
-      const west = spinbuttons[1]
+      const west = screen.getByRole('spinbutton', { name: 'West' })
       await user.type(west, '-45')
 
       expect(west).toHaveValue(-45)
@@ -134,9 +126,7 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const spinbuttons = screen.getAllByRole('spinbutton')
-
-      const south = spinbuttons[3]
+      const south = screen.getByRole('spinbutton', { name: 'South' })
       await user.type(south, '-50')
 
       expect(south).toHaveValue(-50)
@@ -155,9 +145,7 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const spinbuttons = screen.getAllByRole('spinbutton')
-
-      const east = spinbuttons[2]
+      const east = screen.getByRole('spinbutton', { name: 'East' })
       await user.type(east, '45')
 
       expect(east).toHaveValue(45)
@@ -176,9 +164,7 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const spinbuttons = screen.getAllByRole('spinbutton')
-
-      const north = spinbuttons[0]
+      const north = screen.getByRole('spinbutton', { name: 'North' })
       await user.type(north, '60')
 
       expect(north).toHaveValue(60)

--- a/static/src/js/components/BoundingRectangleField/__tests__/BoundingRectangleField.test.jsx
+++ b/static/src/js/components/BoundingRectangleField/__tests__/BoundingRectangleField.test.jsx
@@ -14,6 +14,16 @@ const setup = (overrideProps = {}) => {
       WestBoundingCoordinate: -179,
       EastBoundingCoordinate: 179
     },
+    schema: {
+      properties: {
+        EastBoundingCoordinate: {
+          description: 'The longitude value of a spatially referenced point, in degrees. Longitude values range from -180 to 180.'
+        },
+        NorthBoundingCoordinate: {
+          description: 'The latitude value of a spatially referenced point, in degrees. Latitude values range from -90 to 90.'
+        }
+      }
+    },
     ...overrideProps
   }
 
@@ -32,17 +42,19 @@ describe('BoundingRectangleField', () => {
     test('renders the fields', () => {
       setup()
 
-      const west = screen.getByLabelText('West')
+      const spinbuttons = screen.getAllByRole('spinbutton')
+
+      const north = spinbuttons[0]
+      expect(north).toHaveValue(89)
+
+      const west = spinbuttons[1]
       expect(west).toHaveValue(-179)
 
-      const south = screen.getByLabelText('South')
-      expect(south).toHaveValue(-89)
-
-      const east = screen.getByLabelText('East')
+      const east = spinbuttons[2]
       expect(east).toHaveValue(179)
 
-      const north = screen.getByLabelText('North')
-      expect(north).toHaveValue(89)
+      const south = spinbuttons[3]
+      expect(south).toHaveValue(-89)
     })
   })
 
@@ -52,17 +64,19 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const west = screen.getByLabelText('West')
+      const spinbuttons = screen.getAllByRole('spinbutton')
+
+      const north = spinbuttons[0]
+      expect(north).toHaveValue(null)
+
+      const west = spinbuttons[1]
       expect(west).toHaveValue(null)
 
-      const south = screen.getByLabelText('South')
-      expect(south).toHaveValue(null)
-
-      const east = screen.getByLabelText('East')
+      const east = spinbuttons[2]
       expect(east).toHaveValue(null)
 
-      const north = screen.getByLabelText('North')
-      expect(north).toHaveValue(null)
+      const south = spinbuttons[3]
+      expect(south).toHaveValue(null)
     })
   })
 
@@ -72,19 +86,21 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'Apply Global Spatial Coverage' }))
 
-      const west = screen.getByLabelText('West')
+      const spinbuttons = screen.getAllByRole('spinbutton')
+
+      const north = spinbuttons[0]
+      expect(north).toHaveValue(90)
+
+      const west = spinbuttons[1]
       expect(west).toHaveValue(-180)
 
-      const south = screen.getByLabelText('South')
-      expect(south).toHaveValue(-90)
-
-      const east = screen.getByLabelText('East')
+      const east = spinbuttons[2]
       expect(east).toHaveValue(180)
 
-      const north = screen.getByLabelText('North')
-      expect(north).toHaveValue(90)
+      const south = spinbuttons[3]
+      expect(south).toHaveValue(-90)
     })
   })
 
@@ -97,7 +113,9 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const west = screen.getByLabelText('West')
+      const spinbuttons = screen.getAllByRole('spinbutton')
+
+      const west = spinbuttons[1]
       await user.type(west, '-45')
 
       expect(west).toHaveValue(-45)
@@ -116,7 +134,9 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const south = screen.getByLabelText('South')
+      const spinbuttons = screen.getAllByRole('spinbutton')
+
+      const south = spinbuttons[3]
       await user.type(south, '-50')
 
       expect(south).toHaveValue(-50)
@@ -135,7 +155,9 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const east = screen.getByLabelText('East')
+      const spinbuttons = screen.getAllByRole('spinbutton')
+
+      const east = spinbuttons[2]
       await user.type(east, '45')
 
       expect(east).toHaveValue(45)
@@ -154,7 +176,9 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const north = screen.getByLabelText('North')
+      const spinbuttons = screen.getAllByRole('spinbutton')
+
+      const north = spinbuttons[0]
       await user.type(north, '60')
 
       expect(north).toHaveValue(60)

--- a/static/src/js/components/BoundingRectangleField/__tests__/BoundingRectangleField.test.jsx
+++ b/static/src/js/components/BoundingRectangleField/__tests__/BoundingRectangleField.test.jsx
@@ -42,16 +42,16 @@ describe('BoundingRectangleField', () => {
     test('renders the fields', () => {
       setup()
 
-      const north = screen.getByRole('spinbutton', { name: 'North' })
+      const north = screen.getByLabelText('North')
       expect(north).toHaveValue(89)
 
-      const west = screen.getByRole('spinbutton', { name: 'West' })
+      const west = screen.getByLabelText('West')
       expect(west).toHaveValue(-179)
 
-      const east = screen.getByRole('spinbutton', { name: 'East' })
+      const east = screen.getByLabelText('East')
       expect(east).toHaveValue(179)
 
-      const south = screen.getByRole('spinbutton', { name: 'South' })
+      const south = screen.getByLabelText('South')
       expect(south).toHaveValue(-89)
     })
   })
@@ -62,16 +62,16 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const north = screen.getByRole('spinbutton', { name: 'North' })
+      const north = screen.getByLabelText('North')
       expect(north).toHaveValue(null)
 
-      const west = screen.getByRole('spinbutton', { name: 'West' })
+      const west = screen.getByLabelText('West')
       expect(west).toHaveValue(null)
 
-      const east = screen.getByRole('spinbutton', { name: 'East' })
+      const east = screen.getByLabelText('East')
       expect(east).toHaveValue(null)
 
-      const south = screen.getByRole('spinbutton', { name: 'South' })
+      const south = screen.getByLabelText('South')
       expect(south).toHaveValue(null)
     })
   })
@@ -84,16 +84,16 @@ describe('BoundingRectangleField', () => {
 
       await user.click(screen.getByRole('button', { name: 'Apply Global Spatial Coverage' }))
 
-      const north = screen.getByRole('spinbutton', { name: 'North' })
+      const north = screen.getByLabelText('North')
       expect(north).toHaveValue(90)
 
-      const west = screen.getByRole('spinbutton', { name: 'West' })
+      const west = screen.getByLabelText('West')
       expect(west).toHaveValue(-180)
 
-      const east = screen.getByRole('spinbutton', { name: 'East' })
+      const east = screen.getByLabelText('East')
       expect(east).toHaveValue(180)
 
-      const south = screen.getByRole('spinbutton', { name: 'South' })
+      const south = screen.getByLabelText('South')
       expect(south).toHaveValue(-90)
     })
   })
@@ -107,7 +107,7 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const west = screen.getByRole('spinbutton', { name: 'West' })
+      const west = screen.getByLabelText('West')
       await user.type(west, '-45')
 
       expect(west).toHaveValue(-45)
@@ -126,7 +126,7 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const south = screen.getByRole('spinbutton', { name: 'South' })
+      const south = screen.getByLabelText('South')
       await user.type(south, '-50')
 
       expect(south).toHaveValue(-50)
@@ -145,7 +145,7 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const east = screen.getByRole('spinbutton', { name: 'East' })
+      const east = screen.getByLabelText('East')
       await user.type(east, '45')
 
       expect(east).toHaveValue(45)
@@ -164,7 +164,7 @@ describe('BoundingRectangleField', () => {
         formData: {}
       })
 
-      const north = screen.getByRole('spinbutton', { name: 'North' })
+      const north = screen.getByLabelText('North')
       await user.type(north, '60')
 
       expect(north).toHaveValue(60)

--- a/static/src/js/components/CustomWidgetWrapper/CustomWidgetWrapper.jsx
+++ b/static/src/js/components/CustomWidgetWrapper/CustomWidgetWrapper.jsx
@@ -5,12 +5,14 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Popover from 'react-bootstrap/Popover'
 import pluralize from 'pluralize'
 import commafy from 'commafy'
+import classNames from 'classnames'
 
 import './CustomWidgetWrapper.scss'
 
 /**
  * CustomWidgetWrapper
  * @typedef {Object} CustomWidgetWrapper
+ * @property {Boolean} centered Optional field to edit styling when a label is centered
  * @property {Number} charactersUsed Number of character used.
  * @property {ReactNode} children The widget content.
  * @property {String} description A description of the field.
@@ -19,7 +21,6 @@ import './CustomWidgetWrapper.scss'
  * @property {Boolean} required Is the field required.
  * @property {HTMLDivElement} scrollRef A ref to scroll to.
  * @property {String} title A title of the field.
- * @property {Boolean} centered Optional field to edit styling when a label is centered
  */
 
 /**
@@ -27,6 +28,7 @@ import './CustomWidgetWrapper.scss'
  * @param {CustomWidgetWrapper} props
  */
 const CustomWidgetWrapper = ({
+  centered,
   charactersUsed,
   children,
   description,
@@ -34,8 +36,7 @@ const CustomWidgetWrapper = ({
   maxLength,
   required,
   scrollRef,
-  title,
-  centered
+  title
 }) => {
   const [showHelp, setShowHelp] = useState(false)
 
@@ -47,15 +48,22 @@ const CustomWidgetWrapper = ({
     setShowHelp(false)
   }
 
-  const predeterminedJustification = centered ? 'justify-content-center' : 'justify-content-between'
-
   return (
     <>
       <div
         className="mb-1"
         ref={scrollRef}
       >
-        <div className={`d-flex align-items-center ${predeterminedJustification}`}>
+        <div className={
+          classNames([
+            'd-flex align-items-center',
+            {
+              'justify-content-center': centered,
+              'justify-content-between': !centered
+            }
+          ])
+        }
+        >
           <div>
             {
               title && (
@@ -139,16 +147,17 @@ const CustomWidgetWrapper = ({
 }
 
 CustomWidgetWrapper.defaultProps = {
+  centered: false,
   charactersUsed: null,
   description: null,
-  scrollRef: null,
   maxLength: null,
   required: null,
-  title: null,
-  centered: false
+  scrollRef: null,
+  title: null
 }
 
 CustomWidgetWrapper.propTypes = {
+  centered: PropTypes.bool,
   charactersUsed: PropTypes.number,
   children: PropTypes.node.isRequired,
   description: PropTypes.string,
@@ -156,8 +165,7 @@ CustomWidgetWrapper.propTypes = {
   maxLength: PropTypes.number,
   required: PropTypes.bool,
   scrollRef: PropTypes.shape({}),
-  title: PropTypes.string,
-  centered: PropTypes.bool
+  title: PropTypes.string
 }
 
 export default CustomWidgetWrapper

--- a/static/src/js/components/CustomWidgetWrapper/CustomWidgetWrapper.jsx
+++ b/static/src/js/components/CustomWidgetWrapper/CustomWidgetWrapper.jsx
@@ -19,6 +19,7 @@ import './CustomWidgetWrapper.scss'
  * @property {Boolean} required Is the field required.
  * @property {HTMLDivElement} scrollRef A ref to scroll to.
  * @property {String} title A title of the field.
+ * @property {Boolean} centered Optional field to edit styling when a label is centered
  */
 
 /**
@@ -33,7 +34,8 @@ const CustomWidgetWrapper = ({
   maxLength,
   required,
   scrollRef,
-  title
+  title,
+  centered
 }) => {
   const [showHelp, setShowHelp] = useState(false)
 
@@ -45,13 +47,15 @@ const CustomWidgetWrapper = ({
     setShowHelp(false)
   }
 
+  const predeterminedJustification = centered ? 'justify-content-center' : 'justify-content-between'
+
   return (
     <>
       <div
         className="mb-1"
         ref={scrollRef}
       >
-        <div className="d-flex align-items-center justify-content-between">
+        <div className={`d-flex align-items-center ${predeterminedJustification}`}>
           <div>
             {
               title && (
@@ -106,7 +110,7 @@ const CustomWidgetWrapper = ({
                     type="button"
                   >
                     <FaInfoCircle className="me-1" />
-                    Help
+                    {!centered && 'Help'}
                   </button>
                 </OverlayTrigger>
               </div>
@@ -140,7 +144,8 @@ CustomWidgetWrapper.defaultProps = {
   scrollRef: null,
   maxLength: null,
   required: null,
-  title: null
+  title: null,
+  centered: false
 }
 
 CustomWidgetWrapper.propTypes = {
@@ -151,7 +156,8 @@ CustomWidgetWrapper.propTypes = {
   maxLength: PropTypes.number,
   required: PropTypes.bool,
   scrollRef: PropTypes.shape({}),
-  title: PropTypes.string
+  title: PropTypes.string,
+  centered: PropTypes.bool
 }
 
 export default CustomWidgetWrapper


### PR DESCRIPTION
# Overview

### What is the feature?

umm_c's Spatial Information --> Bounding Rectangle boxes need  i-icons
arrows need to be removed in lat/long widget

### What is the Solution?

Added CustomWidgetWrapper to each bounding rectangle coordinate and adjusted CustomWidgetWrapper to get it styled correctly. Added some scss rules to BoundingRectangle scss file

### What areas of the application does this impact?

CustomWidgetWrapper
BoundingRectangle

# Testing

### Reproduction steps

- **Environment for testing: local
- **Collection to test with: make a collection draft

1. Under Collection draft, go to Spatial information > Horizontal > Bounding Rectangle
2. Check that all cardinal directions have an information i that works when you hover over it
3. Check that only the Bounding Rectangle Boxes have the spinner buttons removed. 

### Attachments

Before
![Screenshot 2024-07-08 at 2 46 45 PM](https://github.com/nasa/mmt/assets/135638667/163ccaeb-755b-4ae1-9152-15385d292a65)

After
![Screenshot 2024-07-08 at 2 46 06 PM](https://github.com/nasa/mmt/assets/135638667/a70d1d6b-661c-4eab-85db-4005707cd790)


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings