### PR TITLE
MMT-3990: Adding Published and Draft Visualizations

### DIFF
--- a/static.config.json
+++ b/static.config.json
@@ -29,7 +29,8 @@
     "ummC": "1.18.3",
     "ummS": "1.5.3",
     "ummT": "1.2.0",
-    "ummV": "1.9.0"
+    "ummV": "1.9.0",
+    "ummVis": "1.1.0"
   },
   "ummJsonSchemaUrl": "http://json-schema.org/draft-07/schema#",
   "edl": {

--- a/static/src/js/components/DraftList/DraftList.jsx
+++ b/static/src/js/components/DraftList/DraftList.jsx
@@ -9,7 +9,6 @@ import Col from 'react-bootstrap/Col'
 import Row from 'react-bootstrap/Row'
 
 import { DATE_FORMAT } from '@/js/constants/dateFormat'
-import conceptIdTypes from '@/js/constants/conceptIdTypes'
 import conceptTypeDraftsQueries from '@/js/constants/conceptTypeDraftsQueries'
 import constructDownloadableFile from '@/js/utils/constructDownloadableFile'
 import urlValueTypeToConceptTypeStringMap from '@/js/constants/urlValueToConceptStringMap'
@@ -58,7 +57,7 @@ const DraftList = () => {
 
     let cellData = originalCellData
 
-    if (!cellData && draftType === conceptIdTypes.C) cellData = '<Blank Short Name>'
+    if (!cellData && draftType === 'Collection') cellData = '<Blank Short Name>'
     if (!cellData) cellData = '<Blank Name>'
 
     return (
@@ -71,7 +70,7 @@ const DraftList = () => {
   const buildEllipsisTextCell = useCallback((originalCellData) => {
     let cellData = originalCellData
 
-    if (!cellData && draftType === conceptIdTypes.C) cellData = '<Blank Entry Title>'
+    if (!cellData && draftType === 'Collection') cellData = '<Blank Entry Title>'
     if (!cellData) cellData = '<Blank Long Name>'
 
     return (
@@ -114,7 +113,23 @@ const DraftList = () => {
       dataAccessorFn: buildEllipsisTextCell
     }
   ]
-  const nonCollectionColumns = [
+
+  const visColumns = [
+    {
+      dataKey: 'previewMetadata.name',
+      title: 'Name',
+      className: 'col-auto',
+      dataAccessorFn: buildPrimaryEllipsisLink
+    },
+    {
+      dataKey: 'previewMetadata.title',
+      title: 'Long Name',
+      className: 'col-auto',
+      dataAccessorFn: buildEllipsisTextCell
+    }
+  ]
+
+  const defaultColumns = [
     {
       dataKey: 'ummMetadata.Name',
       title: 'Name',
@@ -147,9 +162,18 @@ const DraftList = () => {
     }
   ]
 
-  const columns = draftType === conceptIdTypes.C
-    ? [...collectionColumns, ...commonColumns]
-    : [...nonCollectionColumns, ...commonColumns]
+  const getColumns = () => {
+    switch (draftType) {
+      case 'Collection':
+        return [...collectionColumns, ...commonColumns]
+      case 'Visualization':
+        return [...visColumns, ...commonColumns]
+      default:
+        return [...defaultColumns, ...commonColumns]
+    }
+  }
+
+  const columns = getColumns()
 
   return (
     <Row>

--- a/static/src/js/components/DraftList/__tests__/DraftList.test.jsx
+++ b/static/src/js/components/DraftList/__tests__/DraftList.test.jsx
@@ -13,8 +13,15 @@ import constructDownloadableFile from '@/js/utils/constructDownloadableFile'
 
 import { GET_TOOL_DRAFTS } from '@/js/operations/queries/getToolDrafts'
 import { GET_COLLECTION_DRAFTS } from '@/js/operations/queries/getCollectionDrafts'
+import { GET_VISUALIZATION_DRAFTS } from '@/js/operations/queries/getVisualizationDrafts'
 
 import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+
+import {
+  mockCollectionDrafts,
+  mockToolDrafts,
+  mockVisualizationDrafts
+} from './__mocks__/DraftListMocks'
 
 import DraftList from '../DraftList'
 
@@ -26,124 +33,6 @@ vi.mock('react-router-dom', async () => ({
   ...await vi.importActual('react-router-dom'),
   useParams: vi.fn().mockImplementation(() => ({ draftType: 'tools' }))
 }))
-
-const mockToolDrafts = {
-  count: 3,
-  items: [
-    {
-      conceptId: 'TD1200000092-MMT_2',
-      revisionDate: '2023-12-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {
-        Name: 'Tool TD1200000092 short name',
-        LongName: 'Tool TD1200000092 long name'
-      },
-      name: 'Tool TD1200000092 short name',
-      previewMetadata: {
-        conceptId: 'TD1200000092-MMT_2',
-        revisionId: '1',
-        name: 'Tool TD1200000092 short name',
-        longName: 'Tool TD1200000092 long name',
-        __typename: 'Tool'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    },
-    {
-      conceptId: 'TD1200000093-MMT_2',
-      revisionDate: '2023-11-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {},
-      previewMetadata: {
-        conceptId: 'TD1200000093-MMT_2',
-        revisionId: '1',
-        name: null,
-        longName: null,
-        __typename: 'Tool'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    },
-    {
-      conceptId: 'TD1200000094-MMT_2',
-      revisionDate: '2023-10-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {
-        Name: 'Tool TD1200000094 short name',
-        LongName: 'Tool TD1200000094 long name'
-      },
-      previewMetadata: {
-        conceptId: 'TD1200000094-MMT_2',
-        revisionId: '1',
-        name: null,
-        longName: null,
-        __typename: 'Tool'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    }
-  ],
-  __typename: 'DraftList'
-}
-
-const mockCollectionDrafts = {
-  count: 3,
-  items: [
-    {
-      conceptId: 'CD1200000092-MMT_2',
-      revisionDate: '2023-12-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {
-        ShortName: 'Collection CD1200000092 short name',
-        EntryTitle: 'Collection CD1200000092 entry title'
-      },
-      shortName: 'Collection CD1200000092 short name',
-      previewMetadata: {
-        conceptId: 'CD1200000092-MMT_2',
-        revisionId: '1',
-        shortName: 'Collection CD1200000092 short name',
-        entryTitle: 'Collection CD1200000092 entry title',
-        __typename: 'Collection'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    },
-    {
-      conceptId: 'CD1200000093-MMT_2',
-      revisionDate: '2023-11-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {},
-      previewMetadata: {
-        conceptId: 'CD1200000093-MMT_2',
-        revisionId: '1',
-        shortName: null,
-        entryTitle: null,
-        __typename: 'Collection'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    },
-    {
-      conceptId: 'CD1200000094-MMT_2',
-      revisionDate: '2023-10-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {
-        ShortName: 'Collection CD1200000094 short name',
-        EntryTitle: 'Collection CD1200000094 entry title'
-      },
-      previewMetadata: {
-        conceptId: 'CD1200000094-MMT_2',
-        revisionId: '1',
-        shortName: null,
-        entryTitle: null,
-        __typename: 'Collection'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    }
-  ],
-  __typename: 'DraftList'
-}
 
 const setup = ({ overrideMocks = false }) => {
   const mocks = [{
@@ -333,6 +222,53 @@ describe('DraftList', () => {
         JSON.stringify(mockToolDrafts.items[0].ummMetadata, null, 2),
         'TD1200000092-MMT_2'
       )
+    })
+  })
+
+  describe('when draft type Visualization is given', () => {
+    test('renders Visualization draft list', async () => {
+      useParams.mockImplementation(() => ({ draftType: 'visualizations' }))
+
+      setup({
+        overrideMocks: [{
+          request: {
+            query: GET_VISUALIZATION_DRAFTS,
+            variables: {
+              params: {
+                conceptType: 'Visualization',
+                limit: 20,
+                offset: 0,
+                sortKey: ['-revision_date']
+              }
+            }
+          },
+          result: {
+            data: {
+              drafts: mockVisualizationDrafts
+            }
+          }
+        }]
+      })
+
+      const rows = await screen.findAllByRole('row')
+
+      expect(within(rows[1]).getByRole('cell', { name: 'Short Name 1' })).toBeInTheDocument()
+      expect(within(rows[1]).getByRole('cell', { name: 'Long Name 1' })).toBeInTheDocument()
+      expect(within(rows[1]).getByRole('cell', { name: 'Friday, April 25, 2025 5:26 PM' })).toBeInTheDocument()
+      expect(within(rows[1]).getByRole('cell', { name: 'MMT_1' })).toBeInTheDocument()
+      expect(within(rows[1]).getByRole('button', { name: /Download JSON/ })).toBeInTheDocument()
+
+      expect(within(rows[2]).getByRole('cell', { name: '<Blank Name>' })).toBeInTheDocument()
+      expect(within(rows[2]).getByRole('cell', { name: '<Blank Long Name>' })).toBeInTheDocument()
+      expect(within(rows[2]).getByRole('cell', { name: 'Thursday, May 15, 2025 10:30 AM' })).toBeInTheDocument()
+      expect(within(rows[2]).getByRole('cell', { name: 'MMT_1' })).toBeInTheDocument()
+      expect(within(rows[2]).getByRole('button', { name: /Download JSON/ })).toBeInTheDocument()
+
+      expect(within(rows[3]).getByRole('cell', { name: 'Short Name 3' })).toBeInTheDocument()
+      expect(within(rows[3]).getByRole('cell', { name: 'Long Name 3' })).toBeInTheDocument()
+      expect(within(rows[3]).getByRole('cell', { name: 'Thursday, June 5, 2025 2:45 PM' })).toBeInTheDocument()
+      expect(within(rows[3]).getByRole('cell', { name: 'MMT_1' })).toBeInTheDocument()
+      expect(within(rows[3]).getByRole('button', { name: /Download JSON/ })).toBeInTheDocument()
     })
   })
 })

--- a/static/src/js/components/DraftList/__tests__/__mocks__/DraftListMocks.js
+++ b/static/src/js/components/DraftList/__tests__/__mocks__/DraftListMocks.js
@@ -1,0 +1,153 @@
+export const mockToolDrafts = {
+  count: 3,
+  items: [
+    {
+      conceptId: 'TD1200000092-MMT_2',
+      revisionDate: '2023-12-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {
+        Name: 'Tool TD1200000092 short name',
+        LongName: 'Tool TD1200000092 long name'
+      },
+      name: 'Tool TD1200000092 short name',
+      previewMetadata: {
+        conceptId: 'TD1200000092-MMT_2',
+        revisionId: '1',
+        name: 'Tool TD1200000092 short name',
+        longName: 'Tool TD1200000092 long name',
+        __typename: 'Tool'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    },
+    {
+      conceptId: 'TD1200000093-MMT_2',
+      revisionDate: '2023-11-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {},
+      previewMetadata: {
+        conceptId: 'TD1200000093-MMT_2',
+        revisionId: '1',
+        name: null,
+        longName: null,
+        __typename: 'Tool'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    },
+    {
+      conceptId: 'TD1200000094-MMT_2',
+      revisionDate: '2023-10-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {
+        Name: 'Tool TD1200000094 short name',
+        LongName: 'Tool TD1200000094 long name'
+      },
+      previewMetadata: {
+        conceptId: 'TD1200000094-MMT_2',
+        revisionId: '1',
+        name: null,
+        longName: null,
+        __typename: 'Tool'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    }
+  ],
+  __typename: 'DraftList'
+}
+
+export const mockCollectionDrafts = {
+  count: 3,
+  items: [
+    {
+      conceptId: 'CD1200000092-MMT_2',
+      revisionDate: '2023-12-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {
+        ShortName: 'Collection CD1200000092 short name',
+        EntryTitle: 'Collection CD1200000092 entry title'
+      },
+      shortName: 'Collection CD1200000092 short name',
+      previewMetadata: {
+        conceptId: 'CD1200000092-MMT_2',
+        revisionId: '1',
+        shortName: 'Collection CD1200000092 short name',
+        entryTitle: 'Collection CD1200000092 entry title',
+        __typename: 'Collection'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    },
+    {
+      conceptId: 'CD1200000093-MMT_2',
+      revisionDate: '2023-11-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {},
+      previewMetadata: {
+        conceptId: 'CD1200000093-MMT_2',
+        revisionId: '1',
+        shortName: null,
+        entryTitle: null,
+        __typename: 'Collection'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    },
+    {
+      conceptId: 'CD1200000094-MMT_2',
+      revisionDate: '2023-10-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {
+        ShortName: 'Collection CD1200000094 short name',
+        EntryTitle: 'Collection CD1200000094 entry title'
+      },
+      previewMetadata: {
+        conceptId: 'CD1200000094-MMT_2',
+        revisionId: '1',
+        shortName: null,
+        entryTitle: null,
+        __typename: 'Collection'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    }
+  ],
+  __typename: 'DraftList'
+}
+
+export const mockVisualizationDrafts = {
+  count: 3,
+  items: [
+    {
+      conceptId: 'VISD1-MMT_1',
+      previewMetadata: {
+        conceptId: 'VISD1-MMT_1',
+        name: 'Short Name 1',
+        title: 'Long Name 1'
+      },
+      providerId: 'MMT_1',
+      revisionDate: '2025-04-25T17:26:18.052Z'
+    },
+    {
+      conceptId: 'VISD2-MMT_1',
+      previewMetadata: {
+        conceptId: 'VISD2-MMT_1',
+        name: '',
+        title: ''
+      },
+      providerId: 'MMT_1',
+      revisionDate: '2025-05-15T10:30:00.000Z'
+    },
+    {
+      conceptId: 'VISD3-MMT_1',
+      previewMetadata: {
+        conceptId: 'VISD3-MMT_1',
+        name: 'Short Name 3',
+        title: 'Long Name 3'
+      },
+      providerId: 'MMT_1',
+      revisionDate: '2025-06-05T14:45:30.000Z'
+    }
+  ]
+}

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -44,7 +44,8 @@ const Layout = ({ className, displayNav }) => {
     ummC,
     ummS,
     ummT,
-    ummV
+    ummV,
+    ummVis
   } = getUmmVersionsConfig()
 
   const { env, displayProdWarning } = getApplicationConfig()
@@ -185,6 +186,20 @@ const Layout = ({ className, displayNav }) => {
                                   },
                                   {
                                     to: '/drafts/tools',
+                                    title: 'Drafts'
+                                  }
+                                ]
+                              },
+                              {
+                                title: 'Visualizations',
+                                version: `v${ummVis}`,
+                                children: [
+                                  {
+                                    to: '/visualizations',
+                                    title: 'All Visualizations'
+                                  },
+                                  {
+                                    to: '/drafts/visualizations',
                                     title: 'Drafts'
                                   }
                                 ]

--- a/static/src/js/components/Layout/__tests__/Layout.test.jsx
+++ b/static/src/js/components/Layout/__tests__/Layout.test.jsx
@@ -26,7 +26,8 @@ const setup = (loggedIn) => {
     ummC: 'mock-umm-c',
     ummS: 'mock-umm-s',
     ummT: 'mock-umm-t',
-    ummV: 'mock-umm-v'
+    ummV: 'mock-umm-v',
+    ummVis: 'mock-umm-vis'
   }))
 
   vi.setSystemTime('2024-01-01')
@@ -157,6 +158,20 @@ describe('Layout component', () => {
             ]
           },
           {
+            title: 'Visualizations',
+            version: 'vmock-umm-vis',
+            children: [
+              {
+                title: 'All Visualizations',
+                to: '/visualizations'
+              },
+              {
+                title: 'Drafts',
+                to: '/drafts/visualizations'
+              }
+            ]
+          },
+          {
             title: 'Order Options',
             children: [
               {
@@ -273,6 +288,20 @@ describe('Layout component', () => {
                 {
                   to: '/drafts/tools',
                   title: 'Drafts'
+                }
+              ]
+            },
+            {
+              title: 'Visualizations',
+              version: 'vmock-umm-vis',
+              children: [
+                {
+                  title: 'All Visualizations',
+                  to: '/visualizations'
+                },
+                {
+                  title: 'Drafts',
+                  to: '/drafts/visualizations'
                 }
               ]
             },

--- a/static/src/js/constants/conceptTypeDraftsQueries.js
+++ b/static/src/js/constants/conceptTypeDraftsQueries.js
@@ -2,12 +2,14 @@ import { GET_SERVICE_DRAFTS } from '../operations/queries/getServiceDrafts'
 import { GET_TOOL_DRAFTS } from '../operations/queries/getToolDrafts'
 import { GET_VARIABLE_DRAFTS } from '../operations/queries/getVariableDrafts'
 import { GET_COLLECTION_DRAFTS } from '../operations/queries/getCollectionDrafts'
+import { GET_VISUALIZATION_DRAFTS } from '../operations/queries/getVisualizationDrafts'
 
 const conceptTypeDraftsQueries = {
   Collection: GET_COLLECTION_DRAFTS,
   Service: GET_SERVICE_DRAFTS,
   Tool: GET_TOOL_DRAFTS,
-  Variable: GET_VARIABLE_DRAFTS
+  Variable: GET_VARIABLE_DRAFTS,
+  Visualization: GET_VISUALIZATION_DRAFTS
 }
 
 export default conceptTypeDraftsQueries

--- a/static/src/js/constants/conceptTypeQueries.js
+++ b/static/src/js/constants/conceptTypeQueries.js
@@ -8,6 +8,7 @@ import { GET_TOOL } from '@/js/operations/queries/getTool'
 import { GET_TOOLS } from '@/js/operations/queries/getTools'
 import { GET_VARIABLE } from '@/js/operations/queries/getVariable'
 import { GET_VARIABLES } from '@/js/operations/queries/getVariables'
+import { GET_VISUALIZATIONS } from '@/js/operations/queries/getVisualizations'
 
 const conceptTypeQueries = {
   Collection: GET_COLLECTION,
@@ -19,7 +20,8 @@ const conceptTypeQueries = {
   Tool: GET_TOOL,
   Tools: GET_TOOLS,
   Variable: GET_VARIABLE,
-  Variables: GET_VARIABLES
+  Variables: GET_VARIABLES,
+  Visualizations: GET_VISUALIZATIONS
 }
 
 export default conceptTypeQueries

--- a/static/src/js/constants/conceptTypes.js
+++ b/static/src/js/constants/conceptTypes.js
@@ -9,7 +9,8 @@ const conceptTypes = {
   Tool: 'Tool',
   Tools: 'Tools',
   Variable: 'Variable',
-  Variables: 'Variables'
+  Variables: 'Variables',
+  Visualizations: 'Visualizations'
 }
 
 export default conceptTypes

--- a/static/src/js/constants/redirectsMap/redirectsMap.js
+++ b/static/src/js/constants/redirectsMap/redirectsMap.js
@@ -7,11 +7,13 @@ const REDIRECTS = {
   manage_variables: 'variables',
   manage_services: 'services',
   manage_tools: 'tools',
+  manage_visualizations: 'visualizations',
   manage_cmr: 'collections',
   tool_drafts: 'drafts/tools',
   service_drafts: 'drafts/services',
   collection_drafts: 'drafts/collections',
-  variable_drafts: 'drafts/variables'
+  variable_drafts: 'drafts/variables',
+  visualization_drafts: 'drafts/visualizations'
 }
 
 export default REDIRECTS

--- a/static/src/js/constants/typeParamToHumanizedStringMap.js
+++ b/static/src/js/constants/typeParamToHumanizedStringMap.js
@@ -2,7 +2,8 @@ const typeParamToHumanizedStringMap = {
   collections: 'collection',
   services: 'service',
   tools: 'tool',
-  variables: 'variable'
+  variables: 'variable',
+  visualizations: 'visualization'
 }
 
 export default typeParamToHumanizedStringMap

--- a/static/src/js/constants/urlValueToConceptStringMap.js
+++ b/static/src/js/constants/urlValueToConceptStringMap.js
@@ -3,7 +3,8 @@ const urlValueTypeToConceptTypeStringMap = {
   collections: 'Collection',
   tools: 'Tool',
   services: 'Service',
-  cmr: 'CMR'
+  cmr: 'CMR',
+  visualizations: 'Visualization'
 }
 
 export default urlValueTypeToConceptTypeStringMap

--- a/static/src/js/operations/queries/getVisualizationDrafts.js
+++ b/static/src/js/operations/queries/getVisualizationDrafts.js
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client'
+
+export const GET_VISUALIZATION_DRAFTS = gql`
+  query VaisualizationDrafts($params: DraftsInput) {
+    drafts(params: $params) {
+      count
+      items {
+        conceptId
+        providerId
+        revisionDate
+        ummMetadata
+        previewMetadata {
+          ... on Visualization {
+            conceptId
+            name
+            title
+          }
+        }
+      }
+    }
+  }
+`

--- a/static/src/js/operations/queries/getVisualizations.js
+++ b/static/src/js/operations/queries/getVisualizations.js
@@ -1,0 +1,17 @@
+import { gql } from '@apollo/client'
+
+export const GET_VISUALIZATIONS = gql`
+  query GetVisualizations($params: VisualizationsInput) {
+    visualizations(params: $params) {
+      count
+      items {
+        conceptId
+        revisionId
+        name
+        title
+        providerId
+        revisionDate
+      }
+    }
+  }
+`

--- a/static/src/js/pages/SearchList/SearchList.jsx
+++ b/static/src/js/pages/SearchList/SearchList.jsx
@@ -79,6 +79,15 @@ const SearchList = ({ limit }) => {
     }
   }
 
+  if (formattedType === conceptTypes.Visualizations) {
+    params = {
+      limit,
+      offset,
+      provider: providerParam,
+      sortKey: sortKeyParam
+    }
+  }
+
   const { data } = useSuspenseQuery(conceptTypeQueries[formattedType], {
     variables: {
       params
@@ -111,18 +120,28 @@ const SearchList = ({ limit }) => {
   const buildEllipsisLinkCell = useCallback((cellData, rowData) => {
     const { conceptId } = rowData
 
+    let newCellData = cellData
+
+    if (!newCellData && conceptType === 'visualizations') newCellData = '<Blank Short Name>'
+
     return (
       <EllipsisLink to={`/${conceptType}/${conceptId}`}>
-        {cellData}
+        {newCellData}
       </EllipsisLink>
     )
   }, [conceptType])
 
-  const buildEllipsisTextCell = useCallback((cellData) => (
-    <EllipsisText>
-      {cellData}
-    </EllipsisText>
-  ), [])
+  const buildEllipsisTextCell = useCallback((cellData) => {
+    let newCellData = cellData
+
+    if (!newCellData && conceptType === 'visualizations') newCellData = '<Blank Long Name>'
+
+    return (
+      <EllipsisText>
+        {newCellData}
+      </EllipsisText>
+    )
+  }, [])
 
   const buildTagCell = useCallback((cellData, rowData) => {
     const tagCount = getTagCount(cellData)
@@ -204,6 +223,41 @@ const SearchList = ({ limit }) => {
           dataAccessorFn: buildTagCell,
           dataKey: 'tagDefinitions',
           title: 'Tags'
+        },
+        {
+          align: 'end',
+          className: 'col-auto text-nowrap',
+          dataAccessorFn: (cellData) => moment.utc(cellData).format(DATE_FORMAT),
+          dataKey: 'revisionDate',
+          sortFn,
+          title: 'Last Modified (UTC)'
+        }
+      ]
+    }
+
+    if (formattedType === conceptTypes.Visualizations) {
+      return [
+        {
+          className: 'col-auto',
+          dataAccessorFn: buildEllipsisLinkCell,
+          dataKey: 'name',
+          sortFn,
+          title: 'Short Name'
+        },
+        {
+          className: 'col-auto',
+          dataAccessorFn: buildEllipsisTextCell,
+          dataKey: 'title',
+          // SortFn,
+          // sortKey: 'title', // Need to enable something to get this work
+          title: 'Long Name'
+        },
+        {
+          align: 'center',
+          className: 'col-auto text-nowrap',
+          dataKey: 'providerId',
+          sortFn,
+          title: 'Provider'
         },
         {
           align: 'end',

--- a/static/src/js/pages/SearchList/SearchList.jsx
+++ b/static/src/js/pages/SearchList/SearchList.jsx
@@ -248,8 +248,9 @@ const SearchList = ({ limit }) => {
           className: 'col-auto',
           dataAccessorFn: buildEllipsisTextCell,
           dataKey: 'title',
+          // To be completed in MMT-4023
           // SortFn,
-          // sortKey: 'title', // Need to enable something to get this work
+          // sortKey: 'title',
           title: 'Long Name'
         },
         {

--- a/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
+++ b/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
@@ -22,7 +22,8 @@ import {
   singlePageServicesSearch,
   singlePageToolsSearch,
   singlePageToolsSearchWithProvider,
-  singlePageVariablesSearch
+  singlePageVariablesSearch,
+  singlePageVisualizationsSearch
 } from './__mocks__/searchResults'
 
 import SearchList from '../SearchList'
@@ -457,6 +458,54 @@ describe('SearchPage component', () => {
         expect(row1Cells[1].textContent).toBe('Variable Long Name 1')
         expect(row1Cells[2].textContent).toBe('TESTPROV')
         expect(row1Cells[3].textContent).toBe('Thursday, November 30, 2023 12:00 AM')
+      })
+    })
+  })
+
+  describe('when searching for visualizations', () => {
+    beforeEach(() => {
+      setup([singlePageVisualizationsSearch], {}, ['/visualizations'])
+    })
+
+    describe('while the request is loading', () => {
+      test('renders the headers', async () => {
+        expect(screen.getByText('Loading...')).toBeInTheDocument()
+
+        const table = await screen.findByRole('table')
+
+        const tableRows = within(table).getAllByRole('row')
+
+        expect(tableRows.length).toEqual(3)
+
+        expect(within(table).getAllByRole('columnheader')[1].textContent).toContain('Long Name')
+        expect(within(table).getAllByRole('columnheader')[2].textContent).toContain('Provider')
+        expect(within(table).getAllByRole('columnheader')[3].textContent).toContain('Last Modified')
+      })
+    })
+
+    describe('when the request has loaded', () => {
+      test('renders the data', async () => {
+        expect(screen.getByText('Loading...')).toBeInTheDocument()
+
+        const table = await screen.findByRole('table')
+
+        const tableRows = within(table).getAllByRole('row')
+
+        expect(tableRows.length).toEqual(3)
+
+        const row1Cells = within(tableRows[1]).queryAllByRole('cell')
+        const row2Cells = within(tableRows[2]).queryAllByRole('cell')
+
+        expect(row1Cells).toHaveLength(4)
+        expect(row1Cells[0].textContent).toBe('Visualization Name 1')
+        expect(row1Cells[1].textContent).toBe('Visualization Long Name 1')
+        expect(row1Cells[2].textContent).toBe('TESTPROV')
+        expect(row1Cells[3].textContent).toBe('Monday, April 28, 2025 3:13 PM')
+        expect(row2Cells).toHaveLength(4)
+        expect(row2Cells[0].textContent).toBe('<Blank Short Name>')
+        expect(row2Cells[1].textContent).toBe('<Blank Long Name>')
+        expect(row2Cells[2].textContent).toBe('TESTPROV')
+        expect(row2Cells[3].textContent).toBe('Monday, April 28, 2025 3:13 PM')
       })
     })
   })

--- a/static/src/js/pages/SearchList/__tests__/__mocks__/searchResults.js
+++ b/static/src/js/pages/SearchList/__tests__/__mocks__/searchResults.js
@@ -1,8 +1,9 @@
+import { GET_COLLECTIONS } from '@/js/operations/queries/getCollections'
+import { GET_SERVICES } from '@/js/operations/queries/getServices'
+import { GET_TOOLS } from '@/js/operations/queries/getTools'
+import { GET_VARIABLES } from '@/js/operations/queries/getVariables'
+import { GET_VISUALIZATIONS } from '@/js/operations/queries/getVisualizations'
 import { GraphQLError } from 'graphql'
-import { GET_COLLECTIONS } from '../../../../operations/queries/getCollections'
-import { GET_SERVICES } from '../../../../operations/queries/getServices'
-import { GET_VARIABLES } from '../../../../operations/queries/getVariables'
-import { GET_TOOLS } from '../../../../operations/queries/getTools'
 
 export const singlePageCollectionSearch = {
   request: {
@@ -778,6 +779,45 @@ export const singlePageToolsSearchWithProvider = {
             revisionDate: '2023-11-30 00:00:00',
             revisionId: '1',
             userId: 'admin'
+          }
+        ]
+      }
+    }
+  }
+}
+
+export const singlePageVisualizationsSearch = {
+  request: {
+    query: GET_VISUALIZATIONS,
+    variables: {
+      params: {
+        limit: 25,
+        offset: 0,
+        provider: null,
+        sortKey: null
+      }
+    }
+  },
+  result: {
+    data: {
+      visualizations: {
+        count: 2,
+        items: [
+          {
+            conceptId: 'VIS000000001-TESTPROV',
+            name: 'Visualization Name 1',
+            title: 'Visualization Long Name 1',
+            providerId: 'TESTPROV',
+            revisionId: '1',
+            revisionDate: '2025-04-28T15:13:10.461Z'
+          },
+          {
+            conceptId: 'VIS000000002-TESTPROV',
+            name: '',
+            title: '',
+            providerId: 'TESTPROV',
+            revisionId: '1',
+            revisionDate: '2025-04-28T15:13:10.461Z'
           }
         ]
       }

--- a/static/src/js/pages/SearchPage/SearchPage.jsx
+++ b/static/src/js/pages/SearchPage/SearchPage.jsx
@@ -210,6 +210,7 @@ const SearchBar = () => {
  * )
  */
 
+// Remove this in MMT-4023
 const renderSearchBar = () => {
   const { type: searchTypeFromPath } = useParams()
   // Don't render SearchBar for Visualizations

--- a/static/src/js/pages/SearchPage/SearchPage.jsx
+++ b/static/src/js/pages/SearchPage/SearchPage.jsx
@@ -209,6 +209,17 @@ const SearchBar = () => {
  *   <SearchPageHeader />
  * )
  */
+
+const renderSearchBar = () => {
+  const { type: searchTypeFromPath } = useParams()
+  // Don't render SearchBar for Visualizations
+  if (searchTypeFromPath.toLowerCase() === 'visualizations') {
+    return null
+  }
+
+  return <SearchBar />
+}
+
 const SearchPageHeader = () => {
   const { type: conceptType } = useParams()
 
@@ -216,9 +227,7 @@ const SearchPageHeader = () => {
     <PageHeader
       title={`All ${capitalize(getHumanizedNameFromTypeParam(conceptType))}s`}
       pageType="secondary"
-      beforeActions={(
-        <SearchBar />
-      )}
+      beforeActions={renderSearchBar()}
       breadcrumbs={
         [
           {


### PR DESCRIPTION
# Overview

### What is the feature?

Users can navigate to a list of published visualizations
Users can navigate to a list of draft visualizations

### What is the Solution?

Created a new navigation header and subheaders for Visualizations

**NOTE that the search bar and the long name sorting have been removed. These are not currently supported and we need to wait on CMR to get those fixed. There is a separate ticket to take care of these. 

### What areas of the application does this impact?

SearchList and DraftList

# Testing

### Reproduction steps

- **Environment for testing: SIT
- **Collection to test with: N/A

1. Spin up branch and see that the new navigation headers are there and that the page loads as expected. Pagination should work as expected. 

### Attachments

<img width="1709" alt="Screenshot 2025-04-28 at 12 29 11 PM" src="https://github.com/user-attachments/assets/84d47499-ec71-4cc9-b7b5-c727a27a7524" />

<img width="1703" alt="Screenshot 2025-04-28 at 12 29 56 PM" src="https://github.com/user-attachments/assets/45ac8b20-a6df-4936-a448-e06fa4abb2cf" />


Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
