### PR TITLE
MMT-3970: Update the "NASA Official" footers on all dMMT pages to be Doug Newman

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer role="contentinfo">
     <ul class="footer-links">
       <li><span class="version badge eui-badge--md">v <%= Rails.configuration.version %></span></li>
-      <li>NASA Official: Stephen Berrick</li>
+      <li>NASA Official: Doug Newman</li>
       <li><a href="http://www.nasa.gov/FOIA/index.html">FOIA</a></li>
       <li><a href="http://www.nasa.gov/about/highlights/HP_Privacy.html">NASA Privacy Policy</a></li>
       <li><a href="http://www.usa.gov/">USA.gov</a></li>

--- a/spec/vcr/edl/approver_workflow_spec_vcr.yml
+++ b/spec/vcr/edl/approver_workflow_spec_vcr.yml
@@ -171,7 +171,7 @@ http_interactions:
         \ </p>\n  <div class=\"earth\">\n    <div class=\"orbit\"></div>\n  </div>\n</div>\n\n
         \     </div>\n    </main>\n\n    <footer>\n      <div class=\"container\">\n
         \       \n<nav role=\"navigation\">\n  <ul class=\"footer-links\">\n      <li>NASA
-        Official: Stephen Berrick</li>\n      <li><a href=\"https://www.nasa.gov/FOIA/index.html\">FOIA</a></li>\n
+        Official: Doug Newman/li>\n      <li><a href=\"https://www.nasa.gov/FOIA/index.html\">FOIA</a></li>\n
         \     <li><a href=\"https://www.nasa.gov/about/highlights/HP_Privacy.html\">NASA
         Privacy Policy</a></li>\n      <li><a href=\"https://www.usa.gov/\">USA.gov</a></li>\n
         \     <li><a href=\"javascript:feedback.showForm();\">Feedback</a></li>\n


### PR DESCRIPTION
# Overview

### What is the feature?

The nasa official listed on dMMT earthdata sites is Stephen Berrick, we need to update these to be Doug Newman.

### What is the Solution?

Swapped out names in footer and approver workflow

# Testing

### Reproduction steps

1. Spin up local environment and see that change has been made.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
