### PR TITLE
MMT-3884: Edits to Order Option forms are being made under a different provider than the original form is associated with

### DIFF
--- a/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
+++ b/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
@@ -62,7 +62,7 @@ const OrderOptionForm = () => {
 
   const [focusField, setFocusField] = useState(null)
 
-  const [formProviderId, setFormProviderId] = useState()
+  const [fetchProviderId, setFetchProviderId] = useState()
 
   const [createOrderOptionMutation] = useMutation(CREATE_ORDER_OPTION, {
     update: (cache) => {
@@ -143,11 +143,11 @@ const OrderOptionForm = () => {
         form,
         name,
         nativeId: fetchedNativeId,
-        providerId: fetchedProviderId,
+        providerId: formProviderId,
         sortKey
       } = orderOptionData
 
-      setFormProviderId(fetchedProviderId)
+      setFetchProviderId(formProviderId)
 
       const formData = {
         deprecated: false,
@@ -194,7 +194,7 @@ const OrderOptionForm = () => {
     const orderOptionVariables = {
       ...formData,
       scope: 'PROVIDER',
-      providerId: formProviderId || providerId
+      providerId: fetchProviderId || providerId
     }
 
     if (conceptId === 'new') {

--- a/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
+++ b/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
@@ -143,8 +143,8 @@ const OrderOptionForm = () => {
         form,
         name,
         nativeId: fetchedNativeId,
-        sortKey,
-        providerId: fetchedProviderId
+        providerId: fetchedProviderId,
+        sortKey
       } = orderOptionData
 
       setFormProviderId(fetchedProviderId)

--- a/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
+++ b/static/src/js/components/OrderOptionForm/OrderOptionForm.jsx
@@ -62,6 +62,8 @@ const OrderOptionForm = () => {
 
   const [focusField, setFocusField] = useState(null)
 
+  const [formProviderId, setFormProviderId] = useState()
+
   const [createOrderOptionMutation] = useMutation(CREATE_ORDER_OPTION, {
     update: (cache) => {
       cache.modify({
@@ -141,8 +143,11 @@ const OrderOptionForm = () => {
         form,
         name,
         nativeId: fetchedNativeId,
-        sortKey
+        sortKey,
+        providerId: fetchedProviderId
       } = orderOptionData
+
+      setFormProviderId(fetchedProviderId)
 
       const formData = {
         deprecated: false,
@@ -189,7 +194,7 @@ const OrderOptionForm = () => {
     const orderOptionVariables = {
       ...formData,
       scope: 'PROVIDER',
-      providerId
+      providerId: formProviderId || providerId
     }
 
     if (conceptId === 'new') {

--- a/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
+++ b/static/src/js/components/OrderOptionForm/__tests__/OrderOptionForm.test.jsx
@@ -479,4 +479,108 @@ describe('OrderOptionForm', () => {
       })
     })
   })
+
+  describe('when updating an order option under a different provider', () => {
+    test('should update the order option and navigate to /order-option/id', async () => {
+      const navigateSpy = vi.fn()
+      vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
+
+      const { user } = setup(
+        {
+          pageUrl: '/order-options/OO1000000-MMT_1/edit',
+          mocks: [{
+            request: {
+              query: GET_ORDER_OPTION,
+              variables: { params: { conceptId: 'OO1000000-MMT_1' } }
+            },
+            result: {
+              data: {
+                orderOption: {
+                  associationDetails: {},
+                  conceptId: 'OO1000000-MMT_1',
+                  collections: {
+                    count: 0,
+                    items: []
+                  },
+                  deprecated: null,
+                  description: 'Test Description',
+                  form: 'Test Form',
+                  name: 'Test Name',
+                  nativeId: 'dce1859e-774c-4561-9451-fc9d77906015',
+                  pageTitle: 'Test Name',
+                  providerId: 'MMT_1',
+                  revisionId: '1',
+                  revisionDate: '2024-04-23T15:03:34.399Z',
+                  scope: 'PROVIDER',
+                  sortKey: null,
+                  __typename: 'OrderOption'
+                }
+              }
+            }
+          },
+          {
+            request: {
+              query: UPDATE_ORDER_OPTION,
+              variables: {
+                deprecated: false,
+                description: 'Test Description',
+                form: 'Test Form',
+                name: 'Test NameUpdated Name',
+                scope: 'PROVIDER',
+                providerId: 'MMT_1',
+                nativeId: 'dce1859e-774c-4561-9451-fc9d77906015'
+              }
+            },
+            result: {
+              data: {
+                updateOrderOption: {
+                  conceptId: 'OO1000000-MMT_1',
+                  revisionId: '2'
+                }
+              }
+            }
+          },
+          {
+            request: {
+              query: GET_ORDER_OPTION,
+              variables: { params: { conceptId: 'OO1000000-MMT_1' } }
+            },
+            result: {
+              data: {
+                orderOption: {
+                  associationDetails: {},
+                  conceptId: 'OO1000000-MMT_1',
+                  collections: {
+                    count: 0,
+                    items: []
+                  },
+                  deprecated: null,
+                  description: 'Test Description',
+                  form: 'Test Form',
+                  name: 'Test Name',
+                  nativeId: 'dce1859e-774c-4561-9451-fc9d77906015',
+                  pageTitle: 'Test Name',
+                  providerId: 'MMT_1',
+                  revisionId: '1',
+                  revisionDate: '2024-04-23T15:03:34.399Z',
+                  scope: 'PROVIDER',
+                  sortKey: null,
+                  __typename: 'OrderOption'
+                }
+              }
+            }
+          }]
+        }
+      )
+
+      const nameField = await screen.findByRole('textbox', { name: 'Name' })
+      await user.type(nameField, 'Updated Name')
+
+      const submitButton = screen.getByRole('button', { name: 'Submit' })
+      await user.click(submitButton)
+
+      expect(navigateSpy).toHaveBeenCalledTimes(1)
+      expect(navigateSpy).toHaveBeenCalledWith('/order-options/OO1000000-MMT_1')
+    })
+  })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

User reported that when updating an Order Option it was being stored under a different provider than the original form is associated with.

### What is the Solution?

Getting the provider ID from the CMR response and setting that when submitting. 

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings