### PR TITLE
Mmt 3934: CMR Publish Operation Error Not Surfaced to User

### DIFF
--- a/static/src/js/components/Notifications/Notifications.jsx
+++ b/static/src/js/components/Notifications/Notifications.jsx
@@ -48,13 +48,14 @@ const Notifications = () => {
               success: <FaCheck className={iconClassNames} />,
               danger: <FaExclamation className={iconClassNames} />
             }
+            const shouldAutoHide = !(variant === 'danger')
 
             // Set the default delay duration to be passed to the Toast component and the bootstrap css variable
             const delay = 4000
 
             return (
               <Toast
-                autohide
+                autohide={shouldAutoHide}
                 bg="dark"
                 className="position-relative overflow-hidden text-light"
                 delay={delay}

--- a/static/src/js/components/Notifications/__tests__/Notifications.test.jsx
+++ b/static/src/js/components/Notifications/__tests__/Notifications.test.jsx
@@ -10,26 +10,30 @@ import Notifications from '../Notifications'
 import Providers from '../../../providers/Providers/Providers'
 import useNotificationsContext from '../../../hooks/useNotificationsContext'
 
-const MockComponent = () => {
+// eslint-disable-next-line react/prop-types
+const MockComponent = ({ variantType }) => {
   const { addNotification } = useNotificationsContext()
 
   useEffect(() => {
     addNotification({
-      message: 'Mock notification',
-      variant: 'success'
+      message: `Mock ${variantType} notification`,
+      variant: `${variantType}`
     })
   }, [])
 
   return null
 }
 
-const setup = () => {
+const setup = ({
+  overrideVariantType,
+  variantType = 'success'
+} = {}) => {
   const user = userEvent.setup()
 
   render(
     <Providers>
       <Notifications />
-      <MockComponent />
+      <MockComponent variantType={overrideVariantType || variantType} />
     </Providers>
   )
 
@@ -43,7 +47,7 @@ describe('Notifications', () => {
     test('renders a toast', () => {
       setup()
 
-      expect(screen.getByText('Mock notification')).toBeInTheDocument()
+      expect(screen.getByText('Mock success notification')).toBeInTheDocument()
     })
 
     describe('when clicking the close button', () => {
@@ -54,7 +58,7 @@ describe('Notifications', () => {
 
         await user.click(button)
 
-        expect(screen.queryByText('Mock notification')).not.toBeInTheDocument()
+        expect(screen.queryByText('Mock success notification')).not.toBeInTheDocument()
       })
     })
 
@@ -64,13 +68,29 @@ describe('Notifications', () => {
 
         setup()
 
-        expect(screen.getByText('Mock notification')).toBeInTheDocument()
+        expect(screen.getByText('Mock success notification')).toBeInTheDocument()
 
         await act(() => {
           vi.advanceTimersByTimeAsync(4001)
         })
 
-        expect(screen.queryByText('Mock notification')).not.toBeInTheDocument()
+        expect(screen.queryByText('Mock success notification')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('when the the notification is of type danger', () => {
+      test('the notification does not expire', async () => {
+        vi.useFakeTimers()
+
+        setup({ overrideVariantType: 'danger' })
+
+        expect(screen.getByText('Mock danger notification')).toBeInTheDocument()
+
+        await act(() => {
+          vi.advanceTimersByTimeAsync(4001)
+        })
+
+        expect(screen.getByText('Mock danger notification')).toBeInTheDocument()
       })
     })
   })


### PR DESCRIPTION
# Overview

### What is the feature?

Goes along with GQL-87. Now that users are receiving cmr errors, they need to be able to read them. Currently, they are showing up and then autohiding after 4 seconds. 

### What is the Solution?

Error notification with better messages from CMR stay present until user clicks 'close'

### What areas of the application does this impact?

Notifications.jsx

# Testing

### Reproduction steps

- **Environment for testing: local
- **Collection to test with: you own

Create a local collection draft that is ready to publish. Ensure that it does publish then go back to edit.
Under Aquisitional Information, create two ComposedOfs with the same shortName.
If doing this in graphQL, you should see it return with this message: ""message": "Location: Platforms[0] > Instruments[0] > ComposedOf,Composed Of must be unique. This contains duplicates named [ATM]." In MMT, you should get three notifications pop up: one that Saves the Draft and disappears, one for Location and one for the error itself that both stay open until you click close. 

This does affect ALL error messages go around making sure all error messages are working as best as you can. 

### Attachments

# Checklist

- [ x] I have added automated tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings