### PR TITLE
MMT-3823: As a user, I want to filter my search results after choosing a provider without loosing my original search results

### DIFF
--- a/static/src/js/components/EllipsisLink/EllipsisLink.jsx
+++ b/static/src/js/components/EllipsisLink/EllipsisLink.jsx
@@ -68,8 +68,12 @@ const EllipsisLink = ({ children, to }) => {
   )
 }
 
+EllipsisLink.defaultProps = {
+  children: ''
+}
+
 EllipsisLink.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.string,
   to: PropTypes.string.isRequired
 }
 

--- a/static/src/js/pages/SearchList/SearchList.jsx
+++ b/static/src/js/pages/SearchList/SearchList.jsx
@@ -19,6 +19,8 @@ import {
 
 import { useSuspenseQuery } from '@apollo/client'
 
+import handleSort from '@/js/utils/handleSort'
+
 import { DATE_FORMAT } from '../../constants/dateFormat'
 import conceptTypeQueries from '../../constants/conceptTypeQueries'
 import conceptTypes from '../../constants/conceptTypes'
@@ -142,40 +144,11 @@ const SearchList = ({ limit }) => {
       </Button>
     )
   }, [])
+
   const sortFn = useCallback((key, order) => {
     const currentSearchParams = new URLSearchParams(window.location.search)
     const currentProviderParam = currentSearchParams.get('provider')
-    let nextSortKey
-
-    if (!order) {
-      setSearchParams((currentParams) => {
-        currentParams.delete('sortKey')
-
-        return Object.fromEntries(currentParams)
-      })
-
-      return
-    }
-
-    searchParams.set('sortKey', nextSortKey)
-
-    setSearchParams((currentParams) => {
-      if (order === 'ascending') nextSortKey = `-${key}`
-      if (order === 'descending') nextSortKey = key
-
-      // Reset the page parameter
-      currentParams.delete('page')
-
-      // Set the sort key and provider
-      currentParams.set('sortKey', nextSortKey)
-      if (currentProviderParam) {
-        currentParams.set('provider', currentProviderParam)
-      } else {
-        currentParams.delete('provider')
-      }
-
-      return Object.fromEntries(currentParams)
-    })
+    handleSort(currentProviderParam, setSearchParams, key, order)
   }, [])
 
   const getColumnState = () => {

--- a/static/src/js/pages/SearchList/SearchList.jsx
+++ b/static/src/js/pages/SearchList/SearchList.jsx
@@ -1,36 +1,38 @@
-import React, {
-  useEffect,
-  useCallback,
-  useState
-} from 'react'
-import PropTypes from 'prop-types'
-import {
-  useSearchParams,
-  Navigate,
-  useParams
-} from 'react-router-dom'
 import { capitalize, startCase } from 'lodash-es'
-import pluralize from 'pluralize'
+import Col from 'react-bootstrap/Col'
 import ListGroup from 'react-bootstrap/ListGroup'
 import ListGroupItem from 'react-bootstrap/ListGroupItem'
-import Col from 'react-bootstrap/Col'
+import moment from 'moment'
+import pluralize from 'pluralize'
+import PropTypes from 'prop-types'
+import React, {
+  useCallback,
+  useEffect,
+  useState
+} from 'react'
 import Row from 'react-bootstrap/Row'
+import {
+  Navigate,
+  useParams,
+  useSearchParams
+} from 'react-router-dom'
 
 import { useSuspenseQuery } from '@apollo/client'
-import moment from 'moment'
-import conceptTypes from '../../constants/conceptTypes'
 
-import Table from '../../components/Table/Table'
-import Button from '../../components/Button/Button'
-import CustomModal from '../../components/CustomModal/CustomModal'
-import For from '../../components/For/For'
-import EllipsisText from '../../components/EllipsisText/EllipsisText'
-import EllipsisLink from '../../components/EllipsisLink/EllipsisLink'
-import getTagCount from '../../utils/getTagCount'
-import ControlledPaginatedContent from '../../components/ControlledPaginatedContent/ControlledPaginatedContent'
-import typeParamToHumanizedStringMap from '../../constants/typeParamToHumanizedStringMap'
-import conceptTypeQueries from '../../constants/conceptTypeQueries'
 import { DATE_FORMAT } from '../../constants/dateFormat'
+import conceptTypeQueries from '../../constants/conceptTypeQueries'
+import conceptTypes from '../../constants/conceptTypes'
+import typeParamToHumanizedStringMap from '../../constants/typeParamToHumanizedStringMap'
+
+import Button from '../../components/Button/Button'
+import ControlledPaginatedContent from '../../components/ControlledPaginatedContent/ControlledPaginatedContent'
+import CustomModal from '../../components/CustomModal/CustomModal'
+import EllipsisLink from '../../components/EllipsisLink/EllipsisLink'
+import EllipsisText from '../../components/EllipsisText/EllipsisText'
+import For from '../../components/For/For'
+import Table from '../../components/Table/Table'
+
+import getTagCount from '../../utils/getTagCount'
 
 /**
  * Renders a `SearchList` component
@@ -62,9 +64,9 @@ const SearchList = ({ limit }) => {
 
   let params = {
     keyword: keywordParam,
-    provider: providerParam,
     limit,
     offset,
+    provider: providerParam,
     sortKey: sortKeyParam
   }
 
@@ -102,7 +104,7 @@ const SearchList = ({ limit }) => {
   }
 
   const { [conceptType]: concept } = data
-  const { count, items = [] } = concept
+  const { count, items } = concept
 
   const buildEllipsisLinkCell = useCallback((cellData, rowData) => {
     const { conceptId } = rowData
@@ -140,8 +142,9 @@ const SearchList = ({ limit }) => {
       </Button>
     )
   }, [])
-
   const sortFn = useCallback((key, order) => {
+    const currentSearchParams = new URLSearchParams(window.location.search)
+    const currentProviderParam = currentSearchParams.get('provider')
     let nextSortKey
 
     if (!order) {
@@ -163,8 +166,13 @@ const SearchList = ({ limit }) => {
       // Reset the page parameter
       currentParams.delete('page')
 
-      // Set the sort key
+      // Set the sort key and provider
       currentParams.set('sortKey', nextSortKey)
+      if (currentProviderParam) {
+        currentParams.set('provider', currentProviderParam)
+      } else {
+        currentParams.delete('provider')
+      }
 
       return Object.fromEntries(currentParams)
     })
@@ -174,86 +182,86 @@ const SearchList = ({ limit }) => {
     if (formattedType === conceptTypes.Collections) {
       return [
         {
-          dataKey: 'shortName',
-          title: 'Short Name',
           className: 'col-auto',
           dataAccessorFn: buildEllipsisLinkCell,
-          sortFn
+          dataKey: 'shortName',
+          sortFn,
+          title: 'Short Name'
         },
         {
-          dataKey: 'version',
-          title: 'Version',
+          align: 'end',
           className: 'col-auto text-nowrap',
-          align: 'end'
+          dataKey: 'version',
+          title: 'Version'
         },
         {
-          dataKey: 'title',
-          sortKey: 'entryTitle',
-          title: 'Entry Title',
           className: 'col-auto',
           dataAccessorFn: buildEllipsisTextCell,
-          sortFn: (_, order) => sortFn('entryTitle', order)
+          dataKey: 'title',
+          sortFn: (_, order) => sortFn('entryTitle', order),
+          sortKey: 'entryTitle',
+          title: 'Entry Title'
         },
         {
-          dataKey: 'provider',
-          title: 'Provider',
-          className: 'col-auto text-nowrap',
           align: 'center',
-          sortFn
-        },
-        {
-          dataKey: 'granules.count',
-          title: 'Granule Count',
           className: 'col-auto text-nowrap',
-          align: 'end'
+          dataKey: 'provider',
+          sortFn,
+          title: 'Provider'
         },
         {
-          dataKey: 'tagDefinitions',
-          title: 'Tags',
+          align: 'end',
+          className: 'col-auto text-nowrap',
+          dataKey: 'granules.count',
+          title: 'Granule Count'
+        },
+        {
+          align: 'end',
           className: 'col-auto text-nowrap',
           dataAccessorFn: buildTagCell,
-          align: 'end'
+          dataKey: 'tagDefinitions',
+          title: 'Tags'
         },
         {
-          dataKey: 'revisionDate',
-          title: 'Last Modified (UTC)',
+          align: 'end',
           className: 'col-auto text-nowrap',
           dataAccessorFn: (cellData) => moment.utc(cellData).format(DATE_FORMAT),
-          align: 'end',
-          sortFn
+          dataKey: 'revisionDate',
+          sortFn,
+          title: 'Last Modified (UTC)'
         }
       ]
     }
 
     return [
       {
-        dataKey: 'name',
-        title: 'Name',
         className: 'col-auto',
         dataAccessorFn: buildEllipsisLinkCell,
-        sortFn
+        dataKey: 'name',
+        sortFn,
+        title: 'Name'
       },
       {
-        dataKey: 'longName',
-        title: 'Long Name',
         className: 'col-auto',
         dataAccessorFn: buildEllipsisTextCell,
-        sortFn: (_, order) => sortFn('longName', order)
+        dataKey: 'longName',
+        sortFn,
+        title: 'Long Name'
       },
       {
-        dataKey: 'providerId',
-        title: 'Provider',
-        className: 'col-auto text-nowrap',
         align: 'center',
-        sortFn
+        className: 'col-auto text-nowrap',
+        dataKey: 'providerId',
+        sortFn,
+        title: 'Provider'
       },
       {
-        dataKey: 'revisionDate',
-        title: 'Last Modified (UTC)',
+        align: 'end',
         className: 'col-auto text-nowrap',
         dataAccessorFn: (cellData) => moment.utc(cellData).format(DATE_FORMAT),
-        align: 'end',
-        sortFn
+        dataKey: 'revisionDate',
+        sortFn,
+        title: 'Last Modified (UTC)'
       }
     ]
   }
@@ -297,81 +305,58 @@ const SearchList = ({ limit }) => {
           >
             {
               ({
-                totalPages,
-                pagination,
                 firstResultPosition,
-                lastResultPosition
+                lastResultPosition,
+                pagination,
+                totalPages
               }) => {
                 // Checks to see if any filters are provided so that they display in the pagination message
                 const hasFilter = !!keywordParam || !!sortKeyParam
 
-                const paginationMessage = count > 0
-                  ? `${totalPages > 1 ? `${firstResultPosition}-${lastResultPosition} of` : ''} ${count} `
+                const paginationMessage = `${totalPages > 1 ? `${firstResultPosition}-${lastResultPosition} of` : ''} ${count} `
                     + `${hasFilter ? 'matching ' : ''}${pluralize(conceptType, concept.count)}`
                     + `${secondaryTitle ? ` for: ${secondaryTitle}` : ''}`
-                  : `No matching ${conceptType} found`
 
                 return (
                   <>
-                    <>
-                      <Row className="d-flex justify-content-between align-items-center mb-4">
-                        <Col className="flex-grow-1" xs="auto">
-                          {/* {
-                                    !count && (
-                                      <div className="w-100">
-                                        <span className="d-block">
-                                          <Placeholder as="span" animation="glow">
-                                            <Placeholder xs={8} />
-                                          </Placeholder>
-                                        </span>
-                                      </div>
-                                    )
-                                  } */}
-                          {
-                            !!count && (
-                              <span className="text-secondary fw-bolder">{paginationMessage}</span>
-                            )
-                          }
-                        </Col>
+                    <Row className="d-flex justify-content-between align-items-center mb-4">
+                      <Col className="flex-grow-1" xs="auto">
                         {
-                          totalPages > 1 && (
-                            <Col xs="auto">
-                              {pagination}
-                            </Col>
+                          !!count && (
+                            <span className="text-secondary fw-bolder">{paginationMessage}</span>
                           )
                         }
-                      </Row>
-                      <Table
-                        id="search-results-table"
-                        columns={columns}
-                        data={items}
-                        generateCellKey={({ conceptId }, dataKey) => `column_${dataKey}_${conceptId}`}
-                        generateRowKey={({ conceptId }) => `row_${conceptId}`}
-                        noDataMessage="No results"
-                        count={count}
-                        sortKey={sortKeyParam}
-                        limit={limit}
-                      />
+                      </Col>
                       {
                         totalPages > 1 && (
-                          <Row>
-                            <Col xs="12" className="pt-4 d-flex align-items-center justify-content-center">
-                              <div>
-                                {pagination}
-                              </div>
-                            </Col>
-                          </Row>
+                          <Col xs="auto">
+                            {pagination}
+                          </Col>
                         )
                       }
-                    </>
-                    {/* {
-                          !loading && items.length === 0 && (
-                            <Alert className="text-center d-flex flex-column align-items-center p-4" variant="light">
-                              <FaBan className="display-6 mb-2 text-secondary" />
-                              <span>{`No ${getHumanizedNameFromTypeParam(conceptType)}s match the current search criteria.`}</span>
-                            </Alert>
-                          )
-                        } */}
+                    </Row>
+                    <Table
+                      columns={columns}
+                      count={count}
+                      data={items}
+                      generateCellKey={({ conceptId }, dataKey) => `column_${dataKey}_${conceptId}`}
+                      generateRowKey={({ conceptId }) => `row_${conceptId}`}
+                      id="search-results-table"
+                      limit={limit}
+                      noDataMessage="No results"
+                      sortKey={sortKeyParam}
+                    />
+                    {
+                      totalPages > 1 && (
+                        <Row>
+                          <Col xs="12" className="pt-4 d-flex align-items-center justify-content-center">
+                            <div>
+                              {pagination}
+                            </div>
+                          </Col>
+                        </Row>
+                      )
+                    }
                   </>
                 )
               }
@@ -380,9 +365,13 @@ const SearchList = ({ limit }) => {
         </Col>
       </Row>
       <CustomModal
-        show={showTagModal}
-        toggleModal={toggleTagModal}
-        size="lg"
+        actions={
+          [{
+            label: 'Close',
+            onClick: () => toggleTagModal(false),
+            variant: 'primary'
+          }]
+        }
         header={activeTagModalCollection?.tags && `${Object.keys(activeTagModalCollection.tags).length} ${pluralize('tag', Object.keys(activeTagModalCollection.tags).length)}`}
         message={
           (
@@ -417,13 +406,9 @@ const SearchList = ({ limit }) => {
             )
           )
         }
-        actions={
-          [{
-            label: 'Close',
-            onClick: () => toggleTagModal(false),
-            variant: 'primary'
-          }]
-        }
+        show={showTagModal}
+        size="lg"
+        toggleModal={toggleTagModal}
       />
     </>
   )

--- a/static/src/js/pages/SearchList/SearchList.jsx
+++ b/static/src/js/pages/SearchList/SearchList.jsx
@@ -2,6 +2,7 @@ import { capitalize, startCase } from 'lodash-es'
 import Col from 'react-bootstrap/Col'
 import ListGroup from 'react-bootstrap/ListGroup'
 import ListGroupItem from 'react-bootstrap/ListGroupItem'
+import Row from 'react-bootstrap/Row'
 import moment from 'moment'
 import pluralize from 'pluralize'
 import PropTypes from 'prop-types'
@@ -10,7 +11,6 @@ import React, {
   useEffect,
   useState
 } from 'react'
-import Row from 'react-bootstrap/Row'
 import {
   Navigate,
   useParams,

--- a/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
+++ b/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
@@ -266,6 +266,12 @@ describe('SearchPage component', () => {
 
       expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in descending order/ })).toHaveClass('table__sort-button--inactive')
       expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in ascending order/ })).not.toHaveClass('table__sort-button--inactive')
+
+      // Checks to see that table goes back to original order
+      await user.click(ascendingButton)
+
+      expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in descending order/ })).toHaveClass('table__sort-button--inactive')
+      expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in ascending order/ })).toHaveClass('table__sort-button--inactive')
     })
   })
 
@@ -381,7 +387,7 @@ describe('SearchPage component', () => {
 
         const tableRows = within(table).getAllByRole('row')
 
-        expect(tableRows.length).toEqual(2)
+        expect(tableRows.length).toEqual(3)
 
         expect(within(table).getAllByRole('columnheader')[0].textContent).toContain('Name')
         expect(within(table).getAllByRole('columnheader')[1].textContent).toContain('Long Name')
@@ -398,14 +404,14 @@ describe('SearchPage component', () => {
 
         const tableRows = within(table).getAllByRole('row')
 
-        expect(tableRows.length).toEqual(2)
+        expect(tableRows.length).toEqual(3)
 
         const row1Cells = within(tableRows[1]).queryAllByRole('cell')
 
         expect(row1Cells).toHaveLength(4)
-        expect(row1Cells[0].textContent).toBe('Tool Name 1')
-        expect(row1Cells[1].textContent).toBe('Tool Long Name 1')
-        expect(row1Cells[2].textContent).toBe('TESTPROV')
+        expect(row1Cells[0].textContent).toBe('Tool Name 2')
+        expect(row1Cells[1].textContent).toBe('Tool Long Name 2')
+        expect(row1Cells[2].textContent).toBe('MMT_1')
         expect(row1Cells[3].textContent).toBe('Thursday, November 30, 2023 12:00 AM')
       })
     })

--- a/static/src/js/pages/SearchList/__tests__/__mocks__/searchResults.js
+++ b/static/src/js/pages/SearchList/__tests__/__mocks__/searchResults.js
@@ -726,8 +726,17 @@ export const singlePageToolsSearch = {
   result: {
     data: {
       tools: {
-        count: 1,
+        count: 2,
         items: [
+          {
+            conceptId: 'T1000000002-MMT1',
+            name: 'Tool Name 2',
+            longName: 'Tool Long Name 2',
+            providerId: 'MMT_1',
+            revisionDate: '2023-11-30 00:00:00',
+            revisionId: '1',
+            userId: 'admin'
+          },
           {
             conceptId: 'T1000000000-TESTPROV',
             name: 'Tool Name 1',

--- a/static/src/js/utils/__tests__/handleSort.test.js
+++ b/static/src/js/utils/__tests__/handleSort.test.js
@@ -1,0 +1,45 @@
+import handleSort from '../handleSort'
+
+describe('handleSort', () => {
+  const originalSearchParams1 = new URLSearchParams('?keyword=&provider=LARC')
+  const originalProvider1 = originalSearchParams1.get('provider')
+
+  const originalSearchParams2 = new URLSearchParams('?keyword=&provider=')
+  const originalProvider2 = originalSearchParams2.get('provider')
+
+  describe('when given a query', () => {
+    test('returns appropriate search params for sorting', () => {
+      const searchParamsSortKeyAsc = new URLSearchParams('?sortKey=-name')
+      const searchParamsSortKeyDes = new URLSearchParams('?sortKey=name')
+      const searchParamsRemoved = new URLSearchParams('')
+      const setSearchParams = vi.fn()
+      const key = 'name'
+      const orderAsc = 'ascending'
+      const orderDes = 'descending'
+
+      handleSort(originalProvider1, setSearchParams, key, orderAsc)
+
+      // First call setting searchParams to provider = 'LARC' and sortKey = '-name'
+      setSearchParams.mock.calls[0][0](searchParamsSortKeyAsc)
+
+      expect(searchParamsSortKeyAsc.get('sortKey')).toBe('-name')
+      expect(searchParamsSortKeyAsc.get('provider')).toBe('LARC')
+
+      handleSort(originalProvider2, setSearchParams, key, orderDes)
+
+      // Second call setting searchParams after user removes providers and sortKey = 'name'
+      setSearchParams.mock.calls[1][0](searchParamsSortKeyDes)
+
+      expect(searchParamsSortKeyDes.get('sortKey')).toBe('name')
+      expect(searchParamsSortKeyDes.get('provider')).toBeNull()
+
+      handleSort(originalProvider2, setSearchParams)
+
+      // Third call setting searchParams after user removes provider and removes sortKey
+      setSearchParams.mock.calls[2][0](searchParamsRemoved)
+
+      expect(searchParamsRemoved.get('sortKey')).toBeNull()
+      expect(searchParamsRemoved.get('provider')).toBeNull()
+    })
+  })
+})

--- a/static/src/js/utils/handleSort.js
+++ b/static/src/js/utils/handleSort.js
@@ -1,0 +1,28 @@
+const handleSort = (provider, setSearchParams, key, order) => {
+  let nextSortKey
+  if (order === 'ascending') nextSortKey = `-${key}`
+  if (order === 'descending') nextSortKey = key
+
+  if (!order) {
+    setSearchParams((currentParams) => {
+      currentParams.delete('sortKey')
+
+      return Object.fromEntries(currentParams)
+    })
+
+    return
+  }
+
+  setSearchParams((currentParams) => {
+    currentParams.set('sortKey', nextSortKey)
+    if (provider) {
+      currentParams.set('provider', provider)
+    } else {
+      currentParams.delete('provider')
+    }
+
+    return Object.fromEntries(currentParams)
+  })
+}
+
+export default handleSort

--- a/static/src/js/utils/handleSort.js
+++ b/static/src/js/utils/handleSort.js
@@ -1,3 +1,11 @@
+/**
+ * Function to handle 'handleSort
+ * @param {String} provider Optional search parameter provided by user
+ * @param {Function} setSearchParams Sets the searchParams of parent component
+ * @param {String} key Name of column being used for sort function
+ * @param {String} order Direction of sorting (ascending or descending)
+ */
+
 const handleSort = (provider, setSearchParams, key, order) => {
   let nextSortKey
   if (order === 'ascending') nextSortKey = `-${key}`


### PR DESCRIPTION
# Overview

### What is the feature?

In any search list element (Collection, Variable, Service, or Tool), there is an issue where a user cannot sort their results while a provider has been selected. This ticket fixes that so that after a user selects a provider, they can then use the descending and ascending buttons without losing that provider stipulation. 

### What is the Solution?

Capture the url params before they are deleted and send provider down to function. 

### What areas of the application does this impact?

SearchList and tests. Fixed a few other minor issues along the way. 

# Testing

### Reproduction steps

- **Environment for testing: local or sit, just need published records for all concepts
- **Collection to test with: N/A

1. Under Collections select 'All Collections'
2. select a Provider
3. click the up and down arrows for each column header and notice that it only sorts those with the selected provider

### Attachments

Screenshots wouldn't be very helpful here. 

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings