### PR TITLE
MMT-3774: Added live validation to group form, order option form, and permission form.

### DIFF
--- a/static/src/js/components/GroupForm/__tests__/GroupForm.test.jsx
+++ b/static/src/js/components/GroupForm/__tests__/GroupForm.test.jsx
@@ -289,7 +289,7 @@ describe('GroupForm', () => {
         await user.click(descriptionField)
         expect(screen.getByText('must have required property \'name\'')).toBeInTheDocument()
 
-        // Very button is disabled since Name field has not been filled out yet
+        // Verify button is disabled since Name field has not been filled out yet
         const submitButton = screen.getByRole('button', { name: 'Submit' })
         expect(submitButton).toBeDisabled()
 

--- a/static/src/js/components/GroupForm/__tests__/GroupForm.test.jsx
+++ b/static/src/js/components/GroupForm/__tests__/GroupForm.test.jsx
@@ -282,6 +282,17 @@ describe('GroupForm', () => {
         const descriptionField = screen.getByRole('textbox', { name: 'Description' })
         const membersField = screen.getByRole('combobox')
 
+        // Verify inline error does not appear on page load, only when visiting the field
+        // and leaving the field does it appear.
+        expect(screen.queryByText('must have required property \'name\'')).not.toBeInTheDocument()
+        await user.click(nameField)
+        await user.click(descriptionField)
+        expect(screen.getByText('must have required property \'name\'')).toBeInTheDocument()
+
+        // Very button is disabled since Name field has not been filled out yet
+        const submitButton = screen.getByRole('button', { name: 'Submit' })
+        expect(submitButton).toBeDisabled()
+
         await user.type(nameField, 'Test Name')
         await user.type(descriptionField, 'Test Description')
 
@@ -290,7 +301,6 @@ describe('GroupForm', () => {
         const option = screen.getByRole('option', { name: 'Test User 1 testuser1' })
         await user.click(option)
 
-        const submitButton = screen.getByRole('button', { name: 'Submit' })
         await user.click(submitButton)
 
         expect(navigateSpy).toHaveBeenCalledTimes(1)

--- a/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
+++ b/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
@@ -1,4 +1,8 @@
-import React, { useEffect, useState } from 'react'
+import React, {
+  createRef,
+  useEffect,
+  useState
+} from 'react'
 import { useNavigate, useParams } from 'react-router'
 import Button from 'react-bootstrap/Button'
 import Col from 'react-bootstrap/Col'
@@ -81,6 +85,24 @@ const OrderOptionForm = () => {
 
   const [nativeId, setNativeId] = useState()
   const [chooseProviderModalOpen, setChooseProviderModalOpen] = useState(false)
+  const [visitedFields, setVisitedFields] = useState([])
+
+  const formRef = createRef()
+
+  // Handle bluring fields within the form
+  const handleBlur = (fieldId) => {
+    setVisitedFields([...new Set([
+      ...visitedFields,
+      fieldId
+    ])])
+  }
+
+  // eslint-disable-next-line max-len
+  const handleTransformErrors = (errors) => errors.filter((error) => visitedFields.includes(error.property))
+
+  useEffect(() => {
+    formRef?.current?.validateForm()
+  }, [visitedFields])
 
   const fields = {
     TitleField: CustomTitleField,
@@ -237,6 +259,12 @@ const OrderOptionForm = () => {
     })
   }
 
+  const hasErrors = () => {
+    const { errors } = validator.validateFormData(formData, orderOption)
+
+    return errors.length > 0
+  }
+
   return (
     <>
       <Container className="order-option-form__container mx-0" fluid>
@@ -250,18 +278,25 @@ const OrderOptionForm = () => {
                   setFocusField
                 }
               }
-              widgets={widgets}
-              schema={orderOption}
-              validator={validator}
-              templates={templates}
-              uiSchema={orderOptionUiSchema}
-              onChange={handleChange}
               formData={formData}
+              liveValidate
+              onBlur={handleBlur}
+              onChange={handleChange}
               onSubmit={handleSetProviderOrSubmit}
+              ref={formRef}
+              schema={orderOption}
               showErrorList="false"
+              templates={templates}
+              transformErrors={handleTransformErrors}
+              uiSchema={orderOptionUiSchema}
+              validator={validator}
+              widgets={widgets}
             >
               <div className="d-flex gap-2">
-                <Button type="submit">
+                <Button
+                  disabled={hasErrors()}
+                  type="submit"
+                >
                   {saveTypesToHumanizedStringMap[saveTypes.submit]}
                 </Button>
                 <Button

--- a/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
+++ b/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
@@ -174,7 +174,7 @@ describe('OrderOptionForm', () => {
         await user.type(descriptionField, 'Test Description')
         await user.type(formField, 'Test Form')
 
-        // Very button is disabled since Name field has not been filled out yet
+        // Verify button is disabled since Name field has not been filled out yet
         const submitButton = screen.getByRole('button', { name: 'Submit' })
         expect(submitButton).toBeDisabled()
 

--- a/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
+++ b/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
@@ -164,11 +164,21 @@ describe('OrderOptionForm', () => {
         const descriptionField = screen.getByRole('textbox', { name: 'Description' })
         const formField = screen.getByRole('textbox', { name: 'Form XML' })
 
-        await user.type(nameField, 'Test Name')
+        // Verify inline error does not appear on page load, only when visiting the field
+        // and leaving the field does it appear.
+        expect(screen.queryByText('must have required property \'name\'')).not.toBeInTheDocument()
+        await user.click(nameField)
+        await user.click(descriptionField)
+        expect(screen.getByText('must have required property \'name\'')).toBeInTheDocument()
+
         await user.type(descriptionField, 'Test Description')
         await user.type(formField, 'Test Form')
 
+        // Very button is disabled since Name field has not been filled out yet
         const submitButton = screen.getByRole('button', { name: 'Submit' })
+        expect(submitButton).toBeDisabled()
+
+        await user.type(nameField, 'Test Name')
         await user.click(submitButton)
 
         const modal = screen.getByRole('dialog')

--- a/static/src/js/components/PermissionForm/PermissionForm.jsx
+++ b/static/src/js/components/PermissionForm/PermissionForm.jsx
@@ -676,6 +676,7 @@ const PermissionForm = () => {
                   setFocusField
                 }
               }
+              liveValidate
               widgets={widgets}
               schema={collectionPermission}
               validator={validator}


### PR DESCRIPTION
# Overview

### What is the feature?

Currently, validation happens only upon form submission for order option, group, and permission forms. Implement 'hasVisited' logic similar to FormNavigation to enable validation as users interact with the form fields

### What is the Solution?

The solution involved the following: 1) Turning on live validation.  2) Hiding the errors for those fields not visited yet.   3) Disabling the submit button until validation passes.

Note: #2 and #3 were only implemented for the Group and OrderOption form.   For the permission form, the user was not inundated with a lot of red in the form, so no special logic was added to track has visited, I just turned on live validation.

### What areas of the application does this impact?

Permissions Form
Groups Form
Order Option Form

# Testing

1. Try creating a new group, as you visit the fields, live validation should happen.  The submit button should be disabled until the form is completely valid.
2. Try creating a new order option, as you visit the fields, live validation should happen.   The submit button should be disabled until the form is completely valid.
3. Try creating a new permission, in this form, you'll have to fill in the fields to remove the inline validation.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings