### PR TITLE
MMT-3978: MMT can not communicate with GKR

### DIFF
--- a/static.config.json
+++ b/static.config.json
@@ -3,7 +3,7 @@
     "apiHost": "http://localhost:4001/dev",
     "cmrHost": "http://localhost:4000",
     "env": "development",
-    "gkrHost": "https://gkr.sit.earthdatacloud.nasa.gov",
+    "gkrHost": "https://gkr.earthdatacloud.nasa.gov",
     "graphQlHost": "http://localhost:3013/api",
     "mmtHost": "http://localhost:5173",
     "edscHost": "https://search.sit.earthdata.nasa.gov",


### PR DESCRIPTION
# Overview

### What is the feature?

MMT can not communicate with GKR. 

### What is the Solution?

gkrHost was pointing at gkr.sit so I changed it to gkr prod. The response from gkr was <html>

<head><title>503 Service Temporarily Unavailable</title></head>

Which is why we were seeing that error=SyntaxError: Unexpected token < in JSON at position 0

### What areas of the application does this impact?

static.config

# Testing

### Reproduction steps

- **Environment for testing:prod
- **Collection to test with: https://mmt.earthdata.nasa.gov/drafts/collections/CD3474654676-XYZ_PROV

1. Point your local environment at prod 
2. Visit the above link and click 'Descriptive Keywords'. They should now work as expected. Will need to change gkrHost to sit when working in development. 

### Attachments

N/A

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
