### PR TITLE
MMT-3914: Not Allowing Certain GCMD Location Keywords to be Added

### DIFF
--- a/static/src/js/schemas/uiSchemas/collections/spatialInformation.jsx
+++ b/static/src/js/schemas/uiSchemas/collections/spatialInformation.jsx
@@ -1442,7 +1442,7 @@ const spatialInformationUiSchema = {
     'ui:field': 'keywordPicker',
     'ui:keyword_scheme': 'location_keywords',
     'ui:picker_title': 'LOCATION KEYWORD',
-    'ui:keyword_scheme_column_names': ['locationkeywords', 'category', 'type', 'sub_region_1', 'sub_region_2', 'sub_region_3', 'detailed_location'],
+    'ui:keyword_scheme_column_names': ['locationkeywords', 'category', 'type', 'subregion_1', 'subregion_2', 'subregion_3', 'detailed_location'],
     'ui:scheme_values': ['Category', 'Type', 'Subregion 1', 'Subregion 2', 'Subregion 3', 'Detailed Location'
     ]
   }

--- a/static/src/js/utils/__tests__/parseCmrResponse.test.js
+++ b/static/src/js/utils/__tests__/parseCmrResponse.test.js
@@ -253,4 +253,145 @@ describe('cmrKeywords', () => {
       ])
     })
   })
+
+  describe('can return a single list of location keywords', () => {
+    test('returns a parsed list of location keywords from CMR', () => {
+      const cmrResponse = {
+        category: [
+          {
+            value: 'GEOGRAPHIC REGION',
+            uuid: '204270d9-8039-4768-851e-63635af5fb65',
+            subfields: [
+              'type'
+            ],
+            type: [
+              {
+                value: 'ARCTIC',
+                uuid: 'd40d9651-aa19-4b2c-9764-7371bb64b9a7'
+              }
+            ]
+          },
+          {
+            value: 'CONTINENT',
+            uuid: '0a672f19-dad5-4114-819a-2eb55bdbb56a',
+            subfields: [
+              'type'
+            ],
+            type: [
+              {
+                value: 'ASIA',
+                subfields: [
+                  'subregion_1'
+                ],
+                subregion_1: [
+                  {
+                    value: 'WESTERN ASIA',
+                    subfields: [
+                      'subregion_2'
+                    ],
+                    subregion_2: [
+                      {
+                        value: 'MIDDLE EAST',
+                        subfields: [
+                          'subregion_3'
+                        ],
+                        subregion_3: [
+                          {
+                            value: 'GAZA STRIP',
+                            uuid: '302ab5f2-5fa2-482d-9d22-8a7a1546a62d'
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                value: 'AFRICA',
+                uuid: '2ca1b865-5555-4375-aa81-72811335b695',
+                subfields: [
+                  'subregion_1'
+                ],
+                subregion_1: [
+                  {
+                    value: 'CENTRAL AFRICA',
+                    uuid: 'f2ffbe58-8792-413b-805b-3e1c8de1c6ff',
+                    subfields: [
+                      'subregion_2'
+                    ],
+                    subregion_2: [
+                      {
+                        value: 'ANGOLA',
+                        uuid: '9b0a194d-d617-4fed-9625-df176319892d'
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            value: 'OCEAN',
+            uuid: 'ff03e9fc-9882-4a5e-ad0b-830d8f1186cb',
+            subfields: [
+              'type'
+            ],
+            type: [
+              {
+                value: 'ATLANTIC OCEAN',
+                uuid: 'cf249a36-2e82-4d32-84cd-23a4f40bb393',
+                subfields: [
+                  'subregion_1'
+                ],
+                subregion_1: [
+                  {
+                    value: 'NORTH ATLANTIC OCEAN',
+                    uuid: 'a4202721-0cba-4fa1-853f-890f146b04f9',
+                    subfields: [
+                      'subregion_2'
+                    ],
+                    subregion_2: [
+                      {
+                        value: 'MEDITERRANEAN SEA',
+                        subfields: [
+                          'subregion_3'
+                        ],
+                        subregion_3: [
+                          {
+                            value: 'ADRIATIC SEA',
+                            uuid: '7b93c892-2fc4-417b-a4da-5c8a2fca361b'
+                          }
+                        ]
+                      },
+                      {
+                        value: 'BALTIC SEA',
+                        uuid: '41cd228c-4677-4900-9507-70144d8b50bc'
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      const expectedResult = [
+        ['CONTINENT', 'AFRICA', 'CENTRAL AFRICA', 'ANGOLA'],
+        ['CONTINENT', 'ASIA', 'WESTERN ASIA', 'MIDDLE EAST', 'GAZA STRIP'],
+        ['GEOGRAPHIC REGION', 'ARCTIC'],
+        ['OCEAN', 'ATLANTIC OCEAN', 'NORTH ATLANTIC OCEAN', 'BALTIC SEA'],
+        [
+          'OCEAN',
+          'ATLANTIC OCEAN',
+          'NORTH ATLANTIC OCEAN',
+          'MEDITERRANEAN SEA',
+          'ADRIATIC SEA'
+        ]
+      ]
+      const result = parseCmrResponse(cmrResponse, ['locationkeywords', 'category', 'type', 'subregion_1', 'subregion_2', 'subregion_3', 'detailed_location'])
+
+      expect(result).toEqual(expectedResult)
+    })
+  })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

keyword pickers do not allow for searching below the Continent level hierarchy and add keywords such as countries or US States

### What is the Solution?

Column names of sub regions were wrong in the ui schema file, now fixed.

### What areas of the application does this impact?

Location keywords picker in 'Spatial Information'

# Testing

See test session.

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings