### PR TITLE
MMT-3891: Existing country should be displayed in draft form.

### DIFF
--- a/static/src/js/components/CustomCountrySelectWidget/CustomCountrySelectWidget.jsx
+++ b/static/src/js/components/CustomCountrySelectWidget/CustomCountrySelectWidget.jsx
@@ -57,7 +57,8 @@ const CustomCountrySelectWidget = ({
   // Removes a country from the country list
   const remove = (list, aValue) => list.filter((item) => (item.value !== aValue))
 
-  // Returns first country from the country list
+  // Returns first country from the country list,
+  // should pick up both forms of country name: short (example 'US') and long form (example 'United States')
   const getInitialCountrySelection = () => {
     const [selected] = countryData.filter((item) => (item.label === value || item.value === value))
 
@@ -84,6 +85,7 @@ const CustomCountrySelectWidget = ({
   // Selects a country and propagates onChange
   const selectCountry = (val) => {
     setSelectedCountry(val)
+    // Propagates the label (long form of country name)
     onChange(val.label)
   }
 

--- a/static/src/js/components/CustomCountrySelectWidget/CustomCountrySelectWidget.jsx
+++ b/static/src/js/components/CustomCountrySelectWidget/CustomCountrySelectWidget.jsx
@@ -59,7 +59,7 @@ const CustomCountrySelectWidget = ({
 
   // Returns first country from the country list
   const getInitialCountrySelection = () => {
-    const [selected] = countryData.filter((item) => (item.value === value))
+    const [selected] = countryData.filter((item) => (item.label === value || item.value === value))
 
     return selected
   }
@@ -84,7 +84,7 @@ const CustomCountrySelectWidget = ({
   // Selects a country and propagates onChange
   const selectCountry = (val) => {
     setSelectedCountry(val)
-    onChange(val.value)
+    onChange(val.label)
   }
 
   // Handles country select event

--- a/static/src/js/components/CustomCountrySelectWidget/__tests__/CustomCountrySelectWidget.test.jsx
+++ b/static/src/js/components/CustomCountrySelectWidget/__tests__/CustomCountrySelectWidget.test.jsx
@@ -21,7 +21,7 @@ const setup = (overrideProps = {}) => {
       description: 'Test Description'
     },
     uiSchema: {},
-    value: 'TZ',
+    value: 'Tanzania, United Republic of',
     ...overrideProps
   }
 
@@ -41,6 +41,19 @@ describe('CustomCountrySelectWidget', () => {
   describe('when existing data has country', () => {
     test('renders the component with selected country ', () => {
       setup()
+
+      expect(screen.getByText('My Test Data Label')).toBeInTheDocument()
+      expect(screen.getByText('Tanzania, United Republic of').className).toContain('singleValue')
+
+      expect(screen.queryByText('Select MyTestDataLabel')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when existing data has country in short form', () => {
+    test('renders the component with selected country ', () => {
+      setup({
+        value: 'TZ'
+      })
 
       expect(screen.getByText('My Test Data Label')).toBeInTheDocument()
       expect(screen.getByText('Tanzania, United Republic of').className).toContain('singleValue')
@@ -87,7 +100,7 @@ describe('CustomCountrySelectWidget', () => {
       const option = screen.getByRole('option', { name: 'United States' })
       await user.click(option)
 
-      expect(props.onChange).toHaveBeenCalledWith('US')
+      expect(props.onChange).toHaveBeenCalledWith('United States')
     })
   })
 


### PR DESCRIPTION
# Overview

### What is the feature?

Existing country in address form doesn't displayed in the draft form and only short form of country names are written to json.

### What is the Solution?

Issues were that Country selector:
1. When it writes to json, the short form of the country name is written ('US' instead of 'United States', 'TZ' instead of 'Tanzania, United Republic of')
2. When importing into the form (Edit a Collection), values like 'United States' in address field 'Country' will not be displayed in the form.
3. 
Those issues are fixed:
1. Long form of country name is to be written to json.
2. When edit an existing record, both short and long form of country name will be read and displayed. 

### What areas of the application does this impact?

List impacted areas.

Country selector

### Reproduction steps

1. Create a new draft, long form of country name is written out to json.
2. Import an existing collection with 'US' in address field, that should work.

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings