### PR TITLE
MMT-4010b: Adding in real ACL - As a user, I can navigate to a landing page for Keyword Manager.

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -18,6 +18,9 @@ config="`jq '.application.apiHost = $newValue' --arg newValue $bamboo_API_HOST <
 config="`jq '.application.cmrHost = $newValue' --arg newValue $bamboo_CMR_HOST <<< $config`"
 config="`jq '.application.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
 config="`jq '.application.gkrHost = $newValue' --arg newValue $bamboo_GKR_HOST <<< $config`"
+config="`jq '.application.kmsHost = $newValue' --arg newValue $bamboo_KMS_HOST <<< $config`"
+# Remove after CMR-10452 has been completed
+config="`jq '.application.showKeywordManager = $newValue' --arg newValue $bamboo_SHOW_KEYWORD_MANAGER <<< $config`"
 config="`jq '.application.cookieDomain = $newValue' --arg newValue $bamboo_COOKIE_DOMAIN <<< $config`"
 config="`jq '.application.displayProdWarning = $newValue' --arg newValue $bamboo_DISPLAY_PROD_WARNING <<< $config`"
 config="`jq '.application.tokenValidTime = $newValue' --arg newValue $bamboo_JWT_VALID_TIME <<< $config`"

--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -18,9 +18,6 @@ config="`jq '.application.apiHost = $newValue' --arg newValue $bamboo_API_HOST <
 config="`jq '.application.cmrHost = $newValue' --arg newValue $bamboo_CMR_HOST <<< $config`"
 config="`jq '.application.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
 config="`jq '.application.gkrHost = $newValue' --arg newValue $bamboo_GKR_HOST <<< $config`"
-config="`jq '.application.kmsHost = $newValue' --arg newValue $bamboo_KMS_HOST <<< $config`"
-# Remove after CMR-10452 has been completed
-config="`jq '.application.showKeywordManager = $newValue' --arg newValue $bamboo_SHOW_KEYWORD_MANAGER <<< $config`"
 config="`jq '.application.cookieDomain = $newValue' --arg newValue $bamboo_COOKIE_DOMAIN <<< $config`"
 config="`jq '.application.displayProdWarning = $newValue' --arg newValue $bamboo_DISPLAY_PROD_WARNING <<< $config`"
 config="`jq '.application.tokenValidTime = $newValue' --arg newValue $bamboo_JWT_VALID_TIME <<< $config`"

--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -19,8 +19,6 @@ config="`jq '.application.cmrHost = $newValue' --arg newValue $bamboo_CMR_HOST <
 config="`jq '.application.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
 config="`jq '.application.gkrHost = $newValue' --arg newValue $bamboo_GKR_HOST <<< $config`"
 config="`jq '.application.kmsHost = $newValue' --arg newValue $bamboo_KMS_HOST <<< $config`"
-# Remove after CMR-10452 has been completed
-config="`jq '.application.showKeywordManager = $newValue' --arg newValue $bamboo_SHOW_KEYWORD_MANAGER <<< $config`"
 config="`jq '.application.cookieDomain = $newValue' --arg newValue $bamboo_COOKIE_DOMAIN <<< $config`"
 config="`jq '.application.displayProdWarning = $newValue' --arg newValue $bamboo_DISPLAY_PROD_WARNING <<< $config`"
 config="`jq '.application.tokenValidTime = $newValue' --arg newValue $bamboo_JWT_VALID_TIME <<< $config`"

--- a/static.config.json
+++ b/static.config.json
@@ -14,7 +14,6 @@
       "Access-Control-Allow-Headers": "*",
       "Access-Control-Allow-Credentials": true
     },
-    "showKeywordManager": true,
     "cookieDomain": ".localhost",
     "tokenValidTime": "900",
     "displayProdWarning": "true",

--- a/static/src/js/components/SystemPermissions/__tests__/SystemPermissions.test.jsx
+++ b/static/src/js/components/SystemPermissions/__tests__/SystemPermissions.test.jsx
@@ -201,7 +201,7 @@ describe('SystemPermissions', () => {
         const table = screen.getByRole('table')
 
         const checkedCheckboxes = within(table).queryAllByRole('checkbox', { checked: true })
-        expect(checkedCheckboxes.length).toBe(50)
+        expect(checkedCheckboxes.length).toBe(54)
 
         await user.click(checkAll)
 

--- a/static/src/js/constants/systemIdentityPermissions.js
+++ b/static/src/js/constants/systemIdentityPermissions.js
@@ -46,6 +46,10 @@ const systemIdentityPermissions = {
     title: 'Ingest Operations',
     permittedPermissions: ['read', 'update']
   },
+  KEYWORD_MANAGEMENT_SYSTEM: {
+    title: 'Keyword Management System',
+    permittedPermissions: ['create', 'read', 'update', 'delete']
+  },
   METRIC_DATA_POINT_SAMPLE: {
     title: 'Metric Data Point Samples',
     permittedPermissions: ['read']

--- a/static/src/js/hooks/__tests__/usePermissions.test.jsx
+++ b/static/src/js/hooks/__tests__/usePermissions.test.jsx
@@ -63,7 +63,7 @@ const setup = ({
             userId: 'mock-user'
           },
           keywordsPermissionParams: {
-            systemObject: 'INGEST_MANAGEMENT_ACL',
+            systemObject: 'KEYWORD_MANAGEMENT_SYSTEM',
             userId: 'mock-user'
           }
         }
@@ -88,7 +88,7 @@ const setup = ({
             count: 1,
             items: [
               {
-                systemObject: 'INGEST_MANAGEMENT_ACL',
+                systemObject: 'KEYWORD_MANAGEMENT_SYSTEM',
                 permissions: [
                   'read',
                   'create'
@@ -144,7 +144,7 @@ describe('usePermissions', () => {
                     userId: 'mock-user'
                   },
                   keywordsPermissionParams: {
-                    systemObject: 'INGEST_MANAGEMENT_ACL',
+                    systemObject: 'KEYWORD_MANAGEMENT_SYSTEM',
                     userId: 'mock-user'
                   }
                 }
@@ -166,7 +166,7 @@ describe('usePermissions', () => {
                     count: 1,
                     items: [
                       {
-                        systemObject: 'INGEST_MANAGEMENT_ACL',
+                        systemObject: 'KEYWORD_MANAGEMENT_SYSTEM',
                         permissions: [],
                         __typename: 'Permission'
                       }
@@ -212,7 +212,7 @@ describe('usePermissions', () => {
                     userId: 'mock-user'
                   },
                   keywordsPermissionParams: {
-                    systemObject: 'INGEST_MANAGEMENT_ACL',
+                    systemObject: 'KEYWORD_MANAGEMENT_SYSTEM',
                     userId: 'mock-user'
                   }
                 }
@@ -234,7 +234,7 @@ describe('usePermissions', () => {
                     count: 1,
                     items: [
                       {
-                        systemObject: 'INGEST_MANAGEMENT_ACL',
+                        systemObject: 'KEYWORD_MANAGEMENT_SYSTEM',
                         permissions: [],
                         __typename: 'Permission'
                       }
@@ -268,7 +268,7 @@ describe('usePermissions', () => {
                   userId: 'mock-user'
                 },
                 keywordsPermissionParams: {
-                  systemObject: 'INGEST_MANAGEMENT_ACL',
+                  systemObject: 'KEYWORD_MANAGEMENT_SYSTEM',
                   userId: 'mock-user'
                 }
               }
@@ -290,7 +290,7 @@ describe('usePermissions', () => {
                   count: 1,
                   items: [
                     {
-                      systemObject: 'INGEST_MANAGEMENT_ACL',
+                      systemObject: 'KEYWORD_MANAGEMENT_SYSTEM',
                       permissions: ['read'],
                       __typename: 'Permission'
                     }
@@ -325,7 +325,7 @@ describe('usePermissions', () => {
                   userId: 'mock-user'
                 },
                 keywordsPermissionParams: {
-                  systemObject: 'INGEST_MANAGEMENT_ACL',
+                  systemObject: 'KEYWORD_MANAGEMENT_SYSTEM',
                   userId: 'mock-user'
                 }
               }

--- a/static/src/js/hooks/usePermissions.js
+++ b/static/src/js/hooks/usePermissions.js
@@ -26,8 +26,7 @@ const usePermissions = ({
         userId: uid
       },
       keywordsPermissionParams: {
-        // Change to correct systemObject CMR-10452 is complete
-        systemObject: 'INGEST_MANAGEMENT_ACL',
+        systemObject: 'KEYWORD_MANAGEMENT_SYSTEM',
         userId: uid
       }
     }
@@ -54,9 +53,7 @@ const usePermissions = ({
   const { items: keywordItems } = keywordsPermissionsResult
 
   const groupPermissionsObject = groupItems.find((groupItem) => groupItem.systemObject === 'GROUP')
-  const keywordsPermissionsObject = keywordItems.find((keywordItem) => keywordItem.systemObject === 'INGEST_MANAGEMENT_ACL' || keywordItem.systemObject === 'GROUP')
-  // Remove the line above and comment in the line below and change to correct string when CMR-10452 is done
-  // const keywordsPermissionsObject = keywordItems.find((keywordItem) => keywordItem.systemObject === 'INGEST_MANAGEMENT_ACL')
+  const keywordsPermissionsObject = keywordItems.find((keywordItem) => keywordItem.systemObject === 'KEYWORD_MANAGEMENT_SYSTEM')
 
   const { permissions: groupPermissions } = groupPermissionsObject || {}
   const { permissions: keywordsPermissions } = keywordsPermissionsObject || {}


### PR DESCRIPTION
# Overview

### What is the feature?

To pull this down, please use MMT-41010b. Sorry! 
In the previous ticket, I didn't have the ACL. Now that I do, I'm resubmitting this again with the actual ACL.

### What is the Solution?

Swapped out dummy data for the real thing and removed feature toggle.

### What areas of the application does this impact?

usePermissions and systemIdentityPermissions

# Testing

### Reproduction steps

- **Environment for testing: SIT

1. Go to System Groups under Admin and select Administrators. Under Administrators, look for Keyword Management System and toggle the permissions. You should see that the Keyword Manager appears and disappears when you toggle that permission. 

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
