### PR TITLE
MMT-3793: Add script to download schema files

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -35,6 +35,13 @@ config="`jq '.edl.uid = $newValue' --arg newValue $bamboo_EDL_UID <<< $config`"
 # overwrite static.config.json with new values
 echo $config > tmp.$$.json && mv tmp.$$.json static.config.json
 
+# Download schema files
+./download_schemas.sh
+if [ $? -ne 0 ]; then
+  echo "Failed downloading schema files"
+  exit 1
+fi
+
 # Set up Docker image
 #####################
 

--- a/bin/download_schemas.sh
+++ b/bin/download_schemas.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+ummC() {
+    echo "Downloading ummC"
+    #Reads version number
+    schema_version=`jq '.ummVersions.ummC' ../static.config.json`
+    schema_version=${schema_version//\"/}
+    #Download
+    curl https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/raw/collection/v${schema_version}/umm-c-json-schema.json > umm-c-json-schema.json
+    if [ $? -ne 0 ]; then
+      echo "Failed downloading umm-c-json-schema.json"
+      exit 1
+    fi
+    curl https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/raw/collection/v${schema_version}/umm-cmn-json-schema.json > umm-cmn-json-schema.json
+    if [ $? -ne 0 ]; then
+      echo "Failed downloading umm-cmn-json-schema.json"
+      exit 1
+    fi
+    #Remove key '$schema' of the common file because it would overwrite the same key in the main file
+    jq 'del(."$schema")' umm-cmn-json-schema.json > umm-cmn-json-schema-minus-schema-version.json
+    #Merge and create js file
+    echo "$(echo "const ummCSchema =")" "$(jq -s '.[0] * .[1]' umm-c-json-schema.json umm-cmn-json-schema-minus-schema-version.json)" > ummCSchemaRaw.js
+    echo "$(echo "export default ummCSchema")" >> ummCSchemaRaw.js
+    #Replace pointers to the common file
+    sed 's/umm-cmn-json-schema.json#/#/g' ummCSchemaRaw.js > ummCSchema.js
+    #sed "s/\"/\'/g" ummCSchemaRaw.js > ummCSchema.js
+}
+
+ummS() {
+    echo "Downloading ummS"
+    #Reads version number
+    schema_version=`jq '.ummVersions.ummS' ../static.config.json`
+    schema_version=${schema_version//\"/}
+    #Download
+    curl https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/raw/service/v${schema_version}/umm-s-json-schema.json > umm-s-json-schema.json
+    if [ $? -ne 0 ]; then
+      echo "Failed downloading umm-s-json-schema.json"
+      exit 1
+    fi
+    #Create js file
+    echo "$(echo "const ummSSchema =")" "$(jq '.' umm-s-json-schema.json)" > ummSSchema.js
+    echo "$(echo "export default ummSSchema")" >> ummSSchema.js
+}
+
+ummV() {
+    echo "Downloading ummV"
+    #Reads version number
+    schema_version=`jq '.ummVersions.ummV' ../static.config.json`
+    schema_version=${schema_version//\"/}
+    #Download
+    curl https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/raw/variable/v${schema_version}/umm-var-json-schema.json > umm-var-json-schema.json
+    if [ $? -ne 0 ]; then
+      echo "Failed downloading umm-var-json-schema.json"
+      exit 1
+    fi
+    #Create js file
+    echo "$(echo "const ummVarSchema =")" "$(jq '.' umm-var-json-schema.json)" > ummVarSchema.js
+    echo "$(echo "export default ummVarSchema")" >> ummVarSchema.js
+}
+
+ummT() {
+    echo "Downloading ummT"
+    #Reads version number
+    schema_version=`jq '.ummVersions.ummT' ../static.config.json`
+    schema_version=${schema_version//\"/}
+    #Download
+    curl https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/raw/tool/v${schema_version}/umm-t-json-schema.json > umm-t-json-schema.json
+    if [ $? -ne 0 ]; then
+      echo "Failed downloading umm-t-json-schema.json"
+      exit 1
+    fi
+    #Create js file
+    echo "$(echo "const ummTSchema =")" "$(jq '.' umm-t-json-schema.json)" > ummTSchema.js
+    echo "$(echo "export default ummTSchema")" >> ummTSchema.js
+}
+
+{
+  echo "Start downloading schema files"
+  (ummC -ne 1) && (ummS -ne 1) && (ummV -ne 1) && (ummT -ne 1)
+} || {
+  echo "Failed downloading schema files"
+  exit 1
+}
+echo "Successfully downloaded schema files"
+echo "Copying schema files"
+cp ummCSchema.js ummSSchema.js ummVarSchema.js ummTSchema.js ../static/src/js/schemas/umm/
+if [ $? -ne 0 ]; then
+  echo "Failed copying schema files"
+  exit 1
+fi
+echo "Done"


### PR DESCRIPTION
# Overview

### What is the feature?

Download schema files of umm C, Var, T and S when deployment.

### What is the Solution?

Add script to download and process schema files from https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model

### What areas of the application does this impact?

Umm schema files

# Testing

Run bin/download_schemas.sh
1. run 'npm test'
2. Manually test all document types forms (c,s,var,t) 

### Attachments

N/A

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings