### PR TITLE
MMT-3914: Fix umm location element names

### DIFF
--- a/static/src/js/schemas/uiSchemas/collections/spatialInformation.jsx
+++ b/static/src/js/schemas/uiSchemas/collections/spatialInformation.jsx
@@ -1443,7 +1443,7 @@ const spatialInformationUiSchema = {
     'ui:keyword_scheme': 'location_keywords',
     'ui:picker_title': 'LOCATION KEYWORD',
     'ui:keyword_scheme_column_names': ['locationkeywords', 'category', 'type', 'subregion_1', 'subregion_2', 'subregion_3', 'detailed_location'],
-    'ui:scheme_values': ['Category', 'Type', 'Subregion 1', 'Subregion 2', 'Subregion 3', 'Detailed Location'
+    'ui:scheme_values': ['Category', 'Type', 'Subregion1', 'Subregion2', 'Subregion3', 'DetailedLocation'
     ]
   }
 }


### PR DESCRIPTION
# Overview

### What is the feature?

Location keywords umm element names were wrong. 

### What is the Solution?

Correct names

### What areas of the application does this impact?

When selecting location keywords: 'Subregion1', 'Subregion2', 'Subregion3', 'DetailedLocation' should show up in the json view instead of 'Subregion 1', 'Subregion 2', 'Subregion 3', 'Detailed Location'

# Testing

Choose location keyword in "Spatial Information" down to lowest level (for example country), add keyword and then check the json view. 

### Attachments

N/A

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings