### PR TITLE
MMT-3923: Catch intermittent error from EDL

### DIFF
--- a/static/src/js/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/static/src/js/components/ErrorBoundary/ErrorBoundary.jsx
@@ -18,6 +18,7 @@ class ErrorBoundary extends React.Component {
 
   static getDerivedStateFromError(error) {
     let errorMessage = error.message
+    // Check to see if it is a known intermittent error from EDL (MMT-3923)
     if (error.graphQLErrors
       && (error.graphQLErrors[0].extensions?.code === 'INTERNAL_SERVER_ERROR')
       && error.graphQLErrors[0].path?.includes('acl')

--- a/static/src/js/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/static/src/js/components/ErrorBoundary/ErrorBoundary.jsx
@@ -20,9 +20,9 @@ class ErrorBoundary extends React.Component {
     let errorMessage = error.message
     // Check to see if it is a known intermittent error from EDL (MMT-3923)
     if (error.graphQLErrors
-      && (error.graphQLErrors[0].extensions?.code === 'INTERNAL_SERVER_ERROR')
-      && error.graphQLErrors[0].path?.includes('acl')
-      && error.graphQLErrors[0].path?.includes('groups')) {
+      && (error.graphQLErrors[0]?.extensions?.code === 'INTERNAL_SERVER_ERROR')
+      && error.graphQLErrors[0]?.path?.includes('acl')
+      && error.graphQLErrors[0]?.path?.includes('groups')) {
       errorMessage = 'Error retrieving groups. Please refresh'
     }
 

--- a/static/src/js/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/static/src/js/components/ErrorBoundary/ErrorBoundary.jsx
@@ -17,9 +17,17 @@ class ErrorBoundary extends React.Component {
   }
 
   static getDerivedStateFromError(error) {
+    let errorMessage = error.message
+    if (error.graphQLErrors
+      && (error.graphQLErrors[0].extensions?.code === 'INTERNAL_SERVER_ERROR')
+      && error.graphQLErrors[0].path?.includes('acl')
+      && error.graphQLErrors[0].path?.includes('groups')) {
+      errorMessage = 'Error retrieving groups. Please refresh'
+    }
+
     return {
       hasError: true,
-      error: error.message
+      error: errorMessage
     }
   }
 

--- a/static/src/js/components/ErrorBoundary/__tests__/ErrorBoundary.test.jsx
+++ b/static/src/js/components/ErrorBoundary/__tests__/ErrorBoundary.test.jsx
@@ -4,8 +4,6 @@ import { render, screen } from '@testing-library/react'
 import ErrorBoundary from '../ErrorBoundary'
 import ErrorBanner from '../../ErrorBanner/ErrorBanner'
 
-vi.mock('../../ErrorBanner/ErrorBanner')
-
 const setup = () => {
   render(
     <ErrorBoundary>
@@ -37,7 +35,34 @@ describe('ErrorBoundary', () => {
         </ErrorBoundary>
       )
 
-      expect(ErrorBanner).toHaveBeenCalled(1)
+      expect(screen.getByText('Test for ErrorBoundary')).toBeInTheDocument()
+    })
+  })
+
+  describe('when there is an EDL timeout error', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    test('renders error banner asking user to refresh browser', async () => {
+      const ThrowError = () => {
+        const error = new Error('An unknown error occurred')
+        error.graphQLErrors = [
+          {
+            extensions: {
+              code: 'INTERNAL_SERVER_ERROR'
+            },
+            path: ['acl', 'groups']
+          }
+        ]
+
+        throw error
+      }
+
+      render(
+        <ErrorBoundary>
+          <ThrowError />
+        </ErrorBoundary>
+      )
+
+      expect(screen.getByText('Error retrieving groups. Please refresh')).toBeInTheDocument()
     })
   })
 })

--- a/static/src/js/components/ErrorBoundary/__tests__/ErrorBoundary.test.jsx
+++ b/static/src/js/components/ErrorBoundary/__tests__/ErrorBoundary.test.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 
 import ErrorBoundary from '../ErrorBoundary'
-import ErrorBanner from '../../ErrorBanner/ErrorBanner'
 
 const setup = () => {
   render(


### PR DESCRIPTION
# Overview

### What is the feature?

cmr-graphql returns intermittent error getting acl and groups from EDL.

### What is the Solution?

Catch that error and create banner message to refresh browser. 

### What areas of the application does this impact?

View of single Permission

# Testing

See test session.

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings