### PR TITLE
Mmt 3870: As a user I want to be able to supply a service when associating a collection and order option

### DIFF
--- a/static/src/js/components/CollectionAssociationForm/CollectionAssociationForm.jsx
+++ b/static/src/js/components/CollectionAssociationForm/CollectionAssociationForm.jsx
@@ -14,7 +14,11 @@ import {
   useParams,
   useSearchParams
 } from 'react-router-dom'
-import { useLazyQuery, useMutation } from '@apollo/client'
+import {
+  useLazyQuery,
+  useMutation,
+  useQuery
+} from '@apollo/client'
 import { camelCase } from 'lodash-es'
 
 import moment from 'moment'
@@ -51,6 +55,9 @@ import useNotificationsContext from '@/js/hooks/useNotificationsContext'
 
 import { CREATE_ASSOCIATION } from '@/js/operations/mutations/createAssociation'
 import { GET_COLLECTIONS } from '@/js/operations/queries/getCollections'
+import { cloneDeep } from '@apollo/client/utilities'
+import conceptIdTypes from '@/js/constants/conceptIdTypes'
+import conceptTypeQueries from '@/js/constants/conceptTypeQueries'
 
 /**
  * Renders a CollectionAssociationForm component
@@ -114,6 +121,44 @@ const CollectionAssociationForm = ({ metadata }) => {
       removeEmpty(formData)
     )
   }
+
+  const uiSchema = cloneDeep(collectionAssociationUiSchema)
+  const schema = cloneDeep(collectionAssociation)
+
+  const { data: serviceData } = useQuery(conceptTypeQueries.Services, {
+    variables: {
+      params: {
+        limit,
+        offset
+      }
+    }
+  }, { skip: derivedConceptType !== conceptIdTypes.O })
+
+  if (derivedConceptType === conceptIdTypes.O) {
+    const { required } = schema
+    required.push('ServiceField')
+
+    const rows = uiSchema['ui:layout_grid']['ui:row']
+    rows.unshift(
+      {
+        'ui:row': [
+          {
+            'ui:col': {
+              md: 12,
+              children: ['ServiceField']
+            }
+          }
+        ]
+      }
+    )
+
+    uiSchema.ServiceField['ui:options'].enumOptions = serviceData?.services.items?.map(
+      (service) => service.name
+    ).sort()
+  }
+
+  // Validate ummMetadata
+  const { errors: validationErrors } = validator.validateFormData(searchFormData, schema)
 
   // Query to retrieve collections
   const [getCollections] = useLazyQuery(GET_COLLECTIONS, {
@@ -200,14 +245,35 @@ const CollectionAssociationForm = ({ metadata }) => {
 
   // Handles selected collection association button by calling CREATE_ASSOCIATION mutation
   const handleAssociateSelectedCollection = () => {
+    let variables = {
+      conceptId,
+      associatedConceptIds: collectionConceptIds
+    }
+
+    if (derivedConceptType === conceptIdTypes.O) {
+      const serviceItems = serviceData?.services.items
+      const { ServiceField: name } = searchFormData
+      const serviceConceptId = serviceItems?.filter((service) => service.name === name)[0].conceptId
+      const associatedConceptData = collectionConceptIds.map((collectionConceptId) => ({
+        concept_id: collectionConceptId,
+        data: { order_option: conceptId }
+      }))
+      variables = {
+        conceptId: serviceConceptId,
+        associatedConceptData
+      }
+    }
+
     createAssociationMutation({
-      variables: {
-        conceptId,
-        associatedConceptIds: collectionConceptIds
-      },
+      variables,
       onCompleted: () => {
         setLoading(true)
-        navigate(`/${pluralize(camelCase(derivedConceptType)).toLowerCase()}/${conceptId}/collection-association`)
+        if (derivedConceptType === conceptIdTypes.O) {
+          navigate(`/order-options/${conceptId}`)
+        } else {
+          navigate(`/${pluralize(camelCase(derivedConceptType)).toLowerCase()}/${conceptId}/collection-association`)
+        }
+
         addNotification({
           message: 'Created association successfully',
           variant: 'success'
@@ -367,10 +433,10 @@ const CollectionAssociationForm = ({ metadata }) => {
     <>
       <Form
         className="bg-white m-2 pt-2"
-        schema={collectionAssociation}
+        schema={schema}
         validator={validator}
         fields={fields}
-        uiSchema={collectionAssociationUiSchema}
+        uiSchema={uiSchema}
         widgets={widgets}
         templates={templates}
         onChange={handleChange}
@@ -387,6 +453,7 @@ const CollectionAssociationForm = ({ metadata }) => {
         >
 
           <Button
+            disabled={validationErrors.length > 0}
             onClick={handleCollectionSearch}
             variant="primary"
           >
@@ -455,6 +522,7 @@ const CollectionAssociationForm = ({ metadata }) => {
               />
               <Button
                 className="d-flex"
+                disabled={validationErrors.length > 0}
                 onClick={handleAssociateSelectedCollection}
                 variant="primary"
               >

--- a/static/src/js/components/CollectionAssociationForm/CollectionAssociationForm.jsx
+++ b/static/src/js/components/CollectionAssociationForm/CollectionAssociationForm.jsx
@@ -19,7 +19,7 @@ import {
   useMutation,
   useQuery
 } from '@apollo/client'
-import { camelCase } from 'lodash-es'
+import { camelCase, cloneDeep } from 'lodash-es'
 
 import moment from 'moment'
 
@@ -55,7 +55,6 @@ import useNotificationsContext from '@/js/hooks/useNotificationsContext'
 
 import { CREATE_ASSOCIATION } from '@/js/operations/mutations/createAssociation'
 import { GET_COLLECTIONS } from '@/js/operations/queries/getCollections'
-import { cloneDeep } from '@apollo/client/utilities'
 import conceptIdTypes from '@/js/constants/conceptIdTypes'
 import conceptTypeQueries from '@/js/constants/conceptTypeQueries'
 

--- a/static/src/js/components/CollectionAssociationForm/__tests__/CollectionAssociationForm.test.jsx
+++ b/static/src/js/components/CollectionAssociationForm/__tests__/CollectionAssociationForm.test.jsx
@@ -30,9 +30,11 @@ import {
   CollectionResultsWithPages,
   createAssociationErrorRequest,
   createAssociationRequest,
+  createAssociationWithServiceRequest,
   mockTool,
   mockVariable,
   mockToolWithAssociation,
+  mockOrderOption,
   CollectionSortRequest,
   GetServicesRequest,
   GetServicesPagedRequest
@@ -71,6 +73,11 @@ const setup = ({
                 path={overridePath || 'tools/:conceptId/collection-association-search'}
                 element={<CollectionAssociationForm metadata={overrideMock || mockTool} />}
               />
+              <Route
+                path={overridePath || 'order-options/:conceptId/collection-association-search'}
+                element={<CollectionAssociationForm metadata={overrideMock || mockOrderOption} />}
+              />
+
             </Routes>
           </MockedProvider>
         </MemoryRouter>
@@ -289,6 +296,46 @@ describe('CollectionAssociationForm', () => {
 
       expect(navigateSpy).toHaveBeenCalledTimes(2)
       expect(navigateSpy).toHaveBeenCalledWith('/tools/T12000000-MMT_2/collection-association')
+    })
+  })
+
+  describe('when supplying a service when associating a collection and order option', () => {
+    test('should associate and redirect to order option page', async () => {
+      const navigateSpy = vi.fn()
+      vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+
+      const { user } = setup({
+        overrideInitialEntries: ['/order-options/OO1257381321-EDF_OPS/collection-association-search'],
+        additionalMocks: [CollectionAssociationRequest, createAssociationWithServiceRequest]
+      })
+
+      const serviceField = await screen.findByText('Select Service')
+      await user.click(serviceField)
+      const option = screen.getByRole('option', { name: 'Service Name 1' })
+      await user.click(option)
+
+      const searchField = await screen.findByText('Select Search Field')
+
+      await user.click(searchField)
+
+      const selectField = screen.getByText('Entry Title')
+      await user.click(selectField)
+
+      const field = screen.getByRole('textbox')
+      await user.type(field, '*')
+
+      const searchForCollections = screen.getByText('Search for Collection')
+      await user.click(searchForCollections)
+
+      const firstCheckbox = screen.getAllByRole('checkbox')[1]
+      await user.click(firstCheckbox)
+
+      const createSelectedAssociationButton = screen.getByRole('button', { name: 'Associate Selected Collections' })
+
+      await user.click(createSelectedAssociationButton)
+
+      expect(navigateSpy).toHaveBeenCalledTimes(2)
+      expect(navigateSpy).toHaveBeenCalledWith('/order-options/OO1257381321-EDF_OPS')
     })
   })
 

--- a/static/src/js/components/CollectionAssociationForm/__tests__/CollectionAssociationForm.test.jsx
+++ b/static/src/js/components/CollectionAssociationForm/__tests__/CollectionAssociationForm.test.jsx
@@ -33,7 +33,9 @@ import {
   mockTool,
   mockVariable,
   mockToolWithAssociation,
-  CollectionSortRequest
+  CollectionSortRequest,
+  GetServicesRequest,
+  GetServicesPagedRequest
 } from './__mocks__/CollectionAssociationResults'
 
 vi.mock('@/js/components/ErrorBanner/ErrorBanner')
@@ -62,7 +64,7 @@ const setup = ({
       <NotificationsContext.Provider value={notificationContext}>
         <MemoryRouter initialEntries={overrideInitialEntries || ['/tools/T12000000-MMT_2/collection-association-search']}>
           <MockedProvider
-            mocks={additionalMocks}
+            mocks={[GetServicesRequest, GetServicesPagedRequest, ...additionalMocks]}
           >
             <Routes>
               <Route

--- a/static/src/js/components/CollectionAssociationForm/__tests__/__mocks__/CollectionAssociationResults.js
+++ b/static/src/js/components/CollectionAssociationForm/__tests__/__mocks__/CollectionAssociationResults.js
@@ -128,6 +128,16 @@ export const mockToolWithAssociation = {
   __typename: 'Tool'
 }
 
+export const mockOrderOption = {
+  deprecated: false,
+  name: 'Test Name',
+  description: 'Test Description',
+  form: 'Test Form',
+  scope: 'PROVIDER',
+  providerId: 'MMT_2',
+  __typename: 'OrderOption'
+}
+
 export const mockTool = {
   accessConstraints: null,
   ancillaryKeywords: null,
@@ -519,6 +529,28 @@ export const createAssociationRequest = {
     variables: {
       conceptId: 'T12000000-MMT_2',
       associatedConceptIds: ['C12000001124-MMT_2']
+    }
+  },
+  result: {
+    data: {
+      createAssociation: {
+        associatedConceptId: 'C1200000035-SEDAC',
+        conceptId: 'TLA1200000140-CMR',
+        revisionId: 2
+      }
+    }
+  }
+}
+
+export const createAssociationWithServiceRequest = {
+  request: {
+    query: CREATE_ASSOCIATION,
+    variables: {
+      conceptId: 'S1000000000-TESTPROV',
+      associatedConceptData: [{
+        concept_id: 'C12000001124-MMT_2',
+        data: { order_option: 'OO1257381321-EDF_OPS' }
+      }]
     }
   },
   result: {

--- a/static/src/js/components/CollectionAssociationForm/__tests__/__mocks__/CollectionAssociationResults.js
+++ b/static/src/js/components/CollectionAssociationForm/__tests__/__mocks__/CollectionAssociationResults.js
@@ -1,3 +1,4 @@
+import { GET_SERVICES } from '@/js/operations/queries/getServices'
 import { CREATE_ASSOCIATION } from '../../../../operations/mutations/createAssociation'
 import { GET_COLLECTIONS } from '../../../../operations/queries/getCollections'
 
@@ -447,6 +448,66 @@ export const CollectionResultsWithPages = {
         ],
         count: 50,
         __typename: 'CollectionList'
+      }
+    }
+  }
+}
+
+export const GetServicesRequest = {
+  request: {
+    query: GET_SERVICES,
+    variables: {
+      params: {
+        limit: 20,
+        offset: 0
+      }
+    }
+  },
+  result: {
+    data: {
+      services: {
+        count: 1,
+        items: [
+          {
+            conceptId: 'S1000000000-TESTPROV',
+            name: 'Service Name 1',
+            longName: 'Service Long Name 1',
+            providerId: 'TESTPROV',
+            revisionDate: '2023-11-30 00:00:00',
+            revisionId: '1',
+            userId: 'admin'
+          }
+        ]
+      }
+    }
+  }
+}
+
+export const GetServicesPagedRequest = {
+  request: {
+    query: GET_SERVICES,
+    variables: {
+      params: {
+        limit: 20,
+        offset: 40
+      }
+    }
+  },
+  result: {
+    data: {
+      services: {
+        count: 1,
+        items: [
+          {
+            conceptId: 'S1000000000-TESTPROV',
+            name: 'Service Name 1',
+            longName: 'Service Long Name 1',
+            providerId: 'TESTPROV',
+            revisionDate: '2023-11-30 00:00:00',
+            revisionId: '1',
+            userId: 'admin'
+          }
+        ]
       }
     }
   }

--- a/static/src/js/operations/mutations/createAssociation.js
+++ b/static/src/js/operations/mutations/createAssociation.js
@@ -3,11 +3,13 @@ import { gql } from '@apollo/client'
 export const CREATE_ASSOCIATION = gql`
   mutation CreateAssociation (
     $conceptId: String!
-    $associatedConceptIds: [String]!
+    $associatedConceptIds: [String]
+    $associatedConceptData: JSON
   ) {
     createAssociation (
       conceptId: $conceptId
       associatedConceptIds: $associatedConceptIds
+      associatedConceptData: $associatedConceptData
     ) {
       associatedConceptId
       conceptId

--- a/static/src/js/pages/CollectionAssociationFormPage/CollectionAssociationFormPage.jsx
+++ b/static/src/js/pages/CollectionAssociationFormPage/CollectionAssociationFormPage.jsx
@@ -11,6 +11,7 @@ import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
 import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
 
+import conceptIdTypes from '@/js/constants/conceptIdTypes'
 import conceptTypeQueries from '@/js/constants/conceptTypeQueries'
 
 import getConceptTypeByConceptId from '@/js/utils/getConceptTypeByConceptId'
@@ -56,10 +57,11 @@ const CollectionAssociationFormPageHeader = () => {
             label: name,
             to: `/${pluralize(toKebabCase(derivedConceptType)).toLowerCase()}/${conceptId}`
           },
-          {
-            label: 'Collection Associations',
-            to: `/${pluralize(toKebabCase(derivedConceptType)).toLowerCase()}/${conceptId}/collection-association`
-          },
+          derivedConceptType !== conceptIdTypes.O
+            ? {
+              label: 'Collection Associations',
+              to: `/${pluralize(toKebabCase(derivedConceptType)).toLowerCase()}/${conceptId}/collection-association`
+            } : {},
           {
             label: 'Collection Association Search',
             active: true

--- a/static/src/js/pages/OrderOptionPage/OrderOptionPage.jsx
+++ b/static/src/js/pages/OrderOptionPage/OrderOptionPage.jsx
@@ -113,8 +113,8 @@ const OrderOptionPageHeader = () => {
           [
             {
               icon: FaEye,
-              to: `/${pluralize(toKebabCase(derivedConceptType)).toLowerCase()}/${conceptId}/collection-association`,
-              title: 'Collection Associations'
+              to: `/${pluralize(toKebabCase(derivedConceptType)).toLowerCase()}/${conceptId}/collection-association-search`,
+              title: 'Add Collection Associations'
             }
           ]
         }

--- a/static/src/js/schemas/collectionAssociation.js
+++ b/static/src/js/schemas/collectionAssociation.js
@@ -4,6 +4,10 @@ const collectionAssociation = {
   type: 'object',
   additionalProperties: false,
   properties: {
+    ServiceField: {
+      title: 'Service Field',
+      type: 'string'
+    },
     SearchField: {
       title: 'Search Field',
       $ref: '#/definitions/SearchFieldType'

--- a/static/src/js/schemas/uiSchemas/CollectionAssociation.js
+++ b/static/src/js/schemas/uiSchemas/CollectionAssociation.js
@@ -1,3 +1,5 @@
+import CustomSelectWidget from '@/js/components/CustomSelectWidget/CustomSelectWidget'
+
 const collectionAssociationUiSchema = {
   'ui:submitButtonOptions': {
     norender: true
@@ -26,6 +28,14 @@ const collectionAssociationUiSchema = {
   },
   SearchField: {
     'ui:required': true
+  },
+  ServiceField: {
+    'ui:options': {
+      enumOptions: ['Service 1', 'Service 2'] // Overwritten by CollectionAssociationForm.jsx
+    },
+    'ui:required': true,
+    'ui:title': 'Service',
+    'ui:widget': CustomSelectWidget
   }
 }
 


### PR DESCRIPTION
# Overview

### What is the feature?

As a user I want to be able to supply a service when associating a collection and order option

### What is the Solution?

When associating a collection to an order option, for the association page, I've:
1.  Added a services combo box (see screenshot)
2.  Updated the mutation to associate the service with the collection and include the order option data as associated data, i.e., something like this:
`{
  "conceptId": "S1200245793-EDF_OPS",
  "associatedConceptData": [{"concept_id": "C1000000719-EDF_OPS", "data": {"order_option": "OO1200456347-EDF_OPS"}}]
}`
3.  Route the user back to the order option page after the associated is created.   If the user would like to see the assoc, they will need to go to Collection page, then click See associations (see MMT-3872 being worked now).

### What areas of the application does this impact?

Collection Association Form

# Testing

1. Click on a order option from the list.
2. Click Add Collection Association from the ... in the upper right corner.
3. Select a service
4. Perform a collection search
5. Select a few collections
6. Click the Associate button 

To verify the association worked, you will need to retrieve the service that used in the association, via something like this:
https://cmr.sit.earthdata.nasa.gov/search/services.json?concept_id=S1200245793-EDF_OPS&pretty=true

### Attachments

![screenshot_2024-08-22_at_3 18 22___pm_480](https://github.com/user-attachments/assets/8978e733-72a1-476c-9f36-09102a936627)


# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings