### PR TITLE
MMT-3877: Cloning bug fix

### DIFF
--- a/static/src/js/components/ErrorBanner/ErrorBanner.jsx
+++ b/static/src/js/components/ErrorBanner/ErrorBanner.jsx
@@ -24,9 +24,9 @@ export const ErrorBanner = ({
   const currentURL = window.location.pathname
   const conceptKeywords = ['/collections/', '/variables/', '/services/', '/tools/']
 
-  // Checks to see that the endpoint is correct,
+  // Checks to see that the url is a concept URL,
   // indicating that graphQL made a call that returned null
-  const graphQLCallReturnsNull = (url) => {
+  const isConceptUrl = (url) => {
     if (conceptKeywords.some((keyword) => url.includes(keyword))) {
       return true
     }
@@ -35,8 +35,7 @@ export const ErrorBanner = ({
   }
 
   return (
-    // Checks to see if users came from a published record, indicating there is a CMR lag
-    (previousURL && graphQLCallReturnsNull(previousURL)) ? (
+    (previousURL && isConceptUrl(previousURL)) ? (
       <div>
         <Alert className="fst-italic fs-6" variant="warning">
           <i className="eui-icon eui-fa-info-circle" />
@@ -70,7 +69,7 @@ export const ErrorBanner = ({
 
             <span className="visually-hidden">{' '}</span>
 
-            <p data-testid={dataTestId}>{graphQLCallReturnsNull(currentURL) ? 'This record does not exist' : message}</p>
+            <p data-testid={dataTestId}>{isConceptUrl(currentURL) ? 'This record does not exist' : message}</p>
           </Alert>
         </Col>
       </Row>

--- a/static/src/js/components/ErrorBanner/ErrorBanner.jsx
+++ b/static/src/js/components/ErrorBanner/ErrorBanner.jsx
@@ -1,7 +1,8 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import { Button } from 'react-bootstrap'
 import Alert from 'react-bootstrap/Alert'
 import Col from 'react-bootstrap/Col'
+import PropTypes from 'prop-types'
+import React, { useEffect, useState } from 'react'
 import Row from 'react-bootstrap/Row'
 
 /**
@@ -16,28 +17,77 @@ import Row from 'react-bootstrap/Row'
  */
 export const ErrorBanner = ({
   dataTestId,
-  message
-}) => (
-  <Row>
-    <Col>
-      <Alert variant="danger">
-        <Alert.Heading>Sorry!</Alert.Heading>
+  message,
+  previousURL
+}) => {
+  const [hasCMRLagError, setHasCMRLagError] = useState(false)
+  const [conceptIdDoesNotExist, setConceptIdDoesNotExist] = useState(false)
+  const currentURL = window.location.pathname
+  const conceptKeywords = ['/collections/', '/variables/', '/services/', '/tools/']
 
-        <span className="visually-hidden">{' '}</span>
+  // Catches if we are coming from a published record, indicating this is a CMR lag error
+  useEffect(() => {
+    if (previousURL && conceptKeywords.some((keyword) => previousURL.includes(keyword))) {
+      setHasCMRLagError(true)
+    }
 
-        <p data-testid={dataTestId}>{message}</p>
-      </Alert>
-    </Col>
-  </Row>
-)
+    if (currentURL && conceptKeywords.some((keyword) => currentURL.includes(keyword))) {
+      setConceptIdDoesNotExist(true)
+    }
+  }, [])
+
+  return (
+    hasCMRLagError ? (
+      <div>
+        <Alert className="fst-italic fs-6" variant="warning">
+          <i className="eui-icon eui-fa-info-circle" />
+          {' '}
+          Some operations may take time to populate in the Common Metadata Repository.
+          If you are not seeing what you expect below, please
+          {' '}
+          <Button
+            onClick={() => window.location.reload()}
+            className="text-decoration-underline"
+            style={
+              {
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                color: 'blue',
+                textDecoration: 'underline',
+                cursor: 'pointer'
+              }
+            }
+          >
+            refresh the page
+          </Button>
+        </Alert>
+      </div>
+    ) : (
+      <Row>
+        <Col>
+          <Alert variant="danger">
+            <Alert.Heading>Sorry!</Alert.Heading>
+
+            <span className="visually-hidden">{' '}</span>
+
+            <p data-testid={dataTestId}>{conceptIdDoesNotExist ? 'This record does not exist' : message}</p>
+          </Alert>
+        </Col>
+      </Row>
+    )
+  )
+}
 
 ErrorBanner.propTypes = {
   dataTestId: PropTypes.string,
-  message: PropTypes.string.isRequired
+  message: PropTypes.string.isRequired,
+  previousURL: PropTypes.string
 }
 
 ErrorBanner.defaultProps = {
-  dataTestId: 'error-banner__message'
+  dataTestId: 'error-banner__message',
+  previousURL: null
 }
 
 export default ErrorBanner

--- a/static/src/js/components/ErrorBanner/ErrorBanner.jsx
+++ b/static/src/js/components/ErrorBanner/ErrorBanner.jsx
@@ -2,13 +2,14 @@ import { Button } from 'react-bootstrap'
 import Alert from 'react-bootstrap/Alert'
 import Col from 'react-bootstrap/Col'
 import PropTypes from 'prop-types'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import Row from 'react-bootstrap/Row'
 
 /**
  * @typedef {Object} ErrorBannerProps
  * @property {String} dataTestId A data-testid for the error message
  * @property {String} message A message displaying what error has occurred.
+ * @property {String} previousURL A string that is sent down from PublishPreview only
  */
 
 /**
@@ -20,24 +21,22 @@ export const ErrorBanner = ({
   message,
   previousURL
 }) => {
-  const [hasCMRLagError, setHasCMRLagError] = useState(false)
-  const [conceptIdDoesNotExist, setConceptIdDoesNotExist] = useState(false)
   const currentURL = window.location.pathname
   const conceptKeywords = ['/collections/', '/variables/', '/services/', '/tools/']
 
-  // Catches if we are coming from a published record, indicating this is a CMR lag error
-  useEffect(() => {
-    if (previousURL && conceptKeywords.some((keyword) => previousURL.includes(keyword))) {
-      setHasCMRLagError(true)
+  // Checks to see that the endpoint is correct,
+  // indicating that graphQL made a call that returned null
+  const graphQLCallReturnsNull = (url) => {
+    if (conceptKeywords.some((keyword) => url.includes(keyword))) {
+      return true
     }
 
-    if (currentURL && conceptKeywords.some((keyword) => currentURL.includes(keyword))) {
-      setConceptIdDoesNotExist(true)
-    }
-  }, [])
+    return false
+  }
 
   return (
-    hasCMRLagError ? (
+    // Checks to see if users came from a published record, indicating there is a CMR lag
+    (previousURL && graphQLCallReturnsNull(previousURL)) ? (
       <div>
         <Alert className="fst-italic fs-6" variant="warning">
           <i className="eui-icon eui-fa-info-circle" />
@@ -71,7 +70,7 @@ export const ErrorBanner = ({
 
             <span className="visually-hidden">{' '}</span>
 
-            <p data-testid={dataTestId}>{conceptIdDoesNotExist ? 'This record does not exist' : message}</p>
+            <p data-testid={dataTestId}>{graphQLCallReturnsNull(currentURL) ? 'This record does not exist' : message}</p>
           </Alert>
         </Col>
       </Row>

--- a/static/src/js/components/ErrorBanner/__tests__/ErrorBanner.test.jsx
+++ b/static/src/js/components/ErrorBanner/__tests__/ErrorBanner.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { screen, render } from '@testing-library/react'
 
+import userEvent from '@testing-library/user-event'
+
 import { ErrorBanner } from '../ErrorBanner'
 
 describe('Error Banner Component', () => {
@@ -23,6 +25,34 @@ describe('Error Banner Component', () => {
 
       // Ensure the content is displayed correctly
       expect(screen.getByTestId('test-error')).toHaveTextContent('Cras mattis consectetur purus sit amet fermentum.')
+    })
+  })
+
+  describe('Provided a previousURL', () => {
+    test('it renders an error banner with prompt to refresh the page', async () => {
+      render(
+        <ErrorBanner message="Cras mattis consectetur purus sit amet fermentum." dataTestId="test-error" previousURL="/collections/C100000-TEST_PROV" />
+      )
+
+      // Ensure the content is displayed correctly
+      expect(screen.getByRole('alert', { name: '' })).toHaveTextContent('Some operations may take time to populate in the Common Metadata Repository. If you are not seeing what you expect below, please')
+
+      const refreshButton = screen.getByRole('button', { name: 'refresh the page' })
+      await userEvent.click(refreshButton)
+    })
+  })
+
+  describe('CurrentURL indicates the record does not exist', () => {
+    test('it renders an error banner with message', async () => {
+      const mockCurrentURL = new URL('http://localhost:5173/collections/C1000-TEST_PROV')
+      window.location = mockCurrentURL
+
+      render(
+        <ErrorBanner />
+      )
+
+      // Ensure the content is displayed correctly
+      expect(screen.getByRole('alert', { name: '' })).toHaveTextContent('Sorry! This record does not exist')
     })
   })
 })

--- a/static/src/js/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/static/src/js/components/ErrorBoundary/ErrorBoundary.jsx
@@ -25,10 +25,10 @@ class ErrorBoundary extends React.Component {
 
   render() {
     const { hasError, error } = this.state
-    const { children } = this.props
+    const { children, previousURL } = this.props
 
     if (hasError) {
-      return <ErrorBanner message={parseError(error)} />
+      return <ErrorBanner message={parseError(error)} previousURL={previousURL} />
     }
 
     return children
@@ -36,7 +36,12 @@ class ErrorBoundary extends React.Component {
 }
 
 ErrorBoundary.propTypes = {
-  children: PropTypes.shape({}).isRequired
+  children: PropTypes.shape({}).isRequired,
+  previousURL: PropTypes.string
+}
+
+ErrorBoundary.defaultProps = {
+  previousURL: null
 }
 
 export default ErrorBoundary

--- a/static/src/js/components/PublishPreview/PublishPreview.jsx
+++ b/static/src/js/components/PublishPreview/PublishPreview.jsx
@@ -418,7 +418,7 @@ const PublishPreview = ({ isRevision }) => {
           </Row>
         )
       }
-      <ErrorBoundary>
+      <ErrorBoundary previousURL={window.location.pathname}>
         <Suspense fallback={<PublishPreviewPlaceholder />}>
           <MetadataPreview
             conceptId={conceptId}


### PR DESCRIPTION
# Overview

### What is the feature?

When I try to clone a collection and edit, I get the following error (see attached screen shot for details). 
Sorry! Cannot destructure property 'nativeId' of 'Tr' as it is null. See the collection record: 
https://mmt.uat.earthdatacloud.nasa.gov/drafts/collections/CD1269208926-MMT_2 

### What is the Solution?

There are three use cases I'm trying to solve with this:
1. Render the old banner when appropriate 
<img width="1712" alt="Screenshot 2024-09-06 at 2 05 39 PM" src="https://github.com/user-attachments/assets/7fe885df-7131-4f0e-aad8-67e7841b4519">

2. Render an error banner that says "Sorry, the record does not exist" instead of 'Cannot deconstruct 'granules' of 'Cr' as draft is null.' when a record doesn't exist (this is based on the currentURL)
<img width="1706" alt="Screenshot 2024-09-06 at 2 08 37 PM" src="https://github.com/user-attachments/assets/1ee5cc44-b2fd-4191-b544-4bbee39242d4">

3. Render a prompt that tells users to refresh the page if they've come from trying to clone or edit a published record (this is based on the previousURL)
<img width="1710" alt="Screenshot 2024-09-06 at 2 09 22 PM" src="https://github.com/user-attachments/assets/956764d0-6853-4ccb-a55b-3b646d35f742">

### What areas of the application does this impact?

ErrorBanner, ErrorBoundary, and PublishPreview

# Testing

### Reproduction steps

- **Environment for testing: you may run this locally toggle lines 23 and 24 in ErrorBanner to get all use cases
- **Collection to test with:**

1. Make sure application runs as expected when spinning up locally. As in, you can click 'clone' on a published record and it works. 
2. Toggler line 27 in ErrorBoundary to if (!hasError) to see basic error.
3. Toggle line 23 in ErrorBanner to see what happens when the logic decides that cmr is lagging (***please let me know of any other use cases of cmr lagging we'd want to include here)
4. Toggle line 24 to see what happens if the record doesn't exist. 

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings