### PR TITLE
MMT-3839: Add support for Science Keyword Picker to add a higher level keyword even if child keywords exist

### DIFF
--- a/static/src/js/components/KeywordPicker/KeywordPicker.jsx
+++ b/static/src/js/components/KeywordPicker/KeywordPicker.jsx
@@ -44,8 +44,8 @@ const KeywordPicker = ({
   const [fullPath, setFullPath] = useState([])
   const [loading, setLoading] = useState(true)
   const [finalSelectedValue, setFinalSelectedValue] = useState(null)
-  const [finalSelectedList, setFinalSelectedList] = useState([])
-  const [disableButton, setDisableButton] = useState(true)
+  const [currentSelected, setCurrentSelected] = useState([])
+
   const [marginTop, setMarginTop] = useState(0)
   const [marginLeft, setMarginLeft] = useState(0)
 
@@ -169,8 +169,7 @@ const KeywordPicker = ({
 
     finalList.push(item)
     setFinalSelectedValue(item)
-    setDisableButton(false)
-    setFinalSelectedList(finalList)
+    setCurrentSelected(finalList.splice(1))
   }
 
   // Iterates over formData and checks if the keywords has already been added.
@@ -214,19 +213,21 @@ const KeywordPicker = ({
 
     updatedList = getChildren(fullSelectedPath)
     selectedKeywords.push(item)
+    currentSelected.push(item)
     setCurrentList(updatedList)
     setMarginTop(-49 * (selectedKeywords.length - 1))
     setMarginLeft(49 * (selectedKeywords.length - 1))
   }
 
   const handleSubmit = () => {
-    const addedKeywords = addKeywords(finalSelectedList.splice(1))
+    const addedKeywords = addKeywords(currentSelected)
     if (!addedKeywords) return
 
     formData.push(addedKeywords)
-    setFinalSelectedList([])
+
+    setCurrentSelected([])
     setFinalSelectedValue('')
-    setDisableButton(true)
+
     onChange(formData)
   }
 
@@ -242,7 +243,6 @@ const KeywordPicker = ({
     handleSelectParent(tempItem)
     setSelectedKeywords(selectedKeywords)
     setFinalSelectedValue(false)
-    setDisableButton(true)
   }
 
   // Removes a selected keywords from formData.
@@ -441,8 +441,8 @@ const KeywordPicker = ({
 
             <Button
               className="mt-2"
-              disabled={disableButton}
               onClick={handleSubmit}
+              aria-label="add"
             >
               <i className="fa-solid fa-circle-plus fa-sm" />
               {' '}

--- a/static/src/js/components/KeywordPicker/KeywordPicker.jsx
+++ b/static/src/js/components/KeywordPicker/KeywordPicker.jsx
@@ -210,11 +210,19 @@ const KeywordPicker = ({
   const handleSelectParent = (item) => {
     const fullSelectedPath = getFullSelectedPath(item)
     let updatedList = []
+    const currentSelectedList = []
 
     updatedList = getChildren(fullSelectedPath)
+
+    selectedKeywords.forEach((keyword) => {
+      currentSelectedList.push(keyword)
+    })
+
+    currentSelectedList.push(item)
     selectedKeywords.push(item)
-    currentSelected.push(item)
+
     setCurrentList(updatedList)
+    setCurrentSelected(currentSelectedList.splice(1))
     setMarginTop(-49 * (selectedKeywords.length - 1))
     setMarginLeft(49 * (selectedKeywords.length - 1))
   }

--- a/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
+++ b/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
@@ -300,6 +300,34 @@ describe('when selecting previous', () => {
   })
 })
 
+describe('when selecting a keyword that is not a child element', () => {
+  test('should first', async () => {
+    const { props, user } = setup({})
+
+    // Clicking on the first parent element
+    const earthScienceServiceBtn = screen.getByRole('link', { name: 'EARTH SCIENCE SERVICES' })
+    await user.click(earthScienceServiceBtn)
+
+    // Clicking on the second parent element
+    const dataAnalysisButton = screen.getByRole('link', { name: 'DATA ANALYSIS AND VISUALIZATION' })
+    await user.click(dataAnalysisButton)
+
+    const addKeyword = screen.getByRole('button')
+
+    await user.click(addKeyword)
+
+    expect(props.onChange).toHaveBeenCalledTimes(1)
+    expect(props.onChange).toHaveBeenCalledWith([
+      {
+        ToolCategory: 'EARTH SCIENCE SERVICES',
+        ToolTopic: 'DATA ANALYSIS AND VISUALIZATION',
+        ToolTerm: undefined,
+        ToolSpecificTerm: undefined
+      }
+    ])
+  })
+})
+
 describe('when removing selected keyword', () => {
   test('removes the selected keyword', async () => {
     const { props, user } = setup({


### PR DESCRIPTION
# Overview

### What is the feature?

Currently in production, we have always been able to add a higher level keyword even if child keywords exist. For example: EARTH SCIENCE SERVICES > DATA MANAGEMENT/DATA HANDLING > DATA CUSTOMIZATION can be curated as-is in production. In UAT, I am unable to add this keyword. It looks like I need to add one of its child keywords, INTERPOLATION, REPROJECTION, RESAMPLING. Currently our tools catalog uses CUSTOMIZATION as a filter option.

### What is the Solution?

Removed the disabled button and let the user add a keywords at any given level

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings