### PR TITLE
MMT-3895: Now pulls in ALL selected collections.

### DIFF
--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -16,8 +16,8 @@ import MetadataFormPage from '@/js/pages/MetadataFormPage/MetadataFormPage'
 import OrderOptionFormPage from '@/js/pages/OrderOptionFormPage/OrderOptionFormPage'
 import OrderOptionListPage from '@/js/pages/OrderOptionListPage/OrderOptionListPage'
 import OrderOptionPage from '@/js/pages/OrderOptionPage/OrderOptionPage'
-// Import PermissionListPage from '@/js/pages/PermissionListPage/PermissionListPage'
-// Import PermissionPage from '@/js/pages/PermissionPage/PermissionPage'
+import PermissionListPage from '@/js/pages/PermissionListPage/PermissionListPage'
+import PermissionPage from '@/js/pages/PermissionPage/PermissionPage'
 import ProviderPermissionsPage from '@/js/pages/ProviderPermissionsPage/ProviderPermissionsPage'
 import ProvidersPage from '@/js/pages/ProvidersPage/ProvidersPage'
 import RevisionListPage from '@/js/pages/RevisionListPage/RevisionListPage'
@@ -31,7 +31,6 @@ import ErrorPageNotFound from '@/js/components/ErrorPageNotFound/ErrorPageNotFou
 import Layout from '@/js/components/Layout/Layout'
 import LayoutUnauthenticated from '@/js/components/LayoutUnauthenticated/LayoutUnauthenticated'
 import Notifications from '@/js/components/Notifications/Notifications'
-// Import PermissionFormPage from '@/js/pages/PermissionFormPage/PermissionFormPage'
 import PublishPreview from '@/js/components/PublishPreview/PublishPreview'
 import TemplateForm from '@/js/components/TemplateForm/TemplateForm'
 import TemplateList from '@/js/components/TemplateList/TemplateList'
@@ -40,6 +39,7 @@ import TemplatePreview from '@/js/components/TemplatePreview/TemplatePreview'
 import REDIRECTS from '@/js/constants/redirectsMap/redirectsMap'
 
 import withProviders from '@/js/providers/withProviders/withProviders'
+import PermissionFormPage from './pages/PermissionFormPage/PermissionFormPage'
 
 import '../css/index.scss'
 
@@ -140,36 +140,20 @@ export const App = () => {
             },
             {
               path: '/permissions',
-              element: <Navigate replace to="/404" />
+              element: <PermissionListPage />
             },
-            // {
-            //   path: '/permissions',
-            //   element: <PermissionListPage />
-            // },
             {
               path: '/permissions/new',
-              element: <Navigate replace to="/404" />
+              element: <PermissionFormPage />
             },
-            // {
-            //   path: '/permissions/new',
-            //   element: <PermissionFormPage />
-            // },
             {
               path: '/permissions/:conceptId/edit',
-              element: <Navigate replace to="/404" />
+              element: <PermissionFormPage />
             },
-            // {
-            //   path: '/permissions/:conceptId/edit',
-            //   element: <PermissionFormPage />
-            // },
             {
               path: '/permissions/:conceptId',
-              element: <Navigate replace to="/404" />
+              element: <PermissionPage />
             },
-            // {
-            //   path: '/permissions/:conceptId',
-            //   element: <PermissionPage />
-            // },
             {
               path: '/order-options',
               element: <OrderOptionListPage />

--- a/static/src/js/components/CollectionSelector/CollectionSelector.jsx
+++ b/static/src/js/components/CollectionSelector/CollectionSelector.jsx
@@ -192,7 +192,7 @@ const CollectionSelector = ({ onChange, formData }) => {
             }
           },
           shortName: `${inputValue}*`,
-          limit: 20
+          limit: 100
         }
       },
       onCompleted: (data) => {

--- a/static/src/js/components/CollectionSelector/__tests__/CollectionSelector.test.jsx
+++ b/static/src/js/components/CollectionSelector/__tests__/CollectionSelector.test.jsx
@@ -270,7 +270,7 @@ describe('CollectionSelector', () => {
 
       await user.type(searchField, 'C')
 
-      expect(await screen.findByText('Showing 2 items')).toBeInTheDocument()
+      expect(await screen.findByText('Showing 1 items')).toBeInTheDocument()
     })
   })
 

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -138,11 +138,11 @@ const Layout = ({ className, displayNav }) => {
                                   {
                                     to: '/templates/collections',
                                     title: 'Templates'
+                                  },
+                                  {
+                                    to: '/permissions',
+                                    title: 'Permissions'
                                   }
-                                  // {
-                                  //   to: '/permissions',
-                                  //   title: 'Permissions'
-                                  // }
                                 ]
                               },
                               {

--- a/static/src/js/components/Layout/__tests__/Layout.test.jsx
+++ b/static/src/js/components/Layout/__tests__/Layout.test.jsx
@@ -215,11 +215,11 @@ describe('Layout component', () => {
                 {
                   to: '/templates/collections',
                   title: 'Templates'
+                },
+                {
+                  title: 'Permissions',
+                  to: '/permissions'
                 }
-                // {
-                //   title: 'Permissions',
-                //   to: '/permissions'
-                // }
               ]
             },
             {

--- a/static/src/js/components/Layout/__tests__/Layout.test.jsx
+++ b/static/src/js/components/Layout/__tests__/Layout.test.jsx
@@ -103,11 +103,11 @@ describe('Layout component', () => {
               {
                 to: '/templates/collections',
                 title: 'Templates'
+              },
+              {
+                title: 'Permissions',
+                to: '/permissions'
               }
-              // {
-              //   title: 'Permissions',
-              //   to: '/permissions'
-              // }
             ]
           },
           {

--- a/static/src/js/components/PermissionForm/__tests__/PermissionForm.test.jsx
+++ b/static/src/js/components/PermissionForm/__tests__/PermissionForm.test.jsx
@@ -1191,6 +1191,8 @@ describe('PermissionForm', () => {
         const submitButton = screen.getByRole('button', { name: 'Submit' })
         await user.click(submitButton)
 
+        expect(await screen.findByText('Showing selected 2 items')).toBeInTheDocument()
+
         expect(navigateSpy).toHaveBeenCalledTimes(1)
         expect(navigateSpy).toHaveBeenCalledWith('/permissions/ACL1000000-MMT')
       })

--- a/static/src/js/operations/queries/getCollectionForPermissionForm.js
+++ b/static/src/js/operations/queries/getCollectionForPermissionForm.js
@@ -20,6 +20,7 @@ export const GET_COLLECTION_FOR_PERMISSION_FORM = gql`
       }
     }
     collections(params: $params) {
+      count
       items {
         conceptId,
         shortName,


### PR DESCRIPTION
# Overview

### What is the feature?

A user reported that its primary access policy that exposes > 800 collections in ops was reduced to only 20 collections after a update the ACL.

### What is the Solution?

The selected collections pane was only retrieving 20 collections, even though the ACL could have many more.   Therefore, when the ACL was updated, it would only update with the 20 collections it retrieved and not the full list of collections in the ACL.

The solution is to use fetchMore provided by Apollo to request all the collections in the ACL.  

### What areas of the application does this impact?

The collection permissions page.

# Testing

Try finding a ACL that has over 20 collections (or create a ACL that includes more than 20).   Verify you can add and remove collections.   Verify all collections you add show up in the right pane and the submit works properly with your additions and subtractions.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings