### PR TITLE
MMT-3794: Fix number field issue for Firefox and Safari

### DIFF
--- a/static/src/js/components/CustomTextWidget/CustomTextWidget.jsx
+++ b/static/src/js/components/CustomTextWidget/CustomTextWidget.jsx
@@ -83,7 +83,7 @@ const CustomTextWidget = ({
   const handleBlur = () => {
     setFocusField(null)
 
-    if (onBlur) onBlur(id)
+    onBlur(id)
   }
 
   return (

--- a/static/src/js/components/CustomTextWidget/CustomTextWidget.jsx
+++ b/static/src/js/components/CustomTextWidget/CustomTextWidget.jsx
@@ -70,8 +70,13 @@ const CustomTextWidget = ({
   // Handle the value changing in the field
   const handleChange = (event) => {
     const { value: newValue } = event.target
+    let valueToSet = newValue
+    // If type is number, remove everything except digits, '.', 'e', 'E', '+' and '-'
+    if (type === 'number') {
+      valueToSet = newValue.replace(/[^\d.eE+-]/g, '')
+    }
 
-    onChange(newValue)
+    onChange(valueToSet)
   }
 
   // Handle the field losing focus
@@ -103,7 +108,7 @@ const CustomTextWidget = ({
         placeholder={placeholder}
         ref={focusRef}
         tabIndex={0}
-        type={type && type === 'number' ? 'number' : 'text'}
+        type="text"
         value={value}
       />
     </CustomWidgetWrapper>

--- a/static/src/js/components/CustomTextWidget/__tests__/CustomTextWidget.test.jsx
+++ b/static/src/js/components/CustomTextWidget/__tests__/CustomTextWidget.test.jsx
@@ -184,16 +184,16 @@ describe('CustomTextWidget', () => {
     })
   })
 
-  describe('when the input is a number field', () => {
-    test('renders a number field', () => {
-      setup({
-        schema: {
-          type: 'number'
-        }
-      })
-
-      const field = screen.getByRole('spinbutton')
-      expect(field).toHaveAttribute('type', 'number')
-    })
-  })
+  // describe('when the input is a number field', () => {
+  //   test('renders a number field', () => {
+  //     setup({
+  //       schema: {
+  //         type: 'number'
+  //       }
+  //     })
+  //
+  //     const field = screen.getByRole('spinbutton')
+  //     expect(field).toHaveAttribute('type', 'number')
+  //   })
+  // })
 })

--- a/static/src/js/components/CustomTextWidget/__tests__/CustomTextWidget.test.jsx
+++ b/static/src/js/components/CustomTextWidget/__tests__/CustomTextWidget.test.jsx
@@ -148,6 +148,32 @@ describe('CustomTextWidget', () => {
     })
   })
 
+  describe('when the number field is changed', () => {
+    test('calls onChange', async () => {
+      const { props, user } = setup({
+        schema: {
+          type: 'number'
+        }
+      })
+
+      const field = screen.getByRole('textbox')
+
+      // The input in this component is a controlled input by the `value` prop. We don't want to deal with the
+      // setup of saving that value state outside of the test render, so we can only test a single character change
+      // here. If we tried to type multiple letters, onChange toHaveBeenCalledWith only receives a single letter
+      // because the value prop is alway undefined.
+      await user.type(field, '7')
+
+      expect(props.onChange).toHaveBeenCalledTimes(1)
+      expect(props.onChange).toHaveBeenCalledWith('7')
+
+      await user.type(field, 'B')
+      expect(props.onChange).toHaveBeenCalledWith('')
+      await user.type(field, '8')
+      expect(props.onChange).toHaveBeenCalledWith('8')
+    })
+  })
+
   describe('when the field should be focused', () => {
     test('focuses the field', async () => {
       setup({
@@ -183,17 +209,4 @@ describe('CustomTextWidget', () => {
       }), {})
     })
   })
-
-  // describe('when the input is a number field', () => {
-  //   test('renders a number field', () => {
-  //     setup({
-  //       schema: {
-  //         type: 'number'
-  //       }
-  //     })
-  //
-  //     const field = screen.getByRole('spinbutton')
-  //     expect(field).toHaveAttribute('type', 'number')
-  //   })
-  // })
 })

--- a/static/src/js/components/PermissionForm/__tests__/PermissionForm.test.jsx
+++ b/static/src/js/components/PermissionForm/__tests__/PermissionForm.test.jsx
@@ -278,8 +278,8 @@ describe('PermissionForm', () => {
         await user.type(nameField, 'Test Name')
         await user.click(granuleCheckbox)
 
-        const maxValue = screen.getAllByRole('spinbutton', { name: 'Maximum Value' })
-        const minValue = screen.getAllByRole('spinbutton', { name: 'Minimum Value' })
+        const maxValue = screen.getAllByRole('textbox', { name: 'Maximum Value' })
+        const minValue = screen.getAllByRole('textbox', { name: 'Minimum Value' })
 
         await user.type(minValue[0], '1')
         await user.type(maxValue[0], '10')
@@ -444,8 +444,8 @@ describe('PermissionForm', () => {
         await user.type(nameField, 'Test Name')
         await user.click(granuleCheckbox)
 
-        const maxValue = screen.getAllByRole('spinbutton', { name: 'Maximum Value' })
-        const minValue = screen.getAllByRole('spinbutton', { name: 'Minimum Value' })
+        const maxValue = screen.getAllByRole('textbox', { name: 'Maximum Value' })
+        const minValue = screen.getAllByRole('textbox', { name: 'Minimum Value' })
 
         await user.type(minValue[0], '1')
         await user.type(maxValue[0], '10')
@@ -965,8 +965,8 @@ describe('PermissionForm', () => {
         await user.type(nameField, 'Test Name')
         await user.click(granuleCheckbox)
 
-        const maxValue = screen.getAllByRole('spinbutton', { name: 'Maximum Value' })
-        const minValue = screen.getAllByRole('spinbutton', { name: 'Minimum Value' })
+        const maxValue = screen.getAllByRole('textbox', { name: 'Maximum Value' })
+        const minValue = screen.getAllByRole('textbox', { name: 'Minimum Value' })
 
         // Fills out collection field
         await user.type(minValue[0], '10')
@@ -995,8 +995,8 @@ describe('PermissionForm', () => {
         await user.type(nameField, 'Test Name')
         await user.click(granuleCheckbox)
 
-        const maxValue = screen.getAllByRole('spinbutton', { name: 'Maximum Value' })
-        const minValue = screen.getAllByRole('spinbutton', { name: 'Minimum Value' })
+        const maxValue = screen.getAllByRole('textbox', { name: 'Maximum Value' })
+        const minValue = screen.getAllByRole('textbox', { name: 'Minimum Value' })
 
         // Fills out collection field
         await user.type(minValue[0], '1')


### PR DESCRIPTION
# Overview

### What is the feature?

Fixed issue: Firefox and Safari do not prevent input of non numeric characters in number input fields.

### What is the Solution?

Filter out non numeric characters in onChange method

### What areas of the application does this impact?

Number input fields, for example Size in RelatedURL

# Testing

### Reproduction steps
Using Firefox (Safari)
- Go to https://mmt.sit.earthdatacloud.nasa.gov/
- Edit a Draft
- In RelatedURL, choose 'DistributionURL' from URL Content Type and choose 'GET DATA' from Type
- Section 'Get Data' will show up with number input field Size
- Any non numeric character can be entered in Size, for example '30MB'. Since that is invalid number, field Size and value don't show up in the json display.
- In the fixed version, only '30' can be entered in the Size field and so the entry is valid and will show up in the json display.

Number fields in this fixed version will accept number, '+', '-', 'E', 'e' and '.'

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings