### PR TITLE
MMT-3848: Order options fails in Forms XML for character limit although the character limit wasn't exceeded

### DIFF
--- a/static/src/js/components/GroupForm/GroupForm.jsx
+++ b/static/src/js/components/GroupForm/GroupForm.jsx
@@ -80,8 +80,13 @@ const GroupForm = ({ isAdminPage }) => {
     ])])
   }
 
-  // eslint-disable-next-line max-len
-  const handleTransformErrors = (errors) => errors.filter((error) => visitedFields.includes(error.property))
+  const handleTransformErrors = (errors) => errors.filter((error) => {
+    if (id === 'new') {
+      return visitedFields.includes(error.property)
+    }
+
+    return errors
+  })
 
   const [createGroupMutation] = useMutation(CREATE_GROUP, {
     update: (cache) => {

--- a/static/src/js/components/GroupForm/__tests__/GroupForm.test.jsx
+++ b/static/src/js/components/GroupForm/__tests__/GroupForm.test.jsx
@@ -406,6 +406,7 @@ describe('GroupForm', () => {
           await screen.findByRole('textbox', { name: 'Name' })
         })
 
+        // Name is > 85 characters.
         expect(await screen.findByText('must NOT have more than 85 characters')).toBeInTheDocument()
       })
     })

--- a/static/src/js/components/GroupForm/__tests__/GroupForm.test.jsx
+++ b/static/src/js/components/GroupForm/__tests__/GroupForm.test.jsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react'
 import {
   render,
   screen,
+  waitFor,
   within
 } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
@@ -364,6 +365,51 @@ describe('GroupForm', () => {
   })
 
   describe('when getting and updating Group', () => {
+    describe('when getting a group where the incoming data has errors', () => {
+      test('should show the error', async () => {
+        const navigateSpy = vi.fn()
+        vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+
+        setup(
+          {
+            pageUrl: '/groups/1234-abcd-5678-efgh/edit',
+            mocks: [{
+              request: {
+                query: GET_GROUP,
+                variables: { params: { id: '1234-abcd-5678-efgh' } }
+              },
+              result: {
+                data: {
+                  group: {
+                    id: '1234-abcd-5678-efgh',
+                    description: 'Mock group description',
+                    members: {
+                      count: 1,
+                      items: [{
+                        id: 'test.user',
+                        firstName: 'Test',
+                        lastName: 'User',
+                        emailAddress: 'test@example.com',
+                        __typename: 'GroupMember'
+                      }]
+                    },
+                    name: 'Mock group 12345678901234567890123456789012345678901234567890123456789012345678901234567890',
+                    tag: 'MMT_2'
+                  }
+                }
+              }
+            }]
+          }
+        )
+
+        await waitFor(async () => {
+          await screen.findByRole('textbox', { name: 'Name' })
+        })
+
+        expect(await screen.findByText('must NOT have more than 85 characters')).toBeInTheDocument()
+      })
+    })
+
     describe('when getting a group and updating results in success', () => {
       test('should navigate to /groups/id', async () => {
         const navigateSpy = vi.fn()

--- a/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
+++ b/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
@@ -97,8 +97,13 @@ const OrderOptionForm = () => {
     ])])
   }
 
-  // eslint-disable-next-line max-len
-  const handleTransformErrors = (errors) => errors.filter((error) => visitedFields.includes(error.property))
+  const handleTransformErrors = (errors) => errors.filter((error) => {
+    if (conceptId === 'new') {
+      return visitedFields.includes(error.property)
+    }
+
+    return errors
+  })
 
   useEffect(() => {
     formRef?.current?.validateForm()

--- a/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
+++ b/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
@@ -301,6 +301,7 @@ describe('OrderOptionForm', () => {
           await screen.findByRole('textbox', { name: 'Name' })
         })
 
+        // Sort key's length is > 5 characters
         expect(await screen.findByText('must NOT have more than 5 characters')).toBeInTheDocument()
       })
     })

--- a/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
+++ b/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react'
 import {
   render,
   screen,
+  waitFor,
   within
 } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
@@ -255,6 +256,55 @@ describe('OrderOptionForm', () => {
   })
 
   describe('when getting and updating Order Option', () => {
+    describe('when getting a order option where the incoming data has errors', () => {
+      test('should show the error', async () => {
+        const navigateSpy = vi.fn()
+        vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+
+        setup(
+          {
+            pageUrl: '/order-options/OO1000000-MMT_2/edit',
+            mocks: [{
+              request: {
+                query: GET_ORDER_OPTION,
+                variables: { params: { conceptId: 'OO1000000-MMT_2' } }
+              },
+              result: {
+                data: {
+                  orderOption: {
+                    associationDetails: {},
+                    conceptId: 'OO1000000-MMT_2',
+                    collections: {
+                      count: 0,
+                      items: []
+                    },
+                    deprecated: null,
+                    description: 'Test Description',
+                    form: 'Test Form',
+                    name: 'Test Name',
+                    nativeId: 'dce1859e-774c-4561-9451-fc9d77906015',
+                    pageTitle: 'Test Name',
+                    providerId: 'MMT_2',
+                    revisionId: '1',
+                    revisionDate: '2024-04-23T15:03:34.399Z',
+                    scope: 'PROVIDER',
+                    sortKey: '1234567',
+                    __typename: 'OrderOption'
+                  }
+                }
+              }
+            }]
+          }
+        )
+
+        await waitFor(async () => {
+          await screen.findByRole('textbox', { name: 'Name' })
+        })
+
+        expect(await screen.findByText('must NOT have more than 5 characters')).toBeInTheDocument()
+      })
+    })
+
     describe('when getting a order option and updating results in success', () => {
       test('should navigate to /order-options/id', async () => {
         const navigateSpy = vi.fn()

--- a/static/src/js/schemas/orderOption.js
+++ b/static/src/js/schemas/orderOption.js
@@ -29,9 +29,7 @@ const orderOption = {
     },
     form: {
       description: 'The XML of the order option.',
-      type: 'string',
-      minLength: 1,
-      maxLength: 1024
+      type: 'string'
     }
   },
   required: ['name', 'description', 'form']


### PR DESCRIPTION
# Overview

### What is the feature?

Order options fails in Forms XML for character limit although the character limit wasn't exceeded
Also noticed that on form load, existing errors would not appear.

### What is the Solution?

Updated order options schema and removed the char limits.   Also made updates to the form logic so that only "new" records have special logic where it hides the error until the field is visited.

### What areas of the application does this impact?

Order Options and Groups Form.

# Testing

Easiest way to test this is to use CMR graphql to ingest a order option where the form xml > 1024 characters.
It should now load into the form, not show an error, and allow you to publish a order option with a length more than 1024 characters.

To test the other bug fix, upload an order option where the name is > 85 characters directly via CMR graphql.  When the form comes up, you should see an error.   Same thing can be done with group page, upload a new group where the name is > 85 characters, the form should show an error when loading into MMT form.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings