### PR TITLE
MMT-3943: Updated to support times in UTC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "commafy": "^0.0.6",
         "compact-object-deep": "^1.0.0",
         "cookie": "^0.6.0",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "esbuild": "^0.19.5",
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-plugin-testing-library": "^6.2.2",
@@ -13704,18 +13706,20 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/dayjs": {
@@ -25967,6 +25971,21 @@
       "peerDependencies": {
         "react": "^16.9.0 || ^17 || ^18",
         "react-dom": "^16.9.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-datepicker/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "commafy": "^0.0.6",
     "compact-object-deep": "^1.0.0",
     "cookie": "^0.6.0",
+    "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "esbuild": "^0.19.5",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-testing-library": "^6.2.2",

--- a/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
@@ -108,7 +108,7 @@ const CustomDateTimeWidget = ({
       <DatePicker
         className="w-100 p-2 form-control"
         disabled={disabled}
-        dateFormat="yyyy-MM-dd'T'HH:mm:ss.000'Z'"
+        dateFormat="yyyy-MM-dd'T'HH:mm:ss'Z'"
         dropdownMode="select"
         id={id}
         locale="en-GB" // Use the UK locale, located in the Greenwich Mean Time (GMT) zone,

--- a/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
@@ -50,9 +50,6 @@ const CustomDateTimeWidget = ({
 
   const { description } = schema
 
-  const dateWithZone = moment.utc(value).format('YYYY-MM-DDTHH:mm:ss.SSS')
-  const fieldValue = new Date(dateWithZone)
-
   const { formContext } = registry
   const {
     focusField,
@@ -86,9 +83,7 @@ const CustomDateTimeWidget = ({
   }
 
   const handleChange = (newDate) => {
-    let formattedDateTime = newDate.toISOString()
-    formattedDateTime = `${formattedDateTime.substring(0, 10)}T00:00:00.000Z`
-    onChange(formattedDateTime)
+    onChange(newDate.toISOString())
 
     handleBlur()
   }
@@ -105,7 +100,7 @@ const CustomDateTimeWidget = ({
       <DatePicker
         className="w-100 p-2 form-control"
         disabled={disabled}
-        dateFormat="yyyy-MM-dd'T'00:00:00.000'Z'"
+        dateFormat="yyyy-MM-dd'T'H:mm:ss.000'Z'"
         dropdownMode="select"
         id={id}
         onBlur={handleBlur}
@@ -115,13 +110,12 @@ const CustomDateTimeWidget = ({
         peekNextMonth
         placeholderText="YYYY-MM-DDTHH:MM:SSZ"
         wrapperClassName="d-block"
-        selected={
-          value && new Date(fieldValue.toLocaleString('en-US', {
-            timeZone: 'GMT'
-          }))
-        }
+        selected={(
+          value && moment.utc(value).toDate())}
         showMonthDropdown
         showYearDropdown
+        showTimeSelect
+        timeIntervals={1}
       />
     </CustomWidgetWrapper>
   )

--- a/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
@@ -89,7 +89,7 @@ const CustomDateTimeWidget = ({
   }
 
   const handleChange = (newDate) => {
-    // Get the UTC date/time from a date representing local time in a given time zone
+    newDate.setMilliseconds(0)
     const formattedDateTime = fromZonedTime(newDate, 'GMT').toISOString()
     onChange(formattedDateTime)
 
@@ -108,7 +108,7 @@ const CustomDateTimeWidget = ({
       <DatePicker
         className="w-100 p-2 form-control"
         disabled={disabled}
-        dateFormat="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        dateFormat="yyyy-MM-dd'T'HH:mm:ss'Z'"
         dropdownMode="select"
         id={id}
         locale="en-GB" // Use the UK locale, located in the Greenwich Mean Time (GMT) zone,

--- a/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
@@ -89,6 +89,7 @@ const CustomDateTimeWidget = ({
   }
 
   const handleChange = (newDate) => {
+    // The picket widget has a bug where it is not setting millis to 0 when selecting a time.
     newDate.setMilliseconds(0)
     const formattedDateTime = fromZonedTime(newDate, 'GMT').toISOString()
     onChange(formattedDateTime)

--- a/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
@@ -6,13 +6,12 @@ import React, {
 import PropTypes from 'prop-types'
 import { startCase } from 'lodash-es'
 import DatePicker, { registerLocale } from 'react-datepicker'
-import 'react-datepicker/dist/react-datepicker.css'
-
 import enGB from 'date-fns/locale/en-GB'
 import { toZonedTime, fromZonedTime } from 'date-fns-tz'
-
 import shouldFocusField from '../../utils/shouldFocusField'
 import CustomWidgetWrapper from '../CustomWidgetWrapper/CustomWidgetWrapper'
+
+import 'react-datepicker/dist/react-datepicker.css'
 
 /**
  * CustomDateTimeWidget

--- a/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
@@ -50,6 +50,9 @@ const CustomDateTimeWidget = ({
 
   const { description } = schema
 
+  // Parse as a localized date, as the DatePicker is working with localized dates.
+  const fieldValue = value ? new Date(value) : null
+
   const { formContext } = registry
   const {
     focusField,
@@ -83,7 +86,8 @@ const CustomDateTimeWidget = ({
   }
 
   const handleChange = (newDate) => {
-    onChange(newDate.toISOString())
+    const formattedDateTime = moment(newDate).local().format('YYYY-MM-DDTHH:mm:ss.000')
+    onChange(`${formattedDateTime}Z`)
 
     handleBlur()
   }
@@ -100,7 +104,7 @@ const CustomDateTimeWidget = ({
       <DatePicker
         className="w-100 p-2 form-control"
         disabled={disabled}
-        dateFormat="yyyy-MM-dd'T'H:mm:ss.000'Z'"
+        dateFormat="yyyy-MM-dd'T'HH:mm:ss.000'Z'"
         dropdownMode="select"
         id={id}
         onBlur={handleBlur}
@@ -110,8 +114,11 @@ const CustomDateTimeWidget = ({
         peekNextMonth
         placeholderText="YYYY-MM-DDTHH:MM:SSZ"
         wrapperClassName="d-block"
-        selected={(
-          value && moment.utc(value).toDate())}
+        selected={
+          value && new Date(fieldValue.toLocaleString('en-US', {
+            timeZone: 'GMT'
+          }))
+        }
         showMonthDropdown
         showYearDropdown
         showTimeSelect

--- a/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
@@ -8,8 +8,8 @@ import { startCase } from 'lodash-es'
 import DatePicker, { registerLocale } from 'react-datepicker'
 import enGB from 'date-fns/locale/en-GB'
 import { toZonedTime, fromZonedTime } from 'date-fns-tz'
-import shouldFocusField from '../../utils/shouldFocusField'
 import CustomWidgetWrapper from '../CustomWidgetWrapper/CustomWidgetWrapper'
+import shouldFocusField from '../../utils/shouldFocusField'
 
 import 'react-datepicker/dist/react-datepicker.css'
 

--- a/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
@@ -108,7 +108,7 @@ const CustomDateTimeWidget = ({
       <DatePicker
         className="w-100 p-2 form-control"
         disabled={disabled}
-        dateFormat="yyyy-MM-dd'T'HH:mm:ss'Z'"
+        dateFormat="yyyy-MM-dd'T'HH:mm:ss.000'Z'"
         dropdownMode="select"
         id={id}
         locale="en-GB" // Use the UK locale, located in the Greenwich Mean Time (GMT) zone,

--- a/static/src/js/components/CustomDateTimeWidget/__tests__/CustomDateTimeWidget.test.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/__tests__/CustomDateTimeWidget.test.jsx
@@ -167,7 +167,7 @@ describe('CustomDateTimeWidget', () => {
 
       const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SSZ')
 
-      expect(field).toHaveValue('2023-12-05T00:00:00.000Z')
+      expect(field).toHaveValue('2023-12-05T00:00:00Z')
     })
   })
 
@@ -179,7 +179,7 @@ describe('CustomDateTimeWidget', () => {
 
       const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SSZ')
 
-      expect(field).toHaveValue('2023-12-05T16:05:59.000Z')
+      expect(field).toHaveValue('2023-12-05T16:05:59Z')
     })
   })
 })

--- a/static/src/js/components/CustomDateTimeWidget/__tests__/CustomDateTimeWidget.test.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/__tests__/CustomDateTimeWidget.test.jsx
@@ -170,4 +170,16 @@ describe('CustomDateTimeWidget', () => {
       expect(field).toHaveValue('2023-12-05T00:00:00.000Z')
     })
   })
+
+  describe('When a date has a specific time in the form', () => {
+    test('shows the date and time', async () => {
+      setup({
+        value: '2023-12-05T16:05:59.000Z'
+      })
+
+      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SSZ')
+
+      expect(field).toHaveValue('2023-12-05T16:05:59.000Z')
+    })
+  })
 })

--- a/static/src/js/components/RevisionList/__tests__/RevisionList.test.jsx
+++ b/static/src/js/components/RevisionList/__tests__/RevisionList.test.jsx
@@ -12,7 +12,10 @@ import {
 } from 'react-router-dom'
 
 import userEvent from '@testing-library/user-event'
-import { collectionRevisions } from './__mocks__/revisionResults'
+import {
+  collectionRevisions,
+  collectionRevisionsWithDeletedRevision
+} from './__mocks__/revisionResults'
 
 import RevisionList from '../RevisionList'
 import ErrorBoundary from '../../ErrorBoundary/ErrorBoundary'
@@ -115,6 +118,37 @@ describe('RevisionList component', () => {
       expect(row2Cells[0].textContent).toBe('7 - Revision')
       expect(row2Cells[2].textContent).toBe('admin')
       expect(row2Cells[3].textContent).toBe('Revert to this revision')
+    })
+  })
+
+  // Temporary solution from MMT-3946. We are determining that a revision has been deleted if its userId === cmr
+  describe('when there is a revision with userid === cmr', () => {
+    test('renders the revisions and indicates which of them has been deleted', async () => {
+      setup({ overrideMocks: [collectionRevisionsWithDeletedRevision] })
+
+      expect(screen.queryByText('Loading...'))
+
+      const tableRows = await screen.findAllByRole('row')
+      expect(tableRows.length).toEqual(3)
+
+      const date = new Date(2000, 1, 1, 13)
+      vi.setSystemTime(date)
+      const rows = screen.queryAllByRole('row')
+      const row1 = rows[1]
+      const row2 = rows[2]
+
+      const row1Cells = within(row1).queryAllByRole('cell')
+      const row2Cells = within(row2).queryAllByRole('cell')
+      expect(row1Cells).toHaveLength(4)
+      expect(row1Cells[0].textContent).toBe('8 - Published')
+      expect(row1Cells[1].textContent).toBe('Tuesday, February 1, 2000 6:00 PM')
+      expect(row1Cells[2].textContent).toBe('admin')
+      expect(row1Cells[3].textContent).toBe('')
+
+      expect(row2Cells).toHaveLength(4)
+      expect(row2Cells[0].textContent).toBe('7 - Deleted')
+      expect(row2Cells[2].textContent).toBe('cmr')
+      expect(row2Cells[3].textContent).toBe('deleted')
     })
   })
 

--- a/static/src/js/components/RevisionList/__tests__/__mocks__/revisionResults.js
+++ b/static/src/js/components/RevisionList/__tests__/__mocks__/revisionResults.js
@@ -3304,3 +3304,43 @@ export const revertCollectionRevision = {
     }
   }
 }
+
+// We are considering 'deleted' when userId === 'cmr' for now. Will come back better solution has been created
+export const collectionRevisionsWithDeletedRevision = {
+  request: {
+    query: GET_COLLECTION,
+    variables: {
+      params: {
+        conceptId: 'C1200000104-MMT_2'
+      }
+    }
+  },
+  result: {
+    data: {
+      collection: {
+        revisionId: '8',
+        revisions: {
+          count: 8,
+          items: [
+            {
+              conceptId: 'C1200000104-MMT_2',
+              revisionDate: '2000-02-01T18:00:00.000Z',
+              revisionId: '8',
+              userId: 'admin',
+              __typename: 'Collection'
+            },
+            {
+              conceptId: 'C1200000104-MMT_2',
+              revisionDate: '2024-04-24T16:37:11.849Z',
+              revisionId: '7',
+              userId: 'cmr',
+              __typename: 'Collection'
+            }
+          ],
+          __typename: 'CollectionRevisionList'
+        },
+        __typename: 'Collection'
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Overview

### What is the feature?

The existing date/time widget would wipe out any time the user selected.   We should allow them to select a time or type in the time and preserve what they type.

### What is the Solution?

The widget now configures the react-date-picker to show times.   Also if they select a time, it should display in ISO format.   Both the time picker and the text field should show the date in UTC.

### What areas of the application does this impact?

Any forms that use the date time picker (such as Temporal Information page)

# Testing

Go to the Temporal Information page and add a Single Date Time.   Click on the text field, this will bring up the widget.

You'll see the ability to select times on the right.  

You can also type in the time in the text box.

Verify that either what you select or type show up in the JSON below.


### Attachments
![Screenshot 2024-11-19 at 6 41 44 PM](https://github.com/user-attachments/assets/1515b64a-18be-4416-b7cb-39ae73485bec)


# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings