### PR TITLE
MMT-3845: Error message when paginating through Order Options

### DIFF
--- a/static/src/js/components/OrderOptionList/__tests__/OrderOptionList.test.jsx
+++ b/static/src/js/components/OrderOptionList/__tests__/OrderOptionList.test.jsx
@@ -106,7 +106,7 @@ describe('OrderOptionList', () => {
     test('render a table with 2 order options', async () => {
       setup({})
 
-      expect(await screen.findByText(/You are viewing order options for the following providers:/)).toBeInTheDocument()
+      expect(await screen.findByText(/You are viewing order options for the following providers: MMT_2/)).toBeInTheDocument()
       expect(await screen.findByText('Showing 2 order options')).toBeInTheDocument()
       expect(screen.getByText('Test order option 1')).toBeInTheDocument()
       expect(screen.getByText('Test order option 2')).toBeInTheDocument()


### PR DESCRIPTION
# Overview

### What is the feature?

When users were paginating through order options, it would throw an error on page 2. Turns out that page 2 had an order option on it from a provider called ETIM22 which is not available to the public. It was decided to create the functionality to ONLY see order options from providers that a user had access to (as seen under their profile). 

### What is the Solution?

I utilized useAvailableProviders() to grab the available providers and passed that array of providerIds into the existing GET_ORDER_OPTIONS query. 

### What areas of the application does this impact?

OrderOptionList.jsx

# Testing

### Reproduction steps

- **Environment for testing: SIT
- **Collection to test with: N/A

1. Set up your local environment for sit testing. If you are getting an internal error 500 let me know as I have a doc on how to fix this now. 
2. Go to your user profile and select 'providers' to take note of your personal available providers
3. Go to Order Options >> All order options
4. Notice that there is now a banner at the top letting you know which providers you are viewing order options for. You can swap out line 42 with const providerId = ['MMT_2'] or null or whatever you'd like to test out any other functionality. 
5. Regardless of what you choose, you should now be able to paginate freely through the options without running into an error. 

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings