### PR TITLE
Mmt 3869: Cannot Create a Collection Draft From a Template

### DIFF
--- a/static/src/js/components/TemplateForm/TemplateForm.jsx
+++ b/static/src/js/components/TemplateForm/TemplateForm.jsx
@@ -6,7 +6,6 @@ import Row from 'react-bootstrap/Row'
 import Form from '@rjsf/core'
 import validator from '@rjsf/validator-ajv8'
 import { isEmpty, kebabCase } from 'lodash-es'
-import crypto from 'crypto'
 
 import useAppContext from '@/js/hooks/useAppContext'
 

--- a/static/src/js/components/TemplatePreview/TemplatePreview.jsx
+++ b/static/src/js/components/TemplatePreview/TemplatePreview.jsx
@@ -7,7 +7,6 @@ import validator from '@rjsf/validator-ajv8'
 import camelcaseKeys from 'camelcase-keys'
 import { FaCopy, FaTrash } from 'react-icons/fa'
 import { CollectionPreview } from '@edsc/metadata-preview'
-import crypto from 'crypto'
 
 import collectionsTemplateConfiguration from '@/js/schemas/uiForms/collectionTemplatesConfiguration'
 import ummCTemplateSchema from '@/js/schemas/umm/ummCTemplateSchema'


### PR DESCRIPTION
# Overview

### What is the feature?

Users cannot 'create draft' from templates. Console reads 'crypto.randomUUID()' is not a function. 

### What is the Solution?

Remove crypto import from top of files

### What areas of the application does this impact?

Template Preview and Template List

# Testing

### Reproduction steps

- **Environment for testing: local
- **Collection to test with: local

1. Go to templates >> click on a template >> click 'create draft' and you should be redirected to drafts/collections/CD0000

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings