### PR TITLE
MMT-3793: Use cdn site for downloading umm schemas instead of git.ear…

### DIFF
--- a/bin/download_schemas.sh
+++ b/bin/download_schemas.sh
@@ -6,7 +6,7 @@ ummC() {
     #Reads version number
     schema_version=`jq '.ummVersions.ummC' ./static.config.json`
     schema_version=${schema_version//\"/}
-    echo schema_version=${schema_version}
+    echo ummC schema version=${schema_version}
     #Download
     curl -L "https://cdn.earthdata.nasa.gov/umm/collection/v${schema_version}/umm-c-json-schema.json" > umm-c-json-schema-temp.json
     if [ $? -ne 0 ]; then
@@ -33,6 +33,7 @@ ummS() {
     #Reads version number
     schema_version=`jq '.ummVersions.ummS' ./static.config.json`
     schema_version=${schema_version//\"/}
+    echo ummS schema version=${schema_version}
     #Download
     curl -L "https://cdn.earthdata.nasa.gov/umm/service/v${schema_version}/umm-s-json-schema.json" > umm-s-json-schema-temp.json
     if [ $? -ne 0 ]; then
@@ -50,6 +51,7 @@ ummV() {
     #Reads version number
     schema_version=`jq '.ummVersions.ummV' ./static.config.json`
     schema_version=${schema_version//\"/}
+    echo ummV schema version=${schema_version}
     #Download
     curl -L "https://cdn.earthdata.nasa.gov/umm/variable/v${schema_version}/umm-var-json-schema.json" > umm-var-json-schema-temp.json
     if [ $? -ne 0 ]; then
@@ -67,6 +69,7 @@ ummT() {
     #Reads version number
     schema_version=`jq '.ummVersions.ummT' ./static.config.json`
     schema_version=${schema_version//\"/}
+    echo ummT schema version=${schema_version}
     #Download
     curl -L "https://cdn.earthdata.nasa.gov/umm/tool/v${schema_version}/umm-t-json-schema.json" > umm-t-json-schema-temp.json
     if [ $? -ne 0 ]; then

--- a/bin/download_schemas.sh
+++ b/bin/download_schemas.sh
@@ -6,14 +6,15 @@ ummC() {
     #Reads version number
     schema_version=`jq '.ummVersions.ummC' ./static.config.json`
     schema_version=${schema_version//\"/}
+    echo schema_version=${schema_version}
     #Download
-    curl https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/raw/collection/v${schema_version}/umm-c-json-schema.json > umm-c-json-schema-temp.json
+    curl -L "https://cdn.earthdata.nasa.gov/umm/collection/v${schema_version}/umm-c-json-schema.json" > umm-c-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-c-json-schema.json"
       exit 1
     fi
     jq --arg ummJsonSchemaUrl "$ummJsonSchemaUrl" '."$schema" = $ummJsonSchemaUrl' umm-c-json-schema-temp.json > umm-c-json-schema.json
-    curl https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/raw/collection/v${schema_version}/umm-cmn-json-schema.json > umm-cmn-json-schema-temp.json
+    curl -L "https://cdn.earthdata.nasa.gov/umm/collection/v${schema_version}/umm-cmn-json-schema.json" > umm-cmn-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-cmn-json-schema.json"
       exit 1
@@ -33,7 +34,7 @@ ummS() {
     schema_version=`jq '.ummVersions.ummS' ./static.config.json`
     schema_version=${schema_version//\"/}
     #Download
-    curl https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/raw/service/v${schema_version}/umm-s-json-schema.json > umm-s-json-schema-temp.json
+    curl -L "https://cdn.earthdata.nasa.gov/umm/service/v${schema_version}/umm-s-json-schema.json" > umm-s-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-s-json-schema.json"
       exit 1
@@ -50,7 +51,7 @@ ummV() {
     schema_version=`jq '.ummVersions.ummV' ./static.config.json`
     schema_version=${schema_version//\"/}
     #Download
-    curl https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/raw/variable/v${schema_version}/umm-var-json-schema.json > umm-var-json-schema-temp.json
+    curl -L "https://cdn.earthdata.nasa.gov/umm/variable/v${schema_version}/umm-var-json-schema.json" > umm-var-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-var-json-schema.json"
       exit 1
@@ -67,7 +68,7 @@ ummT() {
     schema_version=`jq '.ummVersions.ummT' ./static.config.json`
     schema_version=${schema_version//\"/}
     #Download
-    curl https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/raw/tool/v${schema_version}/umm-t-json-schema.json > umm-t-json-schema-temp.json
+    curl -L "https://cdn.earthdata.nasa.gov/umm/tool/v${schema_version}/umm-t-json-schema.json" > umm-t-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-t-json-schema.json"
       exit 1


### PR DESCRIPTION
…thdata

# Overview

### What is the feature?

Download umm schema files from https://cdn.earthdata.nasa.gov/umm/

### What is the Solution?

Update download script for all data types C,S,V and T

### What areas of the application does this impact?

Download script in deployment time

# Testing

Since this is about updating the URL, test if deployment didn't download empty or invalid files (html file asking for authorization)

### Attachments

N/A

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings