### PR TITLE
SAP-129: Saving Collection Permissions ACLs is removing all but 20 selected collections

### DIFF
--- a/static/src/js/components/CollectionSelector/CollectionSelector.jsx
+++ b/static/src/js/components/CollectionSelector/CollectionSelector.jsx
@@ -56,7 +56,13 @@ const CollectionSelector = ({ onChange, formData }) => {
 
   const [loading, setLoading] = useState(false)
 
-  const { data: collectionList } = useSuspenseQuery(GET_PERMISSION_COLLECTIONS)
+  const { data: collectionList } = useSuspenseQuery(GET_PERMISSION_COLLECTIONS, {
+    variables: {
+      params: {
+        limit: 100
+      }
+    }
+  })
 
   const { collections } = collectionList
   const { items } = collections

--- a/static/src/js/components/CollectionSelector/__tests__/CollectionSelector.test.jsx
+++ b/static/src/js/components/CollectionSelector/__tests__/CollectionSelector.test.jsx
@@ -29,7 +29,11 @@ const setup = ({
       [{
         request: {
           query: GET_PERMISSION_COLLECTIONS,
-          variables: {}
+          variables: {
+            params: {
+              limit: 100
+            }
+          }
         },
         result: {
           data: {
@@ -229,7 +233,7 @@ describe('CollectionSelector', () => {
               params: {
                 options: { shortName: { pattern: true } },
                 shortName: 'C*',
-                limit: 20
+                limit: 100
               }
             }
           },
@@ -266,7 +270,7 @@ describe('CollectionSelector', () => {
 
       await user.type(searchField, 'C')
 
-      expect(await screen.findByText('Showing 1 items')).toBeInTheDocument()
+      expect(await screen.findByText('Showing 2 items')).toBeInTheDocument()
     })
   })
 
@@ -297,7 +301,7 @@ describe('CollectionSelector', () => {
             variables: {
               params: {
                 keyword: 'Col',
-                limit: 20
+                limit: 100
               }
             }
           },

--- a/static/src/js/components/PermissionForm/PermissionForm.jsx
+++ b/static/src/js/components/PermissionForm/PermissionForm.jsx
@@ -220,7 +220,10 @@ const PermissionForm = () => {
   const { data } = useSuspenseQuery(GET_COLLECTION_FOR_PERMISSION_FORM, {
     skip: conceptId === 'new',
     variables: {
-      conceptId
+      conceptId,
+      params: {
+        limit: 2000
+      }
     }
   })
 

--- a/static/src/js/components/PermissionForm/__tests__/PermissionForm.test.jsx
+++ b/static/src/js/components/PermissionForm/__tests__/PermissionForm.test.jsx
@@ -196,7 +196,12 @@ describe('PermissionForm', () => {
           {
             request: {
               query: GET_COLLECTION_FOR_PERMISSION_FORM,
-              variables: { conceptId: 'ACL1000000-MMT' }
+              variables: {
+                conceptId: 'ACL1000000-MMT',
+                params: {
+                  limit: 2000
+                }
+              }
             },
             result: {
               data: {
@@ -362,7 +367,12 @@ describe('PermissionForm', () => {
           {
             request: {
               query: GET_COLLECTION_FOR_PERMISSION_FORM,
-              variables: { conceptId: 'ACL1000000-MMT' }
+              variables: {
+                conceptId: 'ACL1000000-MMT',
+                params: {
+                  limit: 2000
+                }
+              }
             },
             result: {
               data: {
@@ -570,7 +580,12 @@ describe('PermissionForm', () => {
             {
               request: {
                 query: GET_COLLECTION_FOR_PERMISSION_FORM,
-                variables: { conceptId: 'ACL1000000-MMT' }
+                variables: {
+                  conceptId: 'ACL1000000-MMT',
+                  params: {
+                    limit: 2000
+                  }
+                }
               },
               result: {
                 data: {
@@ -708,7 +723,12 @@ describe('PermissionForm', () => {
             {
               request: {
                 query: GET_COLLECTION_FOR_PERMISSION_FORM,
-                variables: { conceptId: 'ACL1000000-MMT' }
+                variables: {
+                  conceptId: 'ACL1000000-MMT',
+                  params: {
+                    limit: 2000
+                  }
+                }
               },
               result: {
                 data: {
@@ -807,7 +827,12 @@ describe('PermissionForm', () => {
             {
               request: {
                 query: GET_COLLECTION_FOR_PERMISSION_FORM,
-                variables: { conceptId: 'ACL1000000-MMT' }
+                variables: {
+                  conceptId: 'ACL1000000-MMT',
+                  params: {
+                    limit: 2000
+                  }
+                }
               },
               result: {
                 data: {

--- a/static/src/js/operations/queries/getCollectionForPermissionForm.js
+++ b/static/src/js/operations/queries/getCollectionForPermissionForm.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export const GET_COLLECTION_FOR_PERMISSION_FORM = gql`
-  query GetCollectionForPermissionForm($conceptId: String!) {
+  query GetCollectionForPermissionForm($conceptId: String!, $params: CollectionsInput) {
     acl(conceptId: $conceptId) {
       catalogItemIdentity {
       providerId
@@ -19,7 +19,7 @@ export const GET_COLLECTION_FOR_PERMISSION_FORM = gql`
         userType
       }
     }
-    collections {
+    collections(params: $params) {
       items {
         conceptId,
         shortName,


### PR DESCRIPTION
# Overview

### What is the feature?

There is a bug in the PermissionForm where it would only load the first 20 selected collections, even though the user may have had 100s.   As a result, when the user saved the permission form, it would only save the first 20 resulting in the rest of the collections be removed from the ACL.

### What is the Solution?

As a temporary solution, I've bumped up the limit parameter to graphql to pull up to 2000 collections.   I've also bumped up the available collections limit to 100, as users where stating that 20 was not large enough list size, due to some searches by short name having more than 20.

A permanent solution to this ticket will be to support more than 2000 selected collections but will require a bit more work.   Also the users would like the search within available collections to be more than just short name.

### What areas of the application does this impact?

The collection permissions form.

# Testing

Find a collection permission with more than 20 selected collections and verify you can see them all in the selected collections pane.   Also verify the available collections pane shows 100 filtered collections.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings