### PR TITLE
MMT-3868: Fixed test that failed do to upgrade of rexml

### DIFF
--- a/spec/controllers/saml_controller_spec.rb
+++ b/spec/controllers/saml_controller_spec.rb
@@ -30,7 +30,7 @@ describe SamlController do
 
     context 'when a user returns from launchpad with an invalid SAMLResponse' do
       it 'raises a ValidationError' do
-        expect { post :acs, params: { SAMLResponse: 'xxxxx' } }.to raise_error(OneLogin::RubySaml::ValidationError)
+        expect { post :acs, params: { SAMLResponse: '<response>xxxxx</response>' } }.to raise_error(OneLogin::RubySaml::ValidationError)
       end
     end
   end


### PR DESCRIPTION
# Overview

### What is the feature?

rexml library was updated in the last gem update.   This resulted in a broken test.

### What is the Solution?

Fixed the test by properly giving it a valid xml string.

### What areas of the application does this impact?

Bamboo, tests should pass now.

# Testing

Verify we get a green build in bamboo.
Brief regression testing of MMT in SIT would be helpful too.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings