### PR TITLE
Mmt 3902: As a user, I would like to paginate through my collection associations

### DIFF
--- a/static/src/js/components/ManageCollectionAssociation/ManageCollectionAssociation.jsx
+++ b/static/src/js/components/ManageCollectionAssociation/ManageCollectionAssociation.jsx
@@ -243,7 +243,7 @@ const ManageCollectionAssociation = () => {
   const lastResultIndex = firstResultIndex + (isLastPage ? count % limit : limit)
 
   const paginationMessage = count > 0
-    ? `Showing ${totalPages > 1 ? `Collection Associations ${firstResultIndex + 1}-${lastResultIndex} of ${count}` : `${count} ${pluralize('collection association', count)}`}`
+    ? `Showing ${totalPages > 1 ? `Collection Associations ${firstResultIndex + 1}-${lastResultIndex} of ${count}` : `${count} ${pluralize('Collection Association', count)}`}`
     : 'No Collection Associations found'
 
   return (

--- a/static/src/js/components/ManageCollectionAssociation/ManageCollectionAssociation.jsx
+++ b/static/src/js/components/ManageCollectionAssociation/ManageCollectionAssociation.jsx
@@ -206,8 +206,6 @@ const ManageCollectionAssociation = () => {
 
       return Object.fromEntries(currentParams)
     })
-
-    refetch()
   }
 
   const toggleShowDeleteModal = (nextState) => {

--- a/static/src/js/components/ManageCollectionAssociation/__tests__/ManageCollectionAssociation.test.jsx
+++ b/static/src/js/components/ManageCollectionAssociation/__tests__/ManageCollectionAssociation.test.jsx
@@ -110,7 +110,7 @@ describe('ManageCollectionAssociation', () => {
     test('renders the collection association page with the associated collections', async () => {
       setup({})
 
-      expect(await screen.findByText('Showing 2 collection associations')).toBeInTheDocument()
+      expect(await screen.findByText('Showing 2 Collection Associations')).toBeInTheDocument()
       expect(screen.getByText('CIESIN_SEDAC_ESI_2000')).toBeInTheDocument()
       expect(screen.getByText('CIESIN_SEDAC_ESI_2001')).toBeInTheDocument()
     })
@@ -178,7 +178,7 @@ describe('ManageCollectionAssociation', () => {
         const noButton = screen.getByRole('button', { name: 'No' })
         await user.click(noButton)
 
-        expect(await screen.findByText('Showing 2 collection associations')).toBeInTheDocument()
+        expect(await screen.findByText('Showing 2 Collection Associations')).toBeInTheDocument()
         expect(screen.getByText('CIESIN_SEDAC_ESI_2000')).toBeInTheDocument()
         expect(screen.getByText('CIESIN_SEDAC_ESI_2001')).toBeInTheDocument()
       })

--- a/static/src/js/components/ManageCollectionAssociation/__tests__/ManageCollectionAssociation.test.jsx
+++ b/static/src/js/components/ManageCollectionAssociation/__tests__/ManageCollectionAssociation.test.jsx
@@ -123,9 +123,11 @@ describe('ManageCollectionAssociation', () => {
       })
 
       expect(await screen.findByText('Showing Collection Associations 1-20 of 50'))
-
       const paginationButton = screen.getByRole('button', { name: 'Goto Page 3' })
       await user.click(paginationButton)
+
+      expect(await screen.findByText('Showing Collection Associations 41-50 of 50'))
+
     })
   })
 

--- a/static/src/js/components/ManageCollectionAssociation/__tests__/ManageCollectionAssociation.test.jsx
+++ b/static/src/js/components/ManageCollectionAssociation/__tests__/ManageCollectionAssociation.test.jsx
@@ -127,7 +127,6 @@ describe('ManageCollectionAssociation', () => {
       await user.click(paginationButton)
 
       expect(await screen.findByText('Showing Collection Associations 41-50 of 50'))
-
     })
   })
 

--- a/static/src/js/components/ManageCollectionAssociation/__tests__/ManageCollectionAssociation.test.jsx
+++ b/static/src/js/components/ManageCollectionAssociation/__tests__/ManageCollectionAssociation.test.jsx
@@ -27,6 +27,8 @@ import {
   deletedAssociationResponse,
   toolRecordSearch,
   toolRecordSearchError,
+  toolRecordSearchTestPage,
+  toolRecordSearchwithPages,
   toolRecordSortSearch
 } from './__mocks__/manageCollectionAssociationResults'
 
@@ -111,6 +113,19 @@ describe('ManageCollectionAssociation', () => {
       expect(await screen.findByText('Showing 2 collection associations')).toBeInTheDocument()
       expect(screen.getByText('CIESIN_SEDAC_ESI_2000')).toBeInTheDocument()
       expect(screen.getByText('CIESIN_SEDAC_ESI_2001')).toBeInTheDocument()
+    })
+  })
+
+  describe('when paging through the table', () => {
+    test('navigate to the next page', async () => {
+      const { user } = setup({
+        overrideMocks: [toolRecordSearchTestPage, toolRecordSearchwithPages]
+      })
+
+      expect(await screen.findByText('Showing Collection Associations 1-20 of 50'))
+
+      const paginationButton = screen.getByRole('button', { name: 'Goto Page 3' })
+      await user.click(paginationButton)
     })
   })
 
@@ -300,7 +315,11 @@ describe('ManageCollectionAssociation', () => {
             ...toolRecordSortSearch.request,
             variables: {
               ...toolRecordSortSearch.request.variables,
-              collectionsParams: { sortKey: '-shortName' }
+              collectionsParams: {
+                limit: 20,
+                offset: 0,
+                sortKey: '-shortName'
+              }
             }
           },
           result: toolRecordSortSearch.result

--- a/static/src/js/components/ManageCollectionAssociation/__tests__/__mocks__/manageCollectionAssociationResults.js
+++ b/static/src/js/components/ManageCollectionAssociation/__tests__/__mocks__/manageCollectionAssociationResults.js
@@ -7,6 +7,10 @@ export const toolRecordSearch = {
     variables: {
       params: {
         conceptId: 'T1200000-TEST'
+      },
+      collectionsParams: {
+        limit: 20,
+        offset: 0
       }
     }
   },
@@ -137,13 +141,297 @@ export const toolRecordSearch = {
     }
   }
 }
+export const toolRecordSearchwithPages = {
+  request: {
+    query: GET_TOOL,
+    variables: {
+      params: {
+        conceptId: 'T1200000-TEST'
+      },
+      collectionsParams: {
+        limit: 20,
+        offset: 40
+      }
+    }
+  },
+  result: {
+    data: {
+      tool: {
+        __typename: 'Tool',
+        accessConstraints: null,
+        ancillaryKeywords: null,
+        associationDetails: {
+          collections: [{
+            conceptId: 'C120000001-TEST'
+          }, {
+            conceptId: 'C120000002-TEST'
+          }]
+        },
+        collections: {
+          count: 50,
+          items: [
+            {
+              title: 'Associated Collection 1',
+              conceptId: 'C120000001-TEST',
+              entryTitle: 'Associated Collection 1',
+              shortName: 'CIESIN_SEDAC_ESI_2000',
+              version: '2000.00',
+              provider: 'SEDAC',
+              __typename: 'Collection'
+            },
+            {
+              title: 'Associated Collection 2',
+              conceptId: 'C120000002-TEST',
+              entryTitle: 'Associated Collection 2',
+              shortName: 'CIESIN_SEDAC_ESI_2001',
+              version: '2001.00',
+              provider: 'SEDAC',
+              __typename: 'Collection'
+            }
+          ],
+          __typename: 'CollectionList'
+        },
+        conceptId: 'T1200000-TEST',
+        contactGroups: null,
+        contactPersons: null,
+        description: '312',
+        doi: null,
+        lastUpdatedDate: null,
+        longName: '123',
+        metadataSpecification: {
+          name: 'UMM-T',
+          url: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.2.0',
+          version: '1.2.0'
+        },
+        name: 'Testing publish with routes',
+        nativeId: 'Test-123',
+        organizations: [{
+          longName: 'Woods Hole Science Center, Coastal and Marine Geology, U.S. Geological Survey, U.S. Department of the Interior',
+          roles: ['DEVELOPER'],
+          shortName: 'DOI/USGS/CMG/WHSC',
+          urlValue: 'http://woodshole.er.usgs.gov/'
+        }],
+        pageTitle: 'Testing publish with routes',
+        potentialAction: null,
+        providerId: 'MMT_2',
+        quality: null,
+        relatedUrls: null,
+        revisionDate: '2024-03-19T17:05:21.642Z',
+        revisionId: '1',
+        revisions: {
+          __typename: 'ToolRevisionList',
+          count: 1,
+          items: [{
+            __typename: 'Tool',
+            conceptId: 'T1200000-TEST',
+            revisionDate: '2024-04-25T17:11:57.611Z',
+            revisionId: '1',
+            userId: 'ECHO_SYS'
+          }]
+        },
+        searchAction: null,
+        supportedBrowsers: null,
+        supportedInputFormats: null,
+        supportedOperatingSystems: null,
+        supportedOutputFormats: null,
+        supportedSoftwareLanguages: null,
+        toolKeywords: [{
+          toolCategory: 'EARTH SCIENCE SERVICES',
+          toolTerm: 'CALIBRATION/VALIDATION',
+          toolTopic: 'DATA ANALYSIS AND VISUALIZATION'
+        }],
+        type: 'Model',
+        ummMetadata: {
+          Description: '312',
+          LongName: '123',
+          MetadataSpecification: {
+            Name: 'UMM-T',
+            URL: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.2.0',
+            Version: '1.2.0'
+          },
+          Name: 'Testing publish with routes',
+          Organizations: [{
+            LongName: 'Woods Hole Science Center, Coastal and Marine Geology, U.S. Geological Survey, U.S. Department of the Interior',
+            Roles: ['DEVELOPER'],
+            ShortName: 'DOI/USGS/CMG/WHSC',
+            URLValue: 'http://woodshole.er.usgs.gov/'
+          }],
+          ToolKeywords: [{
+            ToolCategory: 'EARTH SCIENCE SERVICES',
+            ToolTerm: 'CALIBRATION/VALIDATION',
+            ToolTopic: 'DATA ANALYSIS AND VISUALIZATION'
+          }],
+          Type: 'Model',
+          URL: {
+            Type: 'DOWNLOAD SOFTWARE',
+            URLContentType: 'DistributionURL',
+            URLValue: '132'
+          },
+          Version: '123'
+        },
+        url: {
+          type: 'DOWNLOAD SOFTWARE',
+          urlContentType: 'DistributionURL',
+          urlValue: '132'
+        },
+        useConstraints: null,
+        version: '123',
+        versionDescription: null
+      }
+    }
+  }
+}
+export const toolRecordSearchTestPage = {
+  request: {
+    query: GET_TOOL,
+    variables: {
+      params: {
+        conceptId: 'T1200000-TEST'
+      },
+      collectionsParams: {
+        limit: 20,
+        offset: 0
+      }
+    }
+  },
+  result: {
+    data: {
+      tool: {
+        __typename: 'Tool',
+        accessConstraints: null,
+        ancillaryKeywords: null,
+        associationDetails: {
+          collections: [{
+            conceptId: 'C120000001-TEST'
+          }, {
+            conceptId: 'C120000002-TEST'
+          }]
+        },
+        collections: {
+          count: 50,
+          items: [
+            {
+              title: 'Associated Collection 1',
+              conceptId: 'C120000001-TEST',
+              entryTitle: 'Associated Collection 1',
+              shortName: 'CIESIN_SEDAC_ESI_2000',
+              version: '2000.00',
+              provider: 'SEDAC',
+              __typename: 'Collection'
+            },
+            {
+              title: 'Associated Collection 2',
+              conceptId: 'C120000002-TEST',
+              entryTitle: 'Associated Collection 2',
+              shortName: 'CIESIN_SEDAC_ESI_2001',
+              version: '2001.00',
+              provider: 'SEDAC',
+              __typename: 'Collection'
+            }
+          ],
+          __typename: 'CollectionList'
+        },
+        conceptId: 'T1200000-TEST',
+        contactGroups: null,
+        contactPersons: null,
+        description: '312',
+        doi: null,
+        lastUpdatedDate: null,
+        longName: '123',
+        metadataSpecification: {
+          name: 'UMM-T',
+          url: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.2.0',
+          version: '1.2.0'
+        },
+        name: 'Testing publish with routes',
+        nativeId: 'Test-123',
+        organizations: [{
+          longName: 'Woods Hole Science Center, Coastal and Marine Geology, U.S. Geological Survey, U.S. Department of the Interior',
+          roles: ['DEVELOPER'],
+          shortName: 'DOI/USGS/CMG/WHSC',
+          urlValue: 'http://woodshole.er.usgs.gov/'
+        }],
+        pageTitle: 'Testing publish with routes',
+        potentialAction: null,
+        providerId: 'MMT_2',
+        quality: null,
+        relatedUrls: null,
+        revisionDate: '2024-03-19T17:05:21.642Z',
+        revisionId: '1',
+        revisions: {
+          __typename: 'ToolRevisionList',
+          count: 1,
+          items: [{
+            __typename: 'Tool',
+            conceptId: 'T1200000-TEST',
+            revisionDate: '2024-04-25T17:11:57.611Z',
+            revisionId: '1',
+            userId: 'ECHO_SYS'
+          }]
+        },
+        searchAction: null,
+        supportedBrowsers: null,
+        supportedInputFormats: null,
+        supportedOperatingSystems: null,
+        supportedOutputFormats: null,
+        supportedSoftwareLanguages: null,
+        toolKeywords: [{
+          toolCategory: 'EARTH SCIENCE SERVICES',
+          toolTerm: 'CALIBRATION/VALIDATION',
+          toolTopic: 'DATA ANALYSIS AND VISUALIZATION'
+        }],
+        type: 'Model',
+        ummMetadata: {
+          Description: '312',
+          LongName: '123',
+          MetadataSpecification: {
+            Name: 'UMM-T',
+            URL: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.2.0',
+            Version: '1.2.0'
+          },
+          Name: 'Testing publish with routes',
+          Organizations: [{
+            LongName: 'Woods Hole Science Center, Coastal and Marine Geology, U.S. Geological Survey, U.S. Department of the Interior',
+            Roles: ['DEVELOPER'],
+            ShortName: 'DOI/USGS/CMG/WHSC',
+            URLValue: 'http://woodshole.er.usgs.gov/'
+          }],
+          ToolKeywords: [{
+            ToolCategory: 'EARTH SCIENCE SERVICES',
+            ToolTerm: 'CALIBRATION/VALIDATION',
+            ToolTopic: 'DATA ANALYSIS AND VISUALIZATION'
+          }],
+          Type: 'Model',
+          URL: {
+            Type: 'DOWNLOAD SOFTWARE',
+            URLContentType: 'DistributionURL',
+            URLValue: '132'
+          },
+          Version: '123'
+        },
+        url: {
+          type: 'DOWNLOAD SOFTWARE',
+          urlContentType: 'DistributionURL',
+          urlValue: '132'
+        },
+        useConstraints: null,
+        version: '123',
+        versionDescription: null
+      }
+    }
+  }
+}
 
 export const toolRecordSortSearch = {
   request: {
     query: GET_TOOL,
     variables: {
       params: { conceptId: 'T1200000-TEST' },
-      collectionsParams: { sortKey: '-provider' }
+      collectionsParams: {
+        limit: 20,
+        offset: 0,
+        sortKey: '-provider'
+      }
     }
   },
   result: {
@@ -283,6 +571,7 @@ export const singleAssociationSearch = {
       },
       collectionsParams: {
         limit: 20,
+        offset: 0,
         sortKey: null
       }
     }
@@ -420,7 +709,13 @@ export const deleteAssociationResponse = {
   request: {
     query: DELETE_ASSOCIATION,
     variables: {
-      conceptId: 'T1200000-TEST',
+      params: {
+        conceptId: 'T1200000-TEST'
+      },
+      collectionsParams: {
+        limit: 20,
+        offset: 0
+      },
       associatedConceptIds: ['C120000001-TEST']
     }
   },
@@ -442,6 +737,10 @@ export const deletedAssociationResponse = {
     variables: {
       params: {
         conceptId: 'T1200000-TEST'
+      },
+      collectionsParams: {
+        limit: 20,
+        offset: 0
       }
     }
   },

--- a/static/src/js/components/ManageCollectionAssociation/__tests__/__mocks__/manageCollectionAssociationResults.js
+++ b/static/src/js/components/ManageCollectionAssociation/__tests__/__mocks__/manageCollectionAssociationResults.js
@@ -709,13 +709,7 @@ export const deleteAssociationResponse = {
   request: {
     query: DELETE_ASSOCIATION,
     variables: {
-      params: {
-        conceptId: 'T1200000-TEST'
-      },
-      collectionsParams: {
-        limit: 20,
-        offset: 0
-      },
+      conceptId: 'T1200000-TEST',
       associatedConceptIds: ['C120000001-TEST']
     }
   },


### PR DESCRIPTION
# Overview

### What is the feature?

Users could not paginate through Collection Association Results

### What is the Solution?

Adding Pagination

### What areas of the application does this impact?

ManageCollectionAssociation.jsx

# Testing

### Reproduction steps

- **Environment for testing: Find a Service with more than 20 Associations or do the associations yourself. The one I'm using in UAT is here: /services/S1226158232-MMT_1/collection-association
- **Collection to test with:**

1. Select a service >> go to Collection Associations >> check that you can paginate through associations

### Attachments
<img width="1706" alt="Screenshot 2024-09-20 at 9 46 38 AM" src="https://github.com/user-attachments/assets/44fd877a-b0ae-4013-8d17-234e5d682214">

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings