### PR TITLE
MMT-3804: User cannot clone a collection record

### DIFF
--- a/static/src/js/components/PublishPreview/PublishPreview.jsx
+++ b/static/src/js/components/PublishPreview/PublishPreview.jsx
@@ -125,7 +125,7 @@ const PublishPreviewHeader = () => {
   const handleClone = () => {
     const cloneNativeId = `MMT_${crypto.randomUUID()}`
     // Removes the value from the metadata that has to be unique
-    const modifiedMetadata = removeMetadataKeys(ummMetadata, ['Name', 'LongName', 'ShortName'])
+    const modifiedMetadata = removeMetadataKeys(ummMetadata, ['Name', 'LongName', 'ShortName', 'EntryTitle'])
 
     ingestMutation(derivedConceptType, modifiedMetadata, cloneNativeId, providerId)
   }

--- a/static/src/js/utils/__tests__/removeMetadataKeys.test.js
+++ b/static/src/js/utils/__tests__/removeMetadataKeys.test.js
@@ -13,4 +13,17 @@ describe('removeMetadataKeys', () => {
 
     expect(removeKeys).toMatchObject({ Description: 'test description' })
   })
+
+  test('should remove ShortName and EntryTitle from the metadata', () => {
+    const metadata = {
+      ShortName: 'test short name',
+      EntryTitle: 'test entry title',
+      Description: 'test description'
+    }
+    const keys = ['ShortName', 'EntryTitle']
+
+    const removeKeys = removeMetadataKeys(metadata, keys)
+
+    expect(removeKeys).toMatchObject({ Description: 'test description' })
+  })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

Durning UAT testing Francell noticed that after cloning a record, if a user does not update the entry title the publish fails.

### What is the Solution?

When a user clones a record, now we are removing EntryTitle field as well as shortName field

### What areas of the application does this impact? Collection Draft


# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings