### PR TITLE
MMT-3899: Temporarily removing Permissions Pages

### DIFF
--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -140,20 +140,36 @@ export const App = () => {
             },
             {
               path: '/permissions',
-              element: <PermissionListPage />
+              element: <Navigate replace to='/404' />
             },
+            // {
+            //   path: '/permissions',
+            //   element: <PermissionListPage />
+            // },
             {
               path: '/permissions/new',
-              element: <PermissionFormPage />
+              element: <Navigate replace to='/404' />
             },
+            // {
+            //   path: '/permissions/new',
+            //   element: <PermissionFormPage />
+            // },
             {
               path: '/permissions/:conceptId/edit',
-              element: <PermissionFormPage />
+              element: <Navigate replace to='/404' />
             },
+            // {
+            //   path: '/permissions/:conceptId/edit',
+            //   element: <PermissionFormPage />
+            // },
             {
               path: '/permissions/:conceptId',
-              element: <PermissionPage />
+              element: <Navigate replace to='/404' />
             },
+            // {
+            //   path: '/permissions/:conceptId',
+            //   element: <PermissionPage />
+            // },
             {
               path: '/order-options',
               element: <OrderOptionListPage />

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -138,11 +138,11 @@ const Layout = ({ className, displayNav }) => {
                                   {
                                     to: '/templates/collections',
                                     title: 'Templates'
-                                  },
-                                  {
-                                    to: '/permissions',
-                                    title: 'Permissions'
                                   }
+                                  // {
+                                  //   to: '/permissions',
+                                  //   title: 'Permissions'
+                                  // }
                                 ]
                               },
                               {


### PR DESCRIPTION
# Overview

### What is the feature?

Please summarize the feature or fix.
Currently we are seeing issues adding collections to ACLs, issues with the tables, and corruption of the ACL collection records, so we need to disable this until we can further investigate.
### What is the Solution?

Remove link and add redirect to 404 page so no one can access bookmarks

### What areas of the application does this impact?

List impacted areas.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Try to access an permissions page

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings