### PR TITLE
MMT-3784: Added support to disable publish button if any errors are found.

### DIFF
--- a/static/src/js/components/FormNavigation/FormNavigation.jsx
+++ b/static/src/js/components/FormNavigation/FormNavigation.jsx
@@ -142,6 +142,7 @@ const FormNavigation = ({
             {
               !isTemplate && (
                 <Dropdown.Item
+                  disabled={errors.length > 0}
                   onClick={() => onSaveClick(saveTypes.saveAndPublish)}
                 >
                   {saveTypesToHumanizedStringMap[saveTypes.saveAndPublish]}

--- a/static/src/js/components/FormNavigation/FormNavigation.jsx
+++ b/static/src/js/components/FormNavigation/FormNavigation.jsx
@@ -75,6 +75,18 @@ const FormNavigation = ({
     onSave(type)
   }
 
+  const publishButtonTooltip = () => {
+    if (errors.length === 0) {
+      return null
+    }
+
+    if (conceptId === 'new') {
+      return 'Publishing disabled until you save the record.'
+    }
+
+    return 'Publishing disabled due to errors in metadata record.'
+  }
+
   return (
     <>
       <div className="mb-4">
@@ -141,12 +153,14 @@ const FormNavigation = ({
             }
             {
               !isTemplate && (
-                <Dropdown.Item
-                  disabled={errors.length > 0}
-                  onClick={() => onSaveClick(saveTypes.saveAndPublish)}
-                >
-                  {saveTypesToHumanizedStringMap[saveTypes.saveAndPublish]}
-                </Dropdown.Item>
+                <div role="tooltip" title={publishButtonTooltip()}>
+                  <Dropdown.Item
+                    disabled={errors.length > 0}
+                    onClick={() => onSaveClick(saveTypes.saveAndPublish)}
+                  >
+                    {saveTypesToHumanizedStringMap[saveTypes.saveAndPublish]}
+                  </Dropdown.Item>
+                </div>
 
               )
             }

--- a/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
+++ b/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
@@ -10,7 +10,6 @@ import {
   Route,
   Routes
 } from 'react-router'
-import { beforeEach } from 'vitest'
 
 import Providers from '@/js/providers/Providers/Providers'
 import FormNavigation from '@/js/components/FormNavigation/FormNavigation'
@@ -138,7 +137,6 @@ describe('FormNavigation', () => {
       await user.click(dropdown)
 
       const button = screen.getByRole('button', { name: 'Save' })
-
       await user.click(button)
 
       expect(props.onSave).toHaveBeenCalledTimes(1)
@@ -154,7 +152,6 @@ describe('FormNavigation', () => {
       await user.click(dropdown)
 
       const button = screen.getAllByRole('button', { name: 'Save & Continue' }).at(1)
-
       await user.click(button)
 
       expect(props.onSave).toHaveBeenCalledTimes(1)
@@ -178,21 +175,59 @@ describe('FormNavigation', () => {
       }
     })
 
-    test('shows save and publish option as disabled if draft has errors', async () => {
-      const { user } = setup({
-        overrideProps: {
-          draft: {
-            foo: 'mock string'
-          },
-          schema
-        }
+    describe('when draft has errors', () => {
+      describe('when the metadata record has not been saved', () => {
+        beforeEach(async () => {
+          const { user } = setup({
+            overrideInitialEntries: '/tool-drafts/new',
+            overrideProps: {
+              draft: {
+                foo: 'mock string'
+              },
+              schema
+            }
+          })
+
+          const dropdown = screen.getByRole('button', { name: 'Save Options' })
+          await user.click(dropdown)
+        })
+
+        test('has disabled publish button', async () => {
+          const button = screen.getByRole('button', { name: 'Save & Publish' })
+          expect(button).toHaveClass('disabled')
+        })
+
+        test('shows Publishing disabled until you save the record tooltip ', async () => {
+          const tooltip = screen.getByRole('tooltip')
+          expect(tooltip).toHaveAttribute('title', 'Publishing disabled until you save the record.')
+        })
       })
 
-      const dropdown = screen.getByRole('button', { name: 'Save Options' })
-      await user.click(dropdown)
+      describe('when the metadata record is already saved', () => {
+        beforeEach(async () => {
+          const { user } = setup({
+            overrideProps: {
+              draft: {
+                foo: 'mock string'
+              },
+              schema
+            }
+          })
 
-      const button = screen.getByRole('button', { name: 'Save & Publish' })
-      expect(button).toHaveClass('disabled')
+          const dropdown = screen.getByRole('button', { name: 'Save Options' })
+          await user.click(dropdown)
+        })
+
+        test('has disabled publish button', async () => {
+          const button = screen.getByRole('button', { name: 'Save & Publish' })
+          expect(button).toHaveClass('disabled')
+        })
+
+        test('shows Publishing disabled due to errors in metadata record tooltip', async () => {
+          const tooltip = screen.getByRole('tooltip')
+          expect(tooltip).toHaveAttribute('title', 'Publishing disabled due to errors in metadata record.')
+        })
+      })
     })
 
     test('shows save and publish option as enabled if draft has no errors', async () => {

--- a/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
+++ b/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
@@ -10,6 +10,7 @@ import {
   Route,
   Routes
 } from 'react-router'
+import { beforeEach } from 'vitest'
 
 import Providers from '@/js/providers/Providers/Providers'
 import FormNavigation from '@/js/components/FormNavigation/FormNavigation'
@@ -17,7 +18,6 @@ import NavigationItem from '@/js/components/NavigationItem/NavigationItem'
 
 import saveTypes from '@/js/constants/saveTypes'
 import useAvailableProviders from '@/js/hooks/useAvailableProviders'
-import { beforeEach } from 'vitest'
 
 vi.mock('@/js/components/NavigationItem/NavigationItem')
 

--- a/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
+++ b/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
@@ -165,7 +165,7 @@ describe('FormNavigation', () => {
   describe('when clicking the Save & Publish dropdown item', () => {
     let schema
 
-    beforeEach(async () => {
+    beforeEach(() => {
       schema = {
         properties: {
           bar: {
@@ -178,7 +178,7 @@ describe('FormNavigation', () => {
       }
     })
 
-    test('shows save and publish option as disabled', async () => {
+    test('shows save and publish option as disabled if draft has errors', async () => {
       const { user } = setup({
         overrideProps: {
           draft: {
@@ -192,11 +192,10 @@ describe('FormNavigation', () => {
       await user.click(dropdown)
 
       const button = screen.getByRole('button', { name: 'Save & Publish' })
-      screen.debug(button)
       expect(button).toHaveClass('disabled')
     })
 
-    test('shows save and publish option as enabled', async () => {
+    test('shows save and publish option as enabled if draft has no errors', async () => {
       const { user } = setup({
         overrideProps: {
           draft: {

--- a/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
+++ b/static/src/js/components/FormNavigation/__tests__/FormNavigation.test.jsx
@@ -17,6 +17,7 @@ import NavigationItem from '@/js/components/NavigationItem/NavigationItem'
 
 import saveTypes from '@/js/constants/saveTypes'
 import useAvailableProviders from '@/js/hooks/useAvailableProviders'
+import { beforeEach } from 'vitest'
 
 vi.mock('@/js/components/NavigationItem/NavigationItem')
 
@@ -45,7 +46,6 @@ const setup = ({
     onSave: vi.fn(),
     schema: {},
     setFocusField: vi.fn(),
-    validationErrors: [],
     visitedFields: [],
     ...overrideProps
   }
@@ -163,6 +163,57 @@ describe('FormNavigation', () => {
   })
 
   describe('when clicking the Save & Publish dropdown item', () => {
+    let schema
+
+    beforeEach(async () => {
+      schema = {
+        properties: {
+          bar: {
+            type: 'number'
+          },
+          foo: {
+            type: 'number'
+          }
+        }
+      }
+    })
+
+    test('shows save and publish option as disabled', async () => {
+      const { user } = setup({
+        overrideProps: {
+          draft: {
+            foo: 'mock string'
+          },
+          schema
+        }
+      })
+
+      const dropdown = screen.getByRole('button', { name: 'Save Options' })
+      await user.click(dropdown)
+
+      const button = screen.getByRole('button', { name: 'Save & Publish' })
+      screen.debug(button)
+      expect(button).toHaveClass('disabled')
+    })
+
+    test('shows save and publish option as enabled', async () => {
+      const { user } = setup({
+        overrideProps: {
+          draft: {
+            bar: 2,
+            foo: 1
+          },
+          schema
+        }
+      })
+
+      const dropdown = screen.getByRole('button', { name: 'Save Options' })
+      await user.click(dropdown)
+
+      const button = screen.getByRole('button', { name: 'Save & Publish' })
+      expect(button).not.toHaveClass('disabled')
+    })
+
     test('calls onSave', async () => {
       const { props, user } = setup({})
 

--- a/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
+++ b/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
@@ -352,7 +352,7 @@ describe('MetadataForm', () => {
               properties: expect.objectContaining({
                 RelatedURLs: {
                   description:
-                  'A URL associated with the web user interface or downloadable tool, e.g., the home page for the tool provider which is responsible for the tool.',
+                    'A URL associated with the web user interface or downloadable tool, e.g., the home page for the tool provider which is responsible for the tool.',
                   type: 'array',
                   items: {
                     $ref: '#/definitions/RelatedURLType'
@@ -710,20 +710,66 @@ describe('MetadataForm', () => {
         const navigateSpy = vi.fn()
         vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
 
+        // In order to publish we need to have a valid draft without any errors otherwise
+        // the button will be disabled.
+        const ummMetadata = {
+          Description: 'Mock Description',
+          LongName: 'Long Name',
+          MetadataSpecification: {
+            Name: 'UMM-T',
+            URL: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.2.0',
+            Version: '1.2.0'
+          },
+          Name: 'Mock Name',
+          Organizations: [{
+            LongName: 'CLIVAR and Carbon Hydrographic Data Office',
+            Roles: ['SERVICE PROVIDER'],
+            ShortName: 'CLIVAR/CCHDO',
+            URLValue: 'http://www.bodc.ac.uk/'
+          }],
+          ToolKeywords: [{
+            ToolCategory: 'EARTH SCIENCE SERVICES',
+            ToolSpecificTerm: 'MODEL LOGS',
+            ToolTerm: 'ANCILLARY MODELS',
+            ToolTopic: 'MODELS'
+          }],
+          Type: 'Model',
+          URL: {
+            Subtype: 'MOBILE APP',
+            Type: 'DOWNLOAD SOFTWARE',
+            URLContentType: 'DistributionURL',
+            URLValue: 'mock url'
+          },
+          Version: 'Mock Version'
+        }
+
+        const validMockDraft = {
+          ...mockDraft,
+          ummMetadata
+        }
+
         const { user } = setup({
-          additionalMocks: [{
+          overrideMocks: [{
+            request: {
+              query: conceptTypeDraftQueries.Tool,
+              variables: {
+                params: {
+                  conceptId: 'TD1000000-MMT',
+                  conceptType: 'Tool'
+                }
+              }
+            },
+            result: {
+              data: {
+                draft: validMockDraft
+              }
+            }
+          }, {
             request: {
               query: INGEST_DRAFT,
               variables: {
                 conceptType: 'Tool',
-                metadata: {
-                  LongName: 'Long Name',
-                  MetadataSpecification: {
-                    URL: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.1',
-                    Name: 'UMM-T',
-                    Version: '1.1'
-                  }
-                },
+                metadata: ummMetadata,
                 nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
                 providerId: 'MMT_2',
                 ummVersion: '1.0.0'
@@ -737,8 +783,7 @@ describe('MetadataForm', () => {
                 }
               }
             }
-          },
-          {
+          }, {
             request: {
               query: PUBLISH_DRAFT,
               variables: {
@@ -755,8 +800,7 @@ describe('MetadataForm', () => {
                 }
               }
             }
-          }
-          ]
+          }]
         })
 
         const dropdown = await screen.findByRole('button', { name: 'Save Options' })

--- a/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
+++ b/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
@@ -352,7 +352,7 @@ describe('MetadataForm', () => {
               properties: expect.objectContaining({
                 RelatedURLs: {
                   description:
-                    'A URL associated with the web user interface or downloadable tool, e.g., the home page for the tool provider which is responsible for the tool.',
+                  'A URL associated with the web user interface or downloadable tool, e.g., the home page for the tool provider which is responsible for the tool.',
                   type: 'array',
                   items: {
                     $ref: '#/definitions/RelatedURLType'

--- a/static/src/js/pages/DraftPage/DraftPage.jsx
+++ b/static/src/js/pages/DraftPage/DraftPage.jsx
@@ -16,6 +16,7 @@ import {
 import getConceptTypeByDraftConceptId from '@/js/utils/getConceptTypeByDraftConceptId'
 import createTemplate from '@/js/utils/createTemplate'
 import errorLogger from '@/js/utils/errorLogger'
+import getUmmSchema from '@/js/utils/getUmmSchema'
 
 import useMMTCookie from '@/js/hooks/useMMTCookie'
 import useNotificationsContext from '@/js/hooks/useNotificationsContext'
@@ -33,7 +34,6 @@ import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
 import MetadataPreviewPlaceholder from '@/js/components/MetadataPreviewPlaceholder/MetadataPreviewPlaceholder'
 import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
-import getUmmSchema from '@/js/utils/getUmmSchema'
 
 /**
  * Renders a DraftPageHeader component
@@ -193,6 +193,7 @@ const DraftPageHeader = () => {
           [
             {
               disabled: validationErrors.length > 0,
+              disabledTooltipText: 'Publishing disabled due to errors in metadata record.',
               icon: FaSave,
               iconTitle: 'A save icon',
               onClick: handlePublish,

--- a/static/src/js/pages/DraftPage/DraftPage.jsx
+++ b/static/src/js/pages/DraftPage/DraftPage.jsx
@@ -5,6 +5,7 @@ import React, {
 } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useMutation, useSuspenseQuery } from '@apollo/client'
+import validator from '@rjsf/validator-ajv8'
 import pluralize from 'pluralize'
 import {
   FaCopy,
@@ -32,6 +33,7 @@ import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
 import MetadataPreviewPlaceholder from '@/js/components/MetadataPreviewPlaceholder/MetadataPreviewPlaceholder'
 import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
+import getUmmSchema from '@/js/utils/getUmmSchema'
 
 /**
  * Renders a DraftPageHeader component
@@ -90,6 +92,12 @@ const DraftPageHeader = () => {
     ummMetadata,
     previewMetadata
   } = draft
+
+  // Get the UMM Schema for the draft
+  const schema = getUmmSchema(derivedConceptType)
+
+  // Validate ummMetadata
+  const { errors: validationErrors } = validator.validateFormData(ummMetadata, schema)
 
   const handlePublish = () => {
     publishMutation(derivedConceptType, nativeId)
@@ -184,6 +192,7 @@ const DraftPageHeader = () => {
         primaryActions={
           [
             {
+              disabled: validationErrors.length > 0,
               icon: FaSave,
               iconTitle: 'A save icon',
               onClick: handlePublish,

--- a/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
+++ b/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
@@ -318,7 +318,7 @@ describe('DraftPage', () => {
           }
         }
 
-        const { user } = setup({
+        setup({
           overrideMocks: [{
             request: {
               query: conceptTypeDraftQueries.Tool,
@@ -336,6 +336,7 @@ describe('DraftPage', () => {
             }
           }]
         })
+
         const button = await screen.findByRole('button', { name: /Publish/ })
         expect(button).toHaveAttribute('disabled')
       })

--- a/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
+++ b/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
@@ -337,7 +337,6 @@ describe('DraftPage', () => {
           }]
         })
         const button = await screen.findByRole('button', { name: /Publish/ })
-        await user.click(button)
         expect(button).toHaveAttribute('disabled')
       })
 

--- a/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
+++ b/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
@@ -29,24 +29,46 @@ vi.mock('@/js/components/MetadataPreview/MetadataPreview')
 vi.mock('@/js/utils/createTemplate')
 vi.mock('@/js/utils/errorLogger')
 
+const ummMetadata = {
+  Description: 'Mock Description',
+  LongName: 'Long Name',
+  MetadataSpecification: {
+    Name: 'UMM-T',
+    URL: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.2.0',
+    Version: '1.2.0'
+  },
+  Name: 'Mock Name',
+  Organizations: [{
+    LongName: 'CLIVAR and Carbon Hydrographic Data Office',
+    Roles: ['SERVICE PROVIDER'],
+    ShortName: 'CLIVAR/CCHDO',
+    URLValue: 'http://www.bodc.ac.uk/'
+  }],
+  ToolKeywords: [{
+    ToolCategory: 'EARTH SCIENCE SERVICES',
+    ToolSpecificTerm: 'MODEL LOGS',
+    ToolTerm: 'ANCILLARY MODELS',
+    ToolTopic: 'MODELS'
+  }],
+  Type: 'Model',
+  URL: {
+    Subtype: 'MOBILE APP',
+    Type: 'DOWNLOAD SOFTWARE',
+    URLContentType: 'DistributionURL',
+    URLValue: 'mock url'
+  },
+  Version: 'Mock Version'
+}
+
 const mockDraft = {
+  __typename: 'Draft',
   conceptId: 'TD1000000-MMT',
   conceptType: 'topol-draft',
   deleted: false,
-  name: null,
+  name: 'mock name',
   nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
-  providerId: 'MMT_2',
-  revisionDate: '2023-12-08T16:14:28.177Z',
-  revisionId: '2',
-  ummMetadata: {
-    MetadataSpecification: {
-      URL: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.1',
-      Name: 'UMM-T',
-      Version: '1.1'
-    },
-    LongName: 'Long Name'
-  },
   previewMetadata: {
+    __typename: 'Tool',
     accessConstraints: null,
     ancillaryKeywords: null,
     associationDetails: null,
@@ -55,15 +77,15 @@ const mockDraft = {
     contactPersons: null,
     description: null,
     doi: null,
-    nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
     lastUpdatedDate: null,
     longName: 'Long Name',
     metadataSpecification: {
-      url: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.1',
       name: 'UMM-T',
+      url: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.1',
       version: '1.1'
     },
     name: null,
+    nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
     organizations: null,
     pageTitle: null,
     potentialAction: null,
@@ -81,14 +103,17 @@ const mockDraft = {
     url: null,
     useConstraints: null,
     version: null,
-    versionDescription: null,
-    __typename: 'Tool'
+    versionDescription: null
   },
-  __typename: 'Draft'
+  providerId: 'MMT_2',
+  revisionDate: '2023-12-08T16:14:28.177Z',
+  revisionId: '2',
+  ummMetadata
 }
 
 const setup = ({
   additionalMocks = [],
+  overrideMockDraft = mockDraft,
   overrideMocks = false,
   pageUrl = '/drafts/tools/TD1000000-MMT',
   path = '/drafts/tools'
@@ -105,7 +130,7 @@ const setup = ({
     },
     result: {
       data: {
-        draft: mockDraft
+        draft: overrideMockDraft
       }
     }
   }, ...additionalMocks]
@@ -272,7 +297,34 @@ describe('DraftPage', () => {
       })
     })
 
-    describe('when clicking on Publish Draft button with no errors', () => {
+    describe('when clicking on Publish Draft button', () => {
+      test('is clickable if draft has no errors', async () => {
+        const { user } = setup({})
+
+        const button = await screen.findByRole('button', { name: /Publish/ })
+        await user.click(button)
+        expect(button).not.toHaveAttribute('disabled')
+      })
+
+      test('is disabled if draft has errors', async () => {
+        const navigateSpy = vi.fn()
+        vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+
+        // Overriding ummMetadata and setting Name to a number to make it fail validation.
+        const overrideMockDraft = {
+          ...mockDraft,
+          ummMetadata: {
+            ...ummMetadata,
+            Name: 1
+          }
+        }
+
+        const { user } = setup({ overrideMockDraft })
+        const button = await screen.findByRole('button', { name: /Publish/ })
+        await user.click(button)
+        expect(button).toHaveAttribute('disabled')
+      })
+
       test('calls the publish mutation and navigates to the concept page', async () => {
         const navigateSpy = vi.fn()
         vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)

--- a/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
+++ b/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
@@ -113,7 +113,6 @@ const mockDraft = {
 
 const setup = ({
   additionalMocks = [],
-  overrideMockDraft = mockDraft,
   overrideMocks = false,
   pageUrl = '/drafts/tools/TD1000000-MMT',
   path = '/drafts/tools'
@@ -130,7 +129,7 @@ const setup = ({
     },
     result: {
       data: {
-        draft: overrideMockDraft
+        draft: mockDraft
       }
     }
   }, ...additionalMocks]
@@ -311,7 +310,7 @@ describe('DraftPage', () => {
         vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
 
         // Overriding ummMetadata and setting Name to a number to make it fail validation.
-        const overrideMockDraft = {
+        const invalidMockDraft = {
           ...mockDraft,
           ummMetadata: {
             ...ummMetadata,
@@ -319,7 +318,24 @@ describe('DraftPage', () => {
           }
         }
 
-        const { user } = setup({ overrideMockDraft })
+        const { user } = setup({
+          overrideMocks: [{
+            request: {
+              query: conceptTypeDraftQueries.Tool,
+              variables: {
+                params: {
+                  conceptId: 'TD1000000-MMT',
+                  conceptType: 'Tool'
+                }
+              }
+            },
+            result: {
+              data: {
+                draft: invalidMockDraft
+              }
+            }
+          }]
+        })
         const button = await screen.findByRole('button', { name: /Publish/ })
         await user.click(button)
         expect(button).toHaveAttribute('disabled')

--- a/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
+++ b/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
@@ -297,7 +297,7 @@ describe('DraftPage', () => {
     })
 
     describe('when clicking on Publish Draft button', () => {
-      test('is clickable if draft has no errors', async () => {
+      test('is enabled if draft has no errors', async () => {
         const { user } = setup({})
 
         const button = await screen.findByRole('button', { name: /Publish/ })


### PR DESCRIPTION
# Overview

### What is the feature?

As an MMT operator, don't allow me to attempt to publish a draft until the metadata will pass ingest without errors

### What is the Solution?

Disables the "Publish" button on the preview page when the metadata record has errors.
Disables the "Save and Publish" button in the navigation menu when the metadata record has errors.

This also has another use case when the form shows no errors, yet since the user hasn't saved the record yet, the the validator is still giving back errors because the metadata specification hasn't been populated yet (this happens on the first save).   So if this is the case, I'm providing a tooltip over the disabled button stating the user must save the record in order to publish.

### What areas of the application does this impact?

Navigation menu
Preview Page

# Testing

Try creating a metadata record that has errors.   You should not be able to publish from the preview page or from the form navigation menus (Save and Publish option) if the metadata record has any errors.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings