### PR TITLE
MMT-3823: As a user, I want to filter my search results after choosing a provider without loosing my original search results

### DIFF
--- a/static/src/js/pages/SearchList/SearchList.jsx
+++ b/static/src/js/pages/SearchList/SearchList.jsx
@@ -144,7 +144,6 @@ const SearchList = ({ limit }) => {
       </Button>
     )
   }, [])
-
   const sortFn = useCallback((key, order) => {
     const currentSearchParams = new URLSearchParams(window.location.search)
     const currentProviderParam = currentSearchParams.get('provider')

--- a/static/src/js/pages/SearchList/SearchList.jsx
+++ b/static/src/js/pages/SearchList/SearchList.jsx
@@ -144,6 +144,7 @@ const SearchList = ({ limit }) => {
       </Button>
     )
   }, [])
+
   const sortFn = useCallback((key, order) => {
     const currentSearchParams = new URLSearchParams(window.location.search)
     const currentProviderParam = currentSearchParams.get('provider')

--- a/static/src/js/pages/SearchList/SearchList.jsx
+++ b/static/src/js/pages/SearchList/SearchList.jsx
@@ -146,9 +146,19 @@ const SearchList = ({ limit }) => {
   }, [])
 
   const sortFn = useCallback((key, order) => {
+    // Must be captured before going into handleSort which automatically deletes these
     const currentSearchParams = new URLSearchParams(window.location.search)
     const currentProviderParam = currentSearchParams.get('provider')
-    handleSort(currentProviderParam, setSearchParams, key, order)
+    const currentPageParam = currentSearchParams.get('page')
+    const currentKeywordParam = currentSearchParams.get('keyword')
+    handleSort(
+      currentProviderParam,
+      currentPageParam,
+      currentKeywordParam,
+      setSearchParams,
+      key,
+      order
+    )
   }, [])
 
   const getColumnState = () => {
@@ -171,7 +181,7 @@ const SearchList = ({ limit }) => {
           className: 'col-auto',
           dataAccessorFn: buildEllipsisTextCell,
           dataKey: 'title',
-          sortFn: (_, order) => sortFn('entryTitle', order),
+          sortFn,
           sortKey: 'entryTitle',
           title: 'Entry Title'
         },

--- a/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
+++ b/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
@@ -16,7 +16,6 @@ import {
   multiPageCollectionSearchPage1,
   multiPageCollectionSearchPage1Asc,
   multiPageCollectionSearchPage1Desc,
-  multiPageCollectionSearchPage1TitleAsc,
   multiPageCollectionSearchPage2,
   singlePageCollectionSearch,
   singlePageServicesSearch,
@@ -196,7 +195,7 @@ describe('SearchPage component', () => {
 
   describe('with multiple pages of results', () => {
     test('shows the pagination', async () => {
-      setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage2], { limit: 3 })
+      setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage2], { limit: 3 }, ['/collections?&page=1'])
 
       expect(screen.getByText('Loading...')).toBeInTheDocument()
 
@@ -219,7 +218,7 @@ describe('SearchPage component', () => {
       test('navigates correctly and shows the correct pagination links', async () => {
         const user = userEvent.setup()
 
-        setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage2], { limit: 3 })
+        setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage2], { limit: 3 }, ['/collections?&page=1'])
 
         expect(screen.getByText('Loading...')).toBeInTheDocument()
 
@@ -242,9 +241,7 @@ describe('SearchPage component', () => {
 
   describe('when clicking an ascending sort button', () => {
     test('sorts and shows the the correctly classed sort buttons', async () => {
-      const {
-        user
-      } = setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage1Asc], { limit: 3 })
+      const { user } = setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage1Asc], { limit: 3 }, ['/collections?&page=1'])
 
       expect(screen.getByText('Loading...')).toBeInTheDocument()
 
@@ -254,15 +251,19 @@ describe('SearchPage component', () => {
 
       expect(tableRows.length).toEqual(4)
 
+      const dataRow1Before = await within(table).findAllByRole('row')
+
+      expect(within(dataRow1Before[1]).getAllByRole('cell')[0].textContent).toBe('Collection Short Name 1 multiPageCollectionSearchPage1')
+
       const shortNameHeader = within(table).getAllByRole('columnheader')[0]
 
       const ascendingButton = within(shortNameHeader).getByRole('button', { name: /Sort Short Name in ascending order/ })
 
       await user.click(ascendingButton)
 
-      const dataRow1 = await within(table).findAllByRole('row')
+      const dataRow1After = await within(table).findAllByRole('row')
 
-      expect(within(dataRow1[1]).getAllByRole('cell')[0].textContent).toContain('Collection Short Name 3')
+      expect(within(dataRow1After[1]).getAllByRole('cell')[0].textContent).toBe('Collection Short Name 3')
 
       expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in descending order/ })).toHaveClass('table__sort-button--inactive')
       expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in ascending order/ })).not.toHaveClass('table__sort-button--inactive')
@@ -279,7 +280,7 @@ describe('SearchPage component', () => {
     test('sorts and shows the correctly classed the sort buttons', async () => {
       const {
         user
-      } = setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage1Desc], { limit: 3 })
+      } = setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage1Desc], { limit: 3 }, ['/collections?&page=1'])
 
       expect(screen.getByText('Loading...')).toBeInTheDocument()
 
@@ -297,39 +298,10 @@ describe('SearchPage component', () => {
 
       const dataRow1 = await within(table).findAllByRole('row')
 
-      expect(within(dataRow1[1]).getAllByRole('cell')[0].textContent).toContain('Collection Short Name 3')
+      expect(within(dataRow1[1]).getAllByRole('cell')[0].textContent).toContain('Collection Short Name 1')
 
       expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in descending order/ })).not.toHaveClass('table__sort-button--inactive')
       expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in ascending order/ })).toHaveClass('table__sort-button--inactive')
-    })
-  })
-
-  describe('when clicking the a custom sortFn sort button', () => {
-    test('sorts and shows the button as active', async () => {
-      const user = userEvent.setup()
-
-      setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage1TitleAsc], { limit: 3 })
-
-      expect(screen.getByText('Loading...')).toBeInTheDocument()
-
-      const table = await screen.findByRole('table')
-
-      const tableRows = within(table).getAllByRole('row')
-
-      expect(tableRows.length).toEqual(4)
-
-      const entryTitleHeader = within(table).getAllByRole('columnheader')[2]
-
-      const descendingButton = within(entryTitleHeader).getByRole('button', { name: /Sort Entry Title in ascending order/ })
-
-      await user.click(descendingButton)
-
-      const dataRow1 = await within(table).findAllByRole('row')
-
-      expect(within(dataRow1[1]).getAllByRole('cell')[2].textContent).toContain('Collection Title 3')
-
-      expect(within(entryTitleHeader).getByRole('button', { name: /Sort Entry Title in descending order/ })).toHaveClass('table__sort-button--inactive')
-      expect(within(entryTitleHeader).getByRole('button', { name: /Sort Entry Title in ascending order/ })).not.toHaveClass('table__sort-button--inactive')
     })
   })
 

--- a/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
+++ b/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
@@ -15,6 +15,7 @@ import userEvent from '@testing-library/user-event'
 import {
   multiPageCollectionSearchPage1,
   multiPageCollectionSearchPage1Asc,
+  multiPageCollectionSearchPage1TitleAsc,
   multiPageCollectionSearchPage1Desc,
   multiPageCollectionSearchPage2,
   singlePageCollectionSearch,
@@ -195,7 +196,7 @@ describe('SearchPage component', () => {
 
   describe('with multiple pages of results', () => {
     test('shows the pagination', async () => {
-      setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage2], { limit: 3 }, ['/collections?&page=1'])
+      setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage2], { limit: 3 }, ['/collections'])
 
       expect(screen.getByText('Loading...')).toBeInTheDocument()
 
@@ -218,7 +219,7 @@ describe('SearchPage component', () => {
       test('navigates correctly and shows the correct pagination links', async () => {
         const user = userEvent.setup()
 
-        setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage2], { limit: 3 }, ['/collections?&page=1'])
+        setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage2], { limit: 3 }, ['/collections'])
 
         expect(screen.getByText('Loading...')).toBeInTheDocument()
 
@@ -241,7 +242,7 @@ describe('SearchPage component', () => {
 
   describe('when clicking an ascending sort button', () => {
     test('sorts and shows the the correctly classed sort buttons', async () => {
-      const { user } = setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage1Asc], { limit: 3 }, ['/collections?&page=1'])
+      const { user } = setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage1Asc], { limit: 3 }, ['/collections'])
 
       expect(screen.getByText('Loading...')).toBeInTheDocument()
 
@@ -253,7 +254,7 @@ describe('SearchPage component', () => {
 
       const dataRow1Before = await within(table).findAllByRole('row')
 
-      expect(within(dataRow1Before[1]).getAllByRole('cell')[0].textContent).toBe('Collection Short Name 1 multiPageCollectionSearchPage1')
+      expect(within(dataRow1Before[1]).getAllByRole('cell')[0].textContent).toContain('Collection Short Name 1')
 
       const shortNameHeader = within(table).getAllByRole('columnheader')[0]
 
@@ -263,7 +264,7 @@ describe('SearchPage component', () => {
 
       const dataRow1After = await within(table).findAllByRole('row')
 
-      expect(within(dataRow1After[1]).getAllByRole('cell')[0].textContent).toBe('Collection Short Name 3')
+      expect(within(dataRow1After[1]).getAllByRole('cell')[0].textContent).toContain('Collection Short Name 3')
 
       expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in descending order/ })).toHaveClass('table__sort-button--inactive')
       expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in ascending order/ })).not.toHaveClass('table__sort-button--inactive')
@@ -280,7 +281,7 @@ describe('SearchPage component', () => {
     test('sorts and shows the correctly classed the sort buttons', async () => {
       const {
         user
-      } = setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage1Desc], { limit: 3 }, ['/collections?&page=1'])
+      } = setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage1Desc], { limit: 3 }, ['/collections'])
 
       expect(screen.getByText('Loading...')).toBeInTheDocument()
 
@@ -302,6 +303,35 @@ describe('SearchPage component', () => {
 
       expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in descending order/ })).not.toHaveClass('table__sort-button--inactive')
       expect(within(shortNameHeader).getByRole('button', { name: /Sort Short Name in ascending order/ })).toHaveClass('table__sort-button--inactive')
+    })
+  })
+
+  describe('when clicking the a custom sortFn sort button', () => {
+    test('sorts and shows the button as active', async () => {
+      const user = userEvent.setup()
+
+      setup([multiPageCollectionSearchPage1, multiPageCollectionSearchPage1TitleAsc], { limit: 3 }, ['/collections'])
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument()
+
+      const table = await screen.findByRole('table')
+
+      const tableRows = within(table).getAllByRole('row')
+
+      expect(tableRows.length).toEqual(4)
+
+      const entryTitleHeader = within(table).getAllByRole('columnheader')[2]
+
+      const descendingButton = within(entryTitleHeader).getByRole('button', { name: /Sort Entry Title in ascending order/ })
+
+      await user.click(descendingButton)
+
+      const dataRow1 = await within(table).findAllByRole('row')
+
+      expect(within(dataRow1[1]).getAllByRole('cell')[2].textContent).toContain('Collection Title 3')
+
+      expect(within(entryTitleHeader).getByRole('button', { name: /Sort Entry Title in descending order/ })).toHaveClass('table__sort-button--inactive')
+      expect(within(entryTitleHeader).getByRole('button', { name: /Sort Entry Title in ascending order/ })).not.toHaveClass('table__sort-button--inactive')
     })
   })
 

--- a/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
+++ b/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
@@ -15,8 +15,8 @@ import userEvent from '@testing-library/user-event'
 import {
   multiPageCollectionSearchPage1,
   multiPageCollectionSearchPage1Asc,
-  multiPageCollectionSearchPage1TitleAsc,
   multiPageCollectionSearchPage1Desc,
+  multiPageCollectionSearchPage1TitleAsc,
   multiPageCollectionSearchPage2,
   singlePageCollectionSearch,
   singlePageServicesSearch,

--- a/static/src/js/pages/SearchList/__tests__/__mocks__/searchResults.js
+++ b/static/src/js/pages/SearchList/__tests__/__mocks__/searchResults.js
@@ -91,12 +91,12 @@ export const multiPageCollectionSearchPage1 = {
     query: GET_COLLECTIONS,
     variables: {
       params: {
-        keyword: 'test',
+        keyword: null,
         limit: 3,
         offset: 0,
         provider: null,
-        sortKey: null,
-        includeTags: '*'
+        includeTags: '*',
+        sortKey: null
       }
     }
   },
@@ -107,10 +107,10 @@ export const multiPageCollectionSearchPage1 = {
         items: [
           {
             conceptId: 'C1000000000-TESTPROV',
-            shortName: 'Collection Short Name 1',
+            shortName: 'Collection Short Name 1 multiPageCollectionSearchPage1',
             version: '1',
             revisionId: 1,
-            title: 'Collection Title 1',
+            title: 'Collection Title 1 multiPageCollectionSearchPage1',
             provider: 'TESTPROV',
             granules: {
               count: 1000
@@ -200,7 +200,7 @@ export const multiPageCollectionSearchPage2 = {
     query: GET_COLLECTIONS,
     variables: {
       params: {
-        keyword: 'test',
+        keyword: null,
         limit: 3,
         offset: 3,
         provider: null,
@@ -297,7 +297,7 @@ export const multiPageCollectionSearchPage1Asc = {
     query: GET_COLLECTIONS,
     variables: {
       params: {
-        keyword: 'test',
+        keyword: null,
         limit: 3,
         offset: 0,
         provider: null,
@@ -406,7 +406,7 @@ export const multiPageCollectionSearchPage1Desc = {
     query: GET_COLLECTIONS,
     variables: {
       params: {
-        keyword: 'test',
+        keyword: null,
         limit: 3,
         offset: 0,
         provider: null,
@@ -421,121 +421,12 @@ export const multiPageCollectionSearchPage1Desc = {
         count: 8,
         items: [
           {
-            conceptId: 'C1000000002-TESTPROV',
-            shortName: 'Collection Short Name 3',
-            version: '3',
-            revisionId: 1,
-            title: 'Collection Title 3',
-            provider: 'TESTPROV',
-            entryTitle: null,
-            granules: {
-              count: 1000
-            },
-            tags: {
-              'test.tag.one': {
-                data: 'Tag Data 1'
-              }
-            },
-            tagDefinitions: {
-              items: [{
-                conceptId: 'C100000',
-                description: 'Mock tag description',
-                originatorId: 'test.user',
-                revisionId: '1',
-                tagKey: 'Mock tag key'
-              }]
-            },
-            revisionDate: '2023-11-30 00:00:00'
-          },
-          {
-            conceptId: 'C1000000001-TESTPROV',
-            shortName: 'Collection Short Name 2',
-            version: '2',
-            revisionId: 1,
-            entryTitle: null,
-            title: 'Collection Title 2',
-            provider: 'MMT',
-            granules: {
-              count: 1234
-            },
-            tags: {
-              'test.tag.one': {
-                data: 'Tag Data 1'
-              },
-              'test.tag.two': {
-                data: 'Tag Data 2'
-              }
-            },
-            tagDefinitions: {
-              items: [{
-                conceptId: 'C100000',
-                description: 'Mock tag description',
-                originatorId: 'test.user',
-                revisionId: '1',
-                tagKey: 'Mock tag key'
-              }]
-            },
-            revisionDate: '2023-11-31 00:00:00'
-          },
-          {
             conceptId: 'C1000000000-TESTPROV',
             shortName: 'Collection Short Name 1',
             version: '1',
             revisionId: 1,
             title: 'Collection Title 1',
             entryTitle: null,
-            provider: 'TESTPROV',
-            granules: {
-              count: 1000
-            },
-            tags: {
-              'test.tag.one': {
-                data: 'Tag Data 1'
-              }
-            },
-            tagDefinitions: {
-              items: [{
-                conceptId: 'C100000',
-                description: 'Mock tag description',
-                originatorId: 'test.user',
-                revisionId: '1',
-                tagKey: 'Mock tag key'
-              }]
-            },
-            revisionDate: '2023-11-30 00:00:00'
-          }
-        ]
-      }
-    }
-  }
-}
-
-export const multiPageCollectionSearchPage1TitleAsc = {
-  request: {
-    query: GET_COLLECTIONS,
-    variables: {
-      params: {
-        keyword: 'test',
-        limit: 3,
-        offset: 0,
-        provider: null,
-        includeTags: '*',
-        sortKey: '-entryTitle'
-      }
-    }
-  },
-  result: {
-    data: {
-      collections: {
-        count: 8,
-        items: [
-          {
-            conceptId: 'C1000000002-TESTPROV',
-            shortName: 'Collection Short Name 3',
-            version: '3',
-            revisionId: 1,
-            entryTitle: null,
-            title: 'Collection Title 3',
             provider: 'TESTPROV',
             granules: {
               count: 1000
@@ -587,12 +478,13 @@ export const multiPageCollectionSearchPage1TitleAsc = {
             revisionDate: '2023-11-31 00:00:00'
           },
           {
-            conceptId: 'C1000000000-TESTPROV',
-            shortName: 'Collection Short Name 1',
-            version: '1',
+            conceptId: 'C1000000002-TESTPROV',
+            shortName: 'Collection Short Name 3',
+            version: '3',
             revisionId: 1,
-            title: 'Collection Title 1',
+            title: 'Collection Title 3',
             provider: 'TESTPROV',
+            entryTitle: null,
             granules: {
               count: 1000
             },
@@ -610,8 +502,7 @@ export const multiPageCollectionSearchPage1TitleAsc = {
                 tagKey: 'Mock tag key'
               }]
             },
-            revisionDate: '2023-11-30 00:00:00',
-            entryTitle: null
+            revisionDate: '2023-11-30 00:00:00'
           }
         ]
       }

--- a/static/src/js/pages/SearchList/__tests__/__mocks__/searchResults.js
+++ b/static/src/js/pages/SearchList/__tests__/__mocks__/searchResults.js
@@ -107,10 +107,10 @@ export const multiPageCollectionSearchPage1 = {
         items: [
           {
             conceptId: 'C1000000000-TESTPROV',
-            shortName: 'Collection Short Name 1 multiPageCollectionSearchPage1',
+            shortName: 'Collection Short Name 1',
             version: '1',
             revisionId: 1,
-            title: 'Collection Title 1 multiPageCollectionSearchPage1',
+            title: 'Collection Title 1',
             provider: 'TESTPROV',
             granules: {
               count: 1000
@@ -503,6 +503,115 @@ export const multiPageCollectionSearchPage1Desc = {
               }]
             },
             revisionDate: '2023-11-30 00:00:00'
+          }
+        ]
+      }
+    }
+  }
+}
+
+export const multiPageCollectionSearchPage1TitleAsc = {
+  request: {
+    query: GET_COLLECTIONS,
+    variables: {
+      params: {
+        keyword: null,
+        limit: 3,
+        offset: 0,
+        provider: null,
+        includeTags: '*',
+        sortKey: '-entryTitle'
+      }
+    }
+  },
+  result: {
+    data: {
+      collections: {
+        count: 8,
+        items: [
+          {
+            conceptId: 'C1000000002-TESTPROV',
+            shortName: 'Collection Short Name 3',
+            version: '3',
+            revisionId: 1,
+            entryTitle: null,
+            title: 'Collection Title 3',
+            provider: 'TESTPROV',
+            granules: {
+              count: 1000
+            },
+            tags: {
+              'test.tag.one': {
+                data: 'Tag Data 1'
+              }
+            },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
+            revisionDate: '2023-11-30 00:00:00'
+          },
+          {
+            conceptId: 'C1000000001-TESTPROV',
+            shortName: 'Collection Short Name 2',
+            version: '2',
+            revisionId: 1,
+            entryTitle: null,
+            title: 'Collection Title 2',
+            provider: 'MMT',
+            granules: {
+              count: 1234
+            },
+            tags: {
+              'test.tag.one': {
+                data: 'Tag Data 1'
+              },
+              'test.tag.two': {
+                data: 'Tag Data 2'
+              }
+            },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
+            revisionDate: '2023-11-31 00:00:00'
+          },
+          {
+            conceptId: 'C1000000000-TESTPROV',
+            shortName: 'Collection Short Name 1',
+            version: '1',
+            revisionId: 1,
+            title: 'Collection Title 1',
+            provider: 'TESTPROV',
+            granules: {
+              count: 1000
+            },
+            tags: {
+              'test.tag.one': {
+                data: 'Tag Data 1'
+              }
+            },
+            tagDefinitions: {
+              items: [{
+                conceptId: 'C100000',
+                description: 'Mock tag description',
+                originatorId: 'test.user',
+                revisionId: '1',
+                tagKey: 'Mock tag key'
+              }]
+            },
+            revisionDate: '2023-11-30 00:00:00',
+            entryTitle: null
           }
         ]
       }

--- a/static/src/js/utils/__tests__/handleSort.test.js
+++ b/static/src/js/utils/__tests__/handleSort.test.js
@@ -1,11 +1,15 @@
 import handleSort from '../handleSort'
 
 describe('handleSort', () => {
-  const originalSearchParams1 = new URLSearchParams('?keyword=&provider=LARC')
+  const originalSearchParams1 = new URLSearchParams('?keyword=AIR&provider=LARC&page=2')
   const originalProvider1 = originalSearchParams1.get('provider')
+  const originalPage1 = originalSearchParams1.get('page')
+  const originalKeyword1 = originalSearchParams1.get('keyword')
 
   const originalSearchParams2 = new URLSearchParams('?keyword=&provider=')
   const originalProvider2 = originalSearchParams2.get('provider')
+  const originalPage2 = originalSearchParams2.get('page')
+  const originalKeyword2 = originalSearchParams2.get('keyword')
 
   describe('when given a query', () => {
     test('returns appropriate search params for sorting', () => {
@@ -17,29 +21,35 @@ describe('handleSort', () => {
       const orderAsc = 'ascending'
       const orderDes = 'descending'
 
-      handleSort(originalProvider1, setSearchParams, key, orderAsc)
+      handleSort(originalProvider1, originalPage1, originalKeyword1, setSearchParams, key, orderAsc)
 
       // First call setting searchParams to provider = 'LARC' and sortKey = '-name'
       setSearchParams.mock.calls[0][0](searchParamsSortKeyAsc)
 
       expect(searchParamsSortKeyAsc.get('sortKey')).toBe('-name')
       expect(searchParamsSortKeyAsc.get('provider')).toBe('LARC')
+      expect(searchParamsSortKeyAsc.get('page')).toBe('2')
+      expect(searchParamsSortKeyAsc.get('keyword')).toBe('AIR')
 
-      handleSort(originalProvider2, setSearchParams, key, orderDes)
+      handleSort(originalProvider2, originalPage2, originalKeyword2, setSearchParams, key, orderDes)
 
       // Second call setting searchParams after user removes providers and sortKey = 'name'
       setSearchParams.mock.calls[1][0](searchParamsSortKeyDes)
 
       expect(searchParamsSortKeyDes.get('sortKey')).toBe('name')
       expect(searchParamsSortKeyDes.get('provider')).toBeNull()
+      expect(searchParamsSortKeyDes.get('page')).toBeNull()
+      expect(searchParamsSortKeyDes.get('keyword')).toBeNull()
 
-      handleSort(originalProvider2, setSearchParams)
+      handleSort(originalProvider2, originalPage2, originalKeyword2, setSearchParams)
 
       // Third call setting searchParams after user removes provider and removes sortKey
       setSearchParams.mock.calls[2][0](searchParamsRemoved)
 
       expect(searchParamsRemoved.get('sortKey')).toBeNull()
       expect(searchParamsRemoved.get('provider')).toBeNull()
+      expect(searchParamsRemoved.get('page')).toBeNull()
+      expect(searchParamsRemoved.get('keyword')).toBeNull()
     })
   })
 })

--- a/static/src/js/utils/handleSort.js
+++ b/static/src/js/utils/handleSort.js
@@ -1,12 +1,14 @@
 /**
  * Function to handle 'handleSort
- * @param {String} provider Optional search parameter provided by user
+ * @param {String} provider required search parameter provided by user
+ * @param {String} page required search parameter provided by user
+ * @param {String} keyword required search parameter provided by user
  * @param {Function} setSearchParams Sets the searchParams of parent component
  * @param {String} key Name of column being used for sort function
  * @param {String} order Direction of sorting (ascending or descending)
  */
 
-const handleSort = (provider, setSearchParams, key, order) => {
+const handleSort = (provider, page, keyword, setSearchParams, key, order) => {
   let nextSortKey
   if (order === 'ascending') nextSortKey = `-${key}`
   if (order === 'descending') nextSortKey = key
@@ -27,6 +29,18 @@ const handleSort = (provider, setSearchParams, key, order) => {
       currentParams.set('provider', provider)
     } else {
       currentParams.delete('provider')
+    }
+
+    if (page) {
+      currentParams.set('page', page)
+    } else {
+      currentParams.delete('page')
+    }
+
+    if (keyword) {
+      currentParams.set('keyword', keyword)
+    } else {
+      currentParams.delete('keyword')
     }
 
     return Object.fromEntries(currentParams)


### PR DESCRIPTION
# Overview

### What is the feature?

In reviewing this, I realized that both page and keyword were not being properly passed through. Edited so that now all those things are preserved. 

### What is the Solution?

Added more functionality to handlesort.js

### What areas of the application does this impact?

SearchList.jsx
HandleSort.js

# Testing

### Reproduction steps

- **Environment for testing: set up to run on SIT environment
- **Collection to test with: Test with collections, variables, tools, and services

1. When filtering all published records, make sure to try and break it. Search with a keyword, then remove it. Search on page 2, add a provider, go back to page 1, etc. 

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings