### PR TITLE
MMT-3906: Error deleting Drafts in MMT

### DIFF
--- a/static/src/js/components/DraftPreview/DraftPreview.jsx
+++ b/static/src/js/components/DraftPreview/DraftPreview.jsx
@@ -58,37 +58,50 @@ const DraftPreview = () => {
   // Validate ummMetadata
   const { errors: validationErrors } = validator.validateFormData(ummMetadata, schema)
 
+  const { errors } = ummMetadata
+
   // Pull the formSections out of the formConfigurations
   const formSections = formConfigurations[derivedConceptType]
 
   return (
     <Container id="metadata-form" fluid className="px-0">
-      <Row>
-        <Col md={12}>
+      {
+        errors ? (
           <Row>
-            <Col className="mb-5">
-              <h3 className="sr-only">Metadata Fields</h3>
-              <PreviewProgress
-                draftJson={ummMetadata}
-                schema={schema}
-                sections={formSections}
-                validationErrors={validationErrors}
-              />
+            <Col md={12}>
+              This record does not exist in CMR, please contact support@earthdata.nasa.gov
+              if you believe this is an error.
             </Col>
           </Row>
-        </Col>
-        <Row>
-          <Col md={12} className="draft-preview__preview">
-            <h2 className="fw-bold fs-4">Preview</h2>
-            <ErrorBoundary>
-              <MetadataPreview
-                conceptId={conceptId}
-                conceptType={derivedConceptType}
-              />
-            </ErrorBoundary>
-          </Col>
-        </Row>
-      </Row>
+        ) : (
+          <Row>
+            <Col md={12}>
+              <Row>
+                <Col className="mb-5">
+                  <h3 className="sr-only">Metadata Fields</h3>
+                  <PreviewProgress
+                    draftJson={ummMetadata}
+                    schema={schema}
+                    sections={formSections}
+                    validationErrors={validationErrors}
+                  />
+                </Col>
+              </Row>
+            </Col>
+            <Row>
+              <Col md={12} className="draft-preview__preview">
+                <h2 className="fw-bold fs-4">Preview</h2>
+                <ErrorBoundary>
+                  <MetadataPreview
+                    conceptId={conceptId}
+                    conceptType={derivedConceptType}
+                  />
+                </ErrorBoundary>
+              </Col>
+            </Row>
+          </Row>
+        )
+      }
     </Container>
   )
 }

--- a/static/src/js/components/DraftPreview/__tests__/DraftPreview.test.jsx
+++ b/static/src/js/components/DraftPreview/__tests__/DraftPreview.test.jsx
@@ -1,5 +1,9 @@
 import React, { Suspense } from 'react'
-import { render, waitFor } from '@testing-library/react'
+import {
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MockedProvider } from '@apollo/client/testing'
 import {
@@ -50,6 +54,59 @@ const mockDraft = {
       Version: '1.1'
     },
     LongName: 'Long Name'
+  },
+  previewMetadata: {
+    accessConstraints: null,
+    ancillaryKeywords: null,
+    associationDetails: null,
+    conceptId: 'TD1000000-MMT',
+    contactGroups: null,
+    contactPersons: null,
+    description: null,
+    doi: null,
+    nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
+    lastUpdatedDate: null,
+    longName: 'Long Name',
+    metadataSpecification: {
+      url: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.1',
+      name: 'UMM-T',
+      version: '1.1'
+    },
+    name: null,
+    organizations: null,
+    pageTitle: null,
+    potentialAction: null,
+    quality: null,
+    relatedUrls: null,
+    revisionId: '2',
+    searchAction: null,
+    supportedBrowsers: null,
+    supportedInputFormats: null,
+    supportedOperatingSystems: null,
+    supportedOutputFormats: null,
+    supportedSoftwareLanguages: null,
+    toolKeywords: null,
+    type: null,
+    url: null,
+    useConstraints: null,
+    version: null,
+    versionDescription: null,
+    __typename: 'Tool'
+  },
+  __typename: 'Draft'
+}
+
+const mockErrorDraft = {
+  conceptId: 'TD1000000-MMT',
+  conceptType: 'tool-draft',
+  deleted: false,
+  name: null,
+  nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
+  providerId: 'MMT_2',
+  revisionDate: '2023-12-08T16:14:28.177Z',
+  revisionId: '2',
+  ummMetadata: {
+    errors: 'concept not found in DB'
   },
   previewMetadata: {
     accessConstraints: null,
@@ -242,6 +299,31 @@ describe('DraftPreview', () => {
         conceptId: 'TD1000000-MMT',
         conceptType: 'Tool'
       }, {})
+    })
+  })
+
+  describe('when cmr takes longer than react to populate', () => {
+    test('renders a refresh page banner', async () => {
+      setup({
+        overrideMocks: [{
+          request: {
+            query: conceptTypeDraftQueries.Tool,
+            variables: {
+              params: {
+                conceptId: 'TD1000000-MMT',
+                conceptType: 'Tool'
+              }
+            }
+          },
+          result: {
+            data: {
+              draft: mockErrorDraft
+            }
+          }
+        }]
+      })
+
+      expect(await screen.findByText('This record does not exist in CMR, please contact support@earthdata.nasa.gov if you believe this is an error.')).toBeVisible()
     })
   })
 })

--- a/static/src/js/pages/DraftPage/DraftPage.jsx
+++ b/static/src/js/pages/DraftPage/DraftPage.jsx
@@ -105,6 +105,9 @@ const DraftPageHeader = () => {
   // Validate ummMetadata
   const { errors: validationErrors } = validator.validateFormData(ummMetadata, schema)
 
+  // Check to see if special CMR lag use case is true
+  const { errors } = ummMetadata
+
   const handlePublish = () => {
     publishMutation(derivedConceptType, nativeId)
   }
@@ -219,6 +222,7 @@ const DraftPageHeader = () => {
               variant: 'success'
             },
             {
+              disabled: !!errors,
               icon: FaTrash,
               iconTitle: 'A trash icon',
               onClick: () => toggleShowDeleteModal(true),
@@ -228,6 +232,7 @@ const DraftPageHeader = () => {
             ...[(
               derivedConceptType === conceptTypes.Collection
                 ? {
+                  disabled: !!errors,
                   icon: FaCopy,
                   iconTitle: 'A copy icon',
                   onClick: handleTemplate,


### PR DESCRIPTION
# Overview

### What is the feature?

There is a special use case where users are clicking 'delete' and their drafts are not deleting. It has been determined that the issue is that CMR is returning drafts that do no exist to the concept draft list (this is necessary to render list of drafts and will be fixed by https://bugs.earthdata.nasa.gov/browse/CMR-10190. 

### What is the Solution?

If users click into a draft with this special error case, they will be directed to page with disabled buttons and text reading that the draft does not exist.

### What areas of the application does this impact?

DraftPreview and DraftPage

# Testing

### Reproduction steps

- **Environment for testing: SIT
- **Collection to test with: http://localhost:5173/drafts/collections/CD1200483643-MMT_2

1. Go to link above and see new text
2. Go to any other draft and ensure all other works

### Attachments

<img width="1722" alt="Screenshot 2024-10-07 at 10 53 23 AM" src="https://github.com/user-attachments/assets/5c5cb453-bf3b-47be-9252-11000172c70f">


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings