### PR TITLE
MMT-3872: As a user, I would like to view all services associated with a single collection

### DIFF
--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -11,6 +11,7 @@ import GroupPage from '@/js/pages/GroupPage/GroupPage'
 import HomePage from '@/js/pages/HomePage/HomePage'
 import LogoutPage from '@/js/pages/LogoutPage/LogoutPage'
 import ManageCollectionAssociationPage from '@/js/pages/ManageCollectionAssociationPage/ManageCollectionAssociationPage'
+import ManageServiceAssociationsPage from '@/js/pages/ManageServiceAssociationsPage/ManageServiceAssociationsPage'
 import MetadataFormPage from '@/js/pages/MetadataFormPage/MetadataFormPage'
 import OrderOptionFormPage from '@/js/pages/OrderOptionFormPage/OrderOptionFormPage'
 import OrderOptionListPage from '@/js/pages/OrderOptionListPage/OrderOptionListPage'
@@ -35,7 +36,6 @@ import PublishPreview from '@/js/components/PublishPreview/PublishPreview'
 import TemplateForm from '@/js/components/TemplateForm/TemplateForm'
 import TemplateList from '@/js/components/TemplateList/TemplateList'
 import TemplatePreview from '@/js/components/TemplatePreview/TemplatePreview'
-
 import REDIRECTS from '@/js/constants/redirectsMap/redirectsMap'
 
 import withProviders from '@/js/providers/withProviders/withProviders'
@@ -108,6 +108,10 @@ export const App = () => {
             {
               path: '/:type/:conceptId/collection-association',
               element: <ManageCollectionAssociationPage />
+            },
+            {
+              path: '/collections/:conceptId/service-associations',
+              element: <ManageServiceAssociationsPage />
             },
             {
               path: '/:type/:conceptId/collection-association-search',

--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -36,6 +36,7 @@ import PublishPreview from '@/js/components/PublishPreview/PublishPreview'
 import TemplateForm from '@/js/components/TemplateForm/TemplateForm'
 import TemplateList from '@/js/components/TemplateList/TemplateList'
 import TemplatePreview from '@/js/components/TemplatePreview/TemplatePreview'
+
 import REDIRECTS from '@/js/constants/redirectsMap/redirectsMap'
 
 import withProviders from '@/js/providers/withProviders/withProviders'

--- a/static/src/js/components/CollectionAssociationForm/CollectionAssociationForm.jsx
+++ b/static/src/js/components/CollectionAssociationForm/CollectionAssociationForm.jsx
@@ -452,6 +452,7 @@ const CollectionAssociationForm = ({ metadata }) => {
         >
 
           <Button
+            className="mt-3"
             disabled={validationErrors.length > 0}
             onClick={handleCollectionSearch}
             variant="primary"
@@ -520,7 +521,7 @@ const CollectionAssociationForm = ({ metadata }) => {
                 sortKey={sortKeyParam}
               />
               <Button
-                className="d-flex"
+                className="d-flex mt-4"
                 disabled={validationErrors.length > 0}
                 onClick={handleAssociateSelectedCollection}
                 variant="primary"

--- a/static/src/js/components/ManageServiceAssociations/ManageServiceAssociations.jsx
+++ b/static/src/js/components/ManageServiceAssociations/ManageServiceAssociations.jsx
@@ -108,7 +108,7 @@ const ManageServiceAssociations = () => {
           variant="link"
           onClick={
             () => {
-              navigate(`/order-options/${conceptId}`)
+              navigate(`/order-options/${orderOptionConceptId}`)
             }
           }
         >

--- a/static/src/js/components/ManageServiceAssociations/ManageServiceAssociations.jsx
+++ b/static/src/js/components/ManageServiceAssociations/ManageServiceAssociations.jsx
@@ -1,9 +1,11 @@
 import { useMutation, useSuspenseQuery } from '@apollo/client'
 import React, { useCallback, useState } from 'react'
-import { useParams } from 'react-router'
-import { useSearchParams } from 'react-router-dom'
-import { Alert } from 'react-bootstrap'
-import { camelCase } from 'lodash-es'
+import { useNavigate, useParams } from 'react-router'
+import {
+  Alert,
+  Col,
+  Row
+} from 'react-bootstrap'
 
 import pluralize from 'pluralize'
 
@@ -12,61 +14,44 @@ import CustomModal from '@/js/components/CustomModal/CustomModal'
 import EllipsisText from '@/js/components/EllipsisText/EllipsisText'
 import Table from '@/js/components/Table/Table'
 
-import conceptTypeQueries from '@/js/constants/conceptTypeQueries'
-
 import useAccessibleEvent from '@/js/hooks/useAccessibleEvent'
 import useNotificationsContext from '@/js/hooks/useNotificationsContext'
 
 import { DELETE_ASSOCIATION } from '@/js/operations/mutations/deleteAssociation'
+import { GET_SERVICE_ASSOCIATIONS } from '@/js/operations/queries/getServiceAssociations'
 
 import errorLogger from '@/js/utils/errorLogger'
-import getConceptTypeByConceptId from '@/js/utils/getConceptTypeByConceptId'
 
 /**
- * Renders a ManageCollectionAssociation component
+ * Renders a ManageServiceAssociations component
  *
  * @component
- * @example <caption>Render a ManageCollectionAssociation</caption>
+ * @example <caption>Render a ManageServiceAssociations</caption>
  * return (
- *   <ManageCollectionAssociation />
+ *   <ManageServiceAssociations />
  * )
  */
-const ManageCollectionAssociation = () => {
-  const { conceptId } = useParams()
-
+const ManageServiceAssociations = () => {
   const { addNotification } = useNotificationsContext()
+  const { conceptId } = useParams()
+  const navigate = useNavigate()
 
-  // Const [error, setError] = useState()
-  const [searchParams, setSearchParams] = useSearchParams()
-  const [collectionConceptIds, setCollectionConceptIds] = useState([])
+  const [serviceConceptIds, setServiceConceptIds] = useState([])
   const [showDeleteModal, setShowDeleteModal] = useState(false)
 
-  const derivedConceptType = getConceptTypeByConceptId(conceptId)
-
-  let params = {
+  const params = {
     params: {
       conceptId
     }
   }
 
-  const sortKey = searchParams.get('sortKey')
-
-  if (sortKey) {
-    params = {
-      ...params,
-      collectionsParams: {
-        sortKey
-      }
-    }
-  }
-
-  const { data, refetch } = useSuspenseQuery(conceptTypeQueries[derivedConceptType], {
+  const { data, refetch } = useSuspenseQuery(GET_SERVICE_ASSOCIATIONS, {
     variables: params
   })
 
   const [deleteAssociationMutation] = useMutation(DELETE_ASSOCIATION, {
     refetchQueries: [{
-      query: conceptTypeQueries[derivedConceptType],
+      query: GET_SERVICE_ASSOCIATIONS,
       variables: params
     }],
     onCompleted: () => {
@@ -74,57 +59,74 @@ const ManageCollectionAssociation = () => {
 
       // Add a success notification
       addNotification({
-        message: 'Collection Associations Deleted Successfully!',
+        message: 'Service Associations Deleted Successfully!',
         variant: 'success'
       })
 
-      setCollectionConceptIds([])
+      setServiceConceptIds([])
     },
     onError: () => {
       addNotification({
-        message: 'Error disassociating collection',
+        message: 'Error disassociating service',
         variant: 'danger'
       })
 
-      errorLogger(`Unable to disassociate collection record for ${derivedConceptType}`, 'Manage Collection Association: deleteAssociation Mutation')
+      errorLogger(`Unable to disassociate service record for ${conceptId}`, 'Manage Service Association: deleteAssociation Mutation')
     }
   })
 
-  // Handles deleting selected collection
-  // if no collections selected, returns an error notification
+  // Handles deleting selected service/s
+  // if no services selected, button is disabled
   const handleDeleteAssociation = () => {
     deleteAssociationMutation({
       variables: {
         conceptId,
-        associatedConceptIds: collectionConceptIds
+        associatedConceptIds: serviceConceptIds
       }
     })
   }
-
-  const sortFn = useCallback((key, order) => {
-    let nextSortKey
-
-    searchParams.set('sortKey', nextSortKey)
-
-    setSearchParams((currentParams) => {
-      if (order === 'ascending') nextSortKey = `-${key}`
-      if (order === 'descending') nextSortKey = key
-
-      // Reset the page parameter
-      currentParams.delete('page')
-
-      // Set the sort key
-      currentParams.set('sortKey', nextSortKey)
-
-      return Object.fromEntries(currentParams)
-    })
-  }, [])
 
   const buildEllipsisTextCell = useCallback((cellData) => (
     <EllipsisText>
       {cellData}
     </EllipsisText>
   ), [])
+
+  const buildOrderOptionCell = useCallback((cellData) => {
+    const { items: orderOptionList } = cellData
+
+    const orderOptionNames = []
+
+    orderOptionList?.map((orderOption) => {
+      const { name, conceptId: orderOptionConceptId } = orderOption
+      orderOptionNames.push(
+        <Button
+          inline
+          naked
+          key={orderOptionConceptId}
+          type="button"
+          variant="link"
+          onClick={
+            () => {
+              navigate(`/order-options/${conceptId}`)
+            }
+          }
+        >
+          {name}
+        </Button>
+      )
+
+      return null
+    })
+
+    return (
+      <Row>
+        <Col>
+          {orderOptionNames}
+        </Col>
+      </Row>
+    )
+  }, [])
 
   // Handles checkbox selections, if checked add the conceptId to the state variable
   // and pops the added conceptId from the array.
@@ -133,9 +135,9 @@ const ManageCollectionAssociation = () => {
     const { value } = target
 
     if (target.checked) {
-      setCollectionConceptIds([...collectionConceptIds, value])
+      setServiceConceptIds([...serviceConceptIds, value])
     } else {
-      setCollectionConceptIds(collectionConceptIds.filter((item) => item !== value))
+      setServiceConceptIds(serviceConceptIds.filter((item) => item !== value))
     }
   }
 
@@ -158,30 +160,22 @@ const ManageCollectionAssociation = () => {
 
   const columns = [
     {
-      title: 'Actions',
+      title: 'Selections',
       className: 'col-auto',
       dataAccessorFn: buildActionsCell
     },
     {
-      dataKey: 'shortName',
-      title: 'Short Name',
+      dataKey: 'longName',
+      title: 'Service Name',
       className: 'col-auto',
-      dataAccessorFn: buildEllipsisTextCell,
-      sortFn: (_, order) => sortFn('shortName', order)
+      dataAccessorFn: buildEllipsisTextCell
     },
     {
-      dataKey: 'version',
-      title: 'Version',
-      className: 'col-auto',
-      align: 'center'
-    },
-    {
-      dataKey: 'provider',
-      title: 'Provider',
+      dataKey: 'orderOptions',
+      title: 'Associated Order Option',
       className: 'col-auto',
       align: 'center',
-      dataAccessorFn: buildEllipsisTextCell,
-      sortFn: (_, order) => sortFn('provider', order)
+      dataAccessorFn: buildOrderOptionCell
     }
   ]
 
@@ -204,15 +198,15 @@ const ManageCollectionAssociation = () => {
     handleRefreshPage()
   })
 
-  const { [camelCase(derivedConceptType)]: concept } = data
+  const { collection } = data
 
-  const { collections: associatedCollections } = concept
+  const { services } = collection
 
-  const { items, count } = associatedCollections
+  const { items: servicesList, count: servicesCount } = services
 
   return (
     <>
-      <div className="mt-4">
+      <div>
         <Alert className="fst-italic fs-6" variant="warning">
           <i className="eui-icon eui-fa-info-circle" />
           {' '}
@@ -234,37 +228,36 @@ const ManageCollectionAssociation = () => {
           </span>
         </Alert>
       </div>
-      <div className="mt-4">
+      <div className="mt-4 mb-2">
         <span>
           Showing
           {' '}
-          {count}
+          {servicesCount}
           {' '}
-          {pluralize('collection association', count)}
+          {pluralize('service association', servicesCount)}
         </span>
       </div>
       <Table
-        className="m-5"
         id="associated-collections"
         columns={columns}
-        data={items}
+        data={servicesList}
         generateCellKey={({ conceptId: conceptIdCell }, dataKey) => `column_${dataKey}_${conceptIdCell}`}
         generateRowKey={({ conceptId: conceptIdRow }) => `row_${conceptIdRow}`}
-        noDataMessage="No collection associations found."
-        limit={count}
+        noDataMessage="No service associations found"
+        limit={servicesCount}
       />
 
       <Button
         className="mt-4"
         variant="danger"
-        disabled={collectionConceptIds.length === 0}
+        disabled={serviceConceptIds.length === 0}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...accessibleEventProps}
       >
         Delete Selected Associations
       </Button>
       <CustomModal
-        message="Are you sure you want to delete the selected collection associations?"
+        message="Are you sure you want to delete the selected service associations?"
         show={showDeleteModal}
         toggleModal={toggleShowDeleteModal}
         actions={
@@ -286,4 +279,4 @@ const ManageCollectionAssociation = () => {
   )
 }
 
-export default ManageCollectionAssociation
+export default ManageServiceAssociations

--- a/static/src/js/components/ManageServiceAssociations/__tests__/ManageServiceAssociations.test.jsx
+++ b/static/src/js/components/ManageServiceAssociations/__tests__/ManageServiceAssociations.test.jsx
@@ -1,0 +1,219 @@
+import React, { Suspense } from 'react'
+import {
+  render,
+  screen,
+  waitFor,
+  within
+} from '@testing-library/react'
+import {
+  MemoryRouter,
+  Route,
+  Routes
+} from 'react-router'
+import { MockedProvider } from '@apollo/client/testing'
+import userEvent from '@testing-library/user-event'
+import * as router from 'react-router'
+
+import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+import errorLogger from '@/js/utils/errorLogger'
+import NotificationsContext from '@/js/context/NotificationsContext'
+
+import {
+  deleteAssociationsError,
+  deleteAssociationResponse,
+  serviceAssociationsSearch
+} from './__mocks__/serviceAssociationsResponses'
+
+import ManageServiceAssociations from '../ManageServiceAssociations'
+
+vi.mock('@/js/utils/errorLogger')
+vi.mock('@/js/components/ErrorBanner/ErrorBanner')
+
+const setup = ({
+  additionalMocks = [],
+  overrideInitialEntries,
+  overrideMocks = false,
+  overridePaths
+}) => {
+  const mocks = [
+    serviceAssociationsSearch,
+    ...additionalMocks
+  ]
+
+  const notificationContext = {
+    addNotification: vi.fn()
+  }
+
+  const user = userEvent.setup()
+
+  render(
+    <NotificationsContext.Provider value={notificationContext}>
+      <MemoryRouter initialEntries={overrideInitialEntries || ['/collections/C00000001-TESTPROV/service-associations']}>
+        <MockedProvider
+          mocks={overrideMocks || mocks}
+        >
+          <Routes>
+            <Route
+              path={overridePaths || 'collections/:conceptId/service-associations'}
+              element={
+                (
+                  <ErrorBoundary>
+                    <Suspense>
+                      <ManageServiceAssociations />
+                    </Suspense>
+                  </ErrorBoundary>
+                )
+              }
+            />
+          </Routes>
+        </MockedProvider>
+      </MemoryRouter>
+    </NotificationsContext.Provider>
+  )
+
+  return {
+    user
+  }
+}
+
+describe('ManageServiceAssociation', () => {
+  describe('when the service association page is requested', () => {
+    test('renders the service association page with the associated services', async () => {
+      setup({})
+
+      expect(await screen.findByText('Showing 2 service associations')).toBeInTheDocument()
+      expect(screen.getByText('UARS Read Software')).toBeInTheDocument()
+      expect(screen.getByText('UARS Write Software')).toBeInTheDocument()
+    })
+  })
+
+  describe('when a service association has an order option', () => {
+    test('renders a button that navigates to order option', async () => {
+      const navigateSpy = vi.fn()
+      vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+
+      const { user } = setup({})
+
+      const rows = await screen.findAllByRole('row')
+      const orderOptionRow = rows[1]
+      expect(orderOptionRow).toHaveTextContent('UARS Read SoftwareOrder Option')
+
+      const orderOptionButton = within(orderOptionRow).getByRole('button', { name: 'Order Option' })
+      await user.click(orderOptionButton)
+
+      expect(navigateSpy).toHaveBeenCalledTimes(1)
+      expect(navigateSpy).toHaveBeenCalledWith('/order-options/OO10000-TESTPROV')
+    })
+  })
+
+  describe('when a service association has no order option', () => {
+    test('renders nothing to order option cell', async () => {
+      setup({})
+
+      const rows = await screen.findAllByRole('row')
+      const noOrderOptionRow = rows[2]
+
+      expect(noOrderOptionRow).toHaveTextContent('UARS Write Software')
+    })
+  })
+
+  describe('when disassociating an associated service', () => {
+    describe('when selecting and clicking on Delete Selected Service', () => {
+      test('should show the delete modal and click no', async () => {
+        const { user } = setup({
+          additionalMocks: [deleteAssociationResponse]
+        })
+
+        const checkboxes = await screen.findAllByRole('checkbox')
+        const firstCheckbox = checkboxes[0]
+        const secondCheckbox = checkboxes[1]
+
+        await user.click(secondCheckbox)
+        await user.click(firstCheckbox)
+        await user.click(secondCheckbox)
+
+        const deleteSelectedAssociationButton = screen.getByRole('button', { name: 'Delete Selected Associations' })
+
+        await user.click(deleteSelectedAssociationButton)
+
+        expect(screen.getByText('Are you sure you want to delete the selected service associations?')).toBeInTheDocument()
+
+        const noButton = screen.getByRole('button', { name: 'No' })
+        await user.click(noButton)
+
+        expect(await screen.findByText('Showing 2 service associations')).toBeInTheDocument()
+        expect(screen.getByText('UARS Read Software')).toBeInTheDocument()
+        expect(screen.getByText('UARS Write Software')).toBeInTheDocument()
+      })
+    })
+
+    describe('when selecting Yes in the modal and results in an error ', () => {
+      test('should call errorLogger', async () => {
+        const { user } = setup({
+          additionalMocks: [serviceAssociationsSearch, deleteAssociationsError]
+        })
+
+        const checkboxes = await screen.findAllByRole('checkbox')
+        const firstCheckbox = checkboxes[0]
+        const secondCheckbox = checkboxes[1]
+
+        await user.click(secondCheckbox)
+        await user.click(firstCheckbox)
+        await user.click(secondCheckbox)
+
+        const deleteSelectedAssociationButton = screen.getByRole('button', { name: 'Delete Selected Associations' })
+
+        await user.click(deleteSelectedAssociationButton)
+
+        expect(screen.getByText('Are you sure you want to delete the selected service associations?')).toBeInTheDocument()
+
+        const yesButton = screen.getByRole('button', { name: 'Yes' })
+        await user.click(yesButton)
+
+        await waitFor(() => {
+          expect(errorLogger).toHaveBeenCalledWith('Unable to disassociate service record for C00000001-TESTPROV', 'Manage Service Association: deleteAssociation Mutation')
+        })
+
+        expect(errorLogger).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('when selecting Yes in the modal and results in a success ', () => {
+      test('should remove the deleted service', async () => {
+        const { user } = setup({
+          overrideMocks: [serviceAssociationsSearch, deleteAssociationResponse]
+        })
+
+        const checkboxes = await screen.findAllByRole('checkbox')
+        const firstCheckbox = checkboxes[0]
+
+        await user.click(firstCheckbox)
+
+        const deleteSelectedAssociationButton = screen.getByRole('button', { name: 'Delete Selected Associations' })
+
+        await user.click(deleteSelectedAssociationButton)
+
+        expect(screen.getByText('Are you sure you want to delete the selected service associations?')).toBeInTheDocument()
+
+        const yesButton = screen.getByRole('button', { name: 'Yes' })
+        await user.click(yesButton)
+
+        expect(screen.getByText('UARS Write Software')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when clicking on refresh button', () => {
+    test('should call getMetadata() again', async () => {
+      const { user } = setup({
+        additionalMocks: [serviceAssociationsSearch]
+      })
+
+      const refreshButton = await screen.findByRole('link', { name: 'refresh the page' })
+
+      await user.click(refreshButton)
+
+      expect(screen.getByText('UARS Write Software')).toBeInTheDocument()
+    })
+  })
+})

--- a/static/src/js/components/ManageServiceAssociations/__tests__/__mocks__/serviceAssociationsResponses.js
+++ b/static/src/js/components/ManageServiceAssociations/__tests__/__mocks__/serviceAssociationsResponses.js
@@ -1,0 +1,85 @@
+import { DELETE_ASSOCIATION } from '@/js/operations/mutations/deleteAssociation'
+import { GET_SERVICE_ASSOCIATIONS } from '@/js/operations/queries/getServiceAssociations'
+
+export const serviceAssociationsSearch = {
+  request: {
+    query: GET_SERVICE_ASSOCIATIONS,
+    variables: {
+      params: {
+        conceptId: 'C00000001-TESTPROV'
+      }
+    }
+  },
+  result: {
+    data: {
+      collection: {
+        conceptId: 'C1000000000-TESTPROV',
+        shortName: 'Collection Short Name 1',
+        services: {
+          __typename: 'ServiceList',
+          count: 2,
+          items: [
+            {
+              conceptId: 'S100000-TESTPROV',
+              longName: 'UARS Read Software',
+              orderOptions: {
+                __typename: 'OrderOptionList',
+                count: 1,
+                items: [
+                  {
+                    conceptId: 'OO10000-TESTPROV',
+                    name: 'Order Option'
+                  }
+                ]
+              }
+            },
+            {
+              conceptId: 'S200000-TESTPROV',
+              longName: 'UARS Write Software',
+              orderOptions: {
+                __typename: 'OrderOptionList',
+                count: 0,
+                items: []
+              }
+            }
+          ]
+        },
+        temporalKeywords: null,
+        entryTitle: null,
+        revisionDate: '2023-11-30 00:00:00',
+        previewMetadata: {}
+      }
+    }
+  }
+}
+
+export const deleteAssociationResponse = {
+  request: {
+    query: DELETE_ASSOCIATION,
+    variables: {
+      conceptId: 'C00000001-TESTPROV',
+      associatedConceptIds: ['S100000-TESTPROV']
+    }
+  },
+  result: {
+    data: {
+      deleteAssociation: {
+        associatedConceptId: 'S100000-TESTPROV',
+        conceptId: 'C00000001-TESTPROV',
+        revisionId: 2,
+        __typename: 'AssociationMutationResponse'
+      }
+    }
+  }
+}
+
+export const deleteAssociationsError = {
+  request: {
+    query: DELETE_ASSOCIATION,
+    variables: {
+      conceptId: 'C00000001-TESTPROV',
+      associatedConceptIds: ['S100000-TESTPROV']
+    }
+  },
+  error: new Error('An error occurred')
+}

--- a/static/src/js/components/PublishPreview/PublishPreview.jsx
+++ b/static/src/js/components/PublishPreview/PublishPreview.jsx
@@ -71,6 +71,10 @@ const PublishPreviewHeader = () => {
     setShowTagModal(nextState)
   }
 
+  const navigateToServices = () => {
+    navigate(`/collections/${conceptId}/service-associations`)
+  }
+
   const { addNotification } = useNotificationsContext()
   const [deleteMutation] = useMutation(deleteMutationTypes[derivedConceptType], {
     update: (cache) => {
@@ -99,6 +103,7 @@ const PublishPreviewHeader = () => {
     pageTitle = '<Blank Name>',
     providerId,
     revisions,
+    services,
     tagDefinitions,
     ummMetadata
   } = concept
@@ -113,6 +118,11 @@ const PublishPreviewHeader = () => {
   let tagCount = 0
   if (tagDefinitions) {
     tagCount = tagDefinitions.items.length
+  }
+
+  let serviceCount = 0
+  if (services) {
+    ({ count: serviceCount } = services)
   }
 
   const {
@@ -224,6 +234,12 @@ const PublishPreviewHeader = () => {
                     onClick: () => toggleTagModal(true),
                     title: 'View Tags',
                     count: tagCount
+                  },
+                  {
+                    icon: FaEye,
+                    onClick: () => navigateToServices(),
+                    title: 'View Services',
+                    count: serviceCount
                   }
                 ]
                 : [

--- a/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.jsx
+++ b/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.jsx
@@ -809,7 +809,10 @@ describe('PublishPreview', () => {
 
   describe('Services', () => {
     describe('when the collection has services', () => {
-      test('should display the service count', async () => {
+      test('should display navigation link with service count', async () => {
+        const navigateSpy = vi.fn()
+        vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+
         const { user } = setup({
           overrideInitialEntries: ['/collections/C1000000-MMT/1'],
           overridePath: '/collections',
@@ -837,7 +840,12 @@ describe('PublishPreview', () => {
 
         await user.click(moreActionsButton)
 
-        expect(screen.getByRole('button', { name: 'View Services 1' }))
+        const viewServicesButton = screen.getByRole('button', { name: 'View Services 1' })
+
+        await user.click(viewServicesButton)
+
+        expect(navigateSpy).toHaveBeenCalledTimes(1)
+        expect(navigateSpy).toHaveBeenCalledWith('/collections/C1000000-MMT/service-associations')
       })
     })
 

--- a/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.jsx
+++ b/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.jsx
@@ -30,11 +30,11 @@ import { GET_COLLECTION_REVISIONS } from '@/js/operations/queries/getCollectionR
 
 import PublishPreview from '../PublishPreview'
 import {
-  noTagsOrGranulesCollection,
+  collectionRecordWithRevisions,
+  noTagsOrGranulesOrServicesCollection,
   publishCollectionRecord,
   publishedVariableRecord,
   recordWithRevisions,
-  collectionRecordWithRevisions,
   variableRecordWithRevisions
 } from './__mocks__/publishPreview'
 
@@ -669,7 +669,7 @@ describe('PublishPreview', () => {
               },
               result: {
                 data: {
-                  collection: noTagsOrGranulesCollection
+                  collection: noTagsOrGranulesOrServicesCollection
                 }
               }
             },
@@ -775,7 +775,7 @@ describe('PublishPreview', () => {
               },
               result: {
                 data: {
-                  collection: noTagsOrGranulesCollection
+                  collection: noTagsOrGranulesOrServicesCollection
                 }
               }
             },
@@ -803,6 +803,90 @@ describe('PublishPreview', () => {
         await user.click(moreActionsButton)
 
         expect(screen.getByRole('button', { name: 'View Granules 0' }))
+      })
+    })
+  })
+
+  describe('Services', () => {
+    describe('when the collection has services', () => {
+      test('should display the service count', async () => {
+        const { user } = setup({
+          overrideInitialEntries: ['/collections/C1000000-MMT/1'],
+          overridePath: '/collections',
+          overrideMocks: [
+            {
+              request: {
+                query: conceptTypeQueries.Collection,
+
+                variables: {
+                  params: {
+                    conceptId: 'C1000000-MMT'
+                  }
+                }
+              },
+              result: {
+                data: {
+                  collection: publishCollectionRecord
+                }
+              }
+            }
+          ]
+        })
+
+        const moreActionsButton = await screen.findByText(/More Actions/)
+
+        await user.click(moreActionsButton)
+
+        expect(screen.getByRole('button', { name: 'View Services 1' }))
+      })
+    })
+
+    describe('when the collection has no services', () => {
+      test('should display the services count with 0', async () => {
+        const { user } = setup({
+          overrideInitialEntries: ['/collections/C1000000-MMT/1'],
+          overridePath: '/collections',
+          overrideMocks: [
+            {
+              request: {
+                query: conceptTypeQueries.Collection,
+
+                variables: {
+                  params: {
+                    conceptId: 'C1000000-MMT'
+                  }
+                }
+              },
+              result: {
+                data: {
+                  collection: noTagsOrGranulesOrServicesCollection
+                }
+              }
+            },
+            {
+              request: {
+                query: GET_COLLECTION_REVISIONS,
+                variables: {
+                  params: {
+                    conceptId: 'C1000000-MMT',
+                    allRevisions: true
+                  }
+                }
+              },
+              result: {
+                data: {
+                  collections: collectionRecordWithRevisions
+                }
+              }
+            }
+          ]
+        })
+
+        const moreActionsButton = await screen.findByText(/More Actions/)
+
+        await user.click(moreActionsButton)
+
+        expect(screen.getByRole('button', { name: 'View Services 0' }))
       })
     })
   })

--- a/static/src/js/components/PublishPreview/__tests__/__mocks__/publishPreview.js
+++ b/static/src/js/components/PublishPreview/__tests__/__mocks__/publishPreview.js
@@ -160,8 +160,8 @@ export const publishCollectionRecord = {
   }],
   services: {
     __typename: 'ServiceList',
-    count: 0,
-    items: null
+    count: 1,
+    items: []
   },
   shortName: 'Mock Quick Test Services #2',
   spatialExtent: {
@@ -399,7 +399,7 @@ export const publishCollectionRecord = {
   versionId: '1'
 }
 
-export const noTagsOrGranulesCollection = {
+export const noTagsOrGranulesOrServicesCollection = {
   __typename: 'Collection',
   abstract: 'Mock Testing Collections',
   accessConstraints: null,

--- a/static/src/js/operations/queries/getServiceAssociations.js
+++ b/static/src/js/operations/queries/getServiceAssociations.js
@@ -1,0 +1,24 @@
+import { gql } from '@apollo/client'
+
+export const GET_SERVICE_ASSOCIATIONS = gql`
+  query GetServiceAssociations ($params: CollectionInput) {
+    collection (params: $params) {
+      conceptId
+      shortName
+      services {
+        count
+        items {
+          conceptId
+          longName
+          orderOptions {
+            count
+            items {
+              name
+              conceptId
+            }
+          }
+        }
+      }
+    }
+  }
+`

--- a/static/src/js/pages/ManageCollectionAssociationPage/ManageCollectionAssociationPage.jsx
+++ b/static/src/js/pages/ManageCollectionAssociationPage/ManageCollectionAssociationPage.jsx
@@ -8,6 +8,7 @@ import { useSuspenseQuery } from '@apollo/client'
 import pluralize from 'pluralize'
 
 import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+import LoadingTable from '@/js/components/LoadingTable/LoadingTable'
 import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
 
@@ -93,7 +94,7 @@ const ManageCollectionAssociationPage = () => (
     header={<ManageCollectionAssociationPageHeader />}
   >
     <ErrorBoundary>
-      <Suspense fallback="Loading...">
+      <Suspense fallback={<LoadingTable />}>
         <ManageCollectionAssociation />
       </Suspense>
     </ErrorBoundary>

--- a/static/src/js/pages/ManageServiceAssociationsPage/ManageServiceAssociationsPage.jsx
+++ b/static/src/js/pages/ManageServiceAssociationsPage/ManageServiceAssociationsPage.jsx
@@ -1,0 +1,84 @@
+import React, { Suspense } from 'react'
+
+import { useParams } from 'react-router'
+import { useSuspenseQuery } from '@apollo/client'
+
+import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+import Page from '@/js/components/Page/Page'
+import PageHeader from '@/js/components/PageHeader/PageHeader'
+
+import { GET_SERVICE_ASSOCIATIONS } from '@/js/operations/queries/getServiceAssociations'
+
+import ManageServiceAssociations from '@/js/components/ManageServiceAssociations/ManageServiceAssociations'
+
+/**
+ * Renders a ManageServiceAssociationsPageHeader component
+ *
+ * @component
+ * @example <caption>Render a ManageServiceAssociationsPageHeader</caption>
+ * return (
+ *   <ManageServiceAssociationsPageHeader />
+ * )
+ */
+const ManageServiceAssociationsPageHeader = () => {
+  const { conceptId } = useParams()
+
+  const { data } = useSuspenseQuery(GET_SERVICE_ASSOCIATIONS, {
+    variables: {
+      params: {
+        conceptId
+      }
+    }
+  })
+
+  const { collection } = data
+
+  const { shortName } = collection
+
+  return (
+    <PageHeader
+      title={`${shortName} Service Associations`}
+      breadcrumbs={
+        [
+          {
+            label: 'Collection',
+            to: '/collections'
+          },
+          {
+            label: shortName,
+            to: `/collections/${conceptId}`
+          },
+          {
+            label: 'Service Associations',
+            active: true
+          }
+        ]
+      }
+      pageType="secondary"
+    />
+  )
+}
+
+/**
+ * Renders a ManageServiceAssociationsPage component
+ *
+ * @component
+ * @example <caption>Render a ManageServiceAssociationsPage</caption>
+ * return (
+ *   <ManageServiceAssociationsPage />
+ * )
+ */
+const ManageServiceAssociationsPage = () => (
+  <Page
+    pageType="secondary"
+    header={<ManageServiceAssociationsPageHeader />}
+  >
+    <ErrorBoundary>
+      <Suspense fallback="Loading...">
+        <ManageServiceAssociations />
+      </Suspense>
+    </ErrorBoundary>
+  </Page>
+)
+
+export default ManageServiceAssociationsPage

--- a/static/src/js/pages/ManageServiceAssociationsPage/ManageServiceAssociationsPage.jsx
+++ b/static/src/js/pages/ManageServiceAssociationsPage/ManageServiceAssociationsPage.jsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router'
 import { useSuspenseQuery } from '@apollo/client'
 
 import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+import LoadingTable from '@/js/components/LoadingTable/LoadingTable'
 import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
 
@@ -41,7 +42,7 @@ const ManageServiceAssociationsPageHeader = () => {
       breadcrumbs={
         [
           {
-            label: 'Collection',
+            label: 'Collections',
             to: '/collections'
           },
           {
@@ -74,7 +75,7 @@ const ManageServiceAssociationsPage = () => (
     header={<ManageServiceAssociationsPageHeader />}
   >
     <ErrorBoundary>
-      <Suspense fallback="Loading...">
+      <Suspense fallback={<LoadingTable />}>
         <ManageServiceAssociations />
       </Suspense>
     </ErrorBoundary>

--- a/static/src/js/pages/ManageServiceAssociationsPage/__tests__/ManageServiceAssociationsPage.test.jsx
+++ b/static/src/js/pages/ManageServiceAssociationsPage/__tests__/ManageServiceAssociationsPage.test.jsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import {
+  MemoryRouter,
+  Route,
+  Routes
+} from 'react-router-dom'
+import { render, screen } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+
+import { GET_SERVICE_ASSOCIATIONS } from '@/js/operations/queries/getServiceAssociations'
+
+import ManageServiceAssociationsPage from '../ManageServiceAssociationsPage'
+
+vi.mock('../../../components/ManageServiceAssociations/ManageServiceAssociations')
+
+vi.mock('react-router-dom', async () => ({
+  ...await vi.importActual('react-router-dom'),
+  useParams: vi.fn().mockImplementation(() => ({ conceptId: 'C00000001-TESTPROV' }))
+}))
+
+const setup = () => {
+  const mocks = [
+    {
+      request: {
+        query: GET_SERVICE_ASSOCIATIONS,
+        variables: {
+          params: {
+            conceptId: 'C00000001-TESTPROV'
+          }
+        }
+      },
+      result: {
+        data: {
+          collection: {
+            conceptId: 'C1000000000-TESTPROV',
+            shortName: 'Collection Short Name 1',
+            services: {}
+          }
+        }
+      }
+    }
+  ]
+
+  render(
+    <MockedProvider
+      mocks={mocks}
+    >
+      <MemoryRouter initialEntries={
+        [{
+          pathname: '/collections/C00000001-TESTPROV/service-associations'
+        }]
+      }
+      >
+        <Routes>
+          <Route path="/:type/:conceptId/service-associations" element={<ManageServiceAssociationsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </MockedProvider>
+  )
+}
+
+describe('ManageServiceAssociationsPage', () => {
+  describe('when showing the header', () => {
+    test('render the header', async () => {
+      setup()
+
+      expect(await screen.findByRole('heading', { name: 'Collection Short Name 1 Service Associations' })).toBeInTheDocument()
+
+      expect(screen.getByRole('link', { name: 'Collections' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Collections' })).toHaveAttribute('href', '/collections')
+      expect(screen.getByRole('link', { name: 'Collection Short Name 1' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Collection Short Name 1' })).toHaveAttribute('href', '/collections/C00000001-TESTPROV')
+      expect(screen.getAllByRole('listitem').at(2)).toBeInTheDocument()
+      expect(screen.getAllByRole('listitem').at(2)).toHaveTextContent('Service Associations')
+    })
+  })
+})


### PR DESCRIPTION
# Overview

### What is the feature?

We need to create a feature in react that allows a user to go to a published Collection Preview, click on the three dots, select 'View Services' and get redirected to a table similar to the the one attached. This table will also show any order options associated as well. PLEASE NOTE: Only one order option can be associated with a service

### What is the Solution?

Added View Services to collection preview and created landing page

### What areas of the application does this impact?

List impacted areas.

App.jsx
PublishPreview.jsx

### Reproduction steps

- **Environment for testing: local
- **Collection to test with: Need to associated a service with an order option and a service without an order option to a single collection

1. Go to collection preview and click 'View Services' the badge next to view services should give you the service list count
2. Once on the landing page test out the order option functionality. When there is an associated order option, a button should show up that navigates you to the order option. If no order options are present, nothing should be filled in the cell. 
3. Next, disassociate a service/services and double check they have been successfully deleted and the proper notifications have been populated. 

### Attachments

View Services tab
![Uploading Screenshot 2024-08-26 at 10.41.56 AM.png…]()

New landing page
<img width="1381" alt="Screenshot 2024-08-26 at 10 42 33 AM" src="https://github.com/user-attachments/assets/f250e609-b758-40f8-aca9-ff04d5d6edf7">

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings