### PR TITLE
MMT-3960: Resetting millisecond part only when date time is selected.

### DIFF
--- a/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
@@ -93,9 +93,10 @@ const CustomDateTimeWidget = ({
   }
 
   const handleChange = (newDate) => {
-    // The picket widget has a bug where it is not setting millis to 0 when selecting a time,
-    // so we need to reset the millisecond part. When the date time string is pasted in or a value
-    // exists, do not reset.
+    // The picker widget has a bug where it is not setting the ms. to 0 when a user selects a time.
+    // We are working around this bug by setting the ms to 0 only if the user selects/chooses
+    // a time from the widget. If they type in a date/time or paste in a date/time should ,
+    // we should not perform this reset as we should keep whatever ms they user enters.
     if (!value && dateInputMethod !== 'typed') newDate.setMilliseconds(0)
     const formattedDateTime = fromZonedTime(newDate, 'GMT').toISOString()
     onChange(formattedDateTime)

--- a/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
@@ -104,7 +104,7 @@ const CustomDateTimeWidget = ({
     handleBlur()
   }
 
-  const handleDateInput = (event) => {
+  const handleDateInput = () => {
     // Saves the input method for handleChange
     dateInputMethod = 'typed'
   }
@@ -127,7 +127,7 @@ const CustomDateTimeWidget = ({
         locale="en-GB" // Use the UK locale, located in the Greenwich Mean Time (GMT) zone,
         onBlur={handleBlur}
         onChange={handleChange}
-        onChangeRaw={(event) => handleDateInput(event)}
+        onChangeRaw={() => handleDateInput()}
         onFocus={handleFocus}
         open={showCalender}
         peekNextMonth

--- a/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/CustomDateTimeWidget.jsx
@@ -46,6 +46,10 @@ const CustomDateTimeWidget = ({
 }) => {
   const [showCalender, setShowCalender] = useState(false)
   const datetimeScrollRef = useRef(null)
+  // Variable to flag method of input: selected or typed.
+  // We can't store as state variable because it gets updated
+  // only after some delay.
+  let dateInputMethod = 'selected'
 
   const { description } = schema
 
@@ -89,12 +93,19 @@ const CustomDateTimeWidget = ({
   }
 
   const handleChange = (newDate) => {
-    // The picket widget has a bug where it is not setting millis to 0 when selecting a time.
-    newDate.setMilliseconds(0)
+    // The picket widget has a bug where it is not setting millis to 0 when selecting a time,
+    // so we need to reset the millisecond part. When the date time string is pasted in or a value
+    // exists, do not reset.
+    if (!value && dateInputMethod !== 'typed') newDate.setMilliseconds(0)
     const formattedDateTime = fromZonedTime(newDate, 'GMT').toISOString()
     onChange(formattedDateTime)
 
     handleBlur()
+  }
+
+  const handleDateInput = (event) => {
+    // Saves the input method for handleChange
+    dateInputMethod = 'typed'
   }
 
   return (
@@ -109,16 +120,17 @@ const CustomDateTimeWidget = ({
       <DatePicker
         className="w-100 p-2 form-control"
         disabled={disabled}
-        dateFormat="yyyy-MM-dd'T'HH:mm:ss'Z'"
+        dateFormat="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
         dropdownMode="select"
         id={id}
         locale="en-GB" // Use the UK locale, located in the Greenwich Mean Time (GMT) zone,
         onBlur={handleBlur}
         onChange={handleChange}
+        onChangeRaw={(event) => handleDateInput(event)}
         onFocus={handleFocus}
         open={showCalender}
         peekNextMonth
-        placeholderText="YYYY-MM-DDTHH:MM:SSZ"
+        placeholderText="YYYY-MM-DDTHH:MM:SS.SSSZ"
         wrapperClassName="d-block"
         selected={fieldValue}
         showMonthDropdown

--- a/static/src/js/components/CustomDateTimeWidget/__tests__/CustomDateTimeWidget.test.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/__tests__/CustomDateTimeWidget.test.jsx
@@ -77,7 +77,7 @@ describe('CustomDateTimeWidget', () => {
     test('shows the field description', async () => {
       setup()
 
-      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SSZ')
+      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SS.SSSZ')
 
       await act(async () => {
         field.focus()
@@ -96,7 +96,7 @@ describe('CustomDateTimeWidget', () => {
     test('blurs the field', async () => {
       const { props } = setup()
 
-      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SSZ')
+      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SS.SSSZ')
 
       await act(async () => {
         field.focus()
@@ -115,7 +115,7 @@ describe('CustomDateTimeWidget', () => {
     test('calls onChange', async () => {
       const { props, user } = setup()
 
-      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SSZ')
+      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SS.SSSZ')
 
       await user.type(field, '1')
 
@@ -165,9 +165,9 @@ describe('CustomDateTimeWidget', () => {
         value: '2023-12-05T00:00:00.000Z'
       })
 
-      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SSZ')
+      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SS.SSSZ')
 
-      expect(field).toHaveValue('2023-12-05T00:00:00Z')
+      expect(field).toHaveValue('2023-12-05T00:00:00.000Z')
     })
   })
 
@@ -177,9 +177,9 @@ describe('CustomDateTimeWidget', () => {
         value: '2023-12-05T16:05:59.000Z'
       })
 
-      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SSZ')
+      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SS.SSSZ')
 
-      expect(field).toHaveValue('2023-12-05T16:05:59Z')
+      expect(field).toHaveValue('2023-12-05T16:05:59.000Z')
     })
   })
 })

--- a/static/src/js/components/CustomDateTimeWidget/__tests__/CustomDateTimeWidget.test.jsx
+++ b/static/src/js/components/CustomDateTimeWidget/__tests__/CustomDateTimeWidget.test.jsx
@@ -174,12 +174,24 @@ describe('CustomDateTimeWidget', () => {
   describe('When a date has a specific time in the form', () => {
     test('shows the date and time', async () => {
       setup({
-        value: '2023-12-05T16:05:59.000Z'
+        value: '2023-12-05T16:05:59.090Z'
       })
 
       const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SS.SSSZ')
 
-      expect(field).toHaveValue('2023-12-05T16:05:59.000Z')
+      expect(field).toHaveValue('2023-12-05T16:05:59.090Z')
+    })
+  })
+
+  describe('when the field is typed in', () => {
+    test('calls onChange', async () => {
+      const { props, user } = setup()
+
+      const field = await screen.findByPlaceholderText('YYYY-MM-DDTHH:MM:SS.SSSZ')
+
+      await user.type(field, '2025-01-02T03:20:15.999Z')
+
+      expect(props.onChange).toHaveBeenCalledWith('2025-01-02T03:20:15.999Z')
     })
   })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

Millisecond part of date time input should accept input values.

### What is the Solution?

Preserve input values of millisecond part and reset it only when date time value is selected.   

### What areas of the application does this impact?

All date time fields.

# Testing

1. Existing temporal extends should be preserved when loaded into the form.
2. Copy and pasted values should be preserved.
3. Selected values from the widget should have the millisecond part set to 0.

### Attachments

N/A

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings