### PR TITLE
MMT-3908: Adding pagination to ACL

### DIFF
--- a/static/src/js/components/ManageCollectionAssociation/ManageCollectionAssociation.jsx
+++ b/static/src/js/components/ManageCollectionAssociation/ManageCollectionAssociation.jsx
@@ -41,7 +41,6 @@ const ManageCollectionAssociation = () => {
 
   const { addNotification } = useNotificationsContext()
 
-  // Const [error, setError] = useState()
   const [searchParams, setSearchParams] = useSearchParams()
   const [collectionConceptIds, setCollectionConceptIds] = useState([])
   const [showDeleteModal, setShowDeleteModal] = useState(false)

--- a/static/src/js/components/PermissionCollectionTable/__tests__/__mocks__/permissionCollectionTableResults.js
+++ b/static/src/js/components/PermissionCollectionTable/__tests__/__mocks__/permissionCollectionTableResults.js
@@ -1,0 +1,179 @@
+import { GET_COLLECTION_PERMISSION } from '@/js/operations/queries/getCollectionPermission'
+
+export const mockPermission = {
+  __typename: 'Acl',
+  conceptId: 'ACL00000-CMR',
+  collections: {
+    __typename: 'CollectionList',
+    count: 1,
+    items: [
+      {
+        __typename: 'Collection',
+        conceptId: 'C1200450691-MMT_2',
+        shortName: 'Collection 1',
+        title: 'Mock Collection 1',
+        version: '1',
+        provider: 'MMT_2'
+      },
+      {
+        __typename: 'Collection',
+        conceptId: 'C1200450692-MMT_2',
+        shortName: 'Collection 2',
+        title: 'Mock Collection 2',
+        version: '2',
+        provider: 'MMT_2'
+      }
+    ]
+  },
+  identityType: 'Catalog Item',
+  location: 'https://cmr.sit.earthdata.nasa.gov:443/access-control/acls/ACL00000-CMR',
+  name: 'Mock Permission',
+  providerIdentity: null,
+  revisionId: 5,
+  systemIdentity: null,
+  catalogItemIdentity: {
+    __typename: 'CatalogItemIdentity',
+    collectionApplicable: true,
+    granuleApplicable: false,
+    granuleIdentifier: null,
+    name: 'Mock Permission',
+    providerId: 'MMT_2',
+    collectionIdentifier: {
+      __typename: 'CollectionIdentifier',
+      accessValue: null,
+      temporal: null
+    }
+  },
+  groups: {
+    __typename: 'AclGroupList',
+    items: [
+      {
+        __typename: 'GroupPermission',
+        permissions: [
+          'read'
+        ],
+        userType: 'guest',
+        group: null,
+        id: null,
+        name: null
+      },
+      {
+        __typename: 'GroupPermission',
+        permissions: [
+          'read'
+        ],
+        userType: 'registered',
+        group: null,
+        id: null,
+        name: null
+      }
+    ]
+  }
+}
+
+export const mockPermissions = {
+  __typename: 'Acl',
+  conceptId: 'ACL00000-CMR',
+  collections: {
+    __typename: 'CollectionList',
+    count: 45,
+    items: [
+      {
+        __typename: 'Collection',
+        conceptId: 'C1200450691-MMT_2',
+        shortName: 'Collection 1',
+        title: 'Mock Collection 1',
+        version: '1',
+        provider: 'MMT_2'
+      },
+      {
+        __typename: 'Collection',
+        conceptId: 'C1200450692-MMT_2',
+        shortName: 'Collection 2',
+        title: 'Mock Collection 2',
+        version: '2',
+        provider: 'MMT_2'
+      }
+    ]
+  },
+  identityType: 'Catalog Item',
+  location: 'https://cmr.sit.earthdata.nasa.gov:443/access-control/acls/ACL00000-CMR',
+  name: 'Mock Permission',
+  providerIdentity: null,
+  revisionId: 5,
+  systemIdentity: null,
+  catalogItemIdentity: {
+    __typename: 'CatalogItemIdentity',
+    collectionApplicable: true,
+    granuleApplicable: false,
+    granuleIdentifier: null,
+    name: 'Mock Permission',
+    providerId: 'MMT_2',
+    collectionIdentifier: {
+      __typename: 'CollectionIdentifier',
+      accessValue: null,
+      temporal: null
+    }
+  },
+  groups: {
+    __typename: 'AclGroupList',
+    items: [
+      {
+        __typename: 'GroupPermission',
+        permissions: [
+          'read'
+        ],
+        userType: 'guest',
+        group: null,
+        id: null,
+        name: null
+      },
+      {
+        __typename: 'GroupPermission',
+        permissions: [
+          'read'
+        ],
+        userType: 'registered',
+        group: null,
+        id: null,
+        name: null
+      }
+    ]
+  }
+}
+
+export const mockCollectionPermissionSearch = {
+  request: {
+    query: GET_COLLECTION_PERMISSION,
+    variables: {
+      conceptId: 'ACL00000-CMR',
+      collectionParams: {
+        limit: 20,
+        offset: 0
+      }
+    }
+  },
+  result: {
+    data: {
+      acl: mockPermission
+    }
+  }
+}
+
+export const mockCollectionPermissionSearchWithPages = {
+  request: {
+    query: GET_COLLECTION_PERMISSION,
+    variables: {
+      conceptId: 'ACL00000-CMR',
+      collectionParams: {
+        limit: 20,
+        offset: 0
+      }
+    }
+  },
+  result: {
+    data: {
+      acl: mockPermissions
+    }
+  }
+}


### PR DESCRIPTION
# Overview

### What is the feature?

Needed to add pagination to /permssions/conceptId and the collection table

### What is the Solution?

Added pagination

### What areas of the application does this impact?

PermissionCollectionTable.jsx

# Testing

### Reproduction steps

- **Environment for testing: Any
- **Collection to test with:**

1. Select an ACL and check pagiantion for three use cases: all collections permitted, less than 20 collections permitted, more than 20 collections permitted.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings