### PR TITLE
MMT-3969: Update the "NASA Official" footers on all MMT pages to be Doug Newman

### DIFF
--- a/static/src/js/components/AboutModal/AboutModal.jsx
+++ b/static/src/js/components/AboutModal/AboutModal.jsx
@@ -78,7 +78,7 @@ const AboutModal = ({
             </p>
             <hr />
             <div className="d-flex flex-column align-items-center justify-content-center py-2">
-              <p className="small text-secondary mb-2">NASA Official: Stephen Berrick</p>
+              <p className="small text-secondary mb-2">NASA Official: Doug Newman</p>
               <ul className="list-unstyled d-flex justify-content-center mb-0">
                 <For each={
                   [

--- a/static/src/js/components/Footer/Footer.jsx
+++ b/static/src/js/components/Footer/Footer.jsx
@@ -35,7 +35,7 @@ const Footer = () => {
               each={
                 [
                   {
-                    title: 'NASA Official: Stephen Berrick'
+                    title: 'NASA Official: Doug Newman'
                   },
                   {
                     title: 'FOIA',

--- a/static/src/js/components/Footer/__tests__/Footer.test.jsx
+++ b/static/src/js/components/Footer/__tests__/Footer.test.jsx
@@ -15,17 +15,17 @@ describe('Footer component', () => {
     test('renders the item as a span', () => {
       render(<Footer />)
 
-      expect(screen.getByText('NASA Official: Stephen Berrick').tagName).toBe('SPAN')
-      expect(screen.getByText('NASA Official: Stephen Berrick').href).toBe(undefined)
+      expect(screen.getByText('NASA Official: Doug Newman').tagName).toBe('SPAN')
+      expect(screen.getByText('NASA Official: Doug Newman').href).toBe(undefined)
     })
   })
 
   test('displays the NASA Official as text', async () => {
     render(<Footer />)
 
-    expect(screen.getByText('NASA Official: Stephen Berrick')).toBeInTheDocument()
-    expect(screen.getByText('NASA Official: Stephen Berrick').tagName).toBe('SPAN')
-    expect(screen.getByText('NASA Official: Stephen Berrick').href).toBe(undefined)
+    expect(screen.getByText('NASA Official: Doug Newman')).toBeInTheDocument()
+    expect(screen.getByText('NASA Official: Doug Newman').tagName).toBe('SPAN')
+    expect(screen.getByText('NASA Official: Doug Newman').href).toBe(undefined)
   })
 
   test('displays the FOIA link', async () => {

--- a/static/src/js/schemas/umm/ummCSchema.js
+++ b/static/src/js/schemas/umm/ummCSchema.js
@@ -3814,7 +3814,7 @@ const ummCSchema = {
           description: 'This element represents the URL where the schema lives. The schema can be downloaded.',
           type: 'string',
           enum: [
-            'https://cdn.earthdata.nasa.gov/umm/collection/v1.18.2'
+            'https://cdn.earthdata.nasa.gov/umm/collection/v1.18.3'
           ]
         },
         Name: {


### PR DESCRIPTION
# Overview

### What is the feature?

The nasa official listed on MMT earthdata sites is Stephen Berrick, we need to update these to be Doug Newman.

### What is the Solution?

Changed in footer and About Modal

### What areas of the application does this impact?

Footer and About Modal

# Testing

### Reproduction steps

1. Spin up local environment to see changes on footer before authorizing yourself.
2. Once signed in, click on your name in the bottom left of the screen the select 'About' to see where other change needed to be made

### Attachments
![Screenshot 2025-03-19 at 1 17 34 PM](https://github.com/user-attachments/assets/94769b90-6776-43d0-adc9-ac90f0eb118e)
![Screenshot 2025-03-19 at 1 21 27 PM](https://github.com/user-attachments/assets/05557da1-d76f-4836-9533-be952d955577)



# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
