### PR TITLE
MMT-3766: Implement UMM-C Version 1.18.1 in MMT

### DIFF
--- a/static/src/js/components/CustomSelectWidget/CustomSelectWidget.jsx
+++ b/static/src/js/components/CustomSelectWidget/CustomSelectWidget.jsx
@@ -117,7 +117,7 @@ const CustomSelectWidget = ({
     if (oneOfEnums) {
       setSelectOptions(oneOfEnums)
     }
-  }, [propsSelectOptions])
+  }, [propsSelectOptions, options])
 
   useEffect(() => {
     if (!isEmpty(keywords)) {

--- a/static/src/js/components/GridRow/GridRow.jsx
+++ b/static/src/js/components/GridRow/GridRow.jsx
@@ -167,11 +167,12 @@ const GridRow = (
 }
 
 GridRow.defaultProps = {
+  formData: {},
   required: false
 }
 
 GridRow.propTypes = {
-  formData: PropTypes.shape({}).isRequired,
+  formData: PropTypes.shape({}),
   layout: PropTypes.shape({
     'ui:row': PropTypes.arrayOf(PropTypes.shape({})),
     'ui:group': PropTypes.string,

--- a/static/src/js/schemas/uiSchemas/collections/collectionInformation.js
+++ b/static/src/js/schemas/uiSchemas/collections/collectionInformation.js
@@ -126,73 +126,10 @@ const collectionInformationUiSchema = {
   },
   DOI: {
     'ui:heading-level': 'h5',
-    'ui:field': 'layout',
-    'ui:layout_grid': {
-      'ui:row': [
-        {
-          'ui:group': 'DOI',
-          'ui:group-description': true,
-          'ui:col': {
-            md: 12,
-            children: [
-              {
-                'ui:row': [
-                  {
-                    'ui:col': {
-                      md: 12,
-                      children: ['DOI']
-                    }
-                  }
-                ]
-              },
-              {
-                'ui:row': [
-                  {
-                    'ui:col': {
-                      md: 12,
-                      children: ['Authority']
-                    }
-                  }
-                ]
-              },
-              {
-                'ui:row': [
-                  {
-                    'ui:col': {
-                      md: 12,
-                      children: ['PreviousVersion']
-                    }
-                  }
-                ]
-              },
-              {
-                'ui:row': [
-                  {
-                    'ui:col': {
-                      md: 12,
-                      children: ['MissingReason']
-                    }
-                  }
-                ]
-              },
-              {
-                'ui:row': [
-                  {
-                    'ui:col': {
-                      md: 12,
-                      children: ['Explanation']
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      ]
-    },
     DOI: {
       'ui:widget': 'textarea'
     },
+    Authority: {},
     PreviousVersion: {
       'ui:heading-level': 'h5',
       'ui:field': 'layout',
@@ -255,76 +192,24 @@ const collectionInformationUiSchema = {
       DOI: {
         'ui:widget': 'textarea'
       }
+    },
+    MissingReason: {},
+    Explanation: {
+      'ui:widget': 'textarea'
     }
   },
   AssociatedDOIs: {
     'ui:title': 'Associated DOIs',
     'ui:heading-level': 'h4',
+    'ui:hide-header': true,
     items: {
-      'ui:field': 'layout',
+      'ui:hide-header': true,
+
       'ui:title': 'Associated DOIs',
-      'ui:layout_grid': {
-        'ui:row': [
-          {
-            'ui:col': {
-              md: 12,
-              children: [
-                {
-                  'ui:row': [
-                    {
-                      'ui:col': {
-                        md: 12,
-                        children: ['DOI']
-                      }
-                    }
-                  ]
-                },
-                {
-                  'ui:row': [
-                    {
-                      'ui:col': {
-                        md: 12,
-                        children: ['Title']
-                      }
-                    }
-                  ]
-                },
-                {
-                  'ui:row': [
-                    {
-                      'ui:col': {
-                        md: 12,
-                        children: ['Authority']
-                      }
-                    }
-                  ]
-                },
-                {
-                  'ui:row': [
-                    {
-                      'ui:col': {
-                        md: 12,
-                        children: ['Type']
-                      }
-                    }
-                  ]
-                },
-                {
-                  'ui:row': [
-                    {
-                      'ui:col': {
-                        md: 12,
-                        children: ['DescriptionOfOtherType']
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
-      },
       DOI: {
+        'ui:widget': 'textarea'
+      },
+      Title: {
         'ui:widget': 'textarea'
       },
       DescriptionOfOtherType: {


### PR DESCRIPTION
# Overview

### What is the feature?

During SIT testing, Scott found an issue where with All Documented DOI Types --> click on type you will see all of them but if you click on “Other” you will still see all of “All Documented DOI” Types

### What is the Solution?

After debugging, found out that in CustomSelectWiget the enums that were being passed to the widget were not being updated. 

### What areas of the application does this impact?SIT/UAT

List impacted areas. 

# Testing

### Reproduction steps

- **Environment for testing:** local

1. Create a collection draft
2. Select one of the fields for All Documented DOI and check the Type enums
3. Select other field for DOI 
4. Check if the "Other" enum is visible 


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings