### PR TITLE
MMT-3912: Instrument Long Name not populate in the JSON when populated in MMT Forms

### DIFF
--- a/static/src/js/components/InstrumentField/InstrumentField.jsx
+++ b/static/src/js/components/InstrumentField/InstrumentField.jsx
@@ -27,8 +27,8 @@ const InstrumentField = ({ onChange, uiSchema, formData }) => {
 
   const getMapKey = (keywordObject) => {
     const {
-      category = '',
-      class: keyMapClass = '',
+      category,
+      class: keyMapClass,
       type = '',
       subtype = '',
       short_name: keyMapShortName

--- a/static/src/js/components/InstrumentField/InstrumentField.jsx
+++ b/static/src/js/components/InstrumentField/InstrumentField.jsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+import Select from 'react-select'
+import fetchCmrKeywords from '../../utils/fetchCmrKeywords'
+import parseCmrInstrumentsResponse from '../../utils/parseCmrInstrumentsResponse'
+import './InstrumentField.scss'
+
+/** This is custom field found with Collections >> acquisitionInformation
+ *
+ * @typedef {Object} InstrumentField
+ * @property {Function} onChange A callback function triggered when the user inputs a text.
+ * @property {Object} uiSchema uiSchema for the field being shown.
+ * @property {Object} formData Saved Draft
+ */
+const InstrumentField = ({ onChange, uiSchema, formData }) => {
+  const { ShortName, LongName } = formData
+  const [shortName, setShortName] = useState(ShortName || '')
+  const [longName, setLongName] = useState(LongName || '')
+  const [loading, setLoading] = useState(false)
+  const [keyword, setKeyword] = useState([])
+  const [showMenu, setShowMenu] = useState(false)
+  const [shouldFocus, setShouldFocus] = useState(false)
+  const [longNameMap, setLongNameMap] = useState({})
+
+  const getMapKey = (keywordObject) => {
+    const {
+      category = '',
+      type = '',
+      subtype = '',
+      // eslint-disable-next-line camelcase
+      short_name = ''
+    } = keywordObject
+
+    return category.concat(type).concat(subtype).concat(short_name)
+  }
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const controlled = uiSchema['ui:controlled']
+      const { name, controlName } = controlled
+
+      setLoading(true)
+      const keywordsJson = await fetchCmrKeywords(name)
+      const keywordObjects = parseCmrInstrumentsResponse(keywordsJson, controlName)
+
+      keywordObjects.forEach((keywordObj) => {
+        if (keywordObj.short_name && keywordObj.long_name) {
+          setLongNameMap((prevMap) => ({
+            ...prevMap,
+            [getMapKey(keywordObj)]: keywordObj.long_name
+          }))
+        }
+      })
+
+      setLoading(false)
+      setKeyword(keywordObjects)
+    }
+
+    fetchData()
+  }, [])
+
+  const onHandleMouseDown = (keywordObject) => {
+    const valueShortName = keywordObject.short_name
+    const valueLongName = longNameMap[getMapKey(keywordObject)] || ''
+    setShortName(valueShortName)
+    setLongName(valueLongName)
+    setShowMenu(false)
+    setShouldFocus(false)
+
+    const data = {
+      ShortName: valueShortName,
+      LongName: valueLongName
+    }
+
+    onChange(data)
+  }
+
+  const onHandleFocus = () => {
+    setShowMenu(true)
+    setShouldFocus(true)
+  }
+
+  const onHandleBlur = () => {
+    setShowMenu(false)
+    setShouldFocus(false)
+  }
+
+  const onHandleClear = () => {
+    setShortName('')
+    setLongName('')
+    setShowMenu(false)
+    setShouldFocus(false)
+
+    const data = {
+      ShortName: '',
+      LongName: ''
+    }
+    onChange(data)
+  }
+
+  const displaySelectOption = (keywordObject) => (
+
+    <button
+      type="button"
+      className="instrument-field-select-option"
+      onMouseDown={() => onHandleMouseDown(keywordObject)}
+    >
+      {keywordObject.short_name}
+    </button>
+
+  )
+
+  const displayClearOption = () => (
+    <button
+      type="button"
+      className="instrument-field-clear-option"
+      onClick={onHandleClear}
+    >
+      Clear Short Name
+    </button>
+  )
+
+  const existingValue = {
+    value: shortName,
+    label: shortName
+  }
+
+  const selectOptions = [{
+    value: '',
+    label: ''
+  }, ...keyword.map((currentEnum) => ({
+    value: currentEnum.short_name,
+    label: currentEnum
+  }))]
+
+  const Option = ({ ...data }) => {
+    const keywordObject = data.children
+
+    if (!keywordObject.category) {
+      return displayClearOption()
+    }
+
+    return displaySelectOption(keywordObject)
+  }
+
+  return (
+    <div className="instrument-field mb-4">
+      {/* Short Name field */}
+      Short Name
+      <i className="eui-icon eui-required-o text-success required-icon ms-2" />
+      <div className="mt-1">
+        <Select
+          id="shortName"
+          key={`instrument_short-name--${shouldFocus}`}
+          autoFocus={shouldFocus}
+          placeholder="Select Short Name"
+          options={selectOptions}
+          isLoading={loading}
+          components={{ Option }}
+          value={existingValue.value ? existingValue : null}
+          onFocus={onHandleFocus}
+          onBlur={onHandleBlur}
+          menuIsOpen={showMenu}
+        />
+      </div>
+
+      {/* Long Name field */}
+      <div className="mt-2">
+        Long Name
+        <input
+          className="instrument-field-text-field"
+          name="longName"
+          placeholder="No available Long Name"
+          disabled
+          value={longName}
+        />
+      </div>
+    </div>
+  )
+}
+
+InstrumentField.defaultProps = {
+  formData: {}
+}
+
+InstrumentField.propTypes = {
+  formData: PropTypes.shape({
+    ShortName: PropTypes.string,
+    LongName: PropTypes.string
+  }),
+  uiSchema: PropTypes.shape({
+    'ui:controlled': PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      controlName: PropTypes.arrayOf(PropTypes.string).isRequired
+    })
+  }).isRequired,
+  onChange: PropTypes.func.isRequired
+}
+
+export default InstrumentField

--- a/static/src/js/components/InstrumentField/InstrumentField.jsx
+++ b/static/src/js/components/InstrumentField/InstrumentField.jsx
@@ -34,7 +34,12 @@ const InstrumentField = ({ onChange, uiSchema, formData }) => {
       short_name
     } = keywordObject
 
-    return category.concat(type).concat(subtype).concat(short_name)
+    return category.concat('>')
+      .concat(type)
+      .concat('>')
+      .concat(subtype)
+      .concat('>')
+      .concat(short_name)
   }
 
   const getPath = (keywordObject) => {

--- a/static/src/js/components/InstrumentField/InstrumentField.jsx
+++ b/static/src/js/components/InstrumentField/InstrumentField.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import Select from 'react-select'
+import Tooltip from 'react-bootstrap/Tooltip'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import fetchCmrKeywords from '../../utils/fetchCmrKeywords'
 import parseCmrInstrumentsResponse from '../../utils/parseCmrInstrumentsResponse'
 import './InstrumentField.scss'
@@ -29,13 +31,13 @@ const InstrumentField = ({ onChange, uiSchema, formData }) => {
       type = '',
       subtype = '',
       // eslint-disable-next-line camelcase
-      short_name = ''
+      short_name
     } = keywordObject
 
     return category.concat(type).concat(subtype).concat(short_name)
   }
 
-  const getTitle = (keywordObject) => {
+  const getPath = (keywordObject) => {
     const {
       type = '',
       subtype = ''
@@ -57,14 +59,15 @@ const InstrumentField = ({ onChange, uiSchema, formData }) => {
       setTitles([])
 
       keywordObjects.forEach((keywordObj) => {
-        // Gets title for given keyword.
+        // Gets path of given keyword (type>subtype)
         // If not already exists, creates a new title object
         // to add to the keyword array list to display in the select box
-        const title = getTitle(keywordObj)
+        const title = getPath(keywordObj)
         if (!titles.includes(title)) {
           titles.push(title)
           const titleObj = {}
           titleObj.title = title
+          // Category is needed for select box display
           titleObj.category = 'title'
           keywordArray.push(titleObj)
         }
@@ -133,15 +136,31 @@ const InstrumentField = ({ onChange, uiSchema, formData }) => {
   )
 
   const displaySelectOption = (keywordObject) => (
-
-    <button
-      type="button"
-      className="instrument-field-select-option"
-      onMouseDown={() => onHandleMouseDown(keywordObject)}
+    <OverlayTrigger
+      delay={
+        {
+          hide: 450,
+          show: 300
+        }
+      }
+      overlay={
+        // eslint-disable-next-line react/no-unstable-nested-components
+        (props) => (
+          <Tooltip {...props}>
+            {getPath(keywordObject)}
+          </Tooltip>
+        )
+      }
+      placement="bottom"
     >
-      {keywordObject.short_name}
-    </button>
-
+      <button
+        type="button"
+        className="instrument-field-select-option"
+        onMouseDown={() => onHandleMouseDown(keywordObject)}
+      >
+        {keywordObject.short_name}
+      </button>
+    </OverlayTrigger>
   )
 
   const displayClearOption = () => (

--- a/static/src/js/components/InstrumentField/InstrumentField.jsx
+++ b/static/src/js/components/InstrumentField/InstrumentField.jsx
@@ -28,25 +28,32 @@ const InstrumentField = ({ onChange, uiSchema, formData }) => {
   const getMapKey = (keywordObject) => {
     const {
       category = '',
+      class: keyMapClass = '',
       type = '',
       subtype = '',
-      // eslint-disable-next-line camelcase
-      short_name
+      short_name: keyMapShortName
     } = keywordObject
 
     return category.concat('>')
+      .concat(keyMapClass)
+      .concat('>')
       .concat(type)
       .concat('>')
       .concat(subtype)
       .concat('>')
-      .concat(short_name)
+      .concat(keyMapShortName)
   }
 
   const getPath = (keywordObject) => {
     const {
+      class: keyMapClass,
       type = '',
       subtype = ''
     } = keywordObject
+
+    if (type.length === 0 && subtype.length === 0) {
+      return keyMapClass
+    }
 
     return subtype.length !== 0 ? type.concat('>').concat(subtype) : type
   }

--- a/static/src/js/components/InstrumentField/InstrumentField.scss
+++ b/static/src/js/components/InstrumentField/InstrumentField.scss
@@ -1,0 +1,48 @@
+input[type='text'] {
+  border-radius: 5px;
+}
+
+.instrument-field-select-title {
+  margin-left: 8px;
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
+.instrument-field-select-option,
+.instrument-field-clear-option {
+  padding: 0;
+  border: none;
+  margin: 0;
+  margin-top: 0;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-size: 1.1rem;
+}
+
+.instrument-field-select-option {
+  display: block;
+  padding-left: 20px;
+}
+
+.instrument-field-clear-option {
+  margin-left: 8px;
+  list-style: none;
+}
+
+.instrument-field-text-field {
+  display: flex;
+  min-width: 100%;
+  height: 40px;
+  justify-content: space-between;
+  padding-left: 8px;
+  border-radius: 5px;
+  margin-top: 5px;
+  margin-bottom: 10px;
+}
+
+.instrument-field-select-option:hover,
+.instrument-field-clear-option:hover {
+  background-color: #EBF2F6;
+}

--- a/static/src/js/components/InstrumentField/__tests__/InstrumentField.test.jsx
+++ b/static/src/js/components/InstrumentField/__tests__/InstrumentField.test.jsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen,
+  waitFor,
+  within
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import parseCmrInstrumentsResponse from '../../../utils/parseCmrInstrumentsResponse'
@@ -133,6 +138,13 @@ const setup = (overrideProps = {}) => {
       class: 'Chemical Meters/Analyzers',
       short_name: 'ADS',
       long_name: 'Automated DNA Sequencer'
+    },
+    {
+      category: 'In Situ/Laboratory Instruments',
+      class: 'Chemical Meters/Analyzers',
+      type: 'Analyzers Type',
+      short_name: 'ADS For Type',
+      long_name: 'Automated DNA Sequencer For Type'
     }
   ])
 
@@ -184,6 +196,24 @@ describe('Instrument Field', () => {
     })
   })
 
+  describe('when a user clicks clicks the down arrow on Short Name', () => {
+    test('Title display for existing Type without Subtype', async () => {
+      const { user } = setup()
+
+      expect(screen.getByText('Select Short Name')).toBeInTheDocument()
+
+      const select = screen.getByRole('combobox')
+      await user.click(select)
+
+      expect(screen.getByText('Analyzers Type').className).toContain('instrument-field-select-title')
+      expect(screen.getByText('ADS For Type').className).toContain('instrument-field-select-option')
+
+      await user.click(screen.getByText('ADS For Type'))
+
+      expect(screen.getByDisplayValue('Automated DNA Sequencer For Type')).toBeInTheDocument()
+    })
+  })
+
   describe('when a user selects the clear option', () => {
     test('the state is cleared', async () => {
       const { user } = setup({
@@ -214,6 +244,21 @@ describe('Instrument Field', () => {
       await user.click(blurClick[0])
 
       expect(screen.getByText('Select Short Name')).toBeInTheDocument()
+    })
+  })
+
+  describe('when a user hover over an entry', () => {
+    test('the tooltip shows up', async () => {
+      const { user } = setup()
+
+      const select = screen.getByRole('combobox')
+      await user.click(select)
+
+      await user.hover(screen.getByText('ACOUSTIC SOUNDERS'))
+      await waitFor(() => {
+        const tooltip = screen.getByRole('tooltip')
+        expect(within(tooltip).getByText('Profilers/Sounders>Acoustic Sounders')).toBeInTheDocument()
+      })
     })
   })
 

--- a/static/src/js/components/InstrumentField/__tests__/InstrumentField.test.jsx
+++ b/static/src/js/components/InstrumentField/__tests__/InstrumentField.test.jsx
@@ -1,0 +1,230 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import parseCmrInstrumentsResponse from '../../../utils/parseCmrInstrumentsResponse'
+import fetchCmrKeywords from '../../../utils/fetchCmrKeywords'
+import InstrumentField from '../InstrumentField'
+
+vi.mock('../../../utils/parseCmrInstrumentsResponse')
+vi.mock('../../../utils/fetchCmrKeywords')
+
+const setup = (overrideProps = {}) => {
+  const onChange = vi.fn()
+
+  const formContext = {
+    focusField: '',
+    setFocusField: vi.fn()
+  }
+
+  fetchCmrKeywords.mockReturnValue({
+    category: [{
+      value: 'Earth Remote Sensing Instruments',
+      subfields: ['class'],
+      class: [{
+        value: 'Active Remote Sensing',
+        subfields: ['type'],
+        type: [{
+          value: 'Profilers/Sounders',
+          subfields: ['subtype'],
+          subtype: [{
+            value: 'Acoustic Sounders',
+            subfields: ['short_name'],
+            short_name: [{
+              value: 'ACOUSTIC SOUNDERS',
+              uuid: '7ef0c3e6-1012-411a-b166-482fb35bb1dd'
+            }]
+          }]
+        }, {
+          value: 'Altimeters',
+          subfields: ['subtype'],
+          subtype: [{
+            value: 'Lidar/Laser Altimeters',
+            subfields: ['short_name'],
+            short_name: [{
+              value: 'ATM',
+              subfields: ['long_name'],
+              long_name: [{
+                value: 'Airborne Topographic Mapper',
+                uuid: 'c2428a35-a87c-4ec7-aefd-13ff410b3271'
+              }]
+            }, {
+              value: 'LVIS',
+              subfields: ['long_name'],
+              long_name: [{
+                value: 'Land, Vegetation, and Ice Sensor',
+                uuid: 'aa338429-35e6-4ee2-821f-0eac81802689'
+              }]
+            }]
+          }]
+        }]
+      }, {
+        value: 'Passive Remote Sensing',
+        subfields: ['type'],
+        type: [{
+          value: 'Spectrometers/Radiometers',
+          subfields: ['subtype'],
+          subtype: [{
+            value: 'Imaging Spectrometers/Radiometers',
+            subfields: ['short_name'],
+            short_name: [{
+              value: 'SMAP L-BAND RADIOMETER',
+              subfields: ['long_name'],
+              long_name: [{
+                value: 'SMAP L-Band Radiometer',
+                uuid: 'fee5e9e1-10f1-4f14-94bc-c287f8e2c209'
+              }]
+            }]
+          }]
+        }]
+      }]
+    }, {
+      value: 'In Situ/Laboratory Instruments',
+      subfields: ['class'],
+      class: [{
+        value: 'Chemical Meters/Analyzers',
+        subfields: ['short_name'],
+        short_name: [{
+          value: 'ADS',
+          subfields: ['long_name'],
+          long_name: [{
+            value: 'Automated DNA Sequencer',
+            uuid: '554a3c73-3b48-43ea-bf5b-8b98bc2b11bc'
+          }]
+        }]
+      }]
+    }]
+  })
+
+  parseCmrInstrumentsResponse.mockReturnValue([
+    {
+      category: 'Earth Remote Sensing Instruments',
+      class: 'Active Remote Sensing',
+      type: 'Altimeters',
+      subtype: 'Lidar/Laser Altimeters',
+      short_name: 'ATM',
+      long_name: 'Airborne Topographic Mapper'
+    },
+    {
+      category: 'Earth Remote Sensing Instruments',
+      class: 'Active Remote Sensing',
+      type: 'Altimeters',
+      subtype: 'Lidar/Laser Altimeters',
+      short_name: 'LVIS',
+      long_name: 'Land, Vegetation, and Ice Sensor'
+    },
+    {
+      category: 'Earth Remote Sensing Instruments',
+      class: 'Active Remote Sensing',
+      type: 'Profilers/Sounders',
+      subtype: 'Acoustic Sounders',
+      short_name: 'ACOUSTIC SOUNDERS'
+    },
+    {
+      category: 'Earth Remote Sensing Instruments',
+      class: 'Passive Remote Sensing',
+      type: 'Spectrometers/Radiometers',
+      subtype: 'Imaging Spectrometers/Radiometers',
+      short_name: 'SMAP L-BAND RADIOMETER',
+      long_name: 'SMAP L-Band Radiometer'
+    },
+    {
+      category: 'In Situ/Laboratory Instruments',
+      class: 'Chemical Meters/Analyzers',
+      short_name: 'ADS',
+      long_name: 'Automated DNA Sequencer'
+    }
+  ])
+
+  const uiSchema = {
+    'ui:controlled': {
+      name: 'instruments',
+      controlName: ['category', 'class', 'type', 'subtype', 'short_name', 'long_name']
+    }
+  }
+
+  const props = {
+    formData: {},
+    onChange,
+    registry: {
+      formContext
+    },
+    uiSchema,
+    ...overrideProps
+  }
+
+  const user = userEvent.setup()
+
+  render(
+    <InstrumentField {...props} />
+  )
+
+  return {
+    props,
+    user
+  }
+}
+
+describe('Instrument Field', () => {
+  describe('when a user clicks clicks the down arrow on Short Name', () => {
+    test('renders a list of clickable cmr keywords', async () => {
+      const { user } = setup()
+
+      expect(screen.getByText('Select Short Name')).toBeInTheDocument()
+
+      const select = screen.getByRole('combobox')
+      await user.click(select)
+
+      expect(screen.getByText('Altimeters>Lidar/Laser Altimeters').className).toContain('instrument-field-select-title')
+      expect(screen.getByText('LVIS').className).toContain('instrument-field-select-option')
+
+      await user.click(screen.getByText('LVIS'))
+
+      expect(screen.getByDisplayValue('Land, Vegetation, and Ice Sensor')).toBeInTheDocument()
+    })
+  })
+
+  describe('when a user selects the clear option', () => {
+    test('the state is cleared', async () => {
+      const { user } = setup({
+        formData: {
+          ShortName: 'ACOUSTIC SOUNDERS'
+        }
+      })
+
+      expect(screen.getByText('ACOUSTIC SOUNDERS')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('No available Long Name')).toBeInTheDocument()
+
+      const select = screen.getByRole('combobox')
+      await user.click(select)
+      await user.click(screen.getByText('Clear Short Name'))
+
+      expect(screen.getByText('Select Short Name')).toBeInTheDocument()
+    })
+  })
+
+  describe('when a user clicks away from the menu', () => {
+    test('the screen blurs', async () => {
+      const { user } = setup()
+
+      const select = screen.getByRole('combobox')
+      await user.click(select)
+
+      const blurClick = (screen.getAllByRole('textbox'))
+      await user.click(blurClick[0])
+
+      expect(screen.getByText('Select Short Name')).toBeInTheDocument()
+    })
+  })
+
+  describe('when a user selects an option with no longName', () => {
+    test('the screen blurs', async () => {
+      const { user } = setup()
+
+      const select = screen.getByRole('combobox')
+      await user.click(select)
+
+      await user.click(screen.getByText('ACOUSTIC SOUNDERS'))
+    })
+  })
+})

--- a/static/src/js/schemas/uiSchemas/collections/acquisitionInformation.jsx
+++ b/static/src/js/schemas/uiSchemas/collections/acquisitionInformation.jsx
@@ -4,7 +4,6 @@ import CustomTextWidget from '../../../components/CustomTextWidget/CustomTextWid
 import PlatformField from '../../../components/PlatformField/PlatformField'
 import InstrumentField from '../../../components/InstrumentField/InstrumentField'
 
-
 const acquisitionInformationUiSchema = {
   'ui:submitButtonOptions': {
     norender: true
@@ -287,10 +286,7 @@ const acquisitionInformationUiSchema = {
               'ui:field': 'layout',
               'ui:controlled': {
                 name: 'instruments',
-                map: {
-                  ShortName: 'short_name',
-                  LongName: 'long_name'
-                }
+                controlName: ['category', 'class', 'type', 'subtype', 'short_name', 'long_name']
               },
               'ui:layout_grid': {
                 'ui:row': [
@@ -299,26 +295,13 @@ const acquisitionInformationUiSchema = {
                       md: 12,
                       children: [
                         {
-                          'ui:row': [
-                            {
-                              'ui:col': {
-                                controlName: 'short_name',
-                                md: 12,
-                                children: ['ShortName']
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          'ui:row': [
-                            {
-                              'ui:col': {
-                                controlName: 'long_name',
-                                md: 12,
-                                children: ['LongName']
-                              }
-                            }
-                          ]
+                          md: 12,
+                          // Rendering custom component for ShortName and LongName
+                          render: (props) => (
+                            <div>
+                              <InstrumentField {...props} />
+                            </div>
+                          )
                         },
                         {
                           'ui:row': [

--- a/static/src/js/schemas/uiSchemas/collections/acquisitionInformation.jsx
+++ b/static/src/js/schemas/uiSchemas/collections/acquisitionInformation.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import CustomTextareaWidget from '../../../components/CustomTextareaWidget/CustomTextareaWidget'
 import CustomTextWidget from '../../../components/CustomTextWidget/CustomTextWidget'
 import PlatformField from '../../../components/PlatformField/PlatformField'
+import InstrumentField from '../../../components/InstrumentField/InstrumentField'
+
 
 const acquisitionInformationUiSchema = {
   'ui:submitButtonOptions': {
@@ -141,10 +143,7 @@ const acquisitionInformationUiSchema = {
           'ui:field': 'layout',
           'ui:controlled': {
             name: 'instruments',
-            map: {
-              ShortName: 'short_name',
-              LongName: 'long_name'
-            }
+            controlName: ['category', 'class', 'type', 'subtype', 'short_name', 'long_name']
           },
           'ui:layout_grid': {
             'ui:row': [
@@ -153,26 +152,13 @@ const acquisitionInformationUiSchema = {
                   md: 12,
                   children: [
                     {
-                      'ui:row': [
-                        {
-                          'ui:col': {
-                            controlName: 'short_name',
-                            md: 12,
-                            children: ['ShortName']
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      'ui:row': [
-                        {
-                          'ui:col': {
-                            controlName: 'long_name',
-                            md: 12,
-                            children: ['LongName']
-                          }
-                        }
-                      ]
+                      md: 12,
+                      // Rendering custom component for ShortName and LongName
+                      render: (props) => (
+                        <div>
+                          <InstrumentField {...props} />
+                        </div>
+                      )
                     },
                     {
                       'ui:row': [

--- a/static/src/js/utils/__tests__/parseCmrInstrumentsResponse.test.js
+++ b/static/src/js/utils/__tests__/parseCmrInstrumentsResponse.test.js
@@ -1,0 +1,153 @@
+import parseCmrInstrumentsResponse from '../parseCmrInstrumentsResponse'
+
+describe('cmrKeywords', () => {
+  /**
+   * Cat: [Earth Remote Sensing Instruments, In Situ/Laboratory Instruments]
+   * Class: [Active Remote Sensing, Passive Remote Sensing, Chemical Meters/Analyzers]
+   * Type: [Profilers/Sounders, Altimeters, Spectrometers/Radiometers]
+   * Subtype: [Acoustic Sounders, Lidar/Laser Altimeters, Imaging Spectrometers/Radiometers]
+   * short_name: [ACOUSTIC SOUNDERS, ATM, LVIS, SMAP L-BAND RADIOMETER, ADS]
+   * long_name: [Airborne Topographic Mapper, Land, Vegetation, and Ice Sensor, SMAP L-Band Radiometer, Automated DNA Sequencer]
+   */
+  describe('can return a single list of keywords', () => {
+    test('returns a parsed list of enums from CMR', () => {
+      const cmrResponse = {
+        category: [{
+          value: 'NOT APPLICABLE',
+          subfields: ['class'],
+          class: [{
+            value: 'NOT APPLICABLE',
+            subfields: ['short_name'],
+            short_name: [{
+              value: 'NOT APPLICABLE',
+              uuid: '51963b3c-d82e-441f-8f65-e21b005861ef'
+            }]
+          }]
+        }, {
+          value: 'Earth Remote Sensing Instruments',
+          subfields: ['class'],
+          class: [{
+            value: 'Active Remote Sensing',
+            subfields: ['type'],
+            type: [{
+              value: 'Profilers/Sounders',
+              subfields: ['subtype'],
+              subtype: [{
+                value: 'Acoustic Sounders',
+                subfields: ['short_name'],
+                short_name: [{
+                  value: 'ACOUSTIC SOUNDERS',
+                  uuid: '7ef0c3e6-1012-411a-b166-482fb35bb1dd'
+                }]
+              }]
+            }, {
+              value: 'Altimeters',
+              subfields: ['subtype'],
+              subtype: [{
+                value: 'Lidar/Laser Altimeters',
+                subfields: ['short_name'],
+                short_name: [{
+                  value: 'ATM',
+                  subfields: ['long_name'],
+                  long_name: [{
+                    value: 'Airborne Topographic Mapper',
+                    uuid: 'c2428a35-a87c-4ec7-aefd-13ff410b3271'
+                  }]
+                }, {
+                  value: 'LVIS',
+                  subfields: ['long_name'],
+                  long_name: [{
+                    value: 'Land, Vegetation, and Ice Sensor',
+                    uuid: 'aa338429-35e6-4ee2-821f-0eac81802689'
+                  }]
+                }]
+              }]
+            }]
+          }, {
+            value: 'Passive Remote Sensing',
+            subfields: ['type'],
+            type: [{
+              value: 'Spectrometers/Radiometers',
+              subfields: ['subtype'],
+              subtype: [{
+                value: 'Imaging Spectrometers/Radiometers',
+                subfields: ['short_name'],
+                short_name: [{
+                  value: 'SMAP L-BAND RADIOMETER',
+                  subfields: ['long_name'],
+                  long_name: [{
+                    value: 'SMAP L-Band Radiometer',
+                    uuid: 'fee5e9e1-10f1-4f14-94bc-c287f8e2c209'
+                  }]
+                }]
+              }]
+            }]
+          }]
+        }, {
+          value: 'In Situ/Laboratory Instruments',
+          subfields: ['class'],
+          class: [{
+            value: 'Chemical Meters/Analyzers',
+            subfields: ['short_name'],
+            short_name: [{
+              value: 'ADS',
+              subfields: ['long_name'],
+              long_name: [{
+                value: 'Automated DNA Sequencer',
+                uuid: '554a3c73-3b48-43ea-bf5b-8b98bc2b11bc'
+              }]
+            }]
+          }]
+        }]
+      }
+
+      const expectedResult = [
+        {
+          category: 'Earth Remote Sensing Instruments',
+          class: 'Active Remote Sensing',
+          type: 'Altimeters',
+          subtype: 'Lidar/Laser Altimeters',
+          short_name: 'ATM',
+          long_name: 'Airborne Topographic Mapper'
+        },
+        {
+          category: 'Earth Remote Sensing Instruments',
+          class: 'Active Remote Sensing',
+          type: 'Altimeters',
+          subtype: 'Lidar/Laser Altimeters',
+          short_name: 'LVIS',
+          long_name: 'Land, Vegetation, and Ice Sensor'
+        },
+        {
+          category: 'Earth Remote Sensing Instruments',
+          class: 'Active Remote Sensing',
+          type: 'Profilers/Sounders',
+          subtype: 'Acoustic Sounders',
+          short_name: 'ACOUSTIC SOUNDERS'
+        },
+        {
+          category: 'Earth Remote Sensing Instruments',
+          class: 'Passive Remote Sensing',
+          type: 'Spectrometers/Radiometers',
+          subtype: 'Imaging Spectrometers/Radiometers',
+          short_name: 'SMAP L-BAND RADIOMETER',
+          long_name: 'SMAP L-Band Radiometer'
+        },
+        {
+          category: 'In Situ/Laboratory Instruments',
+          class: 'Chemical Meters/Analyzers',
+          short_name: 'ADS',
+          long_name: 'Automated DNA Sequencer'
+        },
+        {
+          category: 'NOT APPLICABLE',
+          class: 'NOT APPLICABLE',
+          short_name: 'NOT APPLICABLE'
+        }
+      ]
+      const result = parseCmrInstrumentsResponse(cmrResponse, ['category', 'class', 'type', 'subtype', 'short_name', 'long_name'])
+
+      expect(result).toEqual(expectedResult)
+    })
+  })
+})

--- a/static/src/js/utils/parseCmrInstrumentsResponse.js
+++ b/static/src/js/utils/parseCmrInstrumentsResponse.js
@@ -1,0 +1,110 @@
+import { cloneDeep, uniqWith } from 'lodash-es'
+
+/*
+* Helper function that traverses through a CMR facet response and builds a multidimensinal array of keywords.
+* Given the node, it does an in order traversal of the tree.   When it visits the node, it adds node's
+* value to the `path`list.   The `path` list represents the path for the given keyword set
+* (i.e., [ATMOSPHERE, ATMOSPHERIC PHENOMENA, HURRICANES]).
+* You specify a "filter" array which specifies which fields you want to include in
+* multidimensional array (e.g, 'category', 'topic', 'term', 'variable')
+* @param {node} node of the tree being traversed
+* @param {Array} path to where the keywords will be added for the set as it traverses down to the leaf
+* @param {string} filter specify a "filter" array which specifies which fields you want to include in multidimensional array
+@ returns the multidimensional array of keywords
+*/
+const traverseCmrResponse = (
+  node,
+  filter,
+  path = {}
+) => {
+  // Example of `data` being passed in the node object:
+  // {
+  //   "value": "VisualizationURL",
+  //   "subfields": [
+  //     "type"
+  //   ],
+  //   "type": [
+  //     {
+  //       "value": "Color Map",
+  //       "subfields": [
+  //         "subtype"
+  //       ],
+  //       "subtype": [
+  //         {
+  //           "value": "Giovanni",
+  //         },
+  //         {
+  //           "value": "GITC",
+  //         }
+  //       ]
+  //     }
+  const {
+    data,
+    parentName,
+    name
+  } = node
+
+  const children = data[name]
+  // Only add the keyword if it is included in the filtered list of field names
+  if (data.value && filter.includes(name)) {
+    // eslint-disable-next-line no-param-reassign
+    path[parentName] = data.value
+  }
+
+  let paths = []
+
+  // In order traversal into children recursively
+  children.forEach((child) => {
+    const childPath = cloneDeep(path)
+
+    if (child.subfields) {
+      child.subfields.forEach((subfield) => {
+        paths = paths.concat(traverseCmrResponse({
+          data: child,
+          parentName: name,
+          name: subfield
+        }, filter, cloneDeep(childPath)))
+      })
+    } else {
+      if (child.value && filter.includes(name)) {
+        childPath[name] = child.value
+      }
+
+      paths.push(childPath)
+    }
+  })
+
+  paths = paths.sort((value1, value2) => {
+    const join1 = Object.values(value1).join('>')
+    const join2 = Object.values(value2).join('>')
+
+    return join1.localeCompare(join2)
+  })
+
+  paths = uniqWith(paths, (path1, path2) => Object.values(path1).join('>') === Object.values(path2).join('>'))
+
+  return paths
+}
+
+/**
+ * This parses the cmr response and produces an multidimensional array that looks like this:
+ * [
+ *   ['atmosphere', 'atmospheric phenomena', 'hurricanes'],
+ *   ['oceans', 'ocean temperature', 'sea surface temperature'],
+ *   ['land surface', 'soils', 'carbon', 'soil organic'],
+ * ]
+ * You specify a "filter" array which specifies which fields you want to include in
+ * multidimensional array (e.g, 'category', 'topic', 'term', 'variable')
+ * @param {Object} response response from CMR
+ * @param {string} filter specify a "filter" array which specifies which fields you want to include in multidimensional array
+ */
+const parseCmrInstrumentsResponse = (response, filter) => {
+  const paths = traverseCmrResponse({
+    name: Object.keys(response)[0],
+    data: response
+  }, filter)
+
+  return paths
+}
+
+export default parseCmrInstrumentsResponse


### PR DESCRIPTION
# Overview

### What is the feature?

Duplicated instrument name causes the issue that no long name shows up in json view.

### What is the Solution?

Use type, subtype and short name to create key for long name map. Add title and tooltip to select box entries to ease selection of duplicated instrument names. 

### What areas of the application does this impact?

Instrument list and 'Composed Of' in Platforms (Acquisition Information)

# Testing

Instrument list should show titles to group entries in the select box and each entry has a tooltip which shows type>subtype 

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings