### PR TITLE
MMT-3876: MMT should pull down schemas from respective cdn env

### DIFF
--- a/bin/download_schemas.sh
+++ b/bin/download_schemas.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ummJsonSchemaUrl=`jq '.ummJsonSchemaUrl' ./static.config.json`
 ummJsonSchemaUrl=${ummJsonSchemaUrl//\"/}
+bamboo_STAGE_NAME="sit"
 stage=$bamboo_STAGE_NAME
 if [ "$stage" == "prod" ]; then
   stage=""
@@ -8,7 +9,6 @@ fi
 if [[ "$stage" == "sit" || "$stage" == "uat" ]]; then
   stage="${stage}."
 fi
-echo "stage=${stage}"
 ummC() {
     echo "Downloading ummC"
     #Reads version number
@@ -16,13 +16,17 @@ ummC() {
     schema_version=${schema_version//\"/}
     echo ummC schema version=${schema_version}
     #Download
-    curl -L "https://cdn.${stage}earthdata.nasa.gov/umm/collection/v${schema_version}/umm-c-json-schema.json" > umm-c-json-schema-temp.json
+    downloadURL="https://cdn.${stage}earthdata.nasa.gov/umm/collection/v${schema_version}/umm-c-json-schema.json"
+    echo "download URL=${downloadURL}"
+    curl -L "${downloadURL}" > umm-c-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-c-json-schema.json"
       exit 1
     fi
     jq --arg ummJsonSchemaUrl "$ummJsonSchemaUrl" '."$schema" = $ummJsonSchemaUrl' umm-c-json-schema-temp.json > umm-c-json-schema.json
-    curl -L "https://cdn.${stage}earthdata.nasa.gov/umm/collection/v${schema_version}/umm-cmn-json-schema.json" > umm-cmn-json-schema-temp.json
+    downloadURL="https://cdn.${stage}earthdata.nasa.gov/umm/collection/v${schema_version}/umm-cmn-json-schema.json"
+    echo "download URL=${downloadURL}"
+    curl -L "${downloadURL}" > umm-cmn-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-cmn-json-schema.json"
       exit 1
@@ -43,7 +47,9 @@ ummS() {
     schema_version=${schema_version//\"/}
     echo ummS schema version=${schema_version}
     #Download
-    curl -L "https://cdn.${stage}earthdata.nasa.gov/umm/service/v${schema_version}/umm-s-json-schema.json" > umm-s-json-schema-temp.json
+    downloadURL="https://cdn.${stage}earthdata.nasa.gov/umm/service/v${schema_version}/umm-s-json-schema.json"
+    echo "download URL=${downloadURL}"
+    curl -L "${downloadURL}" > umm-s-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-s-json-schema.json"
       exit 1
@@ -61,7 +67,9 @@ ummV() {
     schema_version=${schema_version//\"/}
     echo ummV schema version=${schema_version}
     #Download
-    curl -L "https://cdn.${stage}earthdata.nasa.gov/umm/variable/v${schema_version}/umm-var-json-schema.json" > umm-var-json-schema-temp.json
+    downloadURL="https://cdn.${stage}earthdata.nasa.gov/umm/variable/v${schema_version}/umm-var-json-schema.json"
+    echo "download URL=${downloadURL}"
+    curl -L "${downloadURL}" > umm-var-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-var-json-schema.json"
       exit 1
@@ -79,7 +87,9 @@ ummT() {
     schema_version=${schema_version//\"/}
     echo ummT schema version=${schema_version}
     #Download
-    curl -L "https://cdn.${stage}earthdata.nasa.gov/umm/tool/v${schema_version}/umm-t-json-schema.json" > umm-t-json-schema-temp.json
+    downloadURL="https://cdn.${stage}earthdata.nasa.gov/umm/tool/v${schema_version}/umm-t-json-schema.json"
+    echo "download URL=${downloadURL}"
+    curl -L "${downloadURL}" > umm-t-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-t-json-schema.json"
       exit 1

--- a/bin/download_schemas.sh
+++ b/bin/download_schemas.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 ummJsonSchemaUrl=`jq '.ummJsonSchemaUrl' ./static.config.json`
 ummJsonSchemaUrl=${ummJsonSchemaUrl//\"/}
+stage=$bamboo_STAGE_NAME
+if [ "$stage" == "prod" ]; then
+  stage=""
+fi
+if [[ "$stage" == "sit" || "$stage" == "uat" ]]; then
+  stage="${stage}."
+fi
+echo "stage=${stage}"
 ummC() {
     echo "Downloading ummC"
     #Reads version number
@@ -8,13 +16,13 @@ ummC() {
     schema_version=${schema_version//\"/}
     echo ummC schema version=${schema_version}
     #Download
-    curl -L "https://cdn.earthdata.nasa.gov/umm/collection/v${schema_version}/umm-c-json-schema.json" > umm-c-json-schema-temp.json
+    curl -L "https://cdn.${stage}earthdata.nasa.gov/umm/collection/v${schema_version}/umm-c-json-schema.json" > umm-c-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-c-json-schema.json"
       exit 1
     fi
     jq --arg ummJsonSchemaUrl "$ummJsonSchemaUrl" '."$schema" = $ummJsonSchemaUrl' umm-c-json-schema-temp.json > umm-c-json-schema.json
-    curl -L "https://cdn.earthdata.nasa.gov/umm/collection/v${schema_version}/umm-cmn-json-schema.json" > umm-cmn-json-schema-temp.json
+    curl -L "https://cdn.${stage}earthdata.nasa.gov/umm/collection/v${schema_version}/umm-cmn-json-schema.json" > umm-cmn-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-cmn-json-schema.json"
       exit 1
@@ -35,7 +43,7 @@ ummS() {
     schema_version=${schema_version//\"/}
     echo ummS schema version=${schema_version}
     #Download
-    curl -L "https://cdn.earthdata.nasa.gov/umm/service/v${schema_version}/umm-s-json-schema.json" > umm-s-json-schema-temp.json
+    curl -L "https://cdn.${stage}earthdata.nasa.gov/umm/service/v${schema_version}/umm-s-json-schema.json" > umm-s-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-s-json-schema.json"
       exit 1
@@ -53,7 +61,7 @@ ummV() {
     schema_version=${schema_version//\"/}
     echo ummV schema version=${schema_version}
     #Download
-    curl -L "https://cdn.earthdata.nasa.gov/umm/variable/v${schema_version}/umm-var-json-schema.json" > umm-var-json-schema-temp.json
+    curl -L "https://cdn.${stage}earthdata.nasa.gov/umm/variable/v${schema_version}/umm-var-json-schema.json" > umm-var-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-var-json-schema.json"
       exit 1
@@ -71,7 +79,7 @@ ummT() {
     schema_version=${schema_version//\"/}
     echo ummT schema version=${schema_version}
     #Download
-    curl -L "https://cdn.earthdata.nasa.gov/umm/tool/v${schema_version}/umm-t-json-schema.json" > umm-t-json-schema-temp.json
+    curl -L "https://cdn.${stage}earthdata.nasa.gov/umm/tool/v${schema_version}/umm-t-json-schema.json" > umm-t-json-schema-temp.json
     if [ $? -ne 0 ]; then
       echo "Failed downloading umm-t-json-schema.json"
       exit 1


### PR DESCRIPTION
# Overview

### What is the feature?

MMT should pull down schemas from respective cdn env sit, uat or prod

### What is the Solution?

Download schema script should read $bamboo_STAGE_NAME to build the cdn url.

### What areas of the application does this impact?

Deployment

# Testing

Schema files downloaded and deployed.

### Attachments

N/A

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings