### PR TITLE
MMT-3907: Updated provider dropdown so it is disabled on updating the ACL.   Only creation of the ACL will it be enabled.

### DIFF
--- a/static/src/js/components/PermissionForm/PermissionForm.jsx
+++ b/static/src/js/components/PermissionForm/PermissionForm.jsx
@@ -181,7 +181,13 @@ const PermissionForm = ({ selectedCollectionsPageSize }) => {
   const { conceptId = 'new' } = useParams()
 
   const [focusField, setFocusField] = useState(null)
-  const [uiSchema, setUiSchema] = useState(collectionPermissionUiSchema)
+  const [uiSchema, setUiSchema] = useState({
+    ...collectionPermissionUiSchema,
+    providers: {
+      ...collectionPermissionUiSchema.providers,
+      'ui:disabled': (conceptId !== 'new')
+    }
+  })
   const [schema, setSchema] = useState(collectionPermission)
 
   const { providerIds } = useAvailableProviders()
@@ -309,33 +315,21 @@ const PermissionForm = ({ selectedCollectionsPageSize }) => {
    * @param {boolean} formData.accessPermission.granule - The flag indicating if granule access is allowed.
    */
   const showGranuleFields = (formData) => {
-    if (formData.accessPermission?.granule) {
+    if (formData.accessPermission) {
       const newUiSchema = {
-        ...collectionPermissionUiSchema,
+        ...uiSchema,
         accessConstraintFilter: {
-          ...collectionPermissionUiSchema.accessConstraintFilter,
+          ...uiSchema.accessConstraintFilter,
           granuleAccessConstraint: {
-            ...collectionPermissionUiSchema.accessConstraintFilter.granuleAccessConstraint,
-            'ui:disabled': false
+            ...uiSchema.accessConstraintFilter.granuleAccessConstraint,
+            'ui:disabled': !formData.accessPermission?.granule
           }
         },
         temporalConstraintFilter: {
-          ...collectionPermissionUiSchema.temporalConstraintFilter,
+          ...uiSchema.temporalConstraintFilter,
           granuleTemporalConstraint: {
-            ...collectionPermissionUiSchema.temporalConstraintFilter.granuleTemporalConstraint,
-            'ui:disabled': false
-          }
-        }
-      }
-      setUiSchema(newUiSchema)
-    } else {
-      const newUiSchema = {
-        ...collectionPermissionUiSchema,
-        accessConstraintFilter: {
-          ...collectionPermissionUiSchema.accessConstraintFilter,
-          granuleAccessConstraint: {
-            ...collectionPermissionUiSchema.accessConstraintFilter.granuleAccessConstraint,
-            'ui:disabled': true
+            ...uiSchema.temporalConstraintFilter.granuleTemporalConstraint,
+            'ui:disabled': !formData.accessPermission?.granule
           }
         }
       }

--- a/static/src/js/schemas/collectionPermission.js
+++ b/static/src/js/schemas/collectionPermission.js
@@ -34,7 +34,7 @@ const collectionPermission = {
       type: 'object'
     }
   },
-  required: ['name', 'collectionSelection', 'accessPermission', 'groupPermissions'],
+  required: ['name', 'providers', 'collectionSelection', 'accessPermission', 'groupPermissions'],
 
   definitions: {
     collectionSelectionType: {

--- a/static/src/js/schemas/uiSchemas/collectionPermission.js
+++ b/static/src/js/schemas/uiSchemas/collectionPermission.js
@@ -86,6 +86,8 @@ const collectionPermissionUiSchema = {
     ]
   },
   providers: {
+    'ui:title': 'Provider',
+    'ui:disabled': false,
     'ui:required': true,
     'ui:widget': CustomSelectWidget
   },


### PR DESCRIPTION
# Overview

### What is the feature?

The provider combo box should not allow someone to change the ACL's provider on updating the ACL.   

### What is the Solution?

If the user is updating the ACL (i.e., adding/removing collections and other updates), the provider combo box should be disabled.

If the user is creating a new ACL, it should be enabled.

### What areas of the application does this impact?

ACL permissions creation and updating.

# Testing

### Reproduction steps

Verify that when updating ACL permissions, the provider combo box is disabled.

Verify that when creating ACL permissions, the provider combo box is enabled.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings