### PR TITLE
MMT-3879: Updated page size to 2000.

### DIFF
--- a/static/src/js/components/CollectionAssociationForm/CollectionAssociationForm.jsx
+++ b/static/src/js/components/CollectionAssociationForm/CollectionAssociationForm.jsx
@@ -127,8 +127,8 @@ const CollectionAssociationForm = ({ metadata }) => {
   const { data: serviceData } = useQuery(conceptTypeQueries.Services, {
     variables: {
       params: {
-        limit,
-        offset
+        limit: 2000,
+        offset: 0
       }
     }
   }, { skip: derivedConceptType !== conceptIdTypes.O })

--- a/static/src/js/components/CollectionAssociationForm/CollectionAssociationForm.jsx
+++ b/static/src/js/components/CollectionAssociationForm/CollectionAssociationForm.jsx
@@ -127,8 +127,7 @@ const CollectionAssociationForm = ({ metadata }) => {
   const { data: serviceData } = useQuery(conceptTypeQueries.Services, {
     variables: {
       params: {
-        limit: 2000,
-        offset: 0
+        limit: 2000
       }
     }
   }, { skip: derivedConceptType !== conceptIdTypes.O })

--- a/static/src/js/components/CollectionAssociationForm/__tests__/CollectionAssociationForm.test.jsx
+++ b/static/src/js/components/CollectionAssociationForm/__tests__/CollectionAssociationForm.test.jsx
@@ -66,7 +66,7 @@ const setup = ({
       <NotificationsContext.Provider value={notificationContext}>
         <MemoryRouter initialEntries={overrideInitialEntries || ['/tools/T12000000-MMT_2/collection-association-search']}>
           <MockedProvider
-            mocks={[GetServicesRequest, GetServicesPagedRequest, ...additionalMocks]}
+            mocks={[GetServicesRequest, ...additionalMocks]}
           >
             <Routes>
               <Route

--- a/static/src/js/components/CollectionAssociationForm/__tests__/CollectionAssociationForm.test.jsx
+++ b/static/src/js/components/CollectionAssociationForm/__tests__/CollectionAssociationForm.test.jsx
@@ -36,8 +36,7 @@ import {
   mockToolWithAssociation,
   mockOrderOption,
   CollectionSortRequest,
-  GetServicesRequest,
-  GetServicesPagedRequest
+  GetServicesRequest
 } from './__mocks__/CollectionAssociationResults'
 
 vi.mock('@/js/components/ErrorBanner/ErrorBanner')

--- a/static/src/js/components/CollectionAssociationForm/__tests__/__mocks__/CollectionAssociationResults.js
+++ b/static/src/js/components/CollectionAssociationForm/__tests__/__mocks__/CollectionAssociationResults.js
@@ -468,38 +468,8 @@ export const GetServicesRequest = {
     query: GET_SERVICES,
     variables: {
       params: {
-        limit: 20,
+        limit: 2000,
         offset: 0
-      }
-    }
-  },
-  result: {
-    data: {
-      services: {
-        count: 1,
-        items: [
-          {
-            conceptId: 'S1000000000-TESTPROV',
-            name: 'Service Name 1',
-            longName: 'Service Long Name 1',
-            providerId: 'TESTPROV',
-            revisionDate: '2023-11-30 00:00:00',
-            revisionId: '1',
-            userId: 'admin'
-          }
-        ]
-      }
-    }
-  }
-}
-
-export const GetServicesPagedRequest = {
-  request: {
-    query: GET_SERVICES,
-    variables: {
-      params: {
-        limit: 20,
-        offset: 40
       }
     }
   },

--- a/static/src/js/components/CollectionAssociationForm/__tests__/__mocks__/CollectionAssociationResults.js
+++ b/static/src/js/components/CollectionAssociationForm/__tests__/__mocks__/CollectionAssociationResults.js
@@ -468,8 +468,7 @@ export const GetServicesRequest = {
     query: GET_SERVICES,
     variables: {
       params: {
-        limit: 2000,
-        offset: 0
+        limit: 2000
       }
     }
   },


### PR DESCRIPTION
# Overview

### What is the feature?

The page size for retrieving services was only set to 20 when associate a service to an order option and collection.   This needs to be bumped up to 2000.

### What is the Solution?

Bumped up the page size to 2000.

### What areas of the application does this impact?

Association service with an order option and collections.

# Testing

You should now see more than 20 services when opening up the combo when you try to supply a service when associating a order option with a set of collections.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings