### PR TITLE
MMT-3860: There are several areas in which the drop-down items are sh…

### DIFF
--- a/static/src/js/components/CustomTitleField/CustomTitleField.scss
+++ b/static/src/js/components/CustomTitleField/CustomTitleField.scss
@@ -9,6 +9,7 @@
 
   &__heading {
     font-weight: 700;
+    margin-top: 1em;
   }
 
   &__icon {

--- a/static/src/js/components/CustomTitleField/CustomTitleField.scss
+++ b/static/src/js/components/CustomTitleField/CustomTitleField.scss
@@ -8,8 +8,8 @@
   }
 
   &__heading {
-    font-weight: 700;
     margin-top: 1em;
+    font-weight: 700;
   }
 
   &__icon {

--- a/static/src/js/components/CustomTitleField/CustomTitleField.scss
+++ b/static/src/js/components/CustomTitleField/CustomTitleField.scss
@@ -8,7 +8,7 @@
   }
 
   &__heading {
-    margin-top: 1em;
+    margin-top: 1rem;
     font-weight: 700;
   }
 

--- a/static/src/js/components/GridCheckboxPanel/GridCheckboxPanel.jsx
+++ b/static/src/js/components/GridCheckboxPanel/GridCheckboxPanel.jsx
@@ -92,7 +92,13 @@ const GridCheckboxPanel = ({
   }
 
   return (
-    <div>
+    <div style={
+      {
+        display: 'flex',
+        alignItems: 'center'
+      }
+    }
+    >
       <input className="m-2" type="checkbox" onChange={handleCheckbox} />
       {groupCheckbox}
     </div>

--- a/static/src/js/components/GridCol/GridCol.jsx
+++ b/static/src/js/components/GridCol/GridCol.jsx
@@ -97,7 +97,7 @@ const GridCol = (
           </span>
           {
             groupDescription && (
-              <div className="description-box mb-5">
+              <div className="description-box mb-3">
                 {description}
               </div>
             )

--- a/static/src/js/components/GridLayout/GridLayout.scss
+++ b/static/src/js/components/GridLayout/GridLayout.scss
@@ -2,4 +2,10 @@
   &__.description-box {
     margin-bottom: 1rem;
   }
+
+  &__field-left-border {
+    padding: 1.25rem 1.5rem;
+    border-inline-Start: 4px solid #cad4d8
+  }
 }
+

--- a/static/src/js/components/MetadataForm/MetadataForm.scss
+++ b/static/src/js/components/MetadataForm/MetadataForm.scss
@@ -14,15 +14,13 @@
 .rjsf {
   .custom-array-field-template__description,
   .field-description {
-    margin-top: 1rem;
-    margin-bottom: 2rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
     color: $gray-800;
     font-size: 0.925rem;
   }
 
   .row.row-children {
-    margin-bottom: 3rem;
-
     &:last-child {
       margin-bottom: 0;
     }

--- a/static/src/js/hooks/usePublishMutation.js
+++ b/static/src/js/hooks/usePublishMutation.js
@@ -4,6 +4,7 @@ import { useParams } from 'react-router'
 import { PUBLISH_DRAFT } from '../operations/mutations/publishDraft'
 
 import getUmmVersion from '../utils/getUmmVersion'
+import getHumanizedNameFromTypeParam from '../utils/getHumanizedNameFromTypeParam'
 
 const usePublishMutation = (queryName) => {
   const [error, setError] = useState()
@@ -17,7 +18,9 @@ const usePublishMutation = (queryName) => {
           // Remove the list of drafts from the cache. This ensures that if the user returns to the list page they will see the correct data.
           drafts: () => {},
           // Remove the list of published concepts from the cache. This ensures that if the user returns to the list page they will see the correct data.
-          [queryName]: () => {}
+          [queryName]: () => {},
+          // Remove the list of published concept from the cache. This ensures that if the user returns to the preview page they will see the correct data.
+          [getHumanizedNameFromTypeParam(queryName)]: () => {}
         }
       })
     }

--- a/static/src/js/schemas/uiSchemas/collectionPermission.js
+++ b/static/src/js/schemas/uiSchemas/collectionPermission.js
@@ -44,10 +44,7 @@ const collectionPermissionUiSchema = {
               'ui:row': [
                 {
                   'ui:col': {
-                    style: {
-                      marginLeft: '10px',
-                      borderLeft: 'solid 5px rgb(240,240,240)'
-                    },
+                    className: 'grid-layout__field-left-border',
                     md: 12,
                     children: ['accessConstraintFilter']
                   }
@@ -58,11 +55,7 @@ const collectionPermissionUiSchema = {
               'ui:row': [
                 {
                   'ui:col': {
-                    style: {
-                      marginLeft: '10px',
-                      marginBottom: '5px',
-                      borderLeft: 'solid 5px rgb(240,240,240)'
-                    },
+                    className: 'grid-layout__field-left-border',
                     md: 12,
                     children: ['temporalConstraintFilter']
                   }

--- a/static/src/js/schemas/uiSchemas/collections/collectionInformation.js
+++ b/static/src/js/schemas/uiSchemas/collections/collectionInformation.js
@@ -69,10 +69,7 @@ const collectionInformationUiSchema = {
               'ui:row': [
                 {
                   'ui:col': {
-                    style: {
-                      padding: '1.25rem 1.5rem',
-                      borderInlineStart: '4px solid #cad4d8'
-                    },
+                    className: 'grid-layout__field-left-border',
                     md: 12,
                     children: ['DOI']
                   }

--- a/static/src/js/schemas/uiSchemas/collections/collectionInformation.js
+++ b/static/src/js/schemas/uiSchemas/collections/collectionInformation.js
@@ -71,7 +71,7 @@ const collectionInformationUiSchema = {
                   'ui:col': {
                     style: {
                       padding: '1.25rem 1.5rem',
-                      borderLeft: '4px solid #cad4d8'
+                      borderInlineStart: '4px solid #cad4d8'
                     },
                     md: 12,
                     children: ['DOI']
@@ -140,7 +140,7 @@ const collectionInformationUiSchema = {
           'ui:col': {
             style: {
               padding: '1.25rem 1.5rem',
-              borderLeft: '4px solid #cad4d8'
+              borderInlineStart: '4px solid #cad4d8'
             },
             md: 12,
             children: [

--- a/static/src/js/schemas/uiSchemas/collections/collectionInformation.js
+++ b/static/src/js/schemas/uiSchemas/collections/collectionInformation.js
@@ -69,6 +69,10 @@ const collectionInformationUiSchema = {
               'ui:row': [
                 {
                   'ui:col': {
+                    style: {
+                      padding: '1.25rem 1.5rem',
+                      borderLeft: '4px solid #cad4d8'
+                    },
                     md: 12,
                     children: ['DOI']
                   }
@@ -125,7 +129,76 @@ const collectionInformationUiSchema = {
     'ui:widget': 'textarea'
   },
   DOI: {
+    'ui:title': 'DOI',
     'ui:heading-level': 'h5',
+    'ui:field': 'layout',
+    'ui:layout_grid': {
+      'ui:row': [
+        {
+          'ui:group': 'DOI',
+          'ui:group-description': true,
+          'ui:col': {
+            style: {
+              padding: '1.25rem 1.5rem',
+              borderLeft: '4px solid #cad4d8'
+            },
+            md: 12,
+            children: [
+              {
+                'ui:row': [
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['DOI']
+                    }
+                  }
+                ]
+              },
+              {
+                'ui:row': [
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['Authority']
+                    }
+                  }
+                ]
+              },
+              {
+                'ui:row': [
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['PreviousVersion']
+                    }
+                  }
+                ]
+              },
+              {
+                'ui:row': [
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['MissingReason']
+                    }
+                  }
+                ]
+              },
+              {
+                'ui:row': [
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['Explanation']
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
     DOI: {
       'ui:widget': 'textarea'
     },
@@ -204,8 +277,69 @@ const collectionInformationUiSchema = {
     'ui:hide-header': true,
     items: {
       'ui:hide-header': true,
-
       'ui:title': 'Associated DOIs',
+      'ui:field': 'layout',
+      'ui:layout_grid': {
+        'ui:row': [
+          {
+            'ui:col': {
+              md: 12,
+              children: [
+                {
+                  'ui:row': [
+                    {
+                      'ui:col': {
+                        md: 12,
+                        children: ['DOI']
+                      }
+                    }
+                  ]
+                },
+                {
+                  'ui:row': [
+                    {
+                      'ui:col': {
+                        md: 12,
+                        children: ['Title']
+                      }
+                    }
+                  ]
+                },
+                {
+                  'ui:row': [
+                    {
+                      'ui:col': {
+                        md: 12,
+                        children: ['Authority']
+                      }
+                    }
+                  ]
+                },
+                {
+                  'ui:row': [
+                    {
+                      'ui:col': {
+                        md: 12,
+                        children: ['Type']
+                      }
+                    }
+                  ]
+                },
+                {
+                  'ui:row': [
+                    {
+                      'ui:col': {
+                        md: 12,
+                        children: ['DescriptionOfOtherType']
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      },
       DOI: {
         'ui:widget': 'textarea'
       },

--- a/static/src/js/schemas/uiSchemas/collections/spatialInformation.jsx
+++ b/static/src/js/schemas/uiSchemas/collections/spatialInformation.jsx
@@ -90,10 +90,7 @@ const spatialInformationUiSchema = {
                 'ui:row': [
                   {
                     'ui:col': {
-                      style: {
-                        padding: '1.25rem 1.5rem',
-                        borderInlineStart: '4px solid #cad4d8'
-                      },
+                      className: 'grid-layout__field-left-border',
                       md: 12,
                       children: ['HorizontalSpatialDomain']
                     }
@@ -105,10 +102,7 @@ const spatialInformationUiSchema = {
                 'ui:row': [
                   {
                     'ui:col': {
-                      style: {
-                        padding: '1.25rem 1.5rem',
-                        borderInlineStart: '4px solid #cad4d8'
-                      },
+                      className: 'grid-layout__field-left-border',
                       md: 12,
                       children: ['VerticalSpatialDomains']
                     }
@@ -121,10 +115,7 @@ const spatialInformationUiSchema = {
                 'ui:row': [
                   {
                     'ui:col': {
-                      style: {
-                        padding: '1.25rem 1.5rem',
-                        borderInlineStart: '4px solid #cad4d8'
-                      },
+                      className: 'grid-layout__field-left-border',
                       md: 12,
                       children: ['OrbitParameters']
                     }
@@ -1319,10 +1310,7 @@ const spatialInformationUiSchema = {
                   'ui:row': [
                     {
                       'ui:col': {
-                        style: {
-                          padding: '1.25rem 1.5rem',
-                          borderInlineStart: '4px solid #cad4d8'
-                        },
+                        className: 'grid-layout__field-left-border',
                         md: 12,
                         children: ['AltitudeSystemDefinition']
                       }
@@ -1333,10 +1321,7 @@ const spatialInformationUiSchema = {
                   'ui:row': [
                     {
                       'ui:col': {
-                        style: {
-                          padding: '1.25rem 1.5rem',
-                          borderInlineStart: '4px solid #cad4d8'
-                        },
+                        className: 'grid-layout__field-left-border',
                         md: 12,
                         children: ['DepthSystemDefinition']
                       }

--- a/static/src/js/schemas/uiSchemas/collections/spatialInformation.jsx
+++ b/static/src/js/schemas/uiSchemas/collections/spatialInformation.jsx
@@ -92,7 +92,7 @@ const spatialInformationUiSchema = {
                     'ui:col': {
                       style: {
                         padding: '1.25rem 1.5rem',
-                        borderLeft: '4px solid #cad4d8'
+                        borderInlineStart: '4px solid #cad4d8'
                       },
                       md: 12,
                       children: ['HorizontalSpatialDomain']
@@ -107,7 +107,7 @@ const spatialInformationUiSchema = {
                     'ui:col': {
                       style: {
                         padding: '1.25rem 1.5rem',
-                        borderLeft: '4px solid #cad4d8'
+                        borderInlineStart: '4px solid #cad4d8'
                       },
                       md: 12,
                       children: ['VerticalSpatialDomains']
@@ -123,7 +123,7 @@ const spatialInformationUiSchema = {
                     'ui:col': {
                       style: {
                         padding: '1.25rem 1.5rem',
-                        borderLeft: '4px solid #cad4d8'
+                        borderInlineStart: '4px solid #cad4d8'
                       },
                       md: 12,
                       children: ['OrbitParameters']
@@ -1312,7 +1312,7 @@ const spatialInformationUiSchema = {
               md: 12,
               style: {
                 padding: '1.25rem 1.5rem',
-                borderLeft: '4px solid #cad4d8'
+                borderInlineStart: '4px solid #cad4d8'
               },
               children: [
                 {
@@ -1321,7 +1321,7 @@ const spatialInformationUiSchema = {
                       'ui:col': {
                         style: {
                           padding: '1.25rem 1.5rem',
-                          borderLeft: '4px solid #cad4d8'
+                          borderInlineStart: '4px solid #cad4d8'
                         },
                         md: 12,
                         children: ['AltitudeSystemDefinition']
@@ -1335,7 +1335,7 @@ const spatialInformationUiSchema = {
                       'ui:col': {
                         style: {
                           padding: '1.25rem 1.5rem',
-                          borderLeft: '4px solid #cad4d8'
+                          borderInlineStart: '4px solid #cad4d8'
                         },
                         md: 12,
                         children: ['DepthSystemDefinition']

--- a/static/src/js/schemas/uiSchemas/collections/spatialInformation.jsx
+++ b/static/src/js/schemas/uiSchemas/collections/spatialInformation.jsx
@@ -90,6 +90,10 @@ const spatialInformationUiSchema = {
                 'ui:row': [
                   {
                     'ui:col': {
+                      style: {
+                        padding: '1.25rem 1.5rem',
+                        borderLeft: '4px solid #cad4d8'
+                      },
                       md: 12,
                       children: ['HorizontalSpatialDomain']
                     }
@@ -101,6 +105,10 @@ const spatialInformationUiSchema = {
                 'ui:row': [
                   {
                     'ui:col': {
+                      style: {
+                        padding: '1.25rem 1.5rem',
+                        borderLeft: '4px solid #cad4d8'
+                      },
                       md: 12,
                       children: ['VerticalSpatialDomains']
                     }
@@ -113,6 +121,10 @@ const spatialInformationUiSchema = {
                 'ui:row': [
                   {
                     'ui:col': {
+                      style: {
+                        padding: '1.25rem 1.5rem',
+                        borderLeft: '4px solid #cad4d8'
+                      },
                       md: 12,
                       children: ['OrbitParameters']
                     }
@@ -123,6 +135,7 @@ const spatialInformationUiSchema = {
                 'ui:row': [
                   {
                     'ui:col': {
+                      style: { paddingTop: '15px' },
                       md: 12,
                       children: ['GranuleSpatialRepresentation']
                     }
@@ -182,9 +195,9 @@ const spatialInformationUiSchema = {
         ]
       },
       Geometry: {
-        'ui:fieldReplacesAnyOrOneOf': true,
         'ui:heading-level': 'h6',
         'ui:field': 'layout',
+        'ui:fieldReplacesAnyOrOneOf': true,
         'ui:layout_grid': {
           'ui:row': [
             {
@@ -744,6 +757,7 @@ const spatialInformationUiSchema = {
             'ui:heading-level': 'h6',
             items: {
               'ui:field': 'layout',
+              'ui:fieldReplacesAnyOrOneOf': true,
               'ui:layout_grid': {
                 'ui:row': [
                   {
@@ -817,6 +831,7 @@ const spatialInformationUiSchema = {
             'ui:heading-level': 'h6',
             items: {
               'ui:field': 'layout',
+              'ui:fieldReplacesAnyOrOneOf': true,
               'ui:layout_grid': {
                 'ui:row': [
                   {
@@ -859,6 +874,7 @@ const spatialInformationUiSchema = {
             'ui:heading-level': 'h6',
             items: {
               'ui:field': 'layout',
+              'ui:fieldReplacesAnyOrOneOf': true,
               'ui:layout_grid': {
                 'ui:row': [
                   {
@@ -914,6 +930,7 @@ const spatialInformationUiSchema = {
             'ui:heading-level': 'h6',
             items: {
               'ui:field': 'layout',
+              'ui:fieldReplacesAnyOrOneOf': true,
               'ui:layout_grid': {
                 'ui:row': [
                   {
@@ -934,16 +951,14 @@ const spatialInformationUiSchema = {
                                 md: 12,
                                 children: ['YDimension']
                               }
+                            },
+                            {
+                              'ui:col': {
+                                md: 12,
+                                children: ['Unit']
+                              }
                             }
                           ]
-                        },
-                        {
-                          'ui:row': [{
-                            'ui:col': {
-                              md: 12,
-                              children: ['YDimension']
-                            }
-                          }]
                         }
                       ]
                     }
@@ -1295,11 +1310,19 @@ const spatialInformationUiSchema = {
             'ui:group': 'Vertical Coordinate System',
             'ui:col': {
               md: 12,
+              style: {
+                padding: '1.25rem 1.5rem',
+                borderLeft: '4px solid #cad4d8'
+              },
               children: [
                 {
                   'ui:row': [
                     {
                       'ui:col': {
+                        style: {
+                          padding: '1.25rem 1.5rem',
+                          borderLeft: '4px solid #cad4d8'
+                        },
                         md: 12,
                         children: ['AltitudeSystemDefinition']
                       }
@@ -1310,6 +1333,10 @@ const spatialInformationUiSchema = {
                   'ui:row': [
                     {
                       'ui:col': {
+                        style: {
+                          padding: '1.25rem 1.5rem',
+                          borderLeft: '4px solid #cad4d8'
+                        },
                         md: 12,
                         children: ['DepthSystemDefinition']
                       }

--- a/static/src/js/schemas/uiSchemas/collections/temporalInformation.js
+++ b/static/src/js/schemas/uiSchemas/collections/temporalInformation.js
@@ -89,7 +89,9 @@ const temporalInformationUiSchema = {
                   'ui:row': [
                     {
                       'ui:col': {
-                        style: { paddingTop: '15px' },
+                        style: {
+                          paddingBlockStart: '15px'
+                        },
                         md: 12,
                         children: ['TemporalResolution']
                       }
@@ -100,7 +102,7 @@ const temporalInformationUiSchema = {
                   'ui:row': [
                     {
                       'ui:col': {
-                        style: { paddingTop: '15px' },
+                        style: { paddingBlockStart: '15px' },
                         md: 12,
                         children: ['PrecisionOfSeconds']
                       }

--- a/static/src/js/schemas/uiSchemas/collections/temporalInformation.js
+++ b/static/src/js/schemas/uiSchemas/collections/temporalInformation.js
@@ -44,6 +44,7 @@ const temporalInformationUiSchema = {
     'ui:heading-level': 'h4',
     items: {
       'ui:field': 'layout',
+      'ui:fieldReplacesAnyOrOneOf': true,
       'ui:layout_grid': {
         'ui:row': [
           {

--- a/static/src/js/schemas/uiSchemas/services/index.js
+++ b/static/src/js/schemas/uiSchemas/services/index.js
@@ -6,7 +6,7 @@ import serviceContactsUiSchema from './serviceContacts'
 import serviceInformationUiSchema from './serviceInformation'
 import organizationUiSchema from './serviceOrganizations'
 import serviceQualityUiSchema from './serviceQuality'
-import serviceOptionsUiSchema from './service_options'
+import serviceOptionsUiSchema from './serviceOptions'
 
 const serviceUiSchema = {
   'service-information': serviceInformationUiSchema,

--- a/static/src/js/schemas/uiSchemas/services/serviceOptions.js
+++ b/static/src/js/schemas/uiSchemas/services/serviceOptions.js
@@ -64,6 +64,21 @@ const serviceOptionsUiSchema = {
         }
       ]
     },
+    Aggregation: {
+      'ui:title': 'Aggregation',
+      'ui:fieldReplacesAnyOrOneOf': true,
+      'ui:field': 'layout',
+      'ui:layout_grid': {
+        'ui:row': [
+          {
+            'ui:col': {
+              md: 12,
+              children: ['Concatenate']
+            }
+          }
+        ]
+      }
+    },
     VariableAggregationSupportedMethods: {
       'ui:heading-level': 'h4'
     },
@@ -306,6 +321,7 @@ const serviceOptionsUiSchema = {
     Subset: {
       'ui:heading-level': 'h4',
       'ui:field': 'layout',
+      'ui:fieldReplacesAnyOrOneOf': true,
       'ui:layout_grid': {
 
         'ui:row': [
@@ -356,6 +372,7 @@ const serviceOptionsUiSchema = {
       },
       SpatialSubset: {
         'ui:field': 'layout',
+        'ui:fieldReplacesAnyOrOneOf': true,
         'ui:layout_grid': {
           'ui:row': [
             {

--- a/static/src/js/schemas/uiSchemas/services/serviceOptions.js
+++ b/static/src/js/schemas/uiSchemas/services/serviceOptions.js
@@ -64,21 +64,6 @@ const serviceOptionsUiSchema = {
         }
       ]
     },
-    Aggregation: {
-      'ui:title': 'Aggregation',
-      'ui:fieldReplacesAnyOrOneOf': true,
-      'ui:field': 'layout',
-      'ui:layout_grid': {
-        'ui:row': [
-          {
-            'ui:col': {
-              md: 12,
-              children: ['Concatenate']
-            }
-          }
-        ]
-      }
-    },
     VariableAggregationSupportedMethods: {
       'ui:heading-level': 'h4'
     },


### PR DESCRIPTION
# Overview

### What is the feature?

There are several areas in which the drop-down items are showing up as Option 1, Option 2, Option 3, these need to removed.

### What is the Solution?

UI layout needed `ui:fieldReplacesAnyOrOneOf': true` anywhere there was an anyOf and oneOf used as a constraint.

### What areas of the application does this impact?

Collection Form:

- Collection Information 
- Temporal Information

Service Form:
- Service Operations

# Testing

Steps to repeat:
1) Create a new collection draft
2) Navigate over to Temporal Information
3) Find Temporal Extents
4) If you click it, you will see Options 1, 2, 3 and click it yields  "Null is not an object (evaluating ‘ar[Xr]’" and you can't navigate back, thus losing any unsaved changed.

The other place we are seeing Option 1, 2, 3 is in Spatial Information.
Steps to repeat:
Navigate to:
https://mmt.sit.earthdatacloud.nasa.gov/drafts/collections/CD1200483084-EDF_OPS/spatial-information
There is a error in the right hand navigation, see screenshot.
Also if you look down at:
Non Gridded Range Resolutions
Gridded Resolutions
Gridded Range Resolutions
Generic Resolutions
We will also see the Option 1, 2, 3 combo box.  

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings