### PR TITLE
MMT-3915: Fixed when a user tries to publish a draft and is unsuccessful, there is no error message displayed

### DIFF
--- a/static/src/js/pages/DraftPage/DraftPage.jsx
+++ b/static/src/js/pages/DraftPage/DraftPage.jsx
@@ -68,7 +68,8 @@ const DraftPageHeader = () => {
 
   const {
     publishMutation,
-    publishDraft
+    publishDraft,
+    error: publishErrors
   } = usePublishMutation(pluralize(derivedConceptType).toLowerCase())
 
   const toggleShowDeleteModal = (nextState) => {
@@ -120,6 +121,19 @@ const DraftPageHeader = () => {
       })
     }
   }, [publishDraft])
+
+  useEffect(() => {
+    if (publishErrors) {
+      console.log('publishErrors', publishErrors)
+      const { message } = publishErrors
+      addNotification({
+        message,
+        variant: 'danger'
+      })
+
+      errorLogger(message, 'PublishMutation: publishMutation')
+    }
+  }, [publishErrors])
 
   const handleTemplate = async () => {
     const response = await createTemplate(providerId, mmtJwt, {

--- a/static/src/js/pages/DraftPage/DraftPage.jsx
+++ b/static/src/js/pages/DraftPage/DraftPage.jsx
@@ -124,7 +124,6 @@ const DraftPageHeader = () => {
 
   useEffect(() => {
     if (publishErrors) {
-      console.log('publishErrors', publishErrors)
       const { message } = publishErrors
       addNotification({
         message,

--- a/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
+++ b/static/src/js/pages/DraftPage/__tests__/DraftPage.test.jsx
@@ -15,6 +15,7 @@ import * as router from 'react-router'
 
 import { DELETE_DRAFT } from '@/js/operations/mutations/deleteDraft'
 import { PUBLISH_DRAFT } from '@/js/operations/mutations/publishDraft'
+import { GraphQLError } from 'graphql'
 
 import conceptTypeDraftQueries from '@/js/constants/conceptTypeDraftQueries'
 
@@ -22,9 +23,7 @@ import errorLogger from '@/js/utils/errorLogger'
 import createTemplate from '@/js/utils/createTemplate'
 
 import Providers from '@/js/providers/Providers/Providers'
-
-import DraftPage from '../DraftPage'
-import { GraphQLError } from 'graphql'
+import DraftPage from '@/js/pages/DraftPage/DraftPage'
 
 vi.mock('@/js/components/MetadataPreview/MetadataPreview')
 vi.mock('@/js/utils/createTemplate')


### PR DESCRIPTION
# Overview

### What is the feature?

There was an influx of users trying to publish drafts to CMR, when they clicked published there was no indication of whether or not the published work.  In the cases mentioned, CMR failed to push and the user had no idea.
We should capture any errors during publish and present any errors if there are problems.

### What is the Solution?

The hook provides errors, so I added a useEffect to capture any changes and now presenting them to the user.

### What areas of the application does this impact?

Publishing a draft.

# Testing

This is easier to test before GQL-75 gets merged, as there are a number of records that won't publish due to the native id including special characters.   So you should be able to ingest a record where the native id has '/' in it and try publishing with MMT, it should not work and now MMT will show an error to the UI.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings