### PR TITLE
MMT-3953: Fix for User is encountering latency issue with Save and Publish

### DIFF
--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -233,9 +233,12 @@ const MetadataForm = () => {
           variant: 'success'
         })
 
-        if (type === saveTypes.save) {
+        // We still need to navigate to the new draft revision on save and publish
+        // even though we will end up navigating to the preivew page.  The reason
+        // being is because the publish mutation causes the cache to be cleared and as a
+        // result the draft is refetched.
+        if (type === saveTypes.save || type === saveTypes.saveAndPublish) {
           // Navigate to current form? just scroll to top of page instead?
-
           if (currentSection) navigate(`/drafts/${draftType}/${savedConceptId}/${currentSection}?revisionId=${savedRevisionId}`, { replace: true })
 
           window.scroll(0, 0)

--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -234,7 +234,7 @@ const MetadataForm = () => {
         })
 
         // We still need to navigate to the new draft revision on save and publish
-        // even though we will end up navigating to the preivew page.  The reason
+        // even though we will end up navigating to the preview page.  The reason
         // being is because the publish mutation causes the cache to be cleared and as a
         // result the draft is refetched.
         if (type === saveTypes.save || type === saveTypes.saveAndPublish) {

--- a/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
+++ b/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
@@ -838,7 +838,7 @@ describe('MetadataForm', () => {
         const button = screen.getByRole('button', { name: 'Save & Publish' })
         await user.click(button)
 
-        expect(navigateSpy).toHaveBeenCalledTimes(1)
+        expect(navigateSpy).toHaveBeenCalledTimes(2)
         expect(navigateSpy).toHaveBeenCalledWith('/tools/T1000000-MMT')
       })
     })


### PR DESCRIPTION
# Overview

### What is the feature?

The "Save and Publish" menu option is causing an issue where the user is encountering a latency error mesage after clicking this option.   This happens every time.

### What is the Solution?

When the save and publish updates the draft, there is a use effect that verifies that the revision id saved matches what is in the url after the save.   The issue was that the URL was not being updated in between the time the save happened and the publish navigating away from the page.   The fix was simply to include the navigate to update the page revision id while publishing.

### What areas of the application does this impact?

Metadata Form menu navigate menu options.

# Testing

Create a draft, fill in all the required fields, click Save.   The click Save and Publish.   The draft should now properly redirect to the preview page without any errors.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings