### PR TITLE
MMT-3910: Use entryTitle to display title in collection draft preview

### DIFF
--- a/static/src/js/components/MetadataPreview/__tests__/MetadataPreivew.test.jsx
+++ b/static/src/js/components/MetadataPreview/__tests__/MetadataPreivew.test.jsx
@@ -413,7 +413,7 @@ describe('MetadataPreview', () => {
             tilingIdentificationSystems: null,
             timeEnd: null,
             timeStart: null,
-            title: null,
+            title: 'Title of Testing Collection Preview',
             useConstraints: null,
             version: 'v.1.0.0',
             versionDescription: null,

--- a/static/src/js/components/MetadataPreview/__tests__/__mocks__/MatadataPreviewMocks.js
+++ b/static/src/js/components/MetadataPreview/__tests__/__mocks__/MatadataPreviewMocks.js
@@ -1635,6 +1635,7 @@ export const mockCollectionDraft = {
   revisionId: '1',
   ummMetadata: {
     ShortName: 'Testing Collection Preview',
+    EntryTitle: 'Title of Testing Collection Preview',
     Version: 'v.1.0.0',
     MetadataSpecification: {
       URL: 'https://cdn.earthdata.nasa.gov/umm/collection/v1.17.2',
@@ -1715,7 +1716,7 @@ export const mockCollectionDraft = {
     tilingIdentificationSystems: null,
     timeStart: null,
     timeEnd: null,
-    title: null,
+    title: 'Title of Testing Collection Preview',
     useConstraints: null,
     versionDescription: null,
     versionId: null,

--- a/static/src/js/operations/queries/getCollectionDraft.js
+++ b/static/src/js/operations/queries/getCollectionDraft.js
@@ -86,7 +86,7 @@ export const COLLECTION_DRAFT = gql`
           tilingIdentificationSystems
           timeStart
           timeEnd
-          title
+          title: entryTitle
           useConstraints
           versionDescription
           versionId


### PR DESCRIPTION
# Overview

### What is the feature?

Collection draft preview doesn't display title after short name

### What is the Solution?

In graphql query use entryTitle value for title

### What areas of the application does this impact?

Collection draft preview

# Testing

Collection draft preview should show title after short name

### Attachments

N/A

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings