### PR TITLE
Mmt 3877b: Error When Cloning and Editing a Draft Collection

### DIFF
--- a/static/src/js/components/DraftPreview/DraftPreview.jsx
+++ b/static/src/js/components/DraftPreview/DraftPreview.jsx
@@ -75,7 +75,7 @@ const DraftPreview = () => {
         <Row>
           <Col md={12} className="draft-preview__preview">
             <h2 className="fw-bold fs-4">Preview</h2>
-            <ErrorBoundary>
+            <ErrorBoundary previousUrl={window.location.pathname}>
               <MetadataPreview
                 conceptId={conceptId}
                 conceptType={derivedConceptType}

--- a/static/src/js/components/DraftPreview/DraftPreview.jsx
+++ b/static/src/js/components/DraftPreview/DraftPreview.jsx
@@ -75,7 +75,7 @@ const DraftPreview = () => {
         <Row>
           <Col md={12} className="draft-preview__preview">
             <h2 className="fw-bold fs-4">Preview</h2>
-            <ErrorBoundary previousUrl={window.location.pathname}>
+            <ErrorBoundary>
               <MetadataPreview
                 conceptId={conceptId}
                 conceptType={derivedConceptType}

--- a/static/src/js/components/DraftPreview/DraftPreview.jsx
+++ b/static/src/js/components/DraftPreview/DraftPreview.jsx
@@ -43,6 +43,11 @@ const DraftPreview = () => {
 
   const { draft } = data
 
+  // This may be due to a CMR lag error and affects functionality in ErrorBanner
+  if (!draft) {
+    throw new Error('draft is null')
+  }
+
   const {
     ummMetadata
   } = draft

--- a/static/src/js/components/ErrorBanner/ErrorBanner.jsx
+++ b/static/src/js/components/ErrorBanner/ErrorBanner.jsx
@@ -19,11 +19,7 @@ export const ErrorBanner = ({
   dataTestId,
   message
 }) => {
-  const knownCMRLagErrors = [
-    'Cannot destructure property \'granules\' of \'concept\' as it is null.',
-    'Cannot destructure property \'granules\' of \'Cr\' as it is null.',
-    'Cannot destructure property \'nativeId\' of \'Tr\' as it is null.',
-    'Cannot destructure property \'nativeId\' of \'draft\' as it is null.']
+  const knownCMRLagErrors = ['draft is null', 'concept is null']
 
   // Checks to see if error message is a known CMR Lag Error Message
   const isKnownCMRLagError = () => {

--- a/static/src/js/components/ErrorBanner/ErrorBanner.jsx
+++ b/static/src/js/components/ErrorBanner/ErrorBanner.jsx
@@ -9,7 +9,6 @@ import Row from 'react-bootstrap/Row'
  * @typedef {Object} ErrorBannerProps
  * @property {String} dataTestId A data-testid for the error message
  * @property {String} message A message displaying what error has occurred.
- * @property {String} previousURL A string that is sent down from PublishPreview only
  */
 
 /**
@@ -18,16 +17,17 @@ import Row from 'react-bootstrap/Row'
  */
 export const ErrorBanner = ({
   dataTestId,
-  message,
-  previousURL
+  message
 }) => {
-  const currentURL = window.location.pathname
-  const conceptKeywords = ['/collections/', '/variables/', '/services/', '/tools/']
+  const knownCMRLagErrors = [
+    'Cannot destructure property \'granules\' of \'concept\' as it is null.',
+    'Cannot destructure property \'granules\' of \'Cr\' as it is null.',
+    'Cannot destructure property \'nativeId\' of \'Tr\' as it is null.',
+    'Cannot destructure property \'nativeId\' of \'draft\' as it is null.']
 
-  // Checks to see that the url is a concept URL,
-  // indicating that graphQL made a call that returned null
-  const isConceptUrl = (url) => {
-    if (conceptKeywords.some((keyword) => url.includes(keyword))) {
+  // Checks to see if error message is a known CMR Lag Error Message
+  const isKnownCMRLagError = () => {
+    if (knownCMRLagErrors.some((knownError) => message.includes(knownError))) {
       return true
     }
 
@@ -35,13 +35,13 @@ export const ErrorBanner = ({
   }
 
   return (
-    (previousURL && isConceptUrl(previousURL)) ? (
+    (isKnownCMRLagError()) ? (
       <div>
         <Alert className="fst-italic fs-6" variant="warning">
           <i className="eui-icon eui-fa-info-circle" />
           {' '}
           Some operations may take time to populate in the Common Metadata Repository.
-          If you are not seeing what you expect below, please
+          If you are not seeing what you expect below, consider
           {' '}
           <Button
             onClick={() => window.location.reload()}
@@ -57,8 +57,13 @@ export const ErrorBanner = ({
               }
             }
           >
-            refresh the page
+            refreshing the page
           </Button>
+          .
+          {' '}
+          If it has been over 24 hours and your record has
+          {' '}
+          not been updated, please contact support@earthdata.nasa.gov.
         </Alert>
       </div>
     ) : (
@@ -69,7 +74,7 @@ export const ErrorBanner = ({
 
             <span className="visually-hidden">{' '}</span>
 
-            <p data-testid={dataTestId}>{isConceptUrl(currentURL) ? 'This record does not exist' : message}</p>
+            <p data-testid={dataTestId}>{message}</p>
           </Alert>
         </Col>
       </Row>
@@ -79,13 +84,11 @@ export const ErrorBanner = ({
 
 ErrorBanner.propTypes = {
   dataTestId: PropTypes.string,
-  message: PropTypes.string.isRequired,
-  previousURL: PropTypes.string
+  message: PropTypes.string.isRequired
 }
 
 ErrorBanner.defaultProps = {
-  dataTestId: 'error-banner__message',
-  previousURL: null
+  dataTestId: 'error-banner__message'
 }
 
 export default ErrorBanner

--- a/static/src/js/components/ErrorBanner/__tests__/ErrorBanner.test.jsx
+++ b/static/src/js/components/ErrorBanner/__tests__/ErrorBanner.test.jsx
@@ -31,7 +31,7 @@ describe('Error Banner Component', () => {
   describe('Provided a known CMR Error Message', () => {
     test('it renders an error banner with prompt to refresh the page', async () => {
       render(
-        <ErrorBanner message="Cannot destructure property 'granules' of 'concept' as it is null." dataTestId="test-error" />
+        <ErrorBanner message="draft is null" dataTestId="test-error" />
       )
 
       // Ensure the content is displayed correctly

--- a/static/src/js/components/ErrorBanner/__tests__/ErrorBanner.test.jsx
+++ b/static/src/js/components/ErrorBanner/__tests__/ErrorBanner.test.jsx
@@ -28,31 +28,17 @@ describe('Error Banner Component', () => {
     })
   })
 
-  describe('Provided a previousURL', () => {
+  describe('Provided a known CMR Error Message', () => {
     test('it renders an error banner with prompt to refresh the page', async () => {
       render(
-        <ErrorBanner message="Cras mattis consectetur purus sit amet fermentum." dataTestId="test-error" previousURL="/collections/C100000-TEST_PROV" />
+        <ErrorBanner message="Cannot destructure property 'granules' of 'concept' as it is null." dataTestId="test-error" />
       )
 
       // Ensure the content is displayed correctly
-      expect(screen.getByRole('alert', { name: '' })).toHaveTextContent('Some operations may take time to populate in the Common Metadata Repository. If you are not seeing what you expect below, please')
+      expect(screen.getByRole('alert', { name: '' })).toHaveTextContent('Some operations may take time to populate in the Common Metadata Repository. If you are not seeing what you expect below, consider refreshing the page. If it has been over 24 hours and your record has not been updated, please contact support@earthdata.nasa.gov.')
 
-      const refreshButton = screen.getByRole('button', { name: 'refresh the page' })
+      const refreshButton = screen.getByRole('button', { name: 'refreshing the page' })
       await userEvent.click(refreshButton)
-    })
-  })
-
-  describe('CurrentURL indicates the record does not exist', () => {
-    test('it renders an error banner with message', async () => {
-      const mockCurrentURL = new URL('http://localhost:5173/collections/C1000-TEST_PROV')
-      window.location = mockCurrentURL
-
-      render(
-        <ErrorBanner />
-      )
-
-      // Ensure the content is displayed correctly
-      expect(screen.getByRole('alert', { name: '' })).toHaveTextContent('Sorry! This record does not exist')
     })
   })
 })

--- a/static/src/js/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/static/src/js/components/ErrorBoundary/ErrorBoundary.jsx
@@ -25,10 +25,10 @@ class ErrorBoundary extends React.Component {
 
   render() {
     const { hasError, error } = this.state
-    const { children, previousURL } = this.props
+    const { children } = this.props
 
     if (hasError) {
-      return <ErrorBanner message={parseError(error)} previousURL={previousURL} />
+      return <ErrorBanner message={parseError(error)} />
     }
 
     return children
@@ -36,12 +36,7 @@ class ErrorBoundary extends React.Component {
 }
 
 ErrorBoundary.propTypes = {
-  children: PropTypes.shape({}).isRequired,
-  previousURL: PropTypes.string
-}
-
-ErrorBoundary.defaultProps = {
-  previousURL: null
+  children: PropTypes.shape({}).isRequired
 }
 
 export default ErrorBoundary

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -82,7 +82,9 @@ const Layout = ({ className, displayNav }) => {
             </Alert>
           )
         }
-        <ErrorBoundary>
+        {console.log('Layout ErrorBoundary')}
+        {/* <ErrorBoundary> */}
+        <ErrorBoundary previousURL={window.location.pathname}>
           <main
             className={
               classNames([

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -82,8 +82,6 @@ const Layout = ({ className, displayNav }) => {
             </Alert>
           )
         }
-        {console.log('Layout ErrorBoundary')}
-        {/* <ErrorBoundary> */}
         <ErrorBoundary previousURL={window.location.pathname}>
           <main
             className={

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -82,7 +82,7 @@ const Layout = ({ className, displayNav }) => {
             </Alert>
           )
         }
-        <ErrorBoundary previousURL={window.location.pathname}>
+        <ErrorBoundary>
           <main
             className={
               classNames([

--- a/static/src/js/components/PublishPreview/PublishPreview.jsx
+++ b/static/src/js/components/PublishPreview/PublishPreview.jsx
@@ -97,6 +97,11 @@ const PublishPreviewHeader = () => {
 
   const { [derivedConceptType.toLowerCase()]: concept } = data
 
+  // This may be due to a CMR lag error and affects functionality in ErrorBanner
+  if (!concept) {
+    throw new Error('concept is null')
+  }
+
   const {
     granules,
     nativeId,
@@ -418,7 +423,7 @@ const PublishPreview = ({ isRevision }) => {
           </Row>
         )
       }
-      <ErrorBoundary previousURL={window.location.pathname}>
+      <ErrorBoundary>
         <Suspense fallback={<PublishPreviewPlaceholder />}>
           <MetadataPreview
             conceptId={conceptId}

--- a/static/src/js/pages/DraftPage/DraftPage.jsx
+++ b/static/src/js/pages/DraftPage/DraftPage.jsx
@@ -86,6 +86,11 @@ const DraftPageHeader = () => {
 
   const { draft = {} } = data
 
+  // This may be due to a CMR lag error and affects functionality in ErrorBanner
+  if (!draft) {
+    throw new Error('draft is null')
+  }
+
   const {
     nativeId,
     providerId,

--- a/static/src/js/pages/DraftPage/DraftPage.jsx
+++ b/static/src/js/pages/DraftPage/DraftPage.jsx
@@ -278,7 +278,7 @@ const DraftPage = () => (
     pageType="secondary"
     header={<DraftPageHeader />}
   >
-    <ErrorBoundary previousURL={window.location.pathname}>
+    <ErrorBoundary>
       <Suspense fallback={<DraftPagePlaceholder />}>
         <DraftPreview />
       </Suspense>

--- a/static/src/js/pages/DraftPage/DraftPage.jsx
+++ b/static/src/js/pages/DraftPage/DraftPage.jsx
@@ -278,7 +278,7 @@ const DraftPage = () => (
     pageType="secondary"
     header={<DraftPageHeader />}
   >
-    <ErrorBoundary>
+    <ErrorBoundary previousURL={window.location.pathname}>
       <Suspense fallback={<DraftPagePlaceholder />}>
         <DraftPreview />
       </Suspense>


### PR DESCRIPTION
# Overview

### What is the bug?
Errors occur during two particular use cases:

Collections >> Collection >> Clone >> 'Cannot destructure property \'nativeId\' of \'Tr\' as it is null.' (this error comes from DraftPage.jsx line 90 when MMT tries to ask for the draft but the draft doesn't exist in CMR yet)

Collections >> Collection >> Clone >> Edit >> Save & Publish >> 'Cannot destructure property \'granules\' of \'Cr\' as it is null.' (this error comes from PublishPreview.jsx line 101 when MMT tries to ask for the published record but it doesn't exist in CMR yet) 

Please summarize the feature or fix.

Initially, the thought was that we should use useHistory for this bug. If a user is coming from publishpreview or is coming from draftpage, then render a refresh banner. But there are two issues with this:
1) useHistory is not supported for react-router v6 or above. https://stackoverflow.com/questions/63471931/using-history-with-react-router-dom-v6 it is recommended that you use useNavigation. If you looke up history npm, the use cases are only for actions and blocking certain transitions. There does not appear to be an array of pash urls saved for reference. 
2) Even if I could access history, I don't believe it is wise to use a url as a metric for what error to throw. What if a user does another type of action on PublishPreview or DraftPage that causes an error? It would throw a refresh banner no matter what. 

Rather than use useHistory, I have opted to render a refresh banner based on those repeatable errors I listed above. 

### What is the Solution?

Adding knownCMRLagErrors to ErrorBanner

### What areas of the application does this impact?

ErrorBanner.jsx

# Testing

### Reproduction steps

- **Environment for testing: SIT or UAT
- **Collection to test with: Any

1. From a collection, click clone until you receive the refresh page error message. Let me know if you get 'record does not exist'
2. From a clone, click edit, add in a short name and entry title, then click Save & Publish until you receive the refresh page error message. Again, let me know if you receive any other error. 
3. Try to trigger error banners in any other areas around the app. I want to be sure this fix doesn't accidentally affect other areas that it shouldn't. 

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings