### PR TITLE
MMT-3926: Fix for Science Keyword Picker Adds An Additional Science Keyword That Was Not Originally Selected

### DIFF
--- a/static/src/js/components/KeywordPicker/KeywordPicker.jsx
+++ b/static/src/js/components/KeywordPicker/KeywordPicker.jsx
@@ -262,6 +262,10 @@ const KeywordPicker = ({
   // When a item from the search Typeahead is selected, this will capture that selection and add it
   // formData.
   const handleSearch = (text) => {
+    if (text.length === 0) {
+      return
+    }
+
     const split = text.toString().split('>')
     const filter = fullPath.filter((path) => path.indexOf(split[split.length - 1]) !== -1)
     const filterArr = filter[0].toString().split('>').slice(1)

--- a/static/src/js/components/KeywordPicker/KeywordPicker.jsx
+++ b/static/src/js/components/KeywordPicker/KeywordPicker.jsx
@@ -267,10 +267,6 @@ const KeywordPicker = ({
   // When a item from the search Typeahead is selected, this will capture that selection and add it
   // formData.
   const handleSearch = (text) => {
-    if (text.length === 0) {
-      return
-    }
-
     const split = text.toString().split('>')
     const filter = fullPath.filter((path) => path.indexOf(split[split.length - 1]) !== -1)
     const filterArr = filter[0].toString().split('>').slice(1)

--- a/static/src/js/components/KeywordPicker/KeywordPicker.jsx
+++ b/static/src/js/components/KeywordPicker/KeywordPicker.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { cloneDeep, isEmpty } from 'lodash-es'
 import { Typeahead } from 'react-bootstrap-typeahead'
@@ -48,6 +48,7 @@ const KeywordPicker = ({
 
   const [marginTop, setMarginTop] = useState(0)
   const [marginLeft, setMarginLeft] = useState(0)
+  const typeaheadRef = useRef(null)
 
   const filterKeywords = (path) => {
     const filteredPath = []
@@ -276,6 +277,7 @@ const KeywordPicker = ({
     }
 
     onChange(formData)
+    typeaheadRef.current.clear()
   }
 
   const displayItems = (item) => {
@@ -431,6 +433,7 @@ const KeywordPicker = ({
               <div className="eui-item-list-pane" style={{ marginTop }}>
                 <div className="keyword-picker__search-keywords">
                   <Typeahead
+                    ref={typeaheadRef}
                     clearButton
                     id="keyword-picker-search"
                     isLoading={loading}

--- a/static/src/js/components/KeywordPicker/KeywordPicker.jsx
+++ b/static/src/js/components/KeywordPicker/KeywordPicker.jsx
@@ -1,4 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, {
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 import PropTypes from 'prop-types'
 import { cloneDeep, isEmpty } from 'lodash-es'
 import { Typeahead } from 'react-bootstrap-typeahead'

--- a/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
+++ b/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
@@ -358,12 +358,12 @@ describe('when searching for a keyword', () => {
       await user.click(option)
 
       expect(props.onChange).toHaveBeenCalledTimes(1)
-      expect(props.onChange).not.toHaveBeenCalledWith([
+      expect(props.onChange).toHaveBeenCalledWith([
         {
           ToolCategory: 'EARTH SCIENCE SERVICES',
           ToolTopic: 'DATA ANALYSIS AND VISUALIZATION',
-          ToolTerm: 'CALIBRATION/VALIDATION',
-          ToolSpecificTerm: undefined
+          ToolTerm: 'GEOGRAPHIC INFORMATION SYSTEMS',
+          ToolSpecificTerm: 'DESKTOP GEOGRAPHIC INFORMATION SYSTEMS'
         }
       ])
     })

--- a/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
+++ b/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
@@ -1,4 +1,8 @@
-import { render, screen } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
@@ -364,6 +368,35 @@ describe('when searching for a keyword', () => {
         ToolSpecificTerm: undefined
       }
     ])
+  })
+
+  describe('when clicking the clear button in the textfield', () => {
+    test('it will only clear the text and not add another keyword', async () => {
+      const { props, user } = setup()
+
+      const searchBox = screen.getByRole('combobox')
+
+      await user.type(searchBox, 'Earth')
+      const option = screen.getByRole('option', { name: 'EARTH SCIENCE SERVICES>DATA ANALYSIS AND VISUALIZATION>GEOGRAPHIC INFORMATION SYSTEMS>DESKTOP GEOGRAPHIC INFORMATION SYSTEMS' })
+      await user.click(option)
+
+      const clearButton = screen.getByRole('button', { name: 'Clear' })
+      console.log('clear button is ', clearButton)
+
+      expect(props.onChange).toHaveBeenCalledTimes(1)
+      expect(props.onChange).not.toHaveBeenCalledWith([
+        {
+          ToolCategory: 'EARTH SCIENCE SERVICES',
+          ToolTopic: 'DATA ANALYSIS AND VISUALIZATION',
+          ToolTerm: 'CALIBRATION/VALIDATION',
+          ToolSpecificTerm: undefined
+        }
+      ])
+
+      // MMT-3926 - The behavior before this fix caused it to perform another onChange of a keyword.
+      fireEvent.click(clearButton)
+      expect(props.onChange).toHaveBeenCalledTimes(1) // Still only called once.
+    })
   })
 
   describe('when keyword recommender is included', () => {

--- a/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
+++ b/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
@@ -1,8 +1,4 @@
-import {
-  fireEvent,
-  render,
-  screen
-} from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
@@ -368,34 +364,6 @@ describe('when searching for a keyword', () => {
         ToolSpecificTerm: undefined
       }
     ])
-  })
-
-  describe('when clicking the clear button in the textfield', () => {
-    test('it will only clear the text and not add another keyword', async () => {
-      const { props, user } = setup()
-
-      const searchBox = screen.getByRole('combobox')
-
-      await user.type(searchBox, 'Earth')
-      const option = screen.getByRole('option', { name: 'EARTH SCIENCE SERVICES>DATA ANALYSIS AND VISUALIZATION>GEOGRAPHIC INFORMATION SYSTEMS>DESKTOP GEOGRAPHIC INFORMATION SYSTEMS' })
-      await user.click(option)
-
-      const clearButton = screen.getByRole('button', { name: 'Clear' })
-
-      expect(props.onChange).toHaveBeenCalledTimes(1)
-      expect(props.onChange).not.toHaveBeenCalledWith([
-        {
-          ToolCategory: 'EARTH SCIENCE SERVICES',
-          ToolTopic: 'DATA ANALYSIS AND VISUALIZATION',
-          ToolTerm: 'CALIBRATION/VALIDATION',
-          ToolSpecificTerm: undefined
-        }
-      ])
-
-      // MMT-3926 - The behavior before this fix caused it to perform another onChange of a keyword.
-      fireEvent.click(clearButton)
-      expect(props.onChange).toHaveBeenCalledTimes(1) // Still only called once.
-    })
   })
 
   describe('when keyword recommender is included', () => {

--- a/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
+++ b/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
@@ -381,7 +381,6 @@ describe('when searching for a keyword', () => {
       await user.click(option)
 
       const clearButton = screen.getByRole('button', { name: 'Clear' })
-      console.log('clear button is ', clearButton)
 
       expect(props.onChange).toHaveBeenCalledTimes(1)
       expect(props.onChange).not.toHaveBeenCalledWith([

--- a/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
+++ b/static/src/js/components/KeywordPicker/__tests__/KeywordPicker.test.jsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
+import { test } from 'vitest'
 import useControlledKeywords from '../../../hooks/useControlledKeywords'
 
 import parseCmrResponse from '../../../utils/parseCmrResponse'
@@ -346,24 +347,39 @@ describe('when removing selected keyword', () => {
 })
 
 describe('when searching for a keyword', () => {
-  test('adds the searched keyword', async () => {
-    const { props, user } = setup()
+  describe('and user selects a keyword', () => {
+    test('adds the searched keyword', async () => {
+      const { props, user } = setup()
 
-    const searchBox = screen.getByRole('combobox')
+      const searchBox = screen.getByRole('combobox')
 
-    await user.type(searchBox, 'Earth')
-    const option = screen.getByRole('option', { name: 'EARTH SCIENCE SERVICES>DATA ANALYSIS AND VISUALIZATION>GEOGRAPHIC INFORMATION SYSTEMS>DESKTOP GEOGRAPHIC INFORMATION SYSTEMS' })
-    await user.click(option)
+      await user.type(searchBox, 'Earth')
+      const option = screen.getByRole('option', { name: 'EARTH SCIENCE SERVICES>DATA ANALYSIS AND VISUALIZATION>GEOGRAPHIC INFORMATION SYSTEMS>DESKTOP GEOGRAPHIC INFORMATION SYSTEMS' })
+      await user.click(option)
 
-    expect(props.onChange).toHaveBeenCalledTimes(1)
-    expect(props.onChange).not.toHaveBeenCalledWith([
-      {
-        ToolCategory: 'EARTH SCIENCE SERVICES',
-        ToolTopic: 'DATA ANALYSIS AND VISUALIZATION',
-        ToolTerm: 'CALIBRATION/VALIDATION',
-        ToolSpecificTerm: undefined
-      }
-    ])
+      expect(props.onChange).toHaveBeenCalledTimes(1)
+      expect(props.onChange).not.toHaveBeenCalledWith([
+        {
+          ToolCategory: 'EARTH SCIENCE SERVICES',
+          ToolTopic: 'DATA ANALYSIS AND VISUALIZATION',
+          ToolTerm: 'CALIBRATION/VALIDATION',
+          ToolSpecificTerm: undefined
+        }
+      ])
+    })
+
+    test('clears the search box after the selection', async () => {
+      const { user } = setup()
+
+      const searchBox = screen.getByRole('combobox')
+
+      await user.type(searchBox, 'Earth')
+
+      expect(searchBox).toHaveValue('Earth')
+      const option = screen.getByRole('option', { name: 'EARTH SCIENCE SERVICES>DATA ANALYSIS AND VISUALIZATION>GEOGRAPHIC INFORMATION SYSTEMS>DESKTOP GEOGRAPHIC INFORMATION SYSTEMS' })
+      await user.click(option)
+      expect(searchBox).toHaveValue('')
+    })
   })
 
   describe('when keyword recommender is included', () => {


### PR DESCRIPTION
# Overview

### What is the feature?

Science Keyword Picker Adds An Additional Science Keyword That Was Not Originally Selected

### What is the Solution?

In the onChange event, check if the text to search is empty, if so, ignore the search.

### What areas of the application does this impact?

Science Keyword Picker

# Testing

Here are the steps to reproduce (video demonstration is also attached). 
Navigate to a collection > Descriptive Keywords
Search for a keyword using the keyword widget
Add a keyword
Click x in the search picker
EARTH SCIENCE > AGRICULTURE > AGRICULTURAL AQUATIC SCIENCES > AQUACULTURE is added by mistake (note: this is the 1st keyword in the keyword pick list.) 

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings