### PR TITLE
MMT-3806: Populate DOI & DOI Authority in edit mode for new MMT-UAT

### DIFF
--- a/static/src/js/components/OneOfField/OneOfField.jsx
+++ b/static/src/js/components/OneOfField/OneOfField.jsx
@@ -46,7 +46,9 @@ class OneOfField extends React.Component {
     // Cache the retrieved options in state in case they have $refs to save doing it later
     const retrievedOptions = options.map((opt) => schemaUtils.retrieveSchema(opt, formData))
     const data = removeEmpty(cloneDeep(formData)) || {}
+
     let selectedOption = this.getMatchingOption(NaN, data, retrievedOptions)
+
     if (Object.keys(data).length === 0) {
       selectedOption = NaN
     }
@@ -69,6 +71,7 @@ class OneOfField extends React.Component {
   ) {
     const { formData, options, idSchema } = this.props
     const { selectedOption } = this.state
+
     let newState = this.state
     if (!deepEquals(prevProps.options, options)) {
       const {
@@ -98,12 +101,9 @@ class OneOfField extends React.Component {
       }
     }
 
-    /*
-    *  The code below commented out caused a bug where it would revert the option selected in some cases.
-    */
-    // if (newState !== this.state) {
-    //   this.setState(newState)
-    // }
+    if (newState !== this.state) {
+      this.setState(newState)
+    }
   }
 
   /** Determines the best matching option for the given `formData` and `options`.


### PR DESCRIPTION
# Overview

### What is the feature?

User reported that DOI field was not being auto selected on the first render when field was filled out. 

### What is the Solution?

After further investigation, all of the oneOf field were having the same issue where if an option is selected for the oneOf field, the selected option was not being auto populated when the form rended. 

The fix for this was to add the logic that will update the state from rjsf repo. https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/core/src/components/fields/MultiSchemaField.tsx
```
    if (newState !== this.state) {
      this.setState(newState)
    }

```
### What areas of the application does this impact? : SIT/UAT

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings