### PR TITLE
MMT-4010: As a user, I can navigate to a landing page for Keyword Manager.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,8 @@
       "alias": {
         "map": [
           [ "@", "./static/src" ],
-          [ "sharedConstants", "./sharedConstants"]
+          [ "sharedConstants", "./sharedConstants"],
+          [ "sharedUtils", "./sharedUtils"]
         ],
         "extensions": [
           ".js",

--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -18,6 +18,8 @@ config="`jq '.application.apiHost = $newValue' --arg newValue $bamboo_API_HOST <
 config="`jq '.application.cmrHost = $newValue' --arg newValue $bamboo_CMR_HOST <<< $config`"
 config="`jq '.application.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
 config="`jq '.application.gkrHost = $newValue' --arg newValue $bamboo_GKR_HOST <<< $config`"
+# Remove after CMR-10452 has been completed
+config="`jq '.application.showKeywordManager = $newValue' --arg newValue $bamboo_SHOW_KEYWORD_MANAGER <<< $config`"
 config="`jq '.application.cookieDomain = $newValue' --arg newValue $bamboo_COOKIE_DOMAIN <<< $config`"
 config="`jq '.application.displayProdWarning = $newValue' --arg newValue $bamboo_DISPLAY_PROD_WARNING <<< $config`"
 config="`jq '.application.tokenValidTime = $newValue' --arg newValue $bamboo_JWT_VALID_TIME <<< $config`"

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,8 +3,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["static/src/*"],
-      "sharedConstants/*": ["sharedConstants/*"]
+      "sharedConstants/*": ["sharedConstants/*"],
+      "sharedUtils/*": ["sharedUtils/*"]
     }
   },
-  "include": ["static/src/**/*", "sharedConstants/*"]
+  "include": ["static/src/**/*", "sharedConstants/*", "sharedUtils/*"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18171,9 +18171,9 @@
       "dev": true
     },
     "node_modules/koa": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.0.tgz",
-      "integrity": "sha512-Afhqq0Vq3W7C+/rW6IqHVBDLzqObwZ07JaUNUEF8yCQ6afiyFE3RAy+i7V0E46XOWlH7vPWn/x0vsZwNy6PWxw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
+      "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^1.3.5",
@@ -27067,9 +27067,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.9.tgz",
-      "integrity": "sha512-qK9W4xjgD3gXbC0NmdNFFnVFLMWSNiR3swj957yutwzzN16xF/E7nmtAyp1rT9hviDroQANjE4HK3H4WqWdFtw==",
+      "version": "4.5.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.13.tgz",
+      "integrity": "sha512-Hgp8IF/yZDzKsN1hQWOuQZbrKiaFsbQud+07jJ8h9m9PaHWkpvZ5u55Xw5yYjWRXwRQ4jwFlJvY7T7FUJG9MCA==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -27478,9 +27478,9 @@
       }
     },
     "node_modules/vite-node/node_modules/vite": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
-      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "version": "5.4.18",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.18.tgz",
+      "integrity": "sha512-1oDcnEp3lVyHCuQ2YFelM4Alm2o91xNoMncRm1U7S+JdYfYOvbiGZ3/CxGttrOu2M/KcGz7cRC2DoNUA6urmMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -28281,9 +28281,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
-      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "version": "5.4.18",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.18.tgz",
+      "integrity": "sha512-1oDcnEp3lVyHCuQ2YFelM4Alm2o91xNoMncRm1U7S+JdYfYOvbiGZ3/CxGttrOu2M/KcGz7cRC2DoNUA6urmMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/static.config.json
+++ b/static.config.json
@@ -13,6 +13,7 @@
       "Access-Control-Allow-Headers": "*",
       "Access-Control-Allow-Credentials": true
     },
+    "showKeywordManager": true,
     "cookieDomain": ".localhost",
     "tokenValidTime": "900",
     "displayProdWarning": "true",

--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -9,6 +9,7 @@ import GroupFormPage from '@/js/pages/GroupFormPage/GroupFormPage'
 import GroupListPage from '@/js/pages/GroupListPage/GroupListPage'
 import GroupPage from '@/js/pages/GroupPage/GroupPage'
 import HomePage from '@/js/pages/HomePage/HomePage'
+import KeywordManagerPage from '@/js/pages/KeywordManagerPage/KeywordManagerPage'
 import LogoutPage from '@/js/pages/LogoutPage/LogoutPage'
 import ManageCollectionAssociationPage from '@/js/pages/ManageCollectionAssociationPage/ManageCollectionAssociationPage'
 import ManageServiceAssociationsPage from '@/js/pages/ManageServiceAssociationsPage/ManageServiceAssociationsPage'
@@ -17,6 +18,7 @@ import OrderOptionFormPage from '@/js/pages/OrderOptionFormPage/OrderOptionFormP
 import OrderOptionListPage from '@/js/pages/OrderOptionListPage/OrderOptionListPage'
 import OrderOptionPage from '@/js/pages/OrderOptionPage/OrderOptionPage'
 import PermissionListPage from '@/js/pages/PermissionListPage/PermissionListPage'
+import PermissionFormPage from '@/js/pages/PermissionFormPage/PermissionFormPage'
 import PermissionPage from '@/js/pages/PermissionPage/PermissionPage'
 import ProviderPermissionsPage from '@/js/pages/ProviderPermissionsPage/ProviderPermissionsPage'
 import ProvidersPage from '@/js/pages/ProvidersPage/ProvidersPage'
@@ -39,7 +41,6 @@ import TemplatePreview from '@/js/components/TemplatePreview/TemplatePreview'
 import REDIRECTS from '@/js/constants/redirectsMap/redirectsMap'
 
 import withProviders from '@/js/providers/withProviders/withProviders'
-import PermissionFormPage from './pages/PermissionFormPage/PermissionFormPage'
 
 import '../css/index.scss'
 
@@ -222,6 +223,10 @@ export const App = () => {
                   element: <GroupListPage isAdminPage />
                 },
                 {
+                  path: '/admin/keywordmanager',
+                  element: <KeywordManagerPage isAdminPage />
+                },
+                {
                   path: '/admin/groups/:id',
                   element: <GroupPage isAdminPage />
                 },
@@ -241,6 +246,10 @@ export const App = () => {
                 {
                   path: '/admin/groups/:id/edit',
                   element: <GroupFormPage isAdminPage />
+                },
+                {
+                  path: '/admin/keywordmanager',
+                  element: <KeywordManagerPage isAdminPage />
                 }
               ]
             }

--- a/static/src/js/__tests__/App.test.jsx
+++ b/static/src/js/__tests__/App.test.jsx
@@ -7,6 +7,22 @@ import App from '@/js/App'
 vi.mock('@/js/components/ErrorBanner/ErrorBanner')
 vi.mock('@/js/utils/errorLogger')
 
+vi.mock('@/js/hooks/useAuthContext', () => ({
+  default: vi.fn(() => ({
+    user: {
+      uid: 'testuser'
+    }
+  }))
+}))
+
+vi.mock('@/js/hooks/usePermissions', () => ({
+  default: vi.fn(() => ({
+    hasSystemGroup: true,
+    hasSystemKeywords: true,
+    loading: false
+  }))
+}))
+
 vi.mock('@/js/pages/SearchPage/SearchPage', () => ({
   default: vi.fn(() => {
     const { type } = useParams()
@@ -56,6 +72,12 @@ vi.mock('@/js/components/Layout/Layout', () => ({
 vi.mock('@/js/components/LayoutUnauthenticated/LayoutUnauthenticated', () => ({
   default: vi.fn(() => (
     <div data-testid="mock-layout-unauthenticated"><Outlet /></div>
+  ))
+}))
+
+vi.mock('@/js/pages/KeywordManagerPage/KeywordManagerPage', () => ({
+  default: vi.fn(({ isAdminPage }) => (
+    <div data-testid={`mock-keyword-manager-page${isAdminPage ? '-admin' : ''}`}>Keyword Manager Page</div>
   ))
 }))
 
@@ -191,6 +213,18 @@ describe('App component', () => {
       setup()
 
       expect(window.location.href).toEqual('http://localhost:3000/collections')
+
+      window.history.pushState({}, '', '/')
+    })
+  })
+
+  describe('when rendering the "/admin/keywordmanager" route', () => {
+    test('renders the admin keyword manager page', async () => {
+      window.history.pushState({}, '', '/admin/keywordmanager')
+
+      setup()
+
+      expect(await screen.findByTestId('mock-keyword-manager-page-admin')).toBeInTheDocument()
 
       window.history.pushState({}, '', '/')
     })

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -51,8 +51,9 @@ const Layout = ({ className, displayNav }) => {
 
   const { user } = useAuthContext()
 
-  const { hasSystemGroup, loading } = usePermissions({
-    systemGroup: ['read']
+  const { hasSystemGroup, hasSystemKeywords, loading } = usePermissions({
+    systemGroup: ['read'],
+    systemKeywords: ['read']
   })
 
   const [showAboutModal, setShowAboutModal] = useState(false)
@@ -60,6 +61,7 @@ const Layout = ({ className, displayNav }) => {
   if (loading) return null
 
   const canViewGroups = hasSystemGroup
+  const canViewKeywords = hasSystemKeywords
   const canViewAdmin = canViewGroups // || canView* other permission if needed
 
   return (
@@ -215,6 +217,11 @@ const Layout = ({ className, displayNav }) => {
                                     to: '/admin/groups',
                                     title: 'System Groups',
                                     visible: canViewGroups
+                                  },
+                                  {
+                                    to: '/admin/keywordmanager',
+                                    title: 'Keyword Manager',
+                                    visible: canViewKeywords
                                   }
                                 ]
                               }

--- a/static/src/js/components/Layout/__tests__/Layout.test.jsx
+++ b/static/src/js/components/Layout/__tests__/Layout.test.jsx
@@ -73,7 +73,10 @@ const setup = (loggedIn) => {
 
 describe('Layout component', () => {
   test('renders the content to the React Router Outlet', async () => {
-    usePermissions.mockReturnValue({ hasSystemGroup: true })
+    usePermissions.mockReturnValue({
+      hasSystemGroup: true,
+      hasSystemKeywords: true
+    })
 
     setup()
 
@@ -81,7 +84,8 @@ describe('Layout component', () => {
 
     expect(usePermissions).toHaveBeenCalledTimes(1)
     expect(usePermissions).toHaveBeenCalledWith({
-      systemGroup: ['read']
+      systemGroup: ['read'],
+      systemKeywords: ['read']
     })
 
     expect(PrimaryNavigation).toHaveBeenCalledTimes(1)
@@ -180,6 +184,11 @@ describe('Layout component', () => {
                 to: '/admin/groups',
                 title: 'System Groups',
                 visible: true
+              },
+              {
+                to: '/admin/keywordmanager',
+                title: 'Keyword Manager',
+                visible: true
               }
             ]
           }
@@ -188,9 +197,12 @@ describe('Layout component', () => {
     }, {})
   })
 
-  describe('when the user does not have system group permissions', () => {
+  describe('when the user does not have system group or system keywords permissions', () => {
     test('does not render the admin links', async () => {
-      usePermissions.mockReturnValue({ hasSystemGroup: false })
+      usePermissions.mockReturnValue({
+        hasSystemGroup: false,
+        hasSystemKeywords: false
+      })
 
       setup()
 
@@ -291,6 +303,11 @@ describe('Layout component', () => {
                 {
                   to: '/admin/groups',
                   title: 'System Groups',
+                  visible: false
+                },
+                {
+                  to: '/admin/keywordmanager',
+                  title: 'Keyword Manager',
                   visible: false
                 }
               ]

--- a/static/src/js/hooks/__tests__/usePermissions.test.jsx
+++ b/static/src/js/hooks/__tests__/usePermissions.test.jsx
@@ -63,7 +63,7 @@ const setup = ({
             userId: 'mock-user'
           },
           keywordsPermissionParams: {
-            systemObject: 'KEYWORDS',
+            systemObject: 'INGEST_MANAGEMENT_ACL',
             userId: 'mock-user'
           }
         }
@@ -88,7 +88,7 @@ const setup = ({
             count: 1,
             items: [
               {
-                systemObject: 'KEYWORDS',
+                systemObject: 'INGEST_MANAGEMENT_ACL',
                 permissions: [
                   'read',
                   'create'
@@ -144,7 +144,7 @@ describe('usePermissions', () => {
                     userId: 'mock-user'
                   },
                   keywordsPermissionParams: {
-                    systemObject: 'KEYWORDS',
+                    systemObject: 'INGEST_MANAGEMENT_ACL',
                     userId: 'mock-user'
                   }
                 }
@@ -166,7 +166,7 @@ describe('usePermissions', () => {
                     count: 1,
                     items: [
                       {
-                        systemObject: 'KEYWORDS',
+                        systemObject: 'INGEST_MANAGEMENT_ACL',
                         permissions: [],
                         __typename: 'Permission'
                       }
@@ -212,7 +212,7 @@ describe('usePermissions', () => {
                     userId: 'mock-user'
                   },
                   keywordsPermissionParams: {
-                    systemObject: 'KEYWORDS',
+                    systemObject: 'INGEST_MANAGEMENT_ACL',
                     userId: 'mock-user'
                   }
                 }
@@ -234,7 +234,7 @@ describe('usePermissions', () => {
                     count: 1,
                     items: [
                       {
-                        systemObject: 'KEYWORDS',
+                        systemObject: 'INGEST_MANAGEMENT_ACL',
                         permissions: [],
                         __typename: 'Permission'
                       }
@@ -268,7 +268,7 @@ describe('usePermissions', () => {
                   userId: 'mock-user'
                 },
                 keywordsPermissionParams: {
-                  systemObject: 'KEYWORDS',
+                  systemObject: 'INGEST_MANAGEMENT_ACL',
                   userId: 'mock-user'
                 }
               }
@@ -290,7 +290,7 @@ describe('usePermissions', () => {
                   count: 1,
                   items: [
                     {
-                      systemObject: 'KEYWORDS',
+                      systemObject: 'INGEST_MANAGEMENT_ACL',
                       permissions: ['read'],
                       __typename: 'Permission'
                     }
@@ -325,7 +325,7 @@ describe('usePermissions', () => {
                   userId: 'mock-user'
                 },
                 keywordsPermissionParams: {
-                  systemObject: 'KEYWORDS',
+                  systemObject: 'INGEST_MANAGEMENT_ACL',
                   userId: 'mock-user'
                 }
               }

--- a/static/src/js/hooks/__tests__/usePermissions.test.jsx
+++ b/static/src/js/hooks/__tests__/usePermissions.test.jsx
@@ -9,8 +9,9 @@ import AuthContext from '@/js/context/AuthContext'
 import usePermissions from '../usePermissions'
 
 const TestComponent = () => {
-  const { hasSystemGroup, loading } = usePermissions({
-    systemGroup: ['read']
+  const { hasSystemGroup, hasSystemKeywords, loading } = usePermissions({
+    systemGroup: ['read'],
+    systemKeywords: ['read']
   })
 
   return (
@@ -34,13 +35,23 @@ const TestComponent = () => {
           </span>
         )
       }
+      {
+        hasSystemKeywords && (
+          <span>hasSystemKeywords is true</span>
+        )
+      }
+      {
+        !hasSystemKeywords && (
+          <span>hasSystemKeywords is false</span>
+        )
+      }
     </div>
   )
 }
 
 const setup = ({
   overrideMocks,
-  user = { uid: 'mock-user' }
+  overrideMockAuthContext
 }) => {
   const mocks = [
     {
@@ -49,6 +60,10 @@ const setup = ({
         variables: {
           groupPermissionParams: {
             systemObject: 'GROUP',
+            userId: 'mock-user'
+          },
+          keywordsPermissionParams: {
+            systemObject: 'KEYWORDS',
             userId: 'mock-user'
           }
         }
@@ -68,19 +83,32 @@ const setup = ({
               }
             ],
             __typename: 'PermissionList'
+          },
+          keywordsPermissions: {
+            count: 1,
+            items: [
+              {
+                systemObject: 'KEYWORDS',
+                permissions: [
+                  'read',
+                  'create'
+                ],
+                __typename: 'Permission'
+              }
+            ],
+            __typename: 'PermissionList'
           }
         }
       }
     }
   ]
 
+  const mockAuthContext = {
+    user: { uid: 'mock-user' }
+  }
+
   render(
-    <AuthContext.Provider value={
-      {
-        user
-      }
-    }
-    >
+    <AuthContext.Provider value={overrideMockAuthContext || mockAuthContext}>
       <MockedProvider
         mocks={overrideMocks || mocks}
       >
@@ -114,6 +142,10 @@ describe('usePermissions', () => {
                   groupPermissionParams: {
                     systemObject: 'GROUP',
                     userId: 'mock-user'
+                  },
+                  keywordsPermissionParams: {
+                    systemObject: 'KEYWORDS',
+                    userId: 'mock-user'
                   }
                 }
               },
@@ -124,6 +156,17 @@ describe('usePermissions', () => {
                     items: [
                       {
                         systemObject: 'GROUP',
+                        permissions: [],
+                        __typename: 'Permission'
+                      }
+                    ],
+                    __typename: 'PermissionList'
+                  },
+                  keywordsPermissions: {
+                    count: 1,
+                    items: [
+                      {
+                        systemObject: 'KEYWORDS',
                         permissions: [],
                         __typename: 'Permission'
                       }
@@ -144,15 +187,177 @@ describe('usePermissions', () => {
     })
   })
 
+  describe('systemKeywords', () => {
+    describe('when the user has the given keyword permission', () => {
+      test('returns true', async () => {
+        setup({})
+
+        expect(screen.getByText('Loading')).toBeInTheDocument()
+
+        expect(await screen.findByText('hasSystemKeywords is true')).toBeInTheDocument()
+        expect(screen.queryByText('hasSystemKeywords is false')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('when the user does not have the given keyword permission', () => {
+      test('returns false', async () => {
+        setup({
+          overrideMocks: [
+            {
+              request: {
+                query: GET_PERMISSIONS,
+                variables: {
+                  groupPermissionParams: {
+                    systemObject: 'GROUP',
+                    userId: 'mock-user'
+                  },
+                  keywordsPermissionParams: {
+                    systemObject: 'KEYWORDS',
+                    userId: 'mock-user'
+                  }
+                }
+              },
+              result: {
+                data: {
+                  groupPermissions: {
+                    count: 1,
+                    items: [
+                      {
+                        systemObject: 'GROUP',
+                        permissions: ['read'],
+                        __typename: 'Permission'
+                      }
+                    ],
+                    __typename: 'PermissionList'
+                  },
+                  keywordsPermissions: {
+                    count: 1,
+                    items: [
+                      {
+                        systemObject: 'KEYWORDS',
+                        permissions: [],
+                        __typename: 'Permission'
+                      }
+                    ],
+                    __typename: 'PermissionList'
+                  }
+                }
+              }
+            }
+          ]
+        })
+
+        expect(screen.getByText('Loading')).toBeInTheDocument()
+
+        expect(await screen.findByText('hasSystemKeywords is false')).toBeInTheDocument()
+        expect(screen.queryByText('hasSystemKeywords is true')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when both systemGroup and systemKeywords are provided', () => {
+    test('returns correct values for both', async () => {
+      setup({
+        overrideMocks: [
+          {
+            request: {
+              query: GET_PERMISSIONS,
+              variables: {
+                groupPermissionParams: {
+                  systemObject: 'GROUP',
+                  userId: 'mock-user'
+                },
+                keywordsPermissionParams: {
+                  systemObject: 'KEYWORDS',
+                  userId: 'mock-user'
+                }
+              }
+            },
+            result: {
+              data: {
+                groupPermissions: {
+                  count: 1,
+                  items: [
+                    {
+                      systemObject: 'GROUP',
+                      permissions: ['read'],
+                      __typename: 'Permission'
+                    }
+                  ],
+                  __typename: 'PermissionList'
+                },
+                keywordsPermissions: {
+                  count: 1,
+                  items: [
+                    {
+                      systemObject: 'KEYWORDS',
+                      permissions: ['read'],
+                      __typename: 'Permission'
+                    }
+                  ],
+                  __typename: 'PermissionList'
+                }
+              }
+            }
+          }
+        ]
+      })
+
+      expect(screen.getByText('Loading')).toBeInTheDocument()
+
+      expect(await screen.findByText('hasSystemGroup is true')).toBeInTheDocument()
+      expect(screen.queryByText('hasSystemGroup is false')).not.toBeInTheDocument()
+      expect(await screen.findByText('hasSystemKeywords is true')).toBeInTheDocument()
+      expect(screen.queryByText('hasSystemKeywords is false')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when the data is loading', () => {
+    test('returns loading true', async () => {
+      setup({
+        overrideMocks: [
+          {
+            request: {
+              query: GET_PERMISSIONS,
+              variables: {
+                groupPermissionParams: {
+                  systemObject: 'GROUP',
+                  userId: 'mock-user'
+                },
+                keywordsPermissionParams: {
+                  systemObject: 'KEYWORDS',
+                  userId: 'mock-user'
+                }
+              }
+            },
+            result: {
+              data: {
+                groupPermissions: null,
+                keywordsPermissions: null
+              }
+            }
+          }
+        ]
+      })
+
+      expect(screen.getByText('Loading')).toBeInTheDocument()
+    })
+  })
+
   describe('when the user is not logged in', () => {
     test('loading is set to false and the items are displayed', async () => {
       setup({
         overrideMocks: [],
-        user: {}
+        overrideMockAuthContext: { user: undefined }
       })
 
+      expect(screen.queryByText('Loading')).not.toBeInTheDocument()
+
       expect(await screen.findByText('hasSystemGroup is false')).toBeInTheDocument()
+      expect(await screen.findByText('hasSystemKeywords is false')).toBeInTheDocument()
+
       expect(screen.queryByText('hasSystemGroup is true')).not.toBeInTheDocument()
+      expect(screen.queryByText('hasSystemKeywords is true')).not.toBeInTheDocument()
     })
   })
 })

--- a/static/src/js/hooks/usePermissions.js
+++ b/static/src/js/hooks/usePermissions.js
@@ -26,8 +26,8 @@ const usePermissions = ({
         userId: uid
       },
       keywordsPermissionParams: {
-        // Change to 'GROUP' for testing, Change to correct string when CMR-10452 is complete
-        systemObject: 'KEYWORDS',
+        // Change to correct systemObject CMR-10452 is complete
+        systemObject: 'INGEST_MANAGEMENT_ACL',
         userId: uid
       }
     }
@@ -54,9 +54,9 @@ const usePermissions = ({
   const { items: keywordItems } = keywordsPermissionsResult
 
   const groupPermissionsObject = groupItems.find((groupItem) => groupItem.systemObject === 'GROUP')
-  const keywordsPermissionsObject = keywordItems.find((keywordItem) => keywordItem.systemObject === 'KEYWORDS' || keywordItem.systemObject === 'GROUP')
+  const keywordsPermissionsObject = keywordItems.find((keywordItem) => keywordItem.systemObject === 'INGEST_MANAGEMENT_ACL' || keywordItem.systemObject === 'GROUP')
   // Remove the line above and comment in the line below and change to correct string when CMR-10452 is done
-  // const keywordsPermissionsObject = keywordItems.find((keywordItem) => keywordItem.systemObject === 'KEYWORDS')
+  // const keywordsPermissionsObject = keywordItems.find((keywordItem) => keywordItem.systemObject === 'INGEST_MANAGEMENT_ACL')
 
   const { permissions: groupPermissions } = groupPermissionsObject || {}
   const { permissions: keywordsPermissions } = keywordsPermissionsObject || {}

--- a/static/src/js/hooks/usePermissions.js
+++ b/static/src/js/hooks/usePermissions.js
@@ -26,7 +26,7 @@ const usePermissions = ({
         userId: uid
       },
       keywordsPermissionParams: {
-        // Change to 'GROUP' for testing
+        // Change to 'GROUP' for testing, Change to correct string when CMR-10452 is complete
         systemObject: 'KEYWORDS',
         userId: uid
       }
@@ -55,7 +55,7 @@ const usePermissions = ({
 
   const groupPermissionsObject = groupItems.find((groupItem) => groupItem.systemObject === 'GROUP')
   const keywordsPermissionsObject = keywordItems.find((keywordItem) => keywordItem.systemObject === 'KEYWORDS' || keywordItem.systemObject === 'GROUP')
-  // Remove the line above and comment in the line below when CMR-10452 is done
+  // Remove the line above and comment in the line below and change to correct string when CMR-10452 is done
   // const keywordsPermissionsObject = keywordItems.find((keywordItem) => keywordItem.systemObject === 'KEYWORDS')
 
   const { permissions: groupPermissions } = groupPermissionsObject || {}

--- a/static/src/js/operations/queries/getPermissions.js
+++ b/static/src/js/operations/queries/getPermissions.js
@@ -3,9 +3,17 @@ import { gql } from '@apollo/client'
 export const GET_PERMISSIONS = gql`
   query Permissions(
     $groupPermissionParams: PermissionsInput
+    $keywordsPermissionParams: PermissionsInput
     # $otherParams: PermissionsInput
   ) {
     groupPermissions: permissions(params: $groupPermissionParams) {
+      count
+      items {
+        systemObject
+        permissions
+      }
+    }
+    keywordsPermissions: permissions(params: $keywordsPermissionParams) {
       count
       items {
         systemObject

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -1,0 +1,53 @@
+import React, { Suspense } from 'react'
+import { FaPlus } from 'react-icons/fa'
+
+import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+import LoadingTable from '@/js/components/LoadingTable/LoadingTable'
+import Page from '@/js/components/Page/Page'
+import PageHeader from '@/js/components/PageHeader/PageHeader'
+
+// Placeholder component for the keyword management tree
+const KeywordManagementTree = () => (
+  <div>Keyword Management Tree to be inserted here</div>
+)
+
+const KeywordManagerPageHeader = () => (
+  <PageHeader
+    breadcrumbs={
+      [
+        {
+          label: 'Keyword Manager',
+          to: '/keywords',
+          active: true
+        }
+      ]
+    }
+    pageType="secondary"
+    // To be added to/amended
+    primaryActions={
+      [{
+        icon: FaPlus,
+        iconTitle: 'A plus icon',
+        title: 'Publish New Keyword Version',
+        to: 'new',
+        variant: 'success'
+      }]
+    }
+    title="Keyword Manager"
+  />
+)
+
+const KeywordManagerPage = () => (
+  <Page
+    pageType="secondary"
+    header={<KeywordManagerPageHeader />}
+  >
+    <ErrorBoundary>
+      <Suspense fallback={<LoadingTable />}>
+        <KeywordManagementTree />
+      </Suspense>
+    </ErrorBoundary>
+  </Page>
+)
+
+export default KeywordManagerPage

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -5,8 +5,9 @@ import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
 import LoadingTable from '@/js/components/LoadingTable/LoadingTable'
 import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
+import { getApplicationConfig } from 'sharedUtils/getConfig'
 
-// Placeholder component for the keyword management tree
+// Placeholder component for the keyword management tree. To be made into it's own file.
 const KeywordManagementTree = () => (
   <div>Keyword Management Tree to be inserted here</div>
 )
@@ -37,17 +38,25 @@ const KeywordManagerPageHeader = () => (
   />
 )
 
-const KeywordManagerPage = () => (
-  <Page
-    pageType="secondary"
-    header={<KeywordManagerPageHeader />}
-  >
-    <ErrorBoundary>
-      <Suspense fallback={<LoadingTable />}>
-        <KeywordManagementTree />
-      </Suspense>
-    </ErrorBoundary>
-  </Page>
-)
+const KeywordManagerPage = () => {
+  const { showKeywordManager } = getApplicationConfig()
+
+  if (showKeywordManager === 'false') {
+    return null
+  }
+
+  return (
+    <Page
+      pageType="secondary"
+      header={<KeywordManagerPageHeader />}
+    >
+      <ErrorBoundary>
+        <Suspense fallback={<LoadingTable />}>
+          <KeywordManagementTree />
+        </Suspense>
+      </ErrorBoundary>
+    </Page>
+  )
+}
 
 export default KeywordManagerPage

--- a/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
+++ b/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import KeywordManagerPage from '../KeywordManagerPage'
+
+vi.mock('@/js/components/ErrorBoundary/ErrorBoundary', () => ({
+  default: ({ children }) => <div data-testid="error-boundary">{children}</div>
+}))
+
+vi.mock('@/js/components/Page/Page', () => ({
+  default: ({ children, header }) => (
+    <div data-testid="page">
+      {header}
+      {children}
+    </div>
+  )
+}))
+
+vi.mock('@/js/components/PageHeader/PageHeader', () => ({
+  default: ({ title }) => <h1 data-testid="page-header">{title}</h1>
+}))
+
+const setup = () => {
+  render(
+    <BrowserRouter>
+      <KeywordManagerPage />
+    </BrowserRouter>
+  )
+}
+
+describe('KeywordManagerPage component', () => {
+  describe('when the page loads', () => {
+    test('renders the KeywordManagerPage component', () => {
+      setup()
+
+      expect(screen.getByTestId('page')).toBeInTheDocument()
+
+      expect(screen.getByTestId('page-header')).toBeInTheDocument()
+      expect(screen.getByText('Keyword Manager')).toBeInTheDocument()
+
+      expect(screen.getByTestId('error-boundary')).toBeInTheDocument()
+
+      expect(screen.getByText('Keyword Management Tree to be inserted here')).toBeInTheDocument()
+    })
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -31,6 +31,10 @@ export default defineConfig({
       {
         find: 'sharedConstants',
         replacement: path.resolve(__dirname, 'sharedConstants')
+      },
+      {
+        find: 'sharedUtils',
+        replacement: path.resolve(__dirname, 'sharedUtils')
       }
     ]
   },


### PR DESCRIPTION
# Overview

### What is the feature?

Authorized users can access the Keyword Manager underneath the Admin header.

### What is the Solution?

Under Admin, there is now a tab for Keyword Manager. This tab is only visible to users with access to the Keyword Manager. At the moment, the permission endpoint for this is awaiting creating with CMR-10495. For now, we are using the Group permission to test this. 

### What areas of the application does this impact?

Navigations and new Keyword Manager landing page

# Testing

### Reproduction steps

- **Environment for testing: SIT
- **Collection to test with: N/A

1. Point local environment to SIT and log on. 
2. Under usePermissions.js, change line 30 to 'GROUP'. (change back to KEYWORDS before running tests)
3. Load page and see that Keyword Manager is accessible under Admin. 

### Attachments
![Screenshot 2025-04-14 at 2 49 38 PM](https://github.com/user-attachments/assets/d93a4f2c-2a68-4234-a8f4-6edb5b874a54)



# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
