### PR TITLE
Mmt 3922: User is experiencing an issue with MMT deleting information added even after hitting "Save and Continue."

### DIFF
--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -140,9 +140,22 @@ const MetadataForm = () => {
 
   useEffect(() => {
     const { draft: fetchedDraft } = data || {}
+    const { revisionId: cmrRetrievedRevisionId } = fetchedDraft || ''
+
+    if (cmrRetrievedRevisionId && (cmrRetrievedRevisionId !== appContextRevisionId)) {
+      addNotification({
+        message: 'Delay Detected',
+        variant: 'danger'
+      })
+      
+      // Send the error to the errorLogger
+      errorLogger('A delay has been detected in CMR', 'MetadataForm: retrieveDraftUseEffect')
+    }
+
     setOriginalDraft(fetchedDraft)
     setDraft(fetchedDraft)
-  }, [data, appContextRevisionId])
+    
+  }, [data])
 
   const {
     nativeId = `MMT_${crypto.randomUUID()}`,

--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -38,6 +38,7 @@ import useNotificationsContext from '@/js/hooks/useNotificationsContext'
 
 import { INGEST_DRAFT } from '@/js/operations/mutations/ingestDraft'
 
+import checkForCMRFetchDraftLag from '@/js/utils/checkForCMRFetchDraftLag'
 import errorLogger from '@/js/utils/errorLogger'
 import getConceptTypeByDraftConceptId from '@/js/utils/getConceptTypeByDraftConceptId'
 import getFormSchema from '@/js/utils/getFormSchema'
@@ -142,15 +143,7 @@ const MetadataForm = () => {
     const { draft: fetchedDraft } = data || {}
     const { revisionId: cmrRetrievedRevisionId } = fetchedDraft || ''
 
-    if (cmrRetrievedRevisionId && (cmrRetrievedRevisionId !== appContextRevisionId)) {
-      addNotification({
-        message: 'Delay Detected',
-        variant: 'danger'
-      })
-
-      // Send the error to the errorLogger
-      errorLogger('A delay has been detected in CMR', 'MetadataForm: retrieveDraftUseEffect')
-    }
+    checkForCMRFetchDraftLag(cmrRetrievedRevisionId, appContextRevisionId)
 
     setOriginalDraft(fetchedDraft)
     setDraft(fetchedDraft)

--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -54,18 +54,20 @@ import './MetadataForm.scss'
 const MetadataForm = () => {
   const {
     conceptId = 'new',
-    sectionName,
+    draftType,
     fieldName,
-    draftType
+    sectionName
   } = useParams()
   const navigate = useNavigate()
   const {
     draft,
     originalDraft,
+    providerId,
+    revisionId: appContextRevisionId,
     setDraft,
     setOriginalDraft,
-    setSavedDraft,
-    providerId
+    setRevisionId,
+    setSavedDraft
   } = useAppContext()
 
   const { addNotification } = useNotificationsContext()
@@ -140,7 +142,7 @@ const MetadataForm = () => {
     const { draft: fetchedDraft } = data || {}
     setOriginalDraft(fetchedDraft)
     setDraft(fetchedDraft)
-  }, [data])
+  }, [data, appContextRevisionId])
 
   const {
     nativeId = `MMT_${crypto.randomUUID()}`,
@@ -199,7 +201,7 @@ const MetadataForm = () => {
       },
       onCompleted: (mutationData) => {
         const { ingestDraft } = mutationData
-        const { conceptId: savedConceptId } = ingestDraft
+        const { conceptId: savedConceptId, revisionId: savedRevisionId } = ingestDraft
 
         // Update the original draft with the newly saved draft
         setOriginalDraft({
@@ -217,6 +219,9 @@ const MetadataForm = () => {
 
         // Set savedDraft so the preview page can request the correct version
         setSavedDraft(ingestDraft)
+
+        // Triggers useEffect for newest revision (CMR Lag related)
+        setRevisionId(savedRevisionId)
 
         // Add a success notification
         addNotification({

--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -147,6 +147,7 @@ const MetadataForm = () => {
 
     setOriginalDraft(fetchedDraft)
     setDraft(fetchedDraft)
+    setRevisionId()
   }, [data])
 
   const {

--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -147,14 +147,13 @@ const MetadataForm = () => {
         message: 'Delay Detected',
         variant: 'danger'
       })
-      
+
       // Send the error to the errorLogger
       errorLogger('A delay has been detected in CMR', 'MetadataForm: retrieveDraftUseEffect')
     }
 
     setOriginalDraft(fetchedDraft)
     setDraft(fetchedDraft)
-    
   }, [data])
 
   const {

--- a/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
+++ b/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
@@ -601,7 +601,7 @@ describe('MetadataForm', () => {
         await user.click(button)
 
         expect(navigateSpy).toHaveBeenCalledTimes(1)
-        expect(navigateSpy).toHaveBeenCalledWith('/drafts/tools/TD1000000-MMT/tool-information', { replace: true })
+        expect(navigateSpy).toHaveBeenCalledWith('/drafts/tools/TD1000000-MMT/tool-information?revisionId=3', { replace: true })
 
         expect(window.scroll).toHaveBeenCalledTimes(1)
         expect(window.scroll).toHaveBeenCalledWith(0, 0)
@@ -647,7 +647,7 @@ describe('MetadataForm', () => {
         await user.click(button)
 
         expect(navigateSpy).toHaveBeenCalledTimes(1)
-        expect(navigateSpy).toHaveBeenCalledWith('/drafts/tools/TD1000000-MMT/related-urls')
+        expect(navigateSpy).toHaveBeenCalledWith('/drafts/tools/TD1000000-MMT/related-urls?revisionId=3')
 
         expect(window.scroll).toHaveBeenCalledTimes(1)
         expect(window.scroll).toHaveBeenCalledWith(0, 0)
@@ -696,7 +696,7 @@ describe('MetadataForm', () => {
         await user.click(button)
 
         expect(navigateSpy).toHaveBeenCalledTimes(1)
-        expect(navigateSpy).toHaveBeenCalledWith('/drafts/tools/TD1000000-MMT')
+        expect(navigateSpy).toHaveBeenCalledWith('/drafts/tools/TD1000000-MMT?revisionId=3')
 
         expect(window.scroll).toHaveBeenCalledTimes(1)
         expect(window.scroll).toHaveBeenCalledWith(0, 0)
@@ -959,7 +959,7 @@ describe('MetadataForm', () => {
         await user.click(modalSubmit)
 
         expect(navigateSpy).toHaveBeenCalledTimes(1)
-        expect(navigateSpy).toHaveBeenCalledWith('/drafts/collections/CD1000000-MMT/collection-information', { replace: true })
+        expect(navigateSpy).toHaveBeenCalledWith('/drafts/collections/CD1000000-MMT/collection-information?revisionId=1', { replace: true })
 
         expect(window.scroll).toHaveBeenCalledTimes(1)
         expect(window.scroll).toHaveBeenCalledWith(0, 0)

--- a/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
+++ b/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
@@ -919,7 +919,7 @@ describe('MetadataForm', () => {
 
         expect(navigateSpy).toHaveBeenCalledTimes(0)
 
-        expect(errorLogger).toHaveBeenCalledTimes(1)
+        expect(errorLogger).toHaveBeenCalledTimes(2)
         expect(errorLogger).toHaveBeenCalledWith(new Error('An error occured'), 'MetadataForm: ingestDraftMutation')
       })
     })

--- a/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
+++ b/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
@@ -876,7 +876,7 @@ describe('MetadataForm', () => {
 
         expect(navigateSpy).toHaveBeenCalledTimes(0)
 
-        expect(errorLogger).toHaveBeenCalledTimes(2)
+        expect(errorLogger).toHaveBeenCalledTimes(1)
         expect(errorLogger).toHaveBeenCalledWith(new Error('An error occured'), 'MetadataForm: ingestDraftMutation')
       })
     })

--- a/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
+++ b/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
@@ -654,49 +654,6 @@ describe('MetadataForm', () => {
       })
     })
 
-    describe('when the saveType is save and continue and there is a lag in retreiving the data', () => {
-      test('throws an error', async () => {
-        const navigateSpy = vi.fn()
-        vi.spyOn(router, 'useNavigate').mockImplementation(() => navigateSpy)
-
-        const { user } = setup({
-          additionalMocks: [{
-            request: {
-              query: INGEST_DRAFT,
-              variables: {
-                conceptType: 'Tool',
-                metadata: {
-                  LongName: 'Long Name',
-                  MetadataSpecification: {
-                    URL: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.1',
-                    Name: 'UMM-T',
-                    Version: '1.1'
-                  }
-                },
-                nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
-                providerId: 'MMT_2',
-                ummVersion: '1.0.0'
-              }
-            },
-            result: {
-              data: {
-                ingestDraft: {
-                  conceptId: 'TD1000000-MMT',
-                  revisionId: '3'
-                }
-              }
-            }
-          }]
-        })
-
-        const button = await screen.findByRole('button', { name: 'Save & Continue' })
-        await user.click(button)
-        expect(navigateSpy).toHaveBeenCalledTimes(1)
-
-        expect(errorLogger).toHaveBeenCalledTimes(1)
-      })
-    })
-
     describe('when the saveType is save and preview', () => {
       test('navigates to the current form and calls scrolls to the top', async () => {
         const navigateSpy = vi.fn()

--- a/static/src/js/providers/AppContextProvider/AppContextProvider.jsx
+++ b/static/src/js/providers/AppContextProvider/AppContextProvider.jsx
@@ -24,7 +24,6 @@ const AppContextProvider = ({ children }) => {
   const [draft, setDraft] = useState()
   const [originalDraft, setOriginalDraft] = useState()
   const [providerId, setProviderId] = useState()
-  const [revisionId, setRevisionId] = useState()
   const [savedDraft, setSavedDraft] = useState()
 
   const providerValue = useMemo(() => ({
@@ -37,16 +36,13 @@ const AppContextProvider = ({ children }) => {
     setDraft,
     setOriginalDraft,
     setProviderId,
-    setSavedDraft,
-    revisionId,
-    setRevisionId
+    setSavedDraft
   }), [
     draft,
     keywords,
     originalDraft,
     providerId,
-    savedDraft,
-    revisionId
+    savedDraft
   ])
 
   return (

--- a/static/src/js/providers/AppContextProvider/AppContextProvider.jsx
+++ b/static/src/js/providers/AppContextProvider/AppContextProvider.jsx
@@ -21,10 +21,11 @@ import AppContext from '../../context/AppContext'
  */
 const AppContextProvider = ({ children }) => {
   const { addKeywordsData, keywords } = useKeywords()
-  const [originalDraft, setOriginalDraft] = useState()
   const [draft, setDraft] = useState()
-  const [savedDraft, setSavedDraft] = useState()
+  const [originalDraft, setOriginalDraft] = useState()
   const [providerId, setProviderId] = useState()
+  const [revisionId, setRevisionId] = useState()
+  const [savedDraft, setSavedDraft] = useState()
 
   const providerValue = useMemo(() => ({
     addKeywordsData,
@@ -36,13 +37,16 @@ const AppContextProvider = ({ children }) => {
     setDraft,
     setOriginalDraft,
     setProviderId,
-    setSavedDraft
+    setSavedDraft,
+    revisionId,
+    setRevisionId
   }), [
     draft,
     keywords,
     originalDraft,
     providerId,
-    savedDraft
+    savedDraft,
+    revisionId
   ])
 
   return (

--- a/static/src/js/utils/__tests__/checkForCMRFetchDraftLag.test.js
+++ b/static/src/js/utils/__tests__/checkForCMRFetchDraftLag.test.js
@@ -1,0 +1,15 @@
+import checkForCMRFetchDraftLag from '../checkForCMRFetchDraftLag'
+
+describe('checkForCMRFetchDraftLag', () => {
+  describe('when the fetched revision Id and expected revision Id are undefined', () => {
+    test('returns undefined', () => {
+      expect(checkForCMRFetchDraftLag(`${undefined}`, `${undefined}`)).toEqual(undefined)
+    })
+  })
+
+  describe('when the fetched revision Id does not match expected revision Id', () => {
+    test('throws error', () => {
+      expect(() => checkForCMRFetchDraftLag('1', '2')).toThrow('Delay in CMR has detected. Refresh the page in order to see latest revision')
+    })
+  })
+})

--- a/static/src/js/utils/__tests__/checkForCMRFetchDraftLag.test.js
+++ b/static/src/js/utils/__tests__/checkForCMRFetchDraftLag.test.js
@@ -9,7 +9,7 @@ describe('checkForCMRFetchDraftLag', () => {
 
   describe('when the fetched revision Id does not match expected revision Id', () => {
     test('throws error', () => {
-      expect(() => checkForCMRFetchDraftLag('1', '2')).toThrow('Delay in CMR has detected. Refresh the page in order to see latest revision')
+      expect(() => checkForCMRFetchDraftLag('1', '2')).toThrow('Delay in CMR has been detected. Refresh the page in order to see latest revision')
     })
   })
 })

--- a/static/src/js/utils/checkForCMRFetchDraftLag.js
+++ b/static/src/js/utils/checkForCMRFetchDraftLag.js
@@ -1,0 +1,13 @@
+/**
+ * Compares the revision Ids to ensure the draft retched is the most current
+ * @param {String} fetchedRevisionId The revision Id that comes back from CMR
+ * @param {String} expectedRevisionId The revision Id that was set on ingest (expected revision)
+ */
+
+const checkForCMRFetchDraftLag = (fetchedRevisionId, expectedRevisionId) => {
+  if ((fetchedRevisionId && expectedRevisionId) && (fetchedRevisionId !== expectedRevisionId)) {
+    throw new Error('Delay in CMR has detected. Refresh the page in order to see latest revision')
+  }
+}
+
+export default checkForCMRFetchDraftLag

--- a/static/src/js/utils/checkForCMRFetchDraftLag.js
+++ b/static/src/js/utils/checkForCMRFetchDraftLag.js
@@ -6,7 +6,7 @@
 
 const checkForCMRFetchDraftLag = (fetchedRevisionId, expectedRevisionId) => {
   if ((fetchedRevisionId && expectedRevisionId) && (fetchedRevisionId !== expectedRevisionId)) {
-    throw new Error('Delay in CMR has detected. Refresh the page in order to see latest revision')
+    throw new Error('Delay in CMR has been detected. Refresh the page in order to see latest revision')
   }
 }
 


### PR DESCRIPTION
# Overview

### What is the feature?

When users would click Save & Continue, occationaly an incorrect version of the draft would populate. This code triggers a useEffect if the revisionId that comes back from CMR does not match the revisionId that we expect. 

### What is the Solution?

Add revisionId to AppContextProvider and set it when a user ingests a draft. This triggers a change in the data which triggers a fetchdraft useeffect. 

### What areas of the application does this impact?

MetadataForm and AppContextProvider

# Testing

### Reproduction steps

- **Environment for testing: UAT
- **Collection to test with: Any new draft

1. Insert the following below line 144 in MetadataForm.jsx in order to see what's going on in the useEffect:
    console.log("🚀 ~ useEffect ~ cmrRetrievedRevisionId:", cmrRetrievedRevisionId)
    console.log("🚀 ~ useEffect ~ appContextRevisionId:", appContextRevisionId)
3. Create a new draft and click Save & Continue. It should work as expected. 
4. If doing this does not trigger an error notification at some point, you can force it to send out an error by changing line 239 from setRevisionId(savedRevisionId) to setRevisionId(1000). Or whatever unattainable number you so choose. 

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings