### PR TITLE
MMT-3935: Fix Invalid Access Constraint Definition UI Errors

### DIFF
--- a/static/src/js/components/CustomCheckboxWidget/CustomCheckboxWidget.jsx
+++ b/static/src/js/components/CustomCheckboxWidget/CustomCheckboxWidget.jsx
@@ -26,11 +26,12 @@ const CustomCheckboxWidget = ({
   label,
   onChange,
   registry,
+  uiSchema,
   value
 }) => {
   const checkboxScrollRef = useRef(null)
   const focusRef = useRef(null)
-
+  const { 'ui:clearUnselected': clearUnselected } = uiSchema
   const { formContext } = registry
 
   const {
@@ -39,8 +40,11 @@ const CustomCheckboxWidget = ({
 
   const handleChange = (event) => {
     const { checked } = event.target
-
-    onChange(checked)
+    if (!checked) {
+      onChange(clearUnselected ? null : checked)
+    } else {
+      onChange(checked)
+    }
   }
 
   const shouldFocus = shouldFocusField(focusField, id)
@@ -76,7 +80,10 @@ const CustomCheckboxWidget = ({
 
 CustomCheckboxWidget.defaultProps = {
   disabled: false,
-  value: false
+  value: false,
+  uiSchema: {
+    'ui:clearUnselected': false
+  }
 }
 
 CustomCheckboxWidget.propTypes = {
@@ -89,6 +96,9 @@ CustomCheckboxWidget.propTypes = {
       focusField: PropTypes.string
     }).isRequired
   }).isRequired,
+  uiSchema: PropTypes.shape({
+    'ui:clearUnselected': PropTypes.bool
+  }),
   value: PropTypes.bool
 }
 

--- a/static/src/js/components/CustomCheckboxWidget/CustomCheckboxWidget.jsx
+++ b/static/src/js/components/CustomCheckboxWidget/CustomCheckboxWidget.jsx
@@ -41,6 +41,8 @@ const CustomCheckboxWidget = ({
   const handleChange = (event) => {
     const { checked } = event.target
     if (!checked) {
+      // If clearUnselected is true, propogate up null so it removes/clears the field/value from the formData
+      // Otherwise, propogate up false.
       onChange(clearUnselected ? null : checked)
     } else {
       onChange(checked)

--- a/static/src/js/components/CustomCheckboxWidget/__tests__/CustomCheckboxWidget.test.jsx
+++ b/static/src/js/components/CustomCheckboxWidget/__tests__/CustomCheckboxWidget.test.jsx
@@ -51,6 +51,39 @@ describe('CustomCheckboxWidget', () => {
     })
   })
 
+  describe('when the unchecking a value', () => {
+    describe('and clear unselected is false', () => {
+      test('calls on change with false', async () => {
+        const { props, user } = setup({ value: true })
+
+        const checkboxField = screen.getByRole('checkbox')
+
+        await user.click(checkboxField)
+
+        expect(props.onChange).toHaveBeenCalledTimes(1)
+        expect(props.onChange).toHaveBeenCalledWith(false)
+      })
+    })
+
+    describe('and clear unselected is true', () => {
+      test('calls on change with null', async () => {
+        const { props, user } = setup({
+          value: true,
+          uiSchema: {
+            'ui:clearUnselected': true
+          }
+        })
+
+        const checkboxField = screen.getByRole('checkbox')
+
+        await user.click(checkboxField)
+
+        expect(props.onChange).toHaveBeenCalledTimes(1)
+        expect(props.onChange).toHaveBeenCalledWith(null)
+      })
+    })
+  })
+
   describe('when the field should be focused', () => {
     test('focuses the field', async () => {
       setup({

--- a/static/src/js/schemas/uiSchemas/collectionPermission.js
+++ b/static/src/js/schemas/uiSchemas/collectionPermission.js
@@ -251,6 +251,7 @@ const collectionPermissionUiSchema = {
         ]
       },
       includeUndefined: {
+        'ui:clearUnselected': true,
         'ui:widget': CustomCheckboxWidget
       }
     },
@@ -298,6 +299,7 @@ const collectionPermissionUiSchema = {
         ]
       },
       includeUndefined: {
+        'ui:clearUnselected': true,
         'ui:widget': CustomCheckboxWidget
       }
     }


### PR DESCRIPTION
# Overview

### What is the feature?

The Access Constraint Filter value edit boxes require values, when they are actually optional.   This happens when you click "Include undefined", but if you uncheck it, it never resets the edit boxes to say min/max values are no longer required.   The reason is the way the schema works, clicking the checkbox sets a true/false value for the field.   If that field exists, then it makes the other fields required as well.   

### What is the Solution?

Added a "ui:clearUndefined" to the CustomCheckboxWidget and set this value in the uiSchema for these checkboxes only, default behavior is false as normal.   But if set to true (which this ui schema does), it will propogate up a null instead.   This wil tell the form, this field should be cleared out.   Once that that happens, the required field message disappear because there is no field present causing the required messages.

### What areas of the application does this impact?

Collection Permissions Form

# Testing

Head over to the Collection Permissions Form, try clicking the "Include undefined" checkbox, you will see required messages show up.   Now uncheck the box, these messages should disappear now (this didn't happen before this fix).

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings