### PR TITLE
MMT-3961b: Adding AssociatedDetails

### DIFF
--- a/static/src/js/operations/queries/getCollection.js
+++ b/static/src/js/operations/queries/getCollection.js
@@ -35,35 +35,35 @@ export const GET_COLLECTION = gql`
       publicationReferences
       purpose
       quality
-      # relatedCollections (
-      #   limit: 10
-      # ) {
-      #   count
-      #   items {
-      #     id
-      #     doi
-      #     title
-      #     relationships {
-      #       relationshipType
+      relatedCollections (
+        limit: 10
+      ) {
+        count
+        items {
+          id
+          doi
+          title
+          relationships {
+            relationshipType
 
-      #       ... on GraphDbRelatedUrl {
-      #         description
-      #         subtype
-      #         type
-      #         url
-      #       }
+            ... on GraphDbRelatedUrl {
+              description
+              subtype
+              type
+              url
+            }
 
-      #       ... on GraphDbProject {
-      #         name
-      #       }
+            ... on GraphDbProject {
+              name
+            }
 
-      #       ... on GraphDbPlatformInstrument {
-      #         instrument
-      #         platform
-      #       }
-      #     }
-      #   }
-      # }
+            ... on GraphDbPlatformInstrument {
+              instrument
+              platform
+            }
+          }
+        }
+      }
       relatedUrls
       revisionDate
       revisionId

--- a/static/src/js/operations/queries/getCollection.js
+++ b/static/src/js/operations/queries/getCollection.js
@@ -9,6 +9,7 @@ export const GET_COLLECTION = gql`
       ancillaryKeywords
       archiveAndDistributionInformation
       associatedDois
+      associationDetails
       collectionCitations
       collectionProgress
       conceptId

--- a/static/src/js/operations/queries/getCollection.js
+++ b/static/src/js/operations/queries/getCollection.js
@@ -8,8 +8,8 @@ export const GET_COLLECTION = gql`
       additionalAttributes
       ancillaryKeywords
       archiveAndDistributionInformation
-      associatedDois
       associationDetails
+      associatedDois
       collectionCitations
       collectionProgress
       conceptId
@@ -35,35 +35,35 @@ export const GET_COLLECTION = gql`
       publicationReferences
       purpose
       quality
-      relatedCollections (
-        limit: 10
-      ) {
-        count
-        items {
-          id
-          doi
-          title
-          relationships {
-            relationshipType
+      # relatedCollections (
+      #   limit: 10
+      # ) {
+      #   count
+      #   items {
+      #     id
+      #     doi
+      #     title
+      #     relationships {
+      #       relationshipType
 
-            ... on GraphDbRelatedUrl {
-              description
-              subtype
-              type
-              url
-            }
+      #       ... on GraphDbRelatedUrl {
+      #         description
+      #         subtype
+      #         type
+      #         url
+      #       }
 
-            ... on GraphDbProject {
-              name
-            }
+      #       ... on GraphDbProject {
+      #         name
+      #       }
 
-            ... on GraphDbPlatformInstrument {
-              instrument
-              platform
-            }
-          }
-        }
-      }
+      #       ... on GraphDbPlatformInstrument {
+      #         instrument
+      #         platform
+      #       }
+      #     }
+      #   }
+      # }
       relatedUrls
       revisionDate
       revisionId

--- a/static/src/js/pages/ManageCollectionAssociationPage/__tests__/__mocks__/collectionResult.js
+++ b/static/src/js/pages/ManageCollectionAssociationPage/__tests__/__mocks__/collectionResult.js
@@ -17,6 +17,7 @@ export const collectionResult = {
         additionalAttributes: null,
         ancillaryKeywords: null,
         archiveAndDistributionInformation: null,
+        associationDetails: null,
         associatedDois: null,
         collectionCitations: null,
         collectionProgress: null,

--- a/static/src/js/pages/RevisionListPage/__tests__/__mocks__/searchResults.js
+++ b/static/src/js/pages/RevisionListPage/__tests__/__mocks__/searchResults.js
@@ -17,6 +17,7 @@ export const singlePageCollectionSearch = {
         additionalAttributes: null,
         ancillaryKeywords: null,
         archiveAndDistributionInformation: null,
+        associationDetails: null,
         associatedDois: null,
         collectionCitations: null,
         collectionProgress: null,


### PR DESCRIPTION
# Overview

### What is the feature?

While at first glance it appeared this issue had been resolved, if you go to page 2 of Associated Variables in mmt here https://mmt.sit.earthdata.nasa.gov/collections/C1200277732-EDF_DEV01, you'll notice it is different from the same page here https://access.sit.earthdata.nasa.gov/collections/C1200277732-EDF_DEV01
 
### What is the Solution?

getCollection wasn't asking for AssociationDetails which is needed for the function to work properly in Access. 

### What areas of the application does this impact?

getCollection call

# Testing

### Reproduction steps

- **Environment for testing: SIT
- **Collection to test with: C1200277732-EDF_DEV01

1. Run this collection in your local SIT environment (you'll need to comment out related Collections in getCollection to get the environment working)
2. Go to both pages in AssociatedVariables and make sure that the variables line up with what's in access. The two links above should be identical. 

### Attachments

Beginning of pages 1 and 2 in Access
![Uploading Screenshot 2025-02-11 at 11.02.30 AM.png…]()
![Screenshot 2025-02-11 at 11 02 38 AM](https://github.com/user-attachments/assets/ef87f836-295c-4de3-9503-0ebfbcb6b360)

Beginning and Ending variables in MMT
![Screenshot 2025-02-11 at 11 01 57 AM](https://github.com/user-attachments/assets/702236ce-b914-4024-bc9b-f9c7b6485995)
![Screenshot 2025-02-11 at 11 02 13 AM](https://github.com/user-attachments/assets/29588fad-c165-480e-957b-a5e2df472a82)


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
