### PR TITLE
MMT-3919: Remove invalid group permissions

### DIFF
--- a/static/src/js/components/Permission/Permission.jsx
+++ b/static/src/js/components/Permission/Permission.jsx
@@ -10,6 +10,7 @@ import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
 import LoadingTable from '@/js/components/LoadingTable/LoadingTable'
 import PermissionCollectionTable from '@/js/components/PermissionCollectionTable/PermissionCollectionTable'
 import Table from '@/js/components/Table/Table'
+import validGroupItems from '@/js/utils/validGroupItems'
 
 import { GET_COLLECTION_PERMISSION } from '@/js/operations/queries/getCollectionPermission'
 
@@ -32,7 +33,8 @@ const Permission = () => {
     groups
   } = acl
 
-  const { items: groupItems } = groups
+  // Returns valid group permission items. Invalid items are those without both id and userType.
+  const groupItems = validGroupItems(groups.items)
 
   const {
     collectionApplicable,

--- a/static/src/js/components/Permission/__tests__/Permission.test.jsx
+++ b/static/src/js/components/Permission/__tests__/Permission.test.jsx
@@ -16,7 +16,6 @@ import Permission from '@/js/components/Permission/Permission'
 import PermissionCollectionTable from '@/js/components/PermissionCollectionTable/PermissionCollectionTable'
 
 import { GET_COLLECTION_PERMISSION } from '@/js/operations/queries/getCollectionPermission'
-import { Tab } from 'bootstrap'
 
 vi.mock('../../PermissionCollectionTable/PermissionCollectionTable')
 


### PR DESCRIPTION
# Overview

### What is the feature?

MMT displays invalid group permissions, which show up with empty group name in the UI.

### What is the Solution?

Remove invalid group permissions so they don't show up.

### What areas of the application does this impact?

Single permission view.

# Testing

See test session

### Attachments

See ticket.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings