### PR TITLE
MMT-3946: Bug: Current UI for RevisionList does not indicate to user that a revision has been deleted

### DIFF
--- a/static/src/js/components/RevisionList/RevisionList.jsx
+++ b/static/src/js/components/RevisionList/RevisionList.jsx
@@ -49,6 +49,7 @@ const RevisionList = () => {
     const published = rowData.revisionId === concept.revisionId
 
     const { revisionId, userId } = rowData
+    // Temporary Solution from MMT-3946 until we can pass up a tombstone type instead
     const isDeleted = userId === 'cmr'
 
     let descriptionCellContent
@@ -110,6 +111,7 @@ const RevisionList = () => {
     const { revisionId, userId } = rowData
     const { revisionId: currRevisionId } = concept
     const isPublished = revisionId === currRevisionId
+    // Temporary Solution from MMT-3946 until we can pass up a tombstone type instead
     const isDeleted = userId === 'cmr'
 
     let actionCellContent

--- a/static/src/js/components/RevisionList/RevisionList.jsx
+++ b/static/src/js/components/RevisionList/RevisionList.jsx
@@ -48,18 +48,28 @@ const RevisionList = () => {
   const buildDescriptionCell = useCallback((cellData, rowData) => {
     const published = rowData.revisionId === concept.revisionId
 
-    return (
-      (published) ? (
+    const { revisionId, userId } = rowData
+    const isDeleted = userId === 'cmr'
+
+    let descriptionCellContent
+
+    if (published) {
+      descriptionCellContent = (
         <EllipsisLink to={`/${type}/${conceptId}`}>
-          {[rowData.revisionId, ' - Published'].join('')}
+          {[revisionId, ' - Published'].join('')}
         </EllipsisLink>
       )
-        : (
-          <EllipsisLink to={`/${type}/${conceptId}/revisions/${rowData.revisionId}`}>
-            {[rowData.revisionId, ' - Revision'].join('')}
-          </EllipsisLink>
-        )
-    )
+    } else if (!published && isDeleted) {
+      descriptionCellContent = `${revisionId} - Deleted`
+    } else {
+      descriptionCellContent = (
+        <EllipsisLink to={`/${type}/${conceptId}/revisions/${rowData.revisionId}`}>
+          {[revisionId, ' - Revision'].join('')}
+        </EllipsisLink>
+      )
+    }
+
+    return descriptionCellContent
   }, [])
 
   const [restoreMutation] = useMutation(restoreRevisionMutations[derivedConceptType], {
@@ -97,11 +107,15 @@ const RevisionList = () => {
   }
 
   const buildActionCell = useCallback((cellData, rowData) => {
-    const { revisionId } = rowData
+    const { revisionId, userId } = rowData
     const { revisionId: currRevisionId } = concept
+    const isPublished = revisionId === currRevisionId
+    const isDeleted = userId === 'cmr'
 
-    return (
-      revisionId !== currRevisionId && (
+    let actionCellContent
+
+    if (!isPublished && !isDeleted) {
+      actionCellContent = (
         <Button
           className="btn btn-link"
           type="button"
@@ -111,7 +125,13 @@ const RevisionList = () => {
           Revert to this revision
         </Button>
       )
-    )
+    } else if (!isPublished && isDeleted) {
+      actionCellContent = 'deleted'
+    } else {
+      actionCellContent = null
+    }
+
+    return actionCellContent
   })
 
   const columns = [

--- a/static/src/js/components/RevisionList/__tests__/RevisionList.test.jsx
+++ b/static/src/js/components/RevisionList/__tests__/RevisionList.test.jsx
@@ -121,7 +121,7 @@ describe('RevisionList component', () => {
     })
   })
 
-  // Temporary solution. We are determining that a revision has been deleted if its userId === cmr
+  // Temporary solution from MMT-3946. We are determining that a revision has been deleted if its userId === cmr
   describe('when there is a revision with userid === cmr', () => {
     test('renders the revisions and indicates which of them has been deleted', async () => {
       setup({ overrideMocks: [collectionRevisionsWithDeletedRevision] })

--- a/static/src/js/components/RevisionList/__tests__/RevisionList.test.jsx
+++ b/static/src/js/components/RevisionList/__tests__/RevisionList.test.jsx
@@ -12,7 +12,10 @@ import {
 } from 'react-router-dom'
 
 import userEvent from '@testing-library/user-event'
-import { collectionRevisions } from './__mocks__/revisionResults'
+import {
+  collectionRevisions,
+  collectionRevisionsWithDeletedRevision
+} from './__mocks__/revisionResults'
 
 import RevisionList from '../RevisionList'
 import ErrorBoundary from '../../ErrorBoundary/ErrorBoundary'
@@ -115,6 +118,37 @@ describe('RevisionList component', () => {
       expect(row2Cells[0].textContent).toBe('7 - Revision')
       expect(row2Cells[2].textContent).toBe('admin')
       expect(row2Cells[3].textContent).toBe('Revert to this revision')
+    })
+  })
+
+  // Temporary solution. We are determining that a revision has been deleted if its userId === cmr
+  describe('when there is a revision with userid === cmr', () => {
+    test('renders the revisions and indicates which of them has been deleted', async () => {
+      setup({ overrideMocks: [collectionRevisionsWithDeletedRevision] })
+
+      expect(screen.queryByText('Loading...'))
+
+      const tableRows = await screen.findAllByRole('row')
+      expect(tableRows.length).toEqual(3)
+
+      const date = new Date(2000, 1, 1, 13)
+      vi.setSystemTime(date)
+      const rows = screen.queryAllByRole('row')
+      const row1 = rows[1]
+      const row2 = rows[2]
+
+      const row1Cells = within(row1).queryAllByRole('cell')
+      const row2Cells = within(row2).queryAllByRole('cell')
+      expect(row1Cells).toHaveLength(4)
+      expect(row1Cells[0].textContent).toBe('8 - Published')
+      expect(row1Cells[1].textContent).toBe('Tuesday, February 1, 2000 6:00 PM')
+      expect(row1Cells[2].textContent).toBe('admin')
+      expect(row1Cells[3].textContent).toBe('')
+
+      expect(row2Cells).toHaveLength(4)
+      expect(row2Cells[0].textContent).toBe('7 - Deleted')
+      expect(row2Cells[2].textContent).toBe('cmr')
+      expect(row2Cells[3].textContent).toBe('deleted')
     })
   })
 

--- a/static/src/js/components/RevisionList/__tests__/__mocks__/revisionResults.js
+++ b/static/src/js/components/RevisionList/__tests__/__mocks__/revisionResults.js
@@ -3304,3 +3304,43 @@ export const revertCollectionRevision = {
     }
   }
 }
+
+// We are considering 'deleted' when userId === 'cmr' for now. Will come back better solution has been created
+export const collectionRevisionsWithDeletedRevision = {
+  request: {
+    query: GET_COLLECTION,
+    variables: {
+      params: {
+        conceptId: 'C1200000104-MMT_2'
+      }
+    }
+  },
+  result: {
+    data: {
+      collection: {
+        revisionId: '8',
+        revisions: {
+          count: 8,
+          items: [
+            {
+              conceptId: 'C1200000104-MMT_2',
+              revisionDate: '2000-02-01T18:00:00.000Z',
+              revisionId: '8',
+              userId: 'admin',
+              __typename: 'Collection'
+            },
+            {
+              conceptId: 'C1200000104-MMT_2',
+              revisionDate: '2024-04-24T16:37:11.849Z',
+              revisionId: '7',
+              userId: 'cmr',
+              __typename: 'Collection'
+            }
+          ],
+          __typename: 'CollectionRevisionList'
+        },
+        __typename: 'Collection'
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Overview

### What is the feature?

Bug: Current UI for RevisionList does not indicate to user that a revision has been deleted. Created UI for deleted rows as a temp fix. 

### What is the Solution?

when userId === 'cmr' consider the row deleted. 

### What areas of the application does this impact?

RevisionList.jsx

# Testing

### Reproduction steps

- **Environment for testing: UAT
- **Collection to test with: http://localhost:5173/variables/V1256589611-MMT_2/revisions

1. Check out the revisions for above Variable. You should see that the row shows that it has been deleted and is unactionable. 


### Attachments

<img width="1300" alt="Screenshot 2024-11-21 at 3 21 40 PM" src="https://github.com/user-attachments/assets/3b0c44fe-efed-43ef-b41b-09878253f8bb">


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings