### PR TITLE
MMT-4002: Added custom widget to support editing a keyword.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,5 +52,30 @@
   // Define any global variables to avoid no-undef errors
   "globals": {
     "vi": "readonly"
+  },
+  "plugins": [
+    "import"
+  ],
+  "rules": {
+    "import/order": [
+      "error",
+      {
+        "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        }
+      }
+    ],
+    "sort-imports": [
+      "error",
+      {
+        "ignoreCase": true,
+        "ignoreDeclarationSort": true,
+        "ignoreMemberSort": false,
+        "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
+      }
+    ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -52,30 +52,5 @@
   // Define any global variables to avoid no-undef errors
   "globals": {
     "vi": "readonly"
-  },
-  "plugins": [
-    "import"
-  ],
-  "rules": {
-    "import/order": [
-      "error",
-      {
-        "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
-        "newlines-between": "always",
-        "alphabetize": {
-          "order": "asc",
-          "caseInsensitive": true
-        }
-      }
-    ],
-    "sort-imports": [
-      "error",
-      {
-        "ignoreCase": true,
-        "ignoreDeclarationSort": true,
-        "ignoreMemberSort": false,
-        "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
-      }
-    ]
   }
 }

--- a/static.config.json
+++ b/static.config.json
@@ -29,7 +29,8 @@
     "ummC": "1.18.3",
     "ummS": "1.5.3",
     "ummT": "1.2.0",
-    "ummV": "1.9.0"
+    "ummV": "1.9.0",
+    "ummVis": "1.1.0"
   },
   "ummJsonSchemaUrl": "http://json-schema.org/draft-07/schema#",
   "edl": {

--- a/static/src/js/components/CustomTitleFieldTemplate/__tests__/CustomTitleFieldTemplate.test.jsx
+++ b/static/src/js/components/CustomTitleFieldTemplate/__tests__/CustomTitleFieldTemplate.test.jsx
@@ -56,7 +56,7 @@ describe('CustomTitleFieldTemplate', () => {
   })
 
   describe('when a title field with hide-header set to true', () => {
-    it('renders it with no header', () => {
+    test('renders it with no header', () => {
       setup({
         uiSchema: {
           'ui:hide-header': true

--- a/static/src/js/components/DraftList/DraftList.jsx
+++ b/static/src/js/components/DraftList/DraftList.jsx
@@ -9,7 +9,6 @@ import Col from 'react-bootstrap/Col'
 import Row from 'react-bootstrap/Row'
 
 import { DATE_FORMAT } from '@/js/constants/dateFormat'
-import conceptIdTypes from '@/js/constants/conceptIdTypes'
 import conceptTypeDraftsQueries from '@/js/constants/conceptTypeDraftsQueries'
 import constructDownloadableFile from '@/js/utils/constructDownloadableFile'
 import urlValueTypeToConceptTypeStringMap from '@/js/constants/urlValueToConceptStringMap'
@@ -58,7 +57,7 @@ const DraftList = () => {
 
     let cellData = originalCellData
 
-    if (!cellData && draftType === conceptIdTypes.C) cellData = '<Blank Short Name>'
+    if (!cellData && draftType === 'Collection') cellData = '<Blank Short Name>'
     if (!cellData) cellData = '<Blank Name>'
 
     return (
@@ -71,7 +70,7 @@ const DraftList = () => {
   const buildEllipsisTextCell = useCallback((originalCellData) => {
     let cellData = originalCellData
 
-    if (!cellData && draftType === conceptIdTypes.C) cellData = '<Blank Entry Title>'
+    if (!cellData && draftType === 'Collection') cellData = '<Blank Entry Title>'
     if (!cellData) cellData = '<Blank Long Name>'
 
     return (
@@ -114,7 +113,23 @@ const DraftList = () => {
       dataAccessorFn: buildEllipsisTextCell
     }
   ]
-  const nonCollectionColumns = [
+
+  const visColumns = [
+    {
+      dataKey: 'previewMetadata.name',
+      title: 'Name',
+      className: 'col-auto',
+      dataAccessorFn: buildPrimaryEllipsisLink
+    },
+    {
+      dataKey: 'previewMetadata.title',
+      title: 'Long Name',
+      className: 'col-auto',
+      dataAccessorFn: buildEllipsisTextCell
+    }
+  ]
+
+  const defaultColumns = [
     {
       dataKey: 'ummMetadata.Name',
       title: 'Name',
@@ -147,9 +162,18 @@ const DraftList = () => {
     }
   ]
 
-  const columns = draftType === conceptIdTypes.C
-    ? [...collectionColumns, ...commonColumns]
-    : [...nonCollectionColumns, ...commonColumns]
+  const getColumns = () => {
+    switch (draftType) {
+      case 'Collection':
+        return [...collectionColumns, ...commonColumns]
+      case 'Visualization':
+        return [...visColumns, ...commonColumns]
+      default:
+        return [...defaultColumns, ...commonColumns]
+    }
+  }
+
+  const columns = getColumns()
 
   return (
     <Row>

--- a/static/src/js/components/DraftList/__tests__/DraftList.test.jsx
+++ b/static/src/js/components/DraftList/__tests__/DraftList.test.jsx
@@ -13,8 +13,15 @@ import constructDownloadableFile from '@/js/utils/constructDownloadableFile'
 
 import { GET_TOOL_DRAFTS } from '@/js/operations/queries/getToolDrafts'
 import { GET_COLLECTION_DRAFTS } from '@/js/operations/queries/getCollectionDrafts'
+import { GET_VISUALIZATION_DRAFTS } from '@/js/operations/queries/getVisualizationDrafts'
 
 import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
+
+import {
+  mockCollectionDrafts,
+  mockToolDrafts,
+  mockVisualizationDrafts
+} from './__mocks__/DraftListMocks'
 
 import DraftList from '../DraftList'
 
@@ -26,124 +33,6 @@ vi.mock('react-router-dom', async () => ({
   ...await vi.importActual('react-router-dom'),
   useParams: vi.fn().mockImplementation(() => ({ draftType: 'tools' }))
 }))
-
-const mockToolDrafts = {
-  count: 3,
-  items: [
-    {
-      conceptId: 'TD1200000092-MMT_2',
-      revisionDate: '2023-12-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {
-        Name: 'Tool TD1200000092 short name',
-        LongName: 'Tool TD1200000092 long name'
-      },
-      name: 'Tool TD1200000092 short name',
-      previewMetadata: {
-        conceptId: 'TD1200000092-MMT_2',
-        revisionId: '1',
-        name: 'Tool TD1200000092 short name',
-        longName: 'Tool TD1200000092 long name',
-        __typename: 'Tool'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    },
-    {
-      conceptId: 'TD1200000093-MMT_2',
-      revisionDate: '2023-11-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {},
-      previewMetadata: {
-        conceptId: 'TD1200000093-MMT_2',
-        revisionId: '1',
-        name: null,
-        longName: null,
-        __typename: 'Tool'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    },
-    {
-      conceptId: 'TD1200000094-MMT_2',
-      revisionDate: '2023-10-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {
-        Name: 'Tool TD1200000094 short name',
-        LongName: 'Tool TD1200000094 long name'
-      },
-      previewMetadata: {
-        conceptId: 'TD1200000094-MMT_2',
-        revisionId: '1',
-        name: null,
-        longName: null,
-        __typename: 'Tool'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    }
-  ],
-  __typename: 'DraftList'
-}
-
-const mockCollectionDrafts = {
-  count: 3,
-  items: [
-    {
-      conceptId: 'CD1200000092-MMT_2',
-      revisionDate: '2023-12-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {
-        ShortName: 'Collection CD1200000092 short name',
-        EntryTitle: 'Collection CD1200000092 entry title'
-      },
-      shortName: 'Collection CD1200000092 short name',
-      previewMetadata: {
-        conceptId: 'CD1200000092-MMT_2',
-        revisionId: '1',
-        shortName: 'Collection CD1200000092 short name',
-        entryTitle: 'Collection CD1200000092 entry title',
-        __typename: 'Collection'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    },
-    {
-      conceptId: 'CD1200000093-MMT_2',
-      revisionDate: '2023-11-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {},
-      previewMetadata: {
-        conceptId: 'CD1200000093-MMT_2',
-        revisionId: '1',
-        shortName: null,
-        entryTitle: null,
-        __typename: 'Collection'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    },
-    {
-      conceptId: 'CD1200000094-MMT_2',
-      revisionDate: '2023-10-08T17:56:09.385Z',
-      revisionId: '1',
-      ummMetadata: {
-        ShortName: 'Collection CD1200000094 short name',
-        EntryTitle: 'Collection CD1200000094 entry title'
-      },
-      previewMetadata: {
-        conceptId: 'CD1200000094-MMT_2',
-        revisionId: '1',
-        shortName: null,
-        entryTitle: null,
-        __typename: 'Collection'
-      },
-      providerId: 'MMT_2',
-      __typename: 'Draft'
-    }
-  ],
-  __typename: 'DraftList'
-}
 
 const setup = ({ overrideMocks = false }) => {
   const mocks = [{
@@ -333,6 +222,53 @@ describe('DraftList', () => {
         JSON.stringify(mockToolDrafts.items[0].ummMetadata, null, 2),
         'TD1200000092-MMT_2'
       )
+    })
+  })
+
+  describe('when draft type Visualization is given', () => {
+    test('renders Visualization draft list', async () => {
+      useParams.mockImplementation(() => ({ draftType: 'visualizations' }))
+
+      setup({
+        overrideMocks: [{
+          request: {
+            query: GET_VISUALIZATION_DRAFTS,
+            variables: {
+              params: {
+                conceptType: 'Visualization',
+                limit: 20,
+                offset: 0,
+                sortKey: ['-revision_date']
+              }
+            }
+          },
+          result: {
+            data: {
+              drafts: mockVisualizationDrafts
+            }
+          }
+        }]
+      })
+
+      const rows = await screen.findAllByRole('row')
+
+      expect(within(rows[1]).getByRole('cell', { name: 'Short Name 1' })).toBeInTheDocument()
+      expect(within(rows[1]).getByRole('cell', { name: 'Long Name 1' })).toBeInTheDocument()
+      expect(within(rows[1]).getByRole('cell', { name: 'Friday, April 25, 2025 5:26 PM' })).toBeInTheDocument()
+      expect(within(rows[1]).getByRole('cell', { name: 'MMT_1' })).toBeInTheDocument()
+      expect(within(rows[1]).getByRole('button', { name: /Download JSON/ })).toBeInTheDocument()
+
+      expect(within(rows[2]).getByRole('cell', { name: '<Blank Name>' })).toBeInTheDocument()
+      expect(within(rows[2]).getByRole('cell', { name: '<Blank Long Name>' })).toBeInTheDocument()
+      expect(within(rows[2]).getByRole('cell', { name: 'Thursday, May 15, 2025 10:30 AM' })).toBeInTheDocument()
+      expect(within(rows[2]).getByRole('cell', { name: 'MMT_1' })).toBeInTheDocument()
+      expect(within(rows[2]).getByRole('button', { name: /Download JSON/ })).toBeInTheDocument()
+
+      expect(within(rows[3]).getByRole('cell', { name: 'Short Name 3' })).toBeInTheDocument()
+      expect(within(rows[3]).getByRole('cell', { name: 'Long Name 3' })).toBeInTheDocument()
+      expect(within(rows[3]).getByRole('cell', { name: 'Thursday, June 5, 2025 2:45 PM' })).toBeInTheDocument()
+      expect(within(rows[3]).getByRole('cell', { name: 'MMT_1' })).toBeInTheDocument()
+      expect(within(rows[3]).getByRole('button', { name: /Download JSON/ })).toBeInTheDocument()
     })
   })
 })

--- a/static/src/js/components/DraftList/__tests__/__mocks__/DraftListMocks.js
+++ b/static/src/js/components/DraftList/__tests__/__mocks__/DraftListMocks.js
@@ -1,0 +1,153 @@
+export const mockToolDrafts = {
+  count: 3,
+  items: [
+    {
+      conceptId: 'TD1200000092-MMT_2',
+      revisionDate: '2023-12-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {
+        Name: 'Tool TD1200000092 short name',
+        LongName: 'Tool TD1200000092 long name'
+      },
+      name: 'Tool TD1200000092 short name',
+      previewMetadata: {
+        conceptId: 'TD1200000092-MMT_2',
+        revisionId: '1',
+        name: 'Tool TD1200000092 short name',
+        longName: 'Tool TD1200000092 long name',
+        __typename: 'Tool'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    },
+    {
+      conceptId: 'TD1200000093-MMT_2',
+      revisionDate: '2023-11-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {},
+      previewMetadata: {
+        conceptId: 'TD1200000093-MMT_2',
+        revisionId: '1',
+        name: null,
+        longName: null,
+        __typename: 'Tool'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    },
+    {
+      conceptId: 'TD1200000094-MMT_2',
+      revisionDate: '2023-10-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {
+        Name: 'Tool TD1200000094 short name',
+        LongName: 'Tool TD1200000094 long name'
+      },
+      previewMetadata: {
+        conceptId: 'TD1200000094-MMT_2',
+        revisionId: '1',
+        name: null,
+        longName: null,
+        __typename: 'Tool'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    }
+  ],
+  __typename: 'DraftList'
+}
+
+export const mockCollectionDrafts = {
+  count: 3,
+  items: [
+    {
+      conceptId: 'CD1200000092-MMT_2',
+      revisionDate: '2023-12-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {
+        ShortName: 'Collection CD1200000092 short name',
+        EntryTitle: 'Collection CD1200000092 entry title'
+      },
+      shortName: 'Collection CD1200000092 short name',
+      previewMetadata: {
+        conceptId: 'CD1200000092-MMT_2',
+        revisionId: '1',
+        shortName: 'Collection CD1200000092 short name',
+        entryTitle: 'Collection CD1200000092 entry title',
+        __typename: 'Collection'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    },
+    {
+      conceptId: 'CD1200000093-MMT_2',
+      revisionDate: '2023-11-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {},
+      previewMetadata: {
+        conceptId: 'CD1200000093-MMT_2',
+        revisionId: '1',
+        shortName: null,
+        entryTitle: null,
+        __typename: 'Collection'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    },
+    {
+      conceptId: 'CD1200000094-MMT_2',
+      revisionDate: '2023-10-08T17:56:09.385Z',
+      revisionId: '1',
+      ummMetadata: {
+        ShortName: 'Collection CD1200000094 short name',
+        EntryTitle: 'Collection CD1200000094 entry title'
+      },
+      previewMetadata: {
+        conceptId: 'CD1200000094-MMT_2',
+        revisionId: '1',
+        shortName: null,
+        entryTitle: null,
+        __typename: 'Collection'
+      },
+      providerId: 'MMT_2',
+      __typename: 'Draft'
+    }
+  ],
+  __typename: 'DraftList'
+}
+
+export const mockVisualizationDrafts = {
+  count: 3,
+  items: [
+    {
+      conceptId: 'VISD1-MMT_1',
+      previewMetadata: {
+        conceptId: 'VISD1-MMT_1',
+        name: 'Short Name 1',
+        title: 'Long Name 1'
+      },
+      providerId: 'MMT_1',
+      revisionDate: '2025-04-25T17:26:18.052Z'
+    },
+    {
+      conceptId: 'VISD2-MMT_1',
+      previewMetadata: {
+        conceptId: 'VISD2-MMT_1',
+        name: '',
+        title: ''
+      },
+      providerId: 'MMT_1',
+      revisionDate: '2025-05-15T10:30:00.000Z'
+    },
+    {
+      conceptId: 'VISD3-MMT_1',
+      previewMetadata: {
+        conceptId: 'VISD3-MMT_1',
+        name: 'Short Name 3',
+        title: 'Long Name 3'
+      },
+      providerId: 'MMT_1',
+      revisionDate: '2025-06-05T14:45:30.000Z'
+    }
+  ]
+}

--- a/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
+++ b/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
@@ -17,7 +17,7 @@ const setup = (draft = undefined) => {
 
 describe('JsonPreview Component', () => {
   describe('when draft is not present in the context', () => {
-    it('renders JSONPretty', () => {
+    test('renders JSONPretty', () => {
       setup()
 
       expect(JSONPretty).toHaveBeenCalledTimes(1)
@@ -28,7 +28,7 @@ describe('JsonPreview Component', () => {
   })
 
   describe('when ummMetadata is not present in draft', () => {
-    it('renders JSONPretty', () => {
+    test('renders JSONPretty', () => {
       setup({})
 
       expect(JSONPretty).toHaveBeenCalledTimes(1)
@@ -39,7 +39,7 @@ describe('JsonPreview Component', () => {
   })
 
   describe('when draft metadata exists', () => {
-    it('renders JSONPretty', () => {
+    test('renders JSONPretty', () => {
       setup({
         ummMetadata: {
           Name: 'Mock Name'

--- a/static/src/js/components/KeywordForm/KeywordForm.jsx
+++ b/static/src/js/components/KeywordForm/KeywordForm.jsx
@@ -1,20 +1,23 @@
-import React, { useState, useEffect } from 'react'
-import PropTypes from 'prop-types'
-import validator from '@rjsf/validator-ajv8'
 import Form from '@rjsf/core'
+import validator from '@rjsf/validator-ajv8'
+import PropTypes from 'prop-types'
+import React, { useEffect, useState } from 'react'
 
 import CustomArrayTemplate from '@/js/components/CustomArrayFieldTemplate/CustomArrayFieldTemplate'
 import CustomFieldTemplate from '@/js/components/CustomFieldTemplate/CustomFieldTemplate'
 import CustomTextareaWidget from '@/js/components/CustomTextareaWidget/CustomTextareaWidget'
 import CustomTextWidget from '@/js/components/CustomTextWidget/CustomTextWidget'
 import GridLayout from '@/js/components/GridLayout/GridLayout'
-
 import editKeywordsUiSchema from '@/js/schemas/uiSchemas/keywords/editKeyword'
 import keywordSchema from '@/js/schemas/umm/keywordSchema'
 
+import KmsConceptSelectionWidget from '../KmsConceptSelectionWidget/KmsConceptSelectionWidget'
+
 const KeywordForm = ({
   initialData,
-  onFormDataChange
+  onFormDataChange,
+  scheme,
+  version
 }) => {
   const [formData, setFormData] = useState(initialData)
 
@@ -23,11 +26,12 @@ const KeywordForm = ({
   }, [initialData])
 
   const fields = {
+    kmsConceptSelection: KmsConceptSelectionWidget,
     layout: GridLayout
   }
   const widgets = {
-    TextareaWidget: CustomTextareaWidget,
-    TextWidget: CustomTextWidget
+    TextWidget: CustomTextWidget,
+    TextareaWidget: CustomTextareaWidget
   }
   const templates = {
     ArrayFieldTemplate: CustomArrayTemplate,
@@ -55,6 +59,12 @@ const KeywordForm = ({
         uiSchema={editKeywordsUiSchema}
         formData={formData}
         onChange={handleChange}
+        formContext={
+          {
+            scheme,
+            version
+          }
+        }
         // OnSubmit={handleSubmit}
         validator={validator}
       >
@@ -75,29 +85,36 @@ KeywordForm.defaultProps = {
 
 KeywordForm.propTypes = {
   initialData: PropTypes.shape({
-    KeywordUUID: PropTypes.string,
-    BroaderKeyword: PropTypes.string,
-    NarrowerKeywords: PropTypes.arrayOf(PropTypes.shape({
-      NarrowerUUID: PropTypes.string
-    })),
-    PreferredLabel: PropTypes.string,
     AlternateLabels: PropTypes.arrayOf(PropTypes.shape({
       LabelName: PropTypes.string,
       LabelType: PropTypes.string
     })),
+    BroaderKeyword: PropTypes.string,
+    ChangeLogs: PropTypes.string,
     Definition: PropTypes.string,
     DefinitionReference: PropTypes.string,
+    KeywordUUID: PropTypes.string,
+    NarrowerKeywords: PropTypes.arrayOf(PropTypes.shape({
+      NarrowerUUID: PropTypes.string
+    })),
+    PreferredLabel: PropTypes.string,
+    RelatedKeywords: PropTypes.arrayOf(PropTypes.shape({
+      RelationshipType: PropTypes.string,
+      UUID: PropTypes.string
+    })),
     Resources: PropTypes.arrayOf(PropTypes.shape({
       ResourceType: PropTypes.string,
       ResourceUri: PropTypes.string
-    })),
-    RelatedKeywords: PropTypes.arrayOf(PropTypes.shape({
-      UUID: PropTypes.string,
-      RelationshipType: PropTypes.string
-    })),
-    ChangeLogs: PropTypes.string
+    }))
   }),
-  onFormDataChange: PropTypes.func
+  onFormDataChange: PropTypes.func,
+  scheme: PropTypes.shape({
+    name: PropTypes.string
+  }).isRequired,
+  version: PropTypes.shape({
+    version: PropTypes.string,
+    version_type: PropTypes.string
+  }).isRequired
 }
 
 export default KeywordForm

--- a/static/src/js/components/KeywordForm/__tests__/KeywordForm.test.jsx
+++ b/static/src/js/components/KeywordForm/__tests__/KeywordForm.test.jsx
@@ -1,16 +1,17 @@
-import React from 'react'
 import {
   render,
   screen,
   waitFor
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
 import {
   describe,
-  test,
   expect,
+  test,
   vi
 } from 'vitest'
-import userEvent from '@testing-library/user-event'
+
 import KeywordForm from '../KeywordForm'
 
 vi.mock('@/js/utils/getUmmSchema', () => ({
@@ -40,12 +41,22 @@ describe('when KeywordForm is rendered', () => {
   }
 
   test('should display the form title', () => {
-    render(<KeywordForm initialData={mockInitialData} />)
+    render(<KeywordForm
+      initialData={mockInitialData}
+      scheme={{ name: 'sciencekeywords' }}
+      version={{ version: 'draft' }}
+    />)
+
     expect(screen.getByText('Edit Keyword')).toBeInTheDocument()
   })
 
   test('should render the form with initial data', () => {
-    render(<KeywordForm initialData={mockInitialData} />)
+    render(<KeywordForm
+      initialData={mockInitialData}
+      scheme={{ name: 'sciencekeywords' }}
+      version={{ version: 'draft' }}
+    />)
+
     expect(screen.getByDisplayValue('Test Keyword')).toBeInTheDocument()
     expect(screen.getByDisplayValue('This is a test keyword')).toBeInTheDocument()
   })
@@ -58,6 +69,8 @@ describe('when user types in the form', () => {
 
     render(<KeywordForm
       initialData={{ PreferredLabel: '' }}
+      scheme={{ name: 'sciencekeywords' }}
+      version={{ version: 'draft' }}
       onFormDataChange={mockOnFormDataChange}
     />)
 
@@ -80,10 +93,19 @@ describe('when user types in the form', () => {
 
 describe('when initialData prop changes', () => {
   test('should update the form', () => {
-    const { rerender } = render(<KeywordForm initialData={{ PreferredLabel: 'Initial Keyword' }} />)
+    const { rerender } = render(<KeywordForm
+      initialData={{ PreferredLabel: 'Initial Keyword' }}
+      scheme={{ name: 'sciencekeywords' }}
+      version={{ version: 'draft' }}
+    />)
     expect(screen.getByDisplayValue('Initial Keyword')).toBeInTheDocument()
 
-    rerender(<KeywordForm initialData={{ PreferredLabel: 'Updated Keyword' }} />)
+    rerender(<KeywordForm
+      initialData={{ PreferredLabel: 'Updated Keyword' }}
+      scheme={{ name: 'sciencekeywords' }}
+      version={{ version: 'draft' }}
+    />)
+
     expect(screen.getByDisplayValue('Updated Keyword')).toBeInTheDocument()
   })
 })

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -14,6 +14,42 @@ import { v4 as uuidv4 } from 'uuid'
 
 import './KeywordTree.scss'
 
+/**
+ * ContextMenu Component
+ *
+ * This component renders a context menu at the specified coordinates with given options.
+ * It supports keyboard navigation and accessibility features.
+ *
+ * @component
+ * @param {Object} props
+ * @param {number} props.x - The x-coordinate for positioning the context menu
+ * @param {number} props.y - The y-coordinate for positioning the context menu
+ * @param {Function} props.onClose - Callback function to close the context menu
+ * @param {Array} props.options - An array of option objects for the context menu
+ * @param {React.Ref} props.forwardedRef - Ref to be forwarded to the context menu container
+ *
+ * @example
+ * const contextMenuOptions = [
+ *   { id: 'edit', label: 'Edit', action: () => console.log('Edit clicked') },
+ *   { id: 'delete', label: 'Delete', action: () => console.log('Delete clicked') }
+ * ];
+ *
+ * const handleClose = () => {
+ *   setShowContextMenu(false);
+ * };
+ *
+ * return (
+ *   showContextMenu && (
+ *     <ContextMenu
+ *       x={mousePosition.x}
+ *       y={mousePosition.y}
+ *       onClose={handleClose}
+ *       options={contextMenuOptions}
+ *       forwardedRef={contextMenuRef}
+ *     />
+ *   )
+ * );
+ */
 const ContextMenu = ({
   x, y, onClose, options, forwardedRef
 }) => {
@@ -99,6 +135,42 @@ const ContextMenu = ({
   )
 }
 
+/**
+ * CustomNode Component
+ *
+ * This component renders a single node in the KeywordTree. It handles node
+ * interactions such as toggling, context menu, and hover effects.
+ *
+ * @component
+ * @param {Object} props
+ * @param {Object} props.node - The node data object
+ * @param {Object} props.style - Inline styles for the node
+ * @param {Function|Object} props.dragHandle - Ref or function for drag handle
+ * @param {Function} props.onDelete - Callback function to delete a node
+ * @param {Function} props.setContextMenu - Function to set the context menu
+ * @param {Function} props.onToggle - Callback function to toggle node expansion
+ * @param {Function} props.onEdit - Callback function to edit a node
+ * @param {Function} props.onNodeDoubleClick - Callback function for node double-click
+ * @param {Function} props.handleAdd - Callback function to add a child node
+ *
+ * @example
+ * <CustomNode
+ *   node={{
+ *     id: '1',
+ *     data: { title: 'Node 1', children: [] },
+ *     isOpen: false,
+ *     toggle: () => {}
+ *   }}
+ *   style={{}}
+ *   dragHandle={dragHandleRef}
+ *   onDelete={(id) => console.log('Delete node', id)}
+ *   setContextMenu={(menu) => setContextMenu(menu)}
+ *   onToggle={(node) => node.toggle()}
+ *   onEdit={(id) => console.log('Edit node', id)}
+ *   onNodeDoubleClick={(id) => console.log('Double click on node', id)}
+ *   handleAdd={(parentId) => console.log('Add child to', parentId)}
+ * />
+ */
 const CustomNode = ({
   node, style, dragHandle, onDelete, setContextMenu, onToggle, onEdit, onNodeDoubleClick, handleAdd
 }) => {
@@ -170,6 +242,56 @@ const CustomNode = ({
   )
 }
 
+/**
+ * KeywordTree Component
+ *
+ * This component renders a tree structure of keywords with the ability to add, edit, and delete nodes.
+ * It uses react-arborist for the tree structure and provides context menu functionality.
+ *
+ * @component
+ * @param {Object|Array} props.data - The initial tree data structure
+ * @param {Function} props.onNodeDoubleClick - Callback function when a node is double-clicked
+ * @param {Function} props.onNodeEdit - Callback function when a node is edited
+ *
+ * @example
+ * const treeData = [
+ *   {
+ *     id: '1',
+ *     key: '1',
+ *     title: 'Root',
+ *     children: [
+ *       {
+ *         id: '2',
+ *         key: '2',
+ *         title: 'Child 1',
+ *         children: []
+ *       },
+ *       {
+ *         id: '3',
+ *         key: '3',
+ *         title: 'Child 2',
+ *         children: []
+ *       }
+ *     ]
+ *   }
+ * ];
+ *
+ * const handleNodeDoubleClick = (nodeId) => {
+ *   console.log('Node double-clicked:', nodeId);
+ * };
+ *
+ * const handleNodeEdit = (nodeId) => {
+ *   console.log('Node edit requested:', nodeId);
+ * };
+ *
+ * return (
+ *   <KeywordTree
+ *     data={treeData}
+ *     onNodeDoubleClick={handleNodeDoubleClick}
+ *     onNodeEdit={handleNodeEdit}
+ *   />
+ * );
+ */
 const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
   const [treeData, setTreeData] = useState(Array.isArray(data) ? data : [data])
   const treeRef = useRef(null)

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -10,6 +10,7 @@ import {
   Form,
   Button
 } from 'react-bootstrap'
+import { v4 as uuidv4 } from 'uuid'
 
 import './KeywordTree.scss'
 
@@ -195,8 +196,10 @@ const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
 
   const handleAddChildConfirm = () => {
     if (newChildTitle.trim()) {
+      const newUuid = uuidv4()
       const newChild = {
-        id: Math.random().toString(36).substr(2, 9),
+        id: newUuid,
+        key: newUuid,
         title: newChildTitle.trim(),
         children: []
       }

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -6,62 +6,27 @@ import React, {
 import { Tree } from 'react-arborist'
 import PropTypes from 'prop-types'
 
+import './KeywordTree.scss'
+
 const rightTriangle = '˃'
 const downTriangle = '˅'
-
-const iconButtonStyle = {
-  background: 'none',
-  border: 'none',
-  cursor: 'pointer',
-  padding: '0 5px',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '24px',
-  height: '24px'
-}
-
-const triangleIconStyle = {
-  fontSize: '25px',
-  lineHeight: '1',
-  paddingTop: '6px'
-}
-
-const nodeTextStyle = {
-  fontSize: '14px'
-}
-
-const nodeContentStyle = {
-  display: 'flex',
-  alignItems: 'center',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis'
-}
-
-const treeContainerStyle = {
-  width: '100%',
-  height: '500px',
-  overflowX: 'auto',
-  overflowY: 'auto'
-}
 
 const ContextMenu = ({
   x, y, onClose, options, forwardedRef
 }) => {
   const [hoveredIndex, setHoveredIndex] = useState(null)
-  const style = {
-    position: 'absolute',
-    top: `${y}px`,
-    left: `${x}px`,
-    background: 'white',
-    border: '1px solid #ccc',
-    boxShadow: '2px 2px 5px rgba(0,0,0,0.1)',
-    zIndex: 1000
-  }
 
   return (
-    <div style={style} ref={forwardedRef}>
+    <div
+      className="keyword-tree__context-menu"
+      style={
+        {
+          top: `${y}px`,
+          left: `${x}px`
+        }
+      }
+      ref={forwardedRef}
+    >
       {
         options.map((option, index) => (
           <button
@@ -83,15 +48,10 @@ const ContextMenu = ({
             }
             onMouseEnter={() => setHoveredIndex(index)}
             onMouseLeave={() => setHoveredIndex(null)}
+            className="keyword-tree__context-menu-item"
             style={
               {
-                padding: '5px 10px',
-                cursor: 'pointer',
-                background: hoveredIndex === index ? '#cce5ff' : 'none',
-                border: 'none',
-                width: '100%',
-                textAlign: 'left',
-                transition: 'background-color 0.2s ease'
+                backgroundColor: hoveredIndex === index ? '#cce5ff' : 'none'
               }
             }
           >
@@ -140,12 +100,8 @@ const CustomNode = ({
 
   return (
     <div
-      style={
-        {
-          ...style,
-          ...nodeContentStyle
-        }
-      }
+      className="keyword-tree__node-content"
+      style={style}
       ref={dragHandle}
       onContextMenu={handleContextMenu}
       onMouseEnter={() => setIsHovered(true)}
@@ -157,34 +113,19 @@ const CustomNode = ({
           <button
             type="button"
             onClick={() => onToggle(node)}
-            style={
-              {
-                ...iconButtonStyle,
-                ...triangleIconStyle
-              }
-            }
+            className="keyword-tree__icon-button keyword-tree__triangle-icon"
           >
             {node.isOpen ? downTriangle : rightTriangle}
           </button>
         ) : (
-          <span style={
-            {
-              ...iconButtonStyle,
-              width: '1.25em',
-              display: 'inline-block'
-            }
-          }
-          />
+          <span className="keyword-tree__icon-button" />
         )
       }
       <span
+        className="keyword-tree__node-text"
         style={
           {
-            ...nodeTextStyle,
-            backgroundColor: isHovered ? '#cce5ff' : 'transparent',
-            padding: '2px 4px',
-            borderRadius: '2px',
-            transition: 'background-color 0.2s ease'
+            backgroundColor: isHovered ? '#cce5ff' : 'transparent'
           }
         }
       >
@@ -269,7 +210,7 @@ const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
   }
 
   return (
-    <div style={treeContainerStyle}>
+    <div className="keyword-tree__container">
       <Tree
         data={treeData}
         openByDefault={false}

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -116,7 +116,7 @@ const CustomNode = ({
         },
         {
           id: 'add-child',
-          label: 'Add',
+          label: 'Add Narrower',
           action: () => handleAdd(node.id)
         },
         {
@@ -317,7 +317,7 @@ const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
       }
       <Modal show={showAddChildPopup} onHide={() => setShowAddChildPopup(false)}>
         <Modal.Header closeButton>
-          <Modal.Title>Add Keyword</Modal.Title>
+          <Modal.Title>Add Narrower</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Form.Group>

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -138,6 +138,7 @@ const CustomNode = ({
 
 const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
   const [treeData, setTreeData] = useState(Array.isArray(data) ? data : [data])
+  const treeRef = useRef(null)
   const [contextMenu, setContextMenu] = useState(null)
   const contextMenuRef = useRef(null)
   const idAccessor = (node) => node.id || node.key || node.title
@@ -158,6 +159,16 @@ const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
       document.removeEventListener('mousedown', handleClickOutside)
     }
   }, [])
+
+  useEffect(() => {
+    if (treeRef.current && treeData.length > 0) {
+      const tree = treeRef.current
+      const rootNode = tree.get(treeData[0].id)
+      if (rootNode) {
+        rootNode.open()
+      }
+    }
+  }, [treeData])
 
   const closeAllDescendants = (node) => {
     if (node.isOpen) {
@@ -232,6 +243,7 @@ const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
   return (
     <div className="keyword-tree__container">
       <Tree
+        ref={treeRef}
         data={treeData}
         openByDefault={false}
         width={1000}

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -293,6 +293,5 @@ KeywordTree.propTypes = {
   onNodeClick: PropTypes.func.isRequired,
   onNodeEdit: PropTypes.func.isRequired,
   searchTerm: PropTypes.string,
-  selectedScheme: PropTypes.string.isRequired,
   openAll: PropTypes.bool
 }

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -316,12 +316,14 @@ const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
         )
       }
       <Modal show={showAddChildPopup} onHide={() => setShowAddChildPopup(false)}>
-        <Modal.Header closeButton>
+        <Modal.Header>
           <Modal.Title>Add Narrower</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Form.Group>
+            <Form.Label htmlFor="newChildKeyword">Narrower Keyword:</Form.Label>
             <Form.Control
+              id="newChildKeyword"
               type="text"
               value={newChildTitle}
               onChange={(e) => setNewChildTitle(e.target.value)}

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -14,9 +14,6 @@ import { v4 as uuidv4 } from 'uuid'
 
 import './KeywordTree.scss'
 
-const rightTriangle = '˃'
-const downTriangle = '˅'
-
 const ContextMenu = ({
   x, y, onClose, options, forwardedRef
 }) => {
@@ -110,29 +107,33 @@ const CustomNode = ({
       onMouseLeave={() => setIsHovered(false)}
       onDoubleClick={() => onNodeDoubleClick(node.id)}
     >
-      {
-        node.data.children && node.data.children.length > 0 ? (
-          <button
-            type="button"
-            onClick={() => onToggle(node)}
-            className="keyword-tree__icon-button keyword-tree__triangle-icon"
-          >
-            {node.isOpen ? downTriangle : rightTriangle}
-          </button>
-        ) : (
-          <span className="keyword-tree__icon-button" />
-        )
-      }
-      <span
-        className="keyword-tree__node-text"
-        style={
-          {
-            backgroundColor: isHovered ? '#cce5ff' : 'transparent'
-          }
+      <div className="keyword-tree__icon-wrapper">
+        {
+          node.data.children && node.data.children.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => onToggle(node)}
+              className="keyword-tree__icon-button keyword-tree__triangle-icon"
+            >
+              {node.isOpen ? <i className="fa fa-caret-down keyword-tree__caret-icon" aria-hidden="true" /> : <i className="fa fa-caret-right keyword-tree__caret-icon" aria-hidden="true" />}
+            </button>
+          ) : (
+            <span className="keyword-tree__icon-button" />
+          )
         }
-      >
-        {node.data.title}
-      </span>
+      </div>
+      <div className="keyword-tree__text-wrapper">
+        <span
+          className="keyword-tree__node-text"
+          style={
+            {
+              backgroundColor: isHovered ? '#cce5ff' : 'transparent'
+            }
+          }
+        >
+          {node.data.title}
+        </span>
+      </div>
     </div>
   )
 }

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -360,7 +360,8 @@ const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
           if (node.id === addChildParentId || node.key === addChildParentId) {
             return {
               ...node,
-              children: [...(node.children || []), newChild]
+              children: [...(node.children || []), newChild],
+              isOpen: true
             }
           }
 
@@ -376,6 +377,14 @@ const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
 
         return prevData.map(addChildToNode)
       })
+
+      // Expand the parent node
+      if (treeRef.current) {
+        const parentNode = treeRef.current.get(addChildParentId)
+        if (parentNode && !parentNode.isOpen) {
+          parentNode.toggle()
+        }
+      }
 
       setShowAddChildPopup(false)
       setNewChildTitle('')

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -437,7 +437,7 @@ const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
           />
         )
       }
-      <Modal show={showAddChildPopup} onHide={() => setShowAddChildPopup(false)}>
+      <Modal show={showAddChildPopup}>
         <Modal.Header>
           <Modal.Title>Add Narrower</Modal.Title>
         </Modal.Header>

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -105,7 +105,7 @@ const ContextMenu = ({
 }
 
 const CustomNode = ({
-  node, style, dragHandle, onAdd, onDelete, setContextMenu, onToggle
+  node, style, dragHandle, onAdd, onDelete, setContextMenu, onToggle, onEdit, onNodeDoubleClick
 }) => {
   const [isHovered, setIsHovered] = useState(false)
   const handleContextMenu = (e) => {
@@ -114,6 +114,11 @@ const CustomNode = ({
       x: e.clientX,
       y: e.clientY,
       options: [
+        {
+          id: 'edit',
+          label: 'Edit',
+          action: () => onEdit(node.id)
+        },
         {
           id: 'add-child',
           label: 'Add Child',
@@ -145,6 +150,7 @@ const CustomNode = ({
       onContextMenu={handleContextMenu}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      onDoubleClick={() => onNodeDoubleClick(node.id)}
     >
       {
         node.data.children && node.data.children.length > 0 ? (
@@ -188,7 +194,7 @@ const CustomNode = ({
   )
 }
 
-const KeywordTree = ({ data }) => {
+const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
   const [treeData, setTreeData] = useState(Array.isArray(data) ? data : [data])
   const [contextMenu, setContextMenu] = useState(null)
   const contextMenuRef = useRef(null)
@@ -283,6 +289,9 @@ const KeywordTree = ({ data }) => {
               onDelete={handleDelete}
               setContextMenu={setContextMenu}
               onToggle={handleToggle}
+              onDoubleClick={onNodeDoubleClick}
+              onEdit={onNodeEdit}
+              onNodeDoubleClick={onNodeDoubleClick}
             />
           )
         }
@@ -338,7 +347,9 @@ CustomNode.propTypes = {
   onAdd: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
   setContextMenu: PropTypes.func.isRequired,
-  onToggle: PropTypes.func.isRequired
+  onToggle: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onNodeDoubleClick: PropTypes.func.isRequired
 }
 
 CustomNode.defaultProps = {
@@ -350,7 +361,9 @@ KeywordTree.propTypes = {
   data: PropTypes.oneOfType([
     PropTypes.shape(NodeShape),
     PropTypes.arrayOf(PropTypes.shape(NodeShape))
-  ]).isRequired
+  ]).isRequired,
+  onNodeDoubleClick: PropTypes.func.isRequired,
+  onNodeEdit: PropTypes.func.isRequired
 }
 
 export default KeywordTree

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -79,6 +79,20 @@ export const KeywordTree = ({
   const [addNarrowerParentId, setAddNarrowerParentId] = useState(null)
 
   useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (contextMenuRef.current && !contextMenuRef.current.contains(event.target)) {
+        setContextMenu(null)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [])
+
+  useEffect(() => {
     if (treeRef.current && treeData.length > 0) {
       if (openAll) {
         treeRef.current.openAll()

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -1,204 +1,112 @@
-import React, {
-  useState,
-  useEffect,
-  useRef
-} from 'react'
+import React, { useState } from 'react'
 import { Tree } from 'react-arborist'
-import CustomModal from '@/js/components/CustomModal/CustomModal'
 import PropTypes from 'prop-types'
-import { Form } from 'react-bootstrap'
-import { v4 as uuidv4 } from 'uuid'
-import {
-  KeywordTreeContextMenu
-} from '@/js/components/KeywordTreeContextMenu/KeywordTreeContextMenu'
-import { KeywordTreeCustomNode } from '@/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode'
 
-import './KeywordTree.scss'
+const iconButtonStyle = {
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  fontSize: '16px',
+  padding: '0 5px'
+}
 
-/**
- * KeywordTree Component
- *
- * This component renders a tree structure of keywords with the ability to add, edit, and delete nodes.
- * It uses react-arborist for the tree structure and provides context menu functionality.
- *
- * @component
- * @param {Object|Array} props.data - The initial tree data structure
- * @param {Function} props.onNodeClick - Callback function when a node is clicked
- * @param {Function} props.onNodeEdit - Callback function when a node is edited
- *
- * @example
- * const treeData = [
- *   {
- *     id: '1',
- *     key: '1',
- *     title: 'Root',
- *     children: [
- *       {
- *         id: '2',
- *         key: '2',
- *         title: 'Child 1',
- *         children: []
- *       },
- *       {
- *         id: '3',
- *         key: '3',
- *         title: 'Child 2',
- *         children: []
- *       }
- *     ]
- *   }
- * ];
- *
- * const handleNodeClick = (nodeId) => {
- *   console.log('Node clicked:', nodeId);
- * };
- *
- * const handleNodeEdit = (nodeId) => {
- *   console.log('Node edit requested:', nodeId);
- * };
- *
- * return (
- *   <KeywordTree
- *     data={treeData}
- *     onNodeClick={handleNodeClick}
- *     onNodeEdit={handleNodeEdit}
- *   />
- * );
- */
-export const KeywordTree = ({
-  data, onNodeClick, onNodeEdit
+const nodeTextStyle = {
+  fontSize: '14px'
+}
+
+const nodeContentStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis'
+}
+
+const treeContainerStyle = {
+  width: '100%',
+  height: '500px',
+  overflowX: 'auto',
+  overflowY: 'auto'
+}
+
+const CustomNode = ({
+  node, style, dragHandle, onAdd
 }) => {
+  const addChild = () => {
+    const newChild = {
+      id: Math.random().toString(36).substr(2, 9),
+      title: 'New Child',
+      children: []
+    }
+    onAdd(newChild, node.id)
+  }
+
+  return (
+    <div
+      style={
+        {
+          ...style,
+          ...nodeContentStyle
+        }
+      }
+      ref={dragHandle}
+    >
+      {
+        node.data.children && node.data.children.length > 0 ? (
+          <button type="button" onClick={() => node.toggle()} style={iconButtonStyle}>
+            {node.isOpen ? '−' : '+'}
+          </button>
+        ) : (
+          <span style={
+            {
+              ...iconButtonStyle,
+              width: '1.25em',
+              display: 'inline-block'
+            }
+          }
+          />
+        )
+      }
+      <span style={nodeTextStyle}>{node.data.title}</span>
+      <button type="button" onClick={addChild} style={iconButtonStyle}>
+        ➕
+      </button>
+    </div>
+  )
+}
+
+const KeywordTree = ({ data }) => {
   const [treeData, setTreeData] = useState(Array.isArray(data) ? data : [data])
-  const treeRef = useRef(null)
-  const [contextMenu, setContextMenu] = useState(null)
-  const contextMenuRef = useRef(null)
+
   const idAccessor = (node) => node.id || node.key || node.title
-  const [showAddNarrowerPopup, setShowAddNarrowerPopup] = useState(false)
-  const [newNarrowerTitle, setNewNarrowerTitle] = useState('')
-  const [addNarrowerParentId, setAddNarrowerParentId] = useState(null)
 
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (contextMenuRef.current && !contextMenuRef.current.contains(event.target)) {
-        setContextMenu(null)
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside)
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (treeRef.current && treeData.length > 0) {
-      const tree = treeRef.current
-      const rootNode = tree.get(treeData[0].id)
-      if (rootNode) {
-        rootNode.open()
-      }
-    }
-  }, [treeData])
-
-  const closeAllDescendants = (node) => {
-    if (node.isOpen) {
-      node.toggle()
-    }
-
-    if (node.children) {
-      node.children.forEach(closeAllDescendants)
-    }
-  }
-
-  const handleToggle = (node) => {
-    if (node.isOpen) {
-      closeAllDescendants(node)
-    } else {
-      node.toggle()
-    }
-  }
-
-  const handleAdd = (parentId) => {
-    setAddNarrowerParentId(parentId)
-    setShowAddNarrowerPopup(true)
-  }
-
-  const handleAddNarrowerConfirm = () => {
-    if (newNarrowerTitle.trim()) {
-      const newUuid = uuidv4()
-      const newChild = {
-        id: newUuid,
-        key: newUuid,
-        title: newNarrowerTitle.trim(),
-        children: []
-      }
-      setTreeData((prevData) => {
-        const addChildToNode = (node) => {
-          if (node.id === addNarrowerParentId || node.key === addNarrowerParentId) {
-            return {
-              ...node,
-              children: [...(node.children || []), newChild],
-              isOpen: true
-            }
-          }
-
-          if (node.children) {
-            return {
-              ...node,
-              children: node.children.map(addChildToNode)
-            }
-          }
-
-          return node
-        }
-
-        return prevData.map(addChildToNode)
-      })
-
-      // Expand the parent node
-      if (treeRef.current) {
-        const parentNode = treeRef.current.get(addNarrowerParentId)
-        if (parentNode && !parentNode.isOpen) {
-          parentNode.toggle()
-        }
-      }
-
-      setShowAddNarrowerPopup(false)
-      setNewNarrowerTitle('')
-      setAddNarrowerParentId(null)
-    }
-  }
-
-  const modalActions = [
-    {
-      label: 'Cancel',
-      variant: 'secondary',
-      onClick: () => setShowAddNarrowerPopup(false)
-    },
-    {
-      label: 'Add',
-      variant: 'primary',
-      onClick: handleAddNarrowerConfirm
-    }
-  ]
-
-  const handleDelete = (nodeId) => {
+  const handleAdd = (newChild, parentId) => {
     setTreeData((prevData) => {
-      const deleteNode = (nodes) => nodes.filter((node) => node.id !== nodeId)
-        .map((node) => ({
-          ...node,
-          children: node.children ? deleteNode(node.children) : undefined
-        }))
+      const addChildToNode = (node) => {
+        if (node.id === parentId || node.key === parentId) {
+          return {
+            ...node,
+            children: [...(node.children || []), newChild]
+          }
+        }
 
-      return deleteNode(prevData)
+        if (node.children) {
+          return {
+            ...node,
+            children: node.children.map(addChildToNode)
+          }
+        }
+
+        return node
+      }
+
+      return prevData.map(addChildToNode)
     })
   }
 
   return (
-    <div className="keyword-tree__container">
+    <div style={treeContainerStyle}>
       <Tree
-        ref={treeRef}
         data={treeData}
         openByDefault={false}
         width={1000}
@@ -206,54 +114,10 @@ export const KeywordTree = ({
         rowHeight={36}
         overscanCount={1}
         idAccessor={idAccessor}
+        onchange={setTreeData}
       >
-        {
-          ({ node, ...props }) => (
-            <KeywordTreeCustomNode
-              {...props}
-              node={node}
-              onAdd={handleAdd}
-              onDelete={handleDelete}
-              setContextMenu={setContextMenu}
-              onToggle={handleToggle}
-              onClick={onNodeClick}
-              onEdit={onNodeEdit}
-              onNodeClick={onNodeClick}
-              handleAdd={handleAdd}
-            />
-          )
-        }
+        {({ node, ...props }) => <CustomNode {...props} node={node} onAdd={handleAdd} />}
       </Tree>
-      {
-        contextMenu && (
-          <KeywordTreeContextMenu
-            {...contextMenu}
-            onClose={() => setContextMenu(null)}
-            forwardedRef={contextMenuRef}
-          />
-        )
-      }
-      <CustomModal
-        show={showAddNarrowerPopup}
-        header="Add Narrower"
-        message={
-          (
-            <Form.Group>
-              <Form.Label htmlFor="newChildKeyword">Narrower Keyword:</Form.Label>
-              <Form.Control
-                id="newNarrowerKeyword"
-                type="text"
-                value={newNarrowerTitle}
-                onChange={(e) => setNewNarrowerTitle(e.target.value)}
-                placeholder="Enter Keyword"
-              />
-            </Form.Group>
-          )
-        }
-        actions={modalActions}
-        toggleModal={setShowAddNarrowerPopup}
-      />
-
     </div>
   )
 }
@@ -264,11 +128,34 @@ const NodeShape = {
 }
 NodeShape.children = PropTypes.arrayOf(PropTypes.shape(NodeShape))
 
+CustomNode.propTypes = {
+  node: PropTypes.shape({
+    data: PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      children: NodeShape.children
+    }).isRequired,
+    isOpen: PropTypes.bool.isRequired,
+    toggle: PropTypes.func.isRequired,
+    id: PropTypes.string.isRequired
+  }).isRequired,
+  style: PropTypes.shape({}),
+  dragHandle: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+  ]),
+  onAdd: PropTypes.func.isRequired
+}
+
+CustomNode.defaultProps = {
+  style: {},
+  dragHandle: null
+}
+
 KeywordTree.propTypes = {
   data: PropTypes.oneOfType([
     PropTypes.shape(NodeShape),
     PropTypes.arrayOf(PropTypes.shape(NodeShape))
-  ]).isRequired,
-  onNodeClick: PropTypes.func.isRequired,
-  onNodeEdit: PropTypes.func.isRequired
+  ]).isRequired
 }
+
+export default KeywordTree

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -4,12 +4,9 @@ import React, {
   useRef
 } from 'react'
 import { Tree } from 'react-arborist'
+import CustomModal from '@/js/components/CustomModal/CustomModal'
 import PropTypes from 'prop-types'
-import {
-  Modal,
-  Form,
-  Button
-} from 'react-bootstrap'
+import { Form } from 'react-bootstrap'
 import { v4 as uuidv4 } from 'uuid'
 
 import './KeywordTree.scss'
@@ -386,6 +383,19 @@ const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
     }
   }
 
+  const modalActions = [
+    {
+      label: 'Cancel',
+      variant: 'secondary',
+      onClick: () => setShowAddChildPopup(false)
+    },
+    {
+      label: 'Add',
+      variant: 'primary',
+      onClick: handleAddChildConfirm
+    }
+  ]
+
   const handleDelete = (nodeId) => {
     setTreeData((prevData) => {
       const deleteNode = (nodes) => nodes.filter((node) => node.id !== nodeId)
@@ -437,31 +447,26 @@ const KeywordTree = ({ data, onNodeDoubleClick, onNodeEdit }) => {
           />
         )
       }
-      <Modal show={showAddChildPopup}>
-        <Modal.Header>
-          <Modal.Title>Add Narrower</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <Form.Group>
-            <Form.Label htmlFor="newChildKeyword">Narrower Keyword:</Form.Label>
-            <Form.Control
-              id="newChildKeyword"
-              type="text"
-              value={newChildTitle}
-              onChange={(e) => setNewChildTitle(e.target.value)}
-              placeholder="Enter Keyword"
-            />
-          </Form.Group>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button variant="secondary" onClick={() => setShowAddChildPopup(false)}>
-            Cancel
-          </Button>
-          <Button variant="primary" onClick={handleAddChildConfirm}>
-            Add
-          </Button>
-        </Modal.Footer>
-      </Modal>
+      <CustomModal
+        show={showAddChildPopup}
+        header="Add Narrower"
+        message={
+          (
+            <Form.Group>
+              <Form.Label htmlFor="newChildKeyword">Narrower Keyword:</Form.Label>
+              <Form.Control
+                id="newChildKeyword"
+                type="text"
+                value={newChildTitle}
+                onChange={(e) => setNewChildTitle(e.target.value)}
+                placeholder="Enter Keyword"
+              />
+            </Form.Group>
+          )
+        }
+        actions={modalActions}
+        toggleModal={setShowAddChildPopup}
+      />
 
     </div>
   )

--- a/static/src/js/components/KeywordTree/KeywordTree.scss
+++ b/static/src/js/components/KeywordTree/KeywordTree.scss
@@ -70,34 +70,4 @@
     font-size: 25px;
     line-height: 1;
   }
-
-  &__context-menu {
-    position: absolute;
-    z-index: 1000;
-    border: 1px solid $gray-300;
-    background: $white;
-    box-shadow: 2px 2px 5px rgb(0 0 0 / 10%);
-
-    &-item {
-      width: 100%;
-      padding: 5px 10px;
-      border: none;
-      background: none;
-      cursor: pointer;
-      text-align: left;
-      transition: background-color 0.2s ease;
-
-      &:hover {
-        background-color: rgb(204 229 255);
-      }
-
-      &.focused {
-        background-color: $blue-200;
-      }
-    
-      &.hovered {
-        background-color: $blue-100;
-      }
-    }
-  }
 }

--- a/static/src/js/components/KeywordTree/KeywordTree.scss
+++ b/static/src/js/components/KeywordTree/KeywordTree.scss
@@ -88,6 +88,14 @@
       transition: background-color 0.2s ease;
 
       &:hover {
+        background-color: rgb(204, 229, 255);
+      }
+
+      &.focused {
+        background-color: $blue-200;
+      }
+    
+      &.hovered {
         background-color: $blue-100;
       }
     }

--- a/static/src/js/components/KeywordTree/KeywordTree.scss
+++ b/static/src/js/components/KeywordTree/KeywordTree.scss
@@ -43,6 +43,28 @@
     height: 24px;
   }
 
+  &__caret-icon {
+    font-size: 0.60em;
+  }
+
+  &__node-wrapper {
+    display: flex;
+    align-items: center;
+    height: 100%;
+  }
+  
+  &__icon-wrapper {
+    display: flex;
+    align-items: center;
+    padding-bottom: 6px;
+  }
+  
+  &__text-wrapper {
+    display: flex;
+    align-items: center;
+    height: 100%;
+  }
+
   &__triangle-icon {
     font-size: 25px;
     line-height: 1;

--- a/static/src/js/components/KeywordTree/KeywordTree.scss
+++ b/static/src/js/components/KeywordTree/KeywordTree.scss
@@ -13,16 +13,16 @@
   &__node {
     &-content {
       display: flex;
-      overflow: hidden;
       align-items: center;
-      text-overflow: ellipsis;
       white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     &-text {
+      font-size: 14px;
       padding: 2px 4px;
       border-radius: 2px;
-      font-size: 14px;
       transition: background-color 0.2s ease;
 
       &:hover {
@@ -32,42 +32,42 @@
   }
 
   &__icon-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0 5px;
     display: flex;
-    width: 24px;
-    height: 24px;
     align-items: center;
     justify-content: center;
-    padding: 0 5px;
-    border: none;
-    background: none;
-    cursor: pointer;
-  }
-
-  &__caret-icon {
-    font-size: 0.60em;
-  }
-
-  &__node-wrapper {
-    display: flex;
-    height: 100%;
-    align-items: center;
-  }
-  
-  &__icon-wrapper {
-    display: flex;
-    align-items: center;
-    padding-bottom: 6px;
-  }
-  
-  &__text-wrapper {
-    display: flex;
-    height: 100%;
-    align-items: center;
+    width: 24px;
+    height: 24px;
   }
 
   &__triangle-icon {
-    padding-top: 6px;
     font-size: 25px;
     line-height: 1;
+    padding-top: 6px;
+  }
+
+  &__context-menu {
+    position: absolute;
+    background: $white;
+    border: 1px solid $gray-300;
+    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+
+    &-item {
+      padding: 5px 10px;
+      cursor: pointer;
+      background: none;
+      border: none;
+      width: 100%;
+      text-align: left;
+      transition: background-color 0.2s ease;
+
+      &:hover {
+        background-color: $blue-100;
+      }
+    }
   }
 }

--- a/static/src/js/components/KeywordTree/KeywordTree.scss
+++ b/static/src/js/components/KeywordTree/KeywordTree.scss
@@ -13,16 +13,16 @@
   &__node {
     &-content {
       display: flex;
-      align-items: center;
-      white-space: nowrap;
       overflow: hidden;
+      align-items: center;
       text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     &-text {
-      font-size: 14px;
       padding: 2px 4px;
       border-radius: 2px;
+      font-size: 14px;
       transition: background-color 0.2s ease;
 
       &:hover {
@@ -32,15 +32,15 @@
   }
 
   &__icon-button {
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0 5px;
     display: flex;
-    align-items: center;
-    justify-content: center;
     width: 24px;
     height: 24px;
+    align-items: center;
+    justify-content: center;
+    padding: 0 5px;
+    border: none;
+    background: none;
+    cursor: pointer;
   }
 
   &__caret-icon {
@@ -49,8 +49,8 @@
 
   &__node-wrapper {
     display: flex;
-    align-items: center;
     height: 100%;
+    align-items: center;
   }
   
   &__icon-wrapper {
@@ -61,34 +61,34 @@
   
   &__text-wrapper {
     display: flex;
-    align-items: center;
     height: 100%;
+    align-items: center;
   }
 
   &__triangle-icon {
+    padding-top: 6px;
     font-size: 25px;
     line-height: 1;
-    padding-top: 6px;
   }
 
   &__context-menu {
     position: absolute;
-    background: $white;
-    border: 1px solid $gray-300;
-    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.1);
     z-index: 1000;
+    border: 1px solid $gray-300;
+    background: $white;
+    box-shadow: 2px 2px 5px rgb(0 0 0 / 10%);
 
     &-item {
-      padding: 5px 10px;
-      cursor: pointer;
-      background: none;
-      border: none;
       width: 100%;
+      padding: 5px 10px;
+      border: none;
+      background: none;
+      cursor: pointer;
       text-align: left;
       transition: background-color 0.2s ease;
 
       &:hover {
-        background-color: rgb(204, 229, 255);
+        background-color: rgb(204 229 255);
       }
 
       &.focused {

--- a/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
+++ b/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
@@ -14,12 +14,9 @@ import {
   beforeEach
 } from 'vitest'
 import { v4 as uuidv4 } from 'uuid'
-
-// Add this to your existing imports
 import userEvent from '@testing-library/user-event'
 import KeywordTree from '../KeywordTree'
 
-// Add this to your mocks
 vi.mock('uuid', () => ({
   v4: vi.fn()
 }))
@@ -490,7 +487,13 @@ describe('KeywordTree', () => {
     const newChildUuid = 'new-child-uuid'
     uuidv4.mockReturnValue(newChildUuid)
 
-    const { rerender } = render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+    const { rerender } = render(
+      <KeywordTree
+        data={mockData}
+        onNodeDoubleClick={() => {}}
+        onNodeEdit={() => {}}
+      />
+    )
 
     // Open context menu for 'Child 1'
     fireEvent.contextMenu(screen.getByText('Child 1'))
@@ -536,6 +539,6 @@ describe('KeywordTree', () => {
     await waitFor(() => {
       const newChildNode = screen.getByText('New Child')
       expect(newChildNode).toBeInTheDocument()
-    }, { timeout: 2000 }) // Increase timeout if needed
+    }, { timeout: 2000 })
   })
 })

--- a/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
+++ b/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
@@ -1,17 +1,18 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from '@testing-library/react'
 import React from 'react'
 import {
-  render,
-  fireEvent,
-  screen,
-  within,
-  waitFor
-} from '@testing-library/react'
-import {
   describe,
-  test,
   expect,
+  test,
   vi
 } from 'vitest'
+
 import { KeywordTree } from '../KeywordTree'
 
 describe('KeywordTree', () => {

--- a/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
+++ b/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
@@ -714,9 +714,9 @@ describe('KeywordTree', () => {
       })
     })
   })
-  
+
   describe('When opening the tree', () => {
-    const mockData = [
+    const treeData = [
       {
         id: '1',
         key: '1',
@@ -732,24 +732,26 @@ describe('KeywordTree', () => {
                 key: '3',
                 title: 'Node 3',
                 children: []
-              }    
+              }
             ]
           }
         ]
       }
-    ]  
-    test('should open all nodes when openAll is true', async() => {
+    ]
+    test('should open all nodes when openAll is true', async () => {
       render(
         <KeywordTree
-          data={mockData}
+          data={treeData}
           onNodeClick={vi.fn()}
           onNodeEdit={vi.fn()}
-          openAll={true}
+          openAll
         />
       )
+
       await waitFor(() => {
         expect(screen.getByText('Node 3')).toBeVisible()
       })
+
       expect(screen.getByText('Root')).toBeVisible()
       expect(screen.getByText('Node 3')).toBeVisible()
     })
@@ -757,16 +759,17 @@ describe('KeywordTree', () => {
     test('should scroll to selected node when selectedNodeId is provided', async () => {
       render(
         <KeywordTree
-          data={mockData}
+          data={treeData}
           onNodeClick={vi.fn()}
           onNodeEdit={vi.fn()}
-          selectedNodeId='2'
+          selectedNodeId="2"
         />
       )
 
       await waitFor(() => {
         expect(screen.getByText('Node 2')).toBeVisible()
       })
+
       expect(screen.getByText('Node 2')).toBeVisible()
       expect(screen.queryByText('Node 3')).not.toBeInTheDocument()
     })

--- a/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
+++ b/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
@@ -3,571 +3,713 @@ import {
   render,
   fireEvent,
   screen,
-  waitFor,
-  within
+  within,
+  waitFor
 } from '@testing-library/react'
 import {
   describe,
   test,
   expect,
-  vi,
-  beforeEach
+  vi
 } from 'vitest'
-import { v4 as uuidv4 } from 'uuid'
-import userEvent from '@testing-library/user-event'
-import KeywordTree from '../KeywordTree'
-
-vi.mock('uuid', () => ({
-  v4: vi.fn()
-}))
+import { KeywordTree } from '../KeywordTree'
 
 describe('KeywordTree', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
+  const mockData = [
+    {
+      id: '1',
+      key: '1',
+      title: 'Root',
+      children: [
+        {
+          id: '2',
+          key: '2',
+          title: 'Child 1',
+          children: []
+        },
+        {
+          id: '3',
+          key: '3',
+          title: 'Child 2',
+          children: []
+        }
+      ]
+    }
+  ]
+
+  const mockOnNodeClick = vi.fn()
+  const mockOnNodeEdit = vi.fn()
+  let consoleErrorSpy
+
+  beforeAll(() => {
+    // Suppress console.error for all tests in this file
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
-  const rootUuid = 'root-uuid'
-  const child1Uuid = 'child1-uuid'
-  const child2Uuid = 'child2-uuid'
-
-  const mockData = {
-    id: rootUuid,
-    key: rootUuid,
-    title: 'Root',
-    children: [
-      {
-        id: child1Uuid,
-        key: child1Uuid,
-        title: 'Child 1',
-        children: []
-      },
-      {
-        id: child2Uuid,
-        key: child2Uuid,
-        title: 'Child 2',
-        children: []
-      }
-    ]
-  }
+  afterAll(() => {
+    // Restore console.error after all tests
+    consoleErrorSpy.mockRestore()
+  })
 
   describe('Rendering', () => {
-    test('renders without crashing', () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-      expect(screen.getByText('Root')).toBeInTheDocument()
-    })
-
-    test('renders child nodes', () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-      expect(screen.getByText('Child 1')).toBeInTheDocument()
-      expect(screen.getByText('Child 2')).toBeInTheDocument()
-    })
-
-    test('handles empty data', () => {
+    test('renders KeywordTree component', () => {
       render(
         <KeywordTree
-          data={[]}
-          onNodeDoubleClick={() => {}}
-          onNodeEdit={() => {}}
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
         />
       )
 
-      expect(screen.getByRole('tree')).toBeInTheDocument()
+      expect(screen.getByText('Root')).toBeTruthy()
+    })
+
+    test('expands root node on initial render', () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      expect(screen.getByText('Child 1')).toBeTruthy()
+      expect(screen.getByText('Child 2')).toBeTruthy()
+    })
+
+    test('handles empty data gracefully', () => {
+      render(
+        <KeywordTree
+          data={[]}
+          onNodeClick={vi.fn()}
+          onNodeEdit={vi.fn()}
+        />
+      )
+
+      // Check if the tree container is rendered
+      const treeContainer = screen.getByRole('tree')
+      expect(treeContainer).toBeInTheDocument()
+
+      // Check that no nodes are rendered
+      const nodes = screen.queryAllByRole('button', { name: /Keyword:/i })
+      expect(nodes).toHaveLength(0)
     })
   })
 
   describe('Node Interaction', () => {
-    test('calls onNodeDoubleClick when a node is double-clicked', () => {
-      const onNodeDoubleClick = vi.fn()
+    test('calls onNodeClick when a node is clicked', () => {
       render(
         <KeywordTree
           data={mockData}
-          onNodeDoubleClick={onNodeDoubleClick}
-          onNodeEdit={() => {}}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
         />
       )
 
-      fireEvent.doubleClick(screen.getByText('Child 1'))
-      expect(onNodeDoubleClick).toHaveBeenCalledWith(child1Uuid)
+      fireEvent.click(screen.getByText('Child 1'))
+      expect(mockOnNodeClick).toHaveBeenCalledWith('2')
     })
 
-    test('toggles node expansion', async () => {
-      const grandchildUuid = 'grandchild-uuid'
-      const nestedMockData = {
-        ...mockData,
-        children: [
-          {
-            id: child1Uuid,
-            key: child1Uuid,
-            title: 'Child 1',
-            children: [
-              {
-                id: grandchildUuid,
-                key: grandchildUuid,
-                title: 'Grandchild',
-                children: []
-              }
-            ]
-          }
-        ]
-      }
+    test('toggles node expansion when clicked', async () => {
+      const dataWithGrandchildren = [
+        {
+          id: '1',
+          key: '1',
+          title: 'Root',
+          children: [
+            {
+              id: '2',
+              key: '2',
+              title: 'Child 1',
+              children: [
+                {
+                  id: '4',
+                  key: '4',
+                  title: 'Grandchild 1',
+                  children: []
+                }
+              ]
+            }
+          ]
+        }
+      ]
 
       render(
         <KeywordTree
-          data={nestedMockData}
-          onNodeDoubleClick={() => {}}
-          onNodeEdit={() => {}}
+          data={dataWithGrandchildren}
+          onNodeClick={vi.fn()}
+          onNodeEdit={vi.fn()}
         />
       )
 
-      expect(screen.queryByText('Grandchild')).not.toBeInTheDocument()
+      // Find the root node
+      const rootNode = screen.getByRole('button', { name: /Keyword: Root/i })
+      expect(rootNode).toBeInTheDocument()
 
-      const child1Item = screen.getByRole('treeitem', { name: /child 1/i })
-      const toggleButton = within(child1Item).getByRole('button')
-      fireEvent.click(toggleButton)
+      // Find Child 1 node (it should be visible initially as the root is expanded by default)
+      const child1Node = screen.getByRole('button', { name: /Keyword: Child 1/i })
+      expect(child1Node).toBeInTheDocument()
 
-      const grandchild = await screen.findByText('Grandchild')
-      expect(grandchild).toBeInTheDocument()
+      // Initially, Grandchild 1 should not be visible
+      expect(screen.queryByRole('button', { name: /Keyword: Grandchild 1/i })).not.toBeInTheDocument()
 
-      fireEvent.click(toggleButton)
+      // Find the toggle button for Child 1
+      const child1Toggle = within(child1Node).getByRole('button', { name: /Toggle Child 1/i })
+      expect(child1Toggle).toBeInTheDocument()
 
+      // Click on the toggle button to expand Child 1
+      fireEvent.click(child1Toggle)
+
+      // After clicking, Grandchild 1 should become visible
       await waitFor(() => {
-        expect(screen.queryByText('Grandchild')).not.toBeInTheDocument()
+        const grandchild1Node = screen.getByRole('button', { name: /Keyword: Grandchild 1/i })
+        expect(grandchild1Node).toBeInTheDocument()
+      })
+
+      // Click on the toggle button again to collapse Child 1
+      fireEvent.click(child1Toggle)
+
+      // After collapsing, Grandchild 1 should not be visible again
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /Keyword: Grandchild 1/i })).not.toBeInTheDocument()
       })
     })
 
-    test('node changes background color on hover', async () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+    test('handles node click on leaf nodes', () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
 
-      const node = screen.getByText('Child 1')
+      fireEvent.click(screen.getByText('Child 1'))
+      expect(mockOnNodeClick).toHaveBeenCalledWith('2')
+    })
 
-      expect(node).toHaveStyle('background-color: rgba(0, 0, 0, 0)')
+    test('handles node click on parent nodes', () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
 
-      fireEvent.mouseEnter(node)
-      expect(node).toHaveStyle('background-color: #cce5ff')
+      fireEvent.click(screen.getByText('Root'))
+      expect(mockOnNodeClick).toHaveBeenCalledWith('1')
+    })
 
-      fireEvent.mouseLeave(node)
-      expect(node).toHaveStyle('background-color: rgba(0, 0, 0, 0)')
+    test('handles rapid expansion and collapse of nodes', async () => {
+      const nestedData = [
+        {
+          id: '1',
+          key: '1',
+          title: 'Root',
+          children: [
+            {
+              id: '2',
+              key: '2',
+              title: 'Parent 1',
+              children: [
+                {
+                  id: '3',
+                  key: '3',
+                  title: 'Child 1',
+                  children: []
+                }
+              ]
+            },
+            {
+              id: '4',
+              key: '4',
+              title: 'Parent 2',
+              children: [
+                {
+                  id: '5',
+                  key: '5',
+                  title: 'Child 2',
+                  children: []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+
+      render(
+        <KeywordTree
+          data={nestedData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      const parent1Node = screen.getByText('Parent 1')
+      const parent2Node = screen.getByText('Parent 2')
+
+      // Rapidly expand and collapse nodes
+      fireEvent.click(parent1Node)
+      fireEvent.click(parent2Node)
+      fireEvent.click(parent1Node)
+      fireEvent.click(parent2Node)
+
+      // Check if the tree structure is maintained
+      expect(screen.getByText('Root')).toBeInTheDocument()
+      expect(screen.getByText('Parent 1')).toBeInTheDocument()
+      expect(screen.getByText('Parent 2')).toBeInTheDocument()
+
+      // Check if child nodes are not visible (as parents should be collapsed after the last click)
+      expect(screen.queryByText('Child 1')).not.toBeInTheDocument()
+      expect(screen.queryByText('Child 2')).not.toBeInTheDocument()
     })
   })
 
   describe('Context Menu', () => {
-    test('opens context menu on right-click', () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+    test('context menu appears on right click', () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
 
       fireEvent.contextMenu(screen.getByText('Child 1'))
-      expect(screen.getByText('Edit')).toBeInTheDocument()
-      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-      expect(screen.getByText('Delete')).toBeInTheDocument()
+      expect(screen.getByRole('menu')).toBeTruthy()
     })
 
-    test('deletes a node', () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+    test('context menu closes when clicking outside', () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
 
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      expect(screen.getByRole('menu')).toBeTruthy()
+
+      fireEvent.mouseDown(document.body)
+      expect(screen.queryByRole('menu')).toBeFalsy()
+    })
+
+    test('handles multiple context menu opens without clicking', () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      fireEvent.contextMenu(screen.getByText('Root'))
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      fireEvent.contextMenu(screen.getByText('Child 2'))
+
+      // Only the last context menu should be open
+      expect(screen.getAllByRole('menu')).toHaveLength(1)
+    })
+  })
+
+  describe('Adding Nodes', () => {
+    test('adds a new node when "Add Narrower" is used', async () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      // Open context menu
+      fireEvent.contextMenu(screen.getByText('Root'))
+
+      // Click "Add Narrower" option
+      fireEvent.click(screen.getByText('Add Narrower'))
+
+      // Check if modal is open
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+
+      // Enter new node title
+      fireEvent.change(screen.getByPlaceholderText('Enter Keyword'), {
+        target: { value: 'New Child' }
+      })
+
+      // Click "Add" button
+      fireEvent.click(screen.getByText('Add'))
+
+      // Check if new node is added
+      await waitFor(() => {
+        expect(screen.getByText('New Child')).toBeInTheDocument()
+      })
+    })
+
+    test('closes "Add Narrower" modal when Cancel is clicked', async () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      // Open context menu
+      fireEvent.contextMenu(screen.getByText('Root'))
+
+      // Click "Add Narrower" option
+      fireEvent.click(screen.getByText('Add Narrower'))
+
+      // Check if modal is open
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+
+      // Click "Cancel" button
+      fireEvent.click(screen.getByText('Cancel'))
+
+      // Check if modal is closed
+      await waitFor(() => {
+        expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
+      })
+    })
+
+    test('handles adding a node with empty title', async () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      // Open context menu
+      fireEvent.contextMenu(screen.getByText('Root'))
+      // Click "Add Narrower" option
+      fireEvent.click(screen.getByText('Add Narrower'))
+
+      // Check if modal is open
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+
+      // Don't enter any title (leave it empty)
+
+      // Click "Add" button
+      fireEvent.click(screen.getByText('Add'))
+
+      // Check if modal is still open (because empty title should not be added)
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+    })
+
+    test('expands parent node when a new child is added', async () => {
+      const collapsedData = [
+        {
+          id: '1',
+          key: '1',
+          title: 'Root',
+          children: [
+            {
+              id: '2',
+              key: '2',
+              title: 'Collapsed Parent',
+              children: []
+            }
+          ]
+        }
+      ]
+
+      render(
+        <KeywordTree
+          data={collapsedData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      // Open context menu for Collapsed Parent
+      fireEvent.contextMenu(screen.getByText('Collapsed Parent'))
+
+      // Click "Add Narrower" option
+      fireEvent.click(screen.getByText('Add Narrower'))
+
+      // Enter new node title
+      fireEvent.change(screen.getByPlaceholderText('Enter Keyword'), {
+        target: { value: 'New Child' }
+      })
+
+      // Click "Add" button
+      fireEvent.click(screen.getByText('Add'))
+
+      // Check if new node is added and visible (parent should be expanded)
+      await waitFor(() => {
+        expect(screen.getByText('New Child')).toBeInTheDocument()
+      })
+    })
+
+    test('handles adding a node with a very long title', async () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      fireEvent.contextMenu(screen.getByText('Root'))
+      fireEvent.click(screen.getByText('Add Narrower'))
+      fireEvent.change(screen.getByPlaceholderText('Enter Keyword'), {
+        target: { value: 'This is a very long title for a new node that might cause issues with layout or display' }
+      })
+
+      fireEvent.click(screen.getByText('Add'))
+
+      await waitFor(() => {
+        expect(screen.getByText('This is a very long title for a new node that might cause issues with layout or display')).toBeInTheDocument()
+      })
+    })
+
+    test('handles nodes with very long titles', async () => {
+      const longTitleData = [
+        {
+          id: '1',
+          key: '1',
+          title: 'Root',
+          children: [
+            {
+              id: '2',
+              key: '2',
+              title: 'This is a very long title that might cause issues with layout or display',
+              children: []
+            }
+          ]
+        }
+      ]
+
+      render(
+        <KeywordTree
+          data={longTitleData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      expect(screen.getByText('This is a very long title that might cause issues with layout or display')).toBeInTheDocument()
+    })
+  })
+
+  describe('Editing and Deleting Nodes', () => {
+    test('deletes a node when "Delete" is used', async () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      // Open context menu for Child 1
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+
+      // Click "Delete" option
+      fireEvent.click(screen.getByText('Delete'))
+
+      // Check if node is deleted
+      await waitFor(() => {
+        expect(screen.queryByText('Child 1')).not.toBeInTheDocument()
+      })
+    })
+
+    test('edits a node when "Edit" is used', () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      // Open context menu for Child 1
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+
+      // Click "Edit" option
+      fireEvent.click(screen.getByText('Edit'))
+
+      // Check if onNodeEdit was called with correct id
+      expect(mockOnNodeEdit).toHaveBeenCalledWith('2')
+    })
+  })
+
+  describe('Tree State Management', () => {
+    test('maintains tree state when nodes are added or deleted', async () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
+
+      // Add a new node
+      fireEvent.contextMenu(screen.getByText('Root'))
+      fireEvent.click(screen.getByText('Add Narrower'))
+      fireEvent.change(screen.getByPlaceholderText('Enter Keyword'), {
+        target: { value: 'New Child' }
+      })
+
+      fireEvent.click(screen.getByText('Add'))
+
+      await waitFor(() => {
+        expect(screen.getByText('New Child')).toBeInTheDocument()
+      })
+
+      // Delete an existing node
       fireEvent.contextMenu(screen.getByText('Child 1'))
       fireEvent.click(screen.getByText('Delete'))
 
-      expect(screen.queryByText('Child 1')).not.toBeInTheDocument()
-    })
-
-    test('calls onNodeEdit when edit is selected from context menu', () => {
-      const onNodeEdit = vi.fn()
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={onNodeEdit} />)
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-      fireEvent.click(screen.getByText('Edit'))
-
-      expect(onNodeEdit).toHaveBeenCalledWith(child1Uuid)
-    })
-
-    test('closes context menu when clicking outside', () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-      expect(screen.getByText('Edit')).toBeInTheDocument()
-
-      fireEvent.mouseDown(document.body)
-
-      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
-    })
-
-    test('resets hovered index when mouse leaves context menu', async () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-
-      const editOption = screen.getByText('Edit')
-      fireEvent.mouseEnter(editOption)
-
-      expect(editOption).toHaveClass('hovered')
-
-      const contextMenu = screen.getByRole('menu')
-      fireEvent.mouseLeave(contextMenu)
-
       await waitFor(() => {
-        expect(editOption).not.toHaveClass('hovered')
-      })
-    })
-  })
-
-  describe('Keyboard Navigation', () => {
-    test('supports keyboard navigation in context menu', () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-
-      const editButton = screen.getByText('Edit')
-      editButton.focus()
-
-      fireEvent.keyDown(editButton, {
-        key: 'Enter',
-        code: 'Enter'
+        expect(screen.queryByText('Child 1')).not.toBeInTheDocument()
       })
 
-      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+      // Check if other nodes still exist
+      expect(screen.getByText('Root')).toBeInTheDocument()
+      expect(screen.getByText('Child 2')).toBeInTheDocument()
+      expect(screen.getByText('New Child')).toBeInTheDocument()
     })
 
-    test('handles ArrowDown key in context menu', () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-
-      const contextMenu = screen.getByRole('menu')
-      const editOption = screen.getByText('Edit')
-      const addOption = screen.getByText('Add Narrower')
-      const deleteOption = screen.getByText('Delete')
-
-      contextMenu.focus()
-
-      fireEvent.keyDown(contextMenu, {
-        key: 'ArrowDown',
-        code: 'ArrowDown'
-      })
-
-      expect(editOption).toHaveClass('focused')
-
-      fireEvent.keyDown(contextMenu, {
-        key: 'ArrowDown',
-        code: 'ArrowDown'
-      })
-
-      expect(addOption).toHaveClass('focused')
-
-      fireEvent.keyDown(contextMenu, {
-        key: 'ArrowDown',
-        code: 'ArrowDown'
-      })
-
-      expect(deleteOption).toHaveClass('focused')
-
-      fireEvent.keyDown(contextMenu, {
-        key: 'ArrowDown',
-        code: 'ArrowDown'
-      })
-
-      expect(editOption).toHaveClass('focused')
-    })
-
-    test('handles ArrowUp key in context menu', () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-
-      const contextMenu = screen.getByRole('menu')
-      const editOption = screen.getByText('Edit')
-      const addOption = screen.getByText('Add Narrower')
-      const deleteOption = screen.getByText('Delete')
-
-      contextMenu.focus()
-
-      fireEvent.keyDown(contextMenu, {
-        key: 'ArrowUp',
-        code: 'ArrowUp'
-      })
-
-      expect(deleteOption).toHaveClass('focused')
-
-      fireEvent.keyDown(contextMenu, {
-        key: 'ArrowUp',
-        code: 'ArrowUp'
-      })
-
-      expect(addOption).toHaveClass('focused')
-
-      fireEvent.keyDown(contextMenu, {
-        key: 'ArrowUp',
-        code: 'ArrowUp'
-      })
-
-      expect(editOption).toHaveClass('focused')
-
-      fireEvent.keyDown(contextMenu, {
-        key: 'ArrowUp',
-        code: 'ArrowUp'
-      })
-
-      expect(deleteOption).toHaveClass('focused')
-    })
-
-    test('calls action and closes context menu when Enter is pressed on focused item', () => {
-      const onNodeEdit = vi.fn()
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={onNodeEdit} />)
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-
-      const contextMenu = screen.getByRole('menu')
-      contextMenu.focus()
-
-      fireEvent.keyDown(contextMenu, {
-        key: 'ArrowDown',
-        code: 'ArrowDown'
-      })
-
-      fireEvent.keyDown(contextMenu, {
-        key: 'Enter',
-        code: 'Enter'
-      })
-
-      expect(onNodeEdit).toHaveBeenCalledWith(child1Uuid)
-      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
-    })
-
-    test('closes context menu when Escape is pressed and does nothing for other keys', () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-
-      const contextMenu = screen.getByRole('menu')
-      expect(contextMenu).toBeInTheDocument()
-
-      fireEvent.keyDown(contextMenu, {
-        key: 'Escape',
-        code: 'Escape'
-      })
-
-      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-      const newContextMenu = screen.getByRole('menu')
-
-      fireEvent.keyDown(newContextMenu, {
-        key: 'a',
-        code: 'KeyA'
-      })
-
-      expect(newContextMenu).toBeInTheDocument()
-    })
-  })
-
-  describe('Adding Child Nodes', () => {
-    test('handles add child cancellation', async () => {
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-      fireEvent.click(screen.getByText('Add Narrower'))
-
-      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-      fireEvent.click(screen.getByText('Cancel'))
-
-      await waitFor(() => {
-        expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
-      })
-    })
-
-    test('handles cancelling add new child', async () => {
-      const user = userEvent.setup()
-
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-      await user.click(screen.getByText('Add Narrower'))
-
-      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-      await user.type(screen.getByPlaceholderText('Enter Keyword'), 'Cancelled Child')
-      await user.click(screen.getByRole('button', { name: 'Cancel' }))
-
-      expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
-      expect(screen.queryByText('Cancelled Child')).not.toBeInTheDocument()
-    })
-
-    test('prevents adding empty keyword', async () => {
-      const user = userEvent.setup()
-
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-      await user.click(screen.getByText('Add Narrower'))
-
-      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-      await user.click(screen.getByRole('button', { name: 'Add' }))
-
-      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-      await user.click(screen.getByRole('button', { name: 'Cancel' }))
-    })
-
-    test('adds new child node', async () => {
-      const user = userEvent.setup()
-      const newChildUuid = 'new-child-uuid'
-      uuidv4.mockReturnValue(newChildUuid)
-
-      const { rerender } = render(
+    test('handles concurrent add and delete operations', async () => {
+      render(
         <KeywordTree
           data={mockData}
-          onNodeDoubleClick={() => {}}
-          onNodeEdit={() => {}}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
         />
       )
 
+      // Add a new node
+      fireEvent.contextMenu(screen.getByText('Root'))
+      fireEvent.click(screen.getByText('Add Narrower'))
+      fireEvent.change(screen.getByPlaceholderText('Enter Keyword'), {
+        target: { value: 'New Node' }
+      })
+
+      fireEvent.click(screen.getByText('Add'))
+
+      // Delete an existing node
       fireEvent.contextMenu(screen.getByText('Child 1'))
-      await user.click(screen.getByText('Add Narrower'))
+      fireEvent.click(screen.getByText('Delete'))
 
-      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-      await user.type(screen.getByPlaceholderText('Enter Keyword'), 'New Child')
-      await user.click(screen.getByRole('button', { name: 'Add' }))
-
+      // Check if the new node is added and the deleted node is removed
       await waitFor(() => {
-        expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
+        expect(screen.getByText('New Node')).toBeInTheDocument()
       })
 
-      // Wait for the component to update
-      await waitFor(() => {})
+      expect(screen.queryByText('Child 1')).not.toBeInTheDocument()
 
-      // Force a re-render
-      rerender(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-      // The parent node should now be automatically expanded, so we can directly look for the new child
-      await waitFor(() => {
-        const newChildNode = screen.getByText('New Child')
-        expect(newChildNode).toBeInTheDocument()
-      }, { timeout: 2000 })
-
-      // Verify that the parent node is indeed expanded
-      const treeItem = within(screen.getByRole('tree')).getByRole('treeitem', { name: /Child 1/i })
-      const expandButton = within(treeItem).getByRole('button', {
-        class: /keyword-tree__icon-button keyword-tree__triangle-icon/
-      })
-
-      expect(expandButton).toHaveClass('keyword-tree__icon-button')
-      expect(expandButton).toHaveClass('keyword-tree__triangle-icon')
-
-      // Check if the caret icon is pointing down (expanded state)
-      const caretIcon = within(expandButton).getByText('', { selector: 'i.fa' })
-      expect(caretIcon).toHaveClass('fa-caret-down')
-      expect(caretIcon).not.toHaveClass('fa-caret-right')
+      // Check if other existing nodes are still present
+      expect(screen.getByText('Root')).toBeInTheDocument()
+      expect(screen.getByText('Child 2')).toBeInTheDocument()
     })
 
-    test('handles adding child to a parent with leaf sibling nodes', async () => {
-      const user = userEvent.setup()
+    test('does not modify nodes that are not the target parent and have no children', async () => {
+      const dataWithLeafNodes = [
+        {
+          id: '1',
+          key: '1',
+          title: 'Root',
+          children: [
+            {
+              id: '2',
+              key: '2',
+              title: 'Leaf Node 1'
+            },
+            {
+              id: '3',
+              key: '3',
+              title: 'Leaf Node 2'
+            }
+          ]
+        }
+      ]
 
-      const mockDataWithLeaf = {
-        id: 'root',
-        key: 'root',
-        title: 'Root',
-        children: [
-          {
-            id: 'parent',
-            key: 'parent',
-            title: 'Parent',
-            children: []
-          },
-          {
-            id: 'leaf',
-            key: 'leaf',
-            title: 'Leaf',
-            children: undefined
-          }
-        ]
-      }
-
-      const { rerender } = render(
+      render(
         <KeywordTree
-          data={mockDataWithLeaf}
-          onNodeDoubleClick={() => {}}
-          onNodeEdit={() => {}}
+          data={dataWithLeafNodes}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
         />
       )
 
-      fireEvent.contextMenu(screen.getByText('Parent'))
-      await user.click(screen.getByText('Add Narrower'))
-
-      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-      await user.type(screen.getByPlaceholderText('Enter Keyword'), 'New Child')
-      await user.click(screen.getByRole('button', { name: 'Add' }))
-
-      await waitFor(() => {
-        expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
+      // Attempt to add a child to Leaf Node 1
+      fireEvent.contextMenu(screen.getByText('Leaf Node 1'))
+      fireEvent.click(screen.getByText('Add Narrower'))
+      fireEvent.change(screen.getByPlaceholderText('Enter Keyword'), {
+        target: { value: 'New Child' }
       })
 
-      // Wait for the component to update
-      await waitFor(() => {})
+      fireEvent.click(screen.getByText('Add'))
 
-      // Force a re-render
-      rerender(
+      // Wait for the new node to be added
+      await waitFor(() => {
+        expect(screen.getByText('New Child')).toBeInTheDocument()
+      })
+
+      // Verify that Leaf Node 2 remains unchanged
+      expect(screen.getByText('Leaf Node 2')).toBeInTheDocument()
+
+      // Verify that Leaf Node 2 still doesn't have any children
+      const leafNode2 = screen.getByRole('treeitem', { name: /Leaf Node 2/i })
+      expect(within(leafNode2).queryByRole('group')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Edge Cases and Performance', () => {
+    test('handles nodes with empty children array', () => {
+      const dataWithEmptyChildren = [
+        {
+          id: '1',
+          key: '1',
+          title: 'Root',
+          children: [
+            {
+              id: '2',
+              key: '2',
+              title: 'Node with empty children',
+              children: []
+            }
+          ]
+        }
+      ]
+
+      render(
         <KeywordTree
-          data={mockDataWithLeaf}
-          onNodeDoubleClick={() => {}}
-          onNodeEdit={() => {}}
+          data={dataWithEmptyChildren}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
         />
       )
 
-      const parentNode = screen.getByRole('treeitem', { name: /Parent/i })
-
-      // Instead of using .closest(), we can use within() to search within the parent node
-      const expandButton1 = within(parentNode).getByRole('button', {
-        class: /keyword-tree__icon-button keyword-tree__triangle-icon/
-      })
-
-      if (!expandButton1) {
-        throw new Error('Expand button not found within parent node')
-      }
-
-      const expandButton = within(parentNode).getByRole('button', {
-        class: /keyword-tree__icon-button keyword-tree__triangle-icon/
-      })
-
-      // Ensure the parent node is expanded
-      const caretIcon = within(expandButton).getByText('', { selector: 'i.fa' })
-      if (!caretIcon.classList.contains('fa-caret-down')) {
-        await user.click(expandButton)
-      }
-
-      // Wait for the new child to appear
-      await waitFor(() => {
-        const newChildNode = screen.getByText('New Child')
-        expect(newChildNode).toBeInTheDocument()
-      }, { timeout: 2000 })
-
-      // Verify that the leaf sibling is still present
-      expect(screen.getByText('Leaf')).toBeInTheDocument()
-
-      // Check if the caret icon is pointing down (expanded state)
-      if (expandButton) {
-        const caretIcon1 = within(expandButton).getByText('', { selector: 'i.fa' })
-        expect(caretIcon1).toHaveClass('fa-caret-down')
-      }
+      expect(screen.getByText('Node with empty children')).toBeInTheDocument()
     })
 
-    test('shows and hides add child modal', async () => {
-      const user = userEvent.setup()
+    test('handles very large number of operations without crashing', async () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+        />
+      )
 
-      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+      const root = screen.getByText('Root')
 
-      expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
+      // Perform a large number of expand/collapse operations
+      for (let i = 0; i < 1000; i += 1) {
+        fireEvent.click(root)
+      }
 
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-      await user.click(screen.getByText('Add Narrower'))
-
-      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-      await user.click(screen.getByRole('button', { name: 'Cancel' }))
-
+      // The component should still be responsive after many operations
+      fireEvent.click(root)
       await waitFor(() => {
-        expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
+        expect(screen.getByText('Child 1')).toBeInTheDocument()
       })
     })
   })

--- a/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
+++ b/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
@@ -714,4 +714,61 @@ describe('KeywordTree', () => {
       })
     })
   })
+  
+  describe('When opening the tree', () => {
+    const mockData = [
+      {
+        id: '1',
+        key: '1',
+        title: 'Root',
+        children: [
+          {
+            id: '2',
+            key: '2',
+            title: 'Node 2',
+            children: [
+              {
+                id: '3',
+                key: '3',
+                title: 'Node 3',
+                children: []
+              }    
+            ]
+          }
+        ]
+      }
+    ]  
+    test('should open all nodes when openAll is true', async() => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={vi.fn()}
+          onNodeEdit={vi.fn()}
+          openAll={true}
+        />
+      )
+      await waitFor(() => {
+        expect(screen.getByText('Node 3')).toBeVisible()
+      })
+      expect(screen.getByText('Root')).toBeVisible()
+      expect(screen.getByText('Node 3')).toBeVisible()
+    })
+
+    test('should scroll to selected node when selectedNodeId is provided', async () => {
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeClick={vi.fn()}
+          onNodeEdit={vi.fn()}
+          selectedNodeId='2'
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Node 2')).toBeVisible()
+      })
+      expect(screen.getByText('Node 2')).toBeVisible()
+      expect(screen.queryByText('Node 3')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
+++ b/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
@@ -21,10 +21,6 @@ vi.mock('uuid', () => ({
   v4: vi.fn()
 }))
 
-vi.mock('uuid', () => ({
-  v4: vi.fn()
-}))
-
 describe('KeywordTree', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -54,599 +50,490 @@ describe('KeywordTree', () => {
     ]
   }
 
-  test('renders without crashing', () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-    expect(screen.getByText('Root')).toBeInTheDocument()
+  describe('Rendering', () => {
+    test('renders without crashing', () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+      expect(screen.getByText('Root')).toBeInTheDocument()
+    })
+
+    test('renders child nodes', () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+      expect(screen.getByText('Child 1')).toBeInTheDocument()
+      expect(screen.getByText('Child 2')).toBeInTheDocument()
+    })
+
+    test('handles empty data', () => {
+      render(
+        <KeywordTree
+          data={[]}
+          onNodeDoubleClick={() => {}}
+          onNodeEdit={() => {}}
+        />
+      )
+
+      expect(screen.getByRole('tree')).toBeInTheDocument()
+    })
   })
 
-  test('renders child nodes', () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-    expect(screen.getByText('Child 1')).toBeInTheDocument()
-    expect(screen.getByText('Child 2')).toBeInTheDocument()
-  })
+  describe('Node Interaction', () => {
+    test('calls onNodeDoubleClick when a node is double-clicked', () => {
+      const onNodeDoubleClick = vi.fn()
+      render(
+        <KeywordTree
+          data={mockData}
+          onNodeDoubleClick={onNodeDoubleClick}
+          onNodeEdit={() => {}}
+        />
+      )
 
-  test('calls onNodeDoubleClick when a node is double-clicked', () => {
-    const onNodeDoubleClick = vi.fn()
-    render(
-      <KeywordTree
-        data={mockData}
-        onNodeDoubleClick={onNodeDoubleClick}
-        onNodeEdit={() => {}}
-      />
-    )
+      fireEvent.doubleClick(screen.getByText('Child 1'))
+      expect(onNodeDoubleClick).toHaveBeenCalledWith(child1Uuid)
+    })
 
-    fireEvent.doubleClick(screen.getByText('Child 1'))
-    expect(onNodeDoubleClick).toHaveBeenCalledWith(child1Uuid)
-  })
+    test('toggles node expansion', async () => {
+      const grandchildUuid = 'grandchild-uuid'
+      const nestedMockData = {
+        ...mockData,
+        children: [
+          {
+            id: child1Uuid,
+            key: child1Uuid,
+            title: 'Child 1',
+            children: [
+              {
+                id: grandchildUuid,
+                key: grandchildUuid,
+                title: 'Grandchild',
+                children: []
+              }
+            ]
+          }
+        ]
+      }
 
-  test('opens context menu on right-click', () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+      render(
+        <KeywordTree
+          data={nestedMockData}
+          onNodeDoubleClick={() => {}}
+          onNodeEdit={() => {}}
+        />
+      )
 
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-    expect(screen.getByText('Edit')).toBeInTheDocument()
-    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-    expect(screen.getByText('Delete')).toBeInTheDocument()
-  })
-
-  test('deletes a node', () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-    fireEvent.click(screen.getByText('Delete'))
-
-    expect(screen.queryByText('Child 1')).not.toBeInTheDocument()
-  })
-
-  test('calls onNodeEdit when edit is selected from context menu', () => {
-    const onNodeEdit = vi.fn()
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={onNodeEdit} />)
-
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-    fireEvent.click(screen.getByText('Edit'))
-
-    expect(onNodeEdit).toHaveBeenCalledWith(child1Uuid)
-  })
-
-  test('toggles node expansion', async () => {
-    const grandchildUuid = 'grandchild-uuid'
-    const nestedMockData = {
-      ...mockData,
-      children: [
-        {
-          id: child1Uuid,
-          key: child1Uuid,
-          title: 'Child 1',
-          children: [
-            {
-              id: grandchildUuid,
-              key: grandchildUuid,
-              title: 'Grandchild',
-              children: []
-            }
-          ]
-        }
-      ]
-    }
-
-    render(<KeywordTree data={nestedMockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-    // Initially, the grandchild should not be visible
-    expect(screen.queryByText('Grandchild')).not.toBeInTheDocument()
-
-    // Find and click the toggle button for 'Child 1'
-    const child1Item = screen.getByRole('treeitem', { name: /child 1/i })
-    const toggleButton = within(child1Item).getByRole('button')
-    fireEvent.click(toggleButton)
-
-    // Wait for the grandchild to appear
-    const grandchild = await screen.findByText('Grandchild')
-    expect(grandchild).toBeInTheDocument()
-
-    // Click the toggle button again
-    fireEvent.click(toggleButton)
-
-    // The grandchild should be hidden again
-    await waitFor(() => {
       expect(screen.queryByText('Grandchild')).not.toBeInTheDocument()
+
+      const child1Item = screen.getByRole('treeitem', { name: /child 1/i })
+      const toggleButton = within(child1Item).getByRole('button')
+      fireEvent.click(toggleButton)
+
+      const grandchild = await screen.findByText('Grandchild')
+      expect(grandchild).toBeInTheDocument()
+
+      fireEvent.click(toggleButton)
+
+      await waitFor(() => {
+        expect(screen.queryByText('Grandchild')).not.toBeInTheDocument()
+      })
+    })
+
+    test('node changes background color on hover', async () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+
+      const node = screen.getByText('Child 1')
+
+      expect(node).toHaveStyle('background-color: rgba(0, 0, 0, 0)')
+
+      fireEvent.mouseEnter(node)
+      expect(node).toHaveStyle('background-color: #cce5ff')
+
+      fireEvent.mouseLeave(node)
+      expect(node).toHaveStyle('background-color: rgba(0, 0, 0, 0)')
     })
   })
 
-  test('closes context menu when clicking outside', () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+  describe('Context Menu', () => {
+    test('opens context menu on right-click', () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
 
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-    expect(screen.getByText('Edit')).toBeInTheDocument()
-
-    // Click outside the context menu
-    fireEvent.mouseDown(document.body)
-
-    // Context menu should be closed
-    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
-  })
-
-  test('handles empty data', () => {
-    render(
-      <KeywordTree
-        data={[]}
-        onNodeDoubleClick={() => {}}
-        onNodeEdit={() => {}}
-      />
-    )
-
-    // The component should render without crashing
-    expect(screen.getByRole('tree')).toBeInTheDocument()
-  })
-
-  test('supports keyboard navigation in context menu', () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-
-    const editButton = screen.getByText('Edit')
-    editButton.focus()
-
-    // Simulate pressing Enter key
-    fireEvent.keyDown(editButton, {
-      key: 'Enter',
-      code: 'Enter'
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      expect(screen.getByText('Edit')).toBeInTheDocument()
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+      expect(screen.getByText('Delete')).toBeInTheDocument()
     })
 
-    // Context menu should be closed after selection
-    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    test('deletes a node', () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      fireEvent.click(screen.getByText('Delete'))
+
+      expect(screen.queryByText('Child 1')).not.toBeInTheDocument()
+    })
+
+    test('calls onNodeEdit when edit is selected from context menu', () => {
+      const onNodeEdit = vi.fn()
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={onNodeEdit} />)
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      fireEvent.click(screen.getByText('Edit'))
+
+      expect(onNodeEdit).toHaveBeenCalledWith(child1Uuid)
+    })
+
+    test('closes context menu when clicking outside', () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      expect(screen.getByText('Edit')).toBeInTheDocument()
+
+      fireEvent.mouseDown(document.body)
+
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
+
+    test('resets hovered index when mouse leaves context menu', async () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+
+      const editOption = screen.getByText('Edit')
+      fireEvent.mouseEnter(editOption)
+
+      expect(editOption).toHaveClass('hovered')
+
+      const contextMenu = screen.getByRole('menu')
+      fireEvent.mouseLeave(contextMenu)
+
+      await waitFor(() => {
+        expect(editOption).not.toHaveClass('hovered')
+      })
+    })
   })
 
-  test('handles add child cancellation', async () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+  describe('Keyboard Navigation', () => {
+    test('supports keyboard navigation in context menu', () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
 
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-    fireEvent.click(screen.getByText('Add Narrower'))
+      fireEvent.contextMenu(screen.getByText('Child 1'))
 
-    // Modal should be open
-    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+      const editButton = screen.getByText('Edit')
+      editButton.focus()
 
-    // Click Cancel
-    fireEvent.click(screen.getByText('Cancel'))
+      fireEvent.keyDown(editButton, {
+        key: 'Enter',
+        code: 'Enter'
+      })
 
-    // Wait for the modal to close
-    await waitFor(() => {
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
+
+    test('handles ArrowDown key in context menu', () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+
+      const contextMenu = screen.getByRole('menu')
+      const editOption = screen.getByText('Edit')
+      const addOption = screen.getByText('Add Narrower')
+      const deleteOption = screen.getByText('Delete')
+
+      contextMenu.focus()
+
+      fireEvent.keyDown(contextMenu, {
+        key: 'ArrowDown',
+        code: 'ArrowDown'
+      })
+
+      expect(editOption).toHaveClass('focused')
+
+      fireEvent.keyDown(contextMenu, {
+        key: 'ArrowDown',
+        code: 'ArrowDown'
+      })
+
+      expect(addOption).toHaveClass('focused')
+
+      fireEvent.keyDown(contextMenu, {
+        key: 'ArrowDown',
+        code: 'ArrowDown'
+      })
+
+      expect(deleteOption).toHaveClass('focused')
+
+      fireEvent.keyDown(contextMenu, {
+        key: 'ArrowDown',
+        code: 'ArrowDown'
+      })
+
+      expect(editOption).toHaveClass('focused')
+    })
+
+    test('handles ArrowUp key in context menu', () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+
+      const contextMenu = screen.getByRole('menu')
+      const editOption = screen.getByText('Edit')
+      const addOption = screen.getByText('Add Narrower')
+      const deleteOption = screen.getByText('Delete')
+
+      contextMenu.focus()
+
+      fireEvent.keyDown(contextMenu, {
+        key: 'ArrowUp',
+        code: 'ArrowUp'
+      })
+
+      expect(deleteOption).toHaveClass('focused')
+
+      fireEvent.keyDown(contextMenu, {
+        key: 'ArrowUp',
+        code: 'ArrowUp'
+      })
+
+      expect(addOption).toHaveClass('focused')
+
+      fireEvent.keyDown(contextMenu, {
+        key: 'ArrowUp',
+        code: 'ArrowUp'
+      })
+
+      expect(editOption).toHaveClass('focused')
+
+      fireEvent.keyDown(contextMenu, {
+        key: 'ArrowUp',
+        code: 'ArrowUp'
+      })
+
+      expect(deleteOption).toHaveClass('focused')
+    })
+
+    test('calls action and closes context menu when Enter is pressed on focused item', () => {
+      const onNodeEdit = vi.fn()
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={onNodeEdit} />)
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+
+      const contextMenu = screen.getByRole('menu')
+      contextMenu.focus()
+
+      fireEvent.keyDown(contextMenu, {
+        key: 'ArrowDown',
+        code: 'ArrowDown'
+      })
+
+      fireEvent.keyDown(contextMenu, {
+        key: 'Enter',
+        code: 'Enter'
+      })
+
+      expect(onNodeEdit).toHaveBeenCalledWith(child1Uuid)
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    })
+
+    test('closes context menu when Escape is pressed and does nothing for other keys', () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+
+      const contextMenu = screen.getByRole('menu')
+      expect(contextMenu).toBeInTheDocument()
+
+      fireEvent.keyDown(contextMenu, {
+        key: 'Escape',
+        code: 'Escape'
+      })
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      const newContextMenu = screen.getByRole('menu')
+
+      fireEvent.keyDown(newContextMenu, {
+        key: 'a',
+        code: 'KeyA'
+      })
+
+      expect(newContextMenu).toBeInTheDocument()
+    })
+  })
+
+  describe('Adding Child Nodes', () => {
+    test('handles add child cancellation', async () => {
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      fireEvent.click(screen.getByText('Add Narrower'))
+
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByText('Cancel'))
+
+      await waitFor(() => {
+        expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
+      })
+    })
+
+    test('handles cancelling add new child', async () => {
+      const user = userEvent.setup()
+
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      await user.click(screen.getByText('Add Narrower'))
+
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+
+      await user.type(screen.getByPlaceholderText('Enter Keyword'), 'Cancelled Child')
+      await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
       expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
-    })
-  })
-
-  test('resets hovered index when mouse leaves context menu', async () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-    // Open context menu
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-
-    // Hover over an option
-    const editOption = screen.getByText('Edit')
-    fireEvent.mouseEnter(editOption)
-
-    // Check that the option has the 'hovered' class
-    expect(editOption).toHaveClass('hovered')
-
-    // Move mouse out of the context menu
-    const contextMenu = screen.getByRole('menu')
-    fireEvent.mouseLeave(contextMenu)
-
-    // Wait for any asynchronous updates
-    await waitFor(() => {
-      expect(editOption).not.toHaveClass('hovered')
-    })
-  })
-
-  test('handles ArrowDown key in context menu', () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-
-    const contextMenu = screen.getByRole('menu')
-    const editOption = screen.getByText('Edit')
-    const addOption = screen.getByText('Add Narrower')
-    const deleteOption = screen.getByText('Delete')
-
-    contextMenu.focus()
-
-    // Press ArrowDown
-    fireEvent.keyDown(contextMenu, {
-      key: 'ArrowDown',
-      code: 'ArrowDown'
+      expect(screen.queryByText('Cancelled Child')).not.toBeInTheDocument()
     })
 
-    expect(editOption).toHaveClass('focused')
-    expect(addOption).not.toHaveClass('focused')
-    expect(deleteOption).not.toHaveClass('focused')
+    test('prevents adding empty keyword', async () => {
+      const user = userEvent.setup()
 
-    // Press ArrowDown again
-    fireEvent.keyDown(contextMenu, {
-      key: 'ArrowDown',
-      code: 'ArrowDown'
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      await user.click(screen.getByText('Add Narrower'))
+
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: 'Add' }))
+
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }))
     })
 
-    expect(editOption).not.toHaveClass('focused')
-    expect(addOption).toHaveClass('focused')
-    expect(deleteOption).not.toHaveClass('focused')
+    test('adds new child node', async () => {
+      const user = userEvent.setup()
+      const newChildUuid = 'new-child-uuid'
+      uuidv4.mockReturnValue(newChildUuid)
 
-    // Press ArrowDown on the last item
-    fireEvent.keyDown(contextMenu, {
-      key: 'ArrowDown',
-      code: 'ArrowDown'
+      const { rerender } = render(
+        <KeywordTree
+          data={mockData}
+          onNodeDoubleClick={() => {}}
+          onNodeEdit={() => {}}
+        />
+      )
+
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      await user.click(screen.getByText('Add Narrower'))
+
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+
+      await user.type(screen.getByPlaceholderText('Enter Keyword'), 'New Child')
+      await user.click(screen.getByRole('button', { name: 'Add' }))
+
+      await waitFor(() => {
+        expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
+      })
+
+      await waitFor(() => {})
+
+      rerender(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+
+      const treeItem = within(screen.getByRole('tree')).getByRole('treeitem', { name: /Child 1/i })
+      const possibleExpandButtons = within(treeItem).queryAllByRole('button')
+      const possibleExpandButton = possibleExpandButtons.length > 0
+        ? possibleExpandButtons[0]
+        : null
+
+      if (possibleExpandButton) {
+        await user.click(possibleExpandButton)
+      }
+
+      await waitFor(() => {
+        const newChildNode = screen.getByText('New Child')
+        expect(newChildNode).toBeInTheDocument()
+      }, { timeout: 2000 })
     })
 
-    expect(editOption).not.toHaveClass('focused')
-    expect(addOption).not.toHaveClass('focused')
-    expect(deleteOption).toHaveClass('focused')
+    test('handles adding child to a parent with leaf sibling nodes', async () => {
+      const user = userEvent.setup()
 
-    // Press ArrowDown again to wrap to the first item
-    fireEvent.keyDown(contextMenu, {
-      key: 'ArrowDown',
-      code: 'ArrowDown'
+      const mockDataWithLeaf = {
+        id: 'root',
+        key: 'root',
+        title: 'Root',
+        children: [
+          {
+            id: 'parent',
+            key: 'parent',
+            title: 'Parent',
+            children: []
+          },
+          {
+            id: 'leaf',
+            key: 'leaf',
+            title: 'Leaf',
+            children: undefined
+          }
+        ]
+      }
+
+      const { rerender } = render(
+        <KeywordTree
+          data={mockDataWithLeaf}
+          onNodeDoubleClick={() => {}}
+          onNodeEdit={() => {}}
+        />
+      )
+
+      fireEvent.contextMenu(screen.getByText('Parent'))
+      await user.click(screen.getByText('Add Narrower'))
+
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
+
+      await user.type(screen.getByPlaceholderText('Enter Keyword'), 'New Child')
+      await user.click(screen.getByRole('button', { name: 'Add' }))
+
+      await waitFor(() => {
+        expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
+      })
+
+      await waitFor(() => {})
+
+      rerender(
+        <KeywordTree
+          data={mockDataWithLeaf}
+          onNodeDoubleClick={() => {}}
+          onNodeEdit={() => {}}
+        />
+      )
+
+      const parentNodeContainer = screen.getByRole('treeitem', { name: /Parent/i })
+      const toggleButton = within(parentNodeContainer).getByRole('button')
+      await user.click(toggleButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('New Child')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('Leaf')).toBeInTheDocument()
     })
 
-    expect(editOption).toHaveClass('focused')
-    expect(addOption).not.toHaveClass('focused')
-    expect(deleteOption).not.toHaveClass('focused')
-  })
+    test('shows and hides add child modal', async () => {
+      const user = userEvent.setup()
 
-  test('handles ArrowUp key in context menu', () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+      render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
 
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-
-    const contextMenu = screen.getByRole('menu')
-    const editOption = screen.getByText('Edit')
-    const addOption = screen.getByText('Add Narrower')
-    const deleteOption = screen.getByText('Delete')
-
-    contextMenu.focus()
-
-    // Press ArrowUp (should highlight the last item)
-    fireEvent.keyDown(contextMenu, {
-      key: 'ArrowUp',
-      code: 'ArrowUp'
-    })
-
-    expect(editOption).not.toHaveClass('focused')
-    expect(addOption).not.toHaveClass('focused')
-    expect(deleteOption).toHaveClass('focused')
-
-    // Press ArrowUp again
-    fireEvent.keyDown(contextMenu, {
-      key: 'ArrowUp',
-      code: 'ArrowUp'
-    })
-
-    expect(editOption).not.toHaveClass('focused')
-    expect(addOption).toHaveClass('focused')
-    expect(deleteOption).not.toHaveClass('focused')
-
-    // Press ArrowUp to wrap to the last item
-    fireEvent.keyDown(contextMenu, {
-      key: 'ArrowUp',
-      code: 'ArrowUp'
-    })
-
-    expect(editOption).toHaveClass('focused')
-    expect(addOption).not.toHaveClass('focused')
-    expect(deleteOption).not.toHaveClass('focused')
-
-    // Press ArrowUp again to wrap to the last item
-    fireEvent.keyDown(contextMenu, {
-      key: 'ArrowUp',
-      code: 'ArrowUp'
-    })
-
-    expect(editOption).not.toHaveClass('focused')
-    expect(addOption).not.toHaveClass('focused')
-    expect(deleteOption).toHaveClass('focused')
-  })
-
-  test('calls action and closes context menu when Enter is pressed on focused item', () => {
-    const onNodeEdit = vi.fn()
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={onNodeEdit} />)
-
-    // Open context menu
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-
-    const contextMenu = screen.getByRole('menu')
-
-    // Focus the context menu
-    contextMenu.focus()
-
-    // Press ArrowDown to focus on the first item (Edit)
-    fireEvent.keyDown(contextMenu, {
-      key: 'ArrowDown',
-      code: 'ArrowDown'
-    })
-
-    // Press Enter to select the focused item
-    fireEvent.keyDown(contextMenu, {
-      key: 'Enter',
-      code: 'Enter'
-    })
-
-    // Check if the action was called
-    expect(onNodeEdit).toHaveBeenCalledWith(child1Uuid)
-
-    // Check if the context menu was closed
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
-  })
-
-  test('closes context menu when Escape is pressed and does nothing for other keys', () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-    // Open context menu
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-
-    const contextMenu = screen.getByRole('menu')
-
-    // Verify context menu is open
-    expect(contextMenu).toBeInTheDocument()
-
-    // Press Escape key
-    fireEvent.keyDown(contextMenu, {
-      key: 'Escape',
-      code: 'Escape'
-    })
-
-    // Check if the context menu was closed
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
-
-    // Open context menu again
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-
-    const newContextMenu = screen.getByRole('menu')
-
-    // Press an unhandled key
-    fireEvent.keyDown(newContextMenu, {
-      key: 'a',
-      code: 'KeyA'
-    })
-
-    // Check if the context menu is still open (default case)
-    expect(newContextMenu).toBeInTheDocument()
-  })
-
-  test('node changes background color on hover', async () => {
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-    const node = screen.getByText('Child 1')
-
-    // Check initial background color
-    expect(node).toHaveStyle('background-color: rgba(0, 0, 0, 0)')
-
-    // Simulate mouse enter
-    fireEvent.mouseEnter(node)
-
-    // Check background color after hover
-    expect(node).toHaveStyle('background-color: #cce5ff')
-
-    // Simulate mouse leave
-    fireEvent.mouseLeave(node)
-
-    // Check background color after mouse leave
-    expect(node).toHaveStyle('background-color: rgba(0, 0, 0, 0)')
-  })
-
-  test('handles cancelling add new child', async () => {
-    const user = userEvent.setup()
-
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-    // Open context menu for 'Child 1'
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-
-    // Click 'Add' in the context menu
-    await user.click(screen.getByText('Add Narrower'))
-
-    // Check if the modal is open
-    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-    // Type new keyword
-    await user.type(screen.getByPlaceholderText('Enter Keyword'), 'Cancelled Child')
-
-    // Click 'Cancel' button
-    await user.click(screen.getByRole('button', { name: 'Cancel' }))
-
-    // Check if the modal is closed
-    expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
-
-    // Check that the new child was not added
-    expect(screen.queryByText('Cancelled Child')).not.toBeInTheDocument()
-  })
-
-  test('prevents adding empty keyword', async () => {
-    const user = userEvent.setup()
-
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-    // Open context menu for 'Child 1'
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-
-    // Click 'Add' in the context menu
-    await user.click(screen.getByText('Add Narrower'))
-
-    // Check if the modal is open
-    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-    // Don't type anything (leave input empty)
-
-    // Click 'Add' button
-    await user.click(screen.getByRole('button', { name: 'Add' }))
-
-    // Check that the modal is still open (add was not performed)
-    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-    // Close the modal
-    await user.click(screen.getByRole('button', { name: 'Cancel' }))
-  })
-
-  test('adds new child node', async () => {
-    const user = userEvent.setup()
-    const newChildUuid = 'new-child-uuid'
-    uuidv4.mockReturnValue(newChildUuid)
-
-    const { rerender } = render(
-      <KeywordTree
-        data={mockData}
-        onNodeDoubleClick={() => {}}
-        onNodeEdit={() => {}}
-      />
-    )
-
-    // Open context menu for 'Child 1'
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-
-    // Click 'Add' in the context menu
-    await user.click(screen.getByText('Add Narrower'))
-
-    // Check if the modal is open
-    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-    // Type new keyword
-    await user.type(screen.getByPlaceholderText('Enter Keyword'), 'New Child')
-
-    // Click 'Add' button
-    await user.click(screen.getByRole('button', { name: 'Add' }))
-
-    // Check if the modal is closed
-    await waitFor(() => {
       expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
-    })
 
-    // Wait for any asynchronous updates
-    await waitFor(() => {})
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      await user.click(screen.getByText('Add Narrower'))
 
-    // Force a re-render with the updated data
-    rerender(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
+      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
 
-    // Find the tree item containing 'Child 1'
-    const treeItem = within(screen.getByRole('tree')).getByRole('treeitem', { name: /Child 1/i })
+      await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
-    // Check if there's any clickable element within this tree item
-    const possibleExpandButtons = within(treeItem).queryAllByRole('button')
-
-    // Find the first button that might be used for expanding (usually the first button in the tree item)
-    const possibleExpandButton = possibleExpandButtons.length > 0 ? possibleExpandButtons[0] : null
-
-    // If there's a clickable element, click it to potentially expand 'Child 1'
-    if (possibleExpandButton) {
-      await user.click(possibleExpandButton)
-    }
-
-    // Check that the new child is visible
-    await waitFor(() => {
-      const newChildNode = screen.getByText('New Child')
-      expect(newChildNode).toBeInTheDocument()
-    }, { timeout: 2000 })
-  })
-
-  test('handles adding child to a parent with leaf sibling nodes', async () => {
-    const user = userEvent.setup()
-
-    // Create a mock data structure with a leaf node
-    const mockDataWithLeaf = {
-      id: 'root',
-      key: 'root',
-      title: 'Root',
-      children: [
-        {
-          id: 'parent',
-          key: 'parent',
-          title: 'Parent',
-          children: []
-        },
-        {
-          id: 'leaf',
-          key: 'leaf',
-          title: 'Leaf',
-          children: undefined // This is a leaf node
-        }
-      ]
-    }
-
-    const { rerender } = render(
-      <KeywordTree
-        data={mockDataWithLeaf}
-        onNodeDoubleClick={() => {}}
-        onNodeEdit={() => {}}
-      />
-    )
-
-    // Open context menu for 'Parent'
-    fireEvent.contextMenu(screen.getByText('Parent'))
-
-    // Click 'Add Narrower' in the context menu
-    await user.click(screen.getByText('Add Narrower'))
-
-    // Check if the modal is open
-    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-    // Type new keyword
-    await user.type(screen.getByPlaceholderText('Enter Keyword'), 'New Child')
-
-    // Click 'Add' button
-    await user.click(screen.getByRole('button', { name: 'Add' }))
-
-    // Check if the modal is closed
-    await waitFor(() => {
-      expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
-    })
-
-    // Wait for any asynchronous updates
-    await waitFor(() => {})
-
-    // Force a re-render with the updated data
-    rerender(
-      <KeywordTree
-        data={mockDataWithLeaf}
-        onNodeDoubleClick={() => {}}
-        onNodeEdit={() => {}}
-      />
-    )
-
-    // Find the 'Parent' node container
-    const parentNodeContainer = screen.getByRole('treeitem', { name: /Parent/i })
-
-    // Find the toggle button for 'Parent' node
-    const toggleButton = within(parentNodeContainer).getByRole('button')
-
-    // Click the toggle button to expand 'Parent' node
-    await user.click(toggleButton)
-
-    // Now check that the new child was added to 'Parent'
-    await waitFor(() => {
-      expect(screen.getByText('New Child')).toBeInTheDocument()
-    })
-
-    // Check that 'Leaf' node still exists and wasn't modified
-    expect(screen.getByText('Leaf')).toBeInTheDocument()
-  })
-
-  test('shows and hides add child modal', async () => {
-    const user = userEvent.setup()
-
-    render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
-
-    // Initially, the modal should not be in the document
-    expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
-
-    // Open context menu for 'Child 1'
-    fireEvent.contextMenu(screen.getByText('Child 1'))
-
-    // Click 'Add Narrower' in the context menu
-    await user.click(screen.getByText('Add Narrower'))
-
-    // Check if the modal is open
-    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-    // Close the modal
-    await user.click(screen.getByRole('button', { name: 'Cancel' }))
-
-    // Check if the modal is closed
-    await waitFor(() => {
-      expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
+      })
     })
   })
 })

--- a/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
+++ b/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
@@ -87,7 +87,7 @@ describe('KeywordTree', () => {
 
     fireEvent.contextMenu(screen.getByText('Child 1'))
     expect(screen.getByText('Edit')).toBeInTheDocument()
-    expect(screen.getByText('Add')).toBeInTheDocument()
+    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
     expect(screen.getByText('Delete')).toBeInTheDocument()
   })
 
@@ -202,17 +202,17 @@ describe('KeywordTree', () => {
     render(<KeywordTree data={mockData} onNodeDoubleClick={() => {}} onNodeEdit={() => {}} />)
 
     fireEvent.contextMenu(screen.getByText('Child 1'))
-    fireEvent.click(screen.getByText('Add'))
+    fireEvent.click(screen.getByText('Add Narrower'))
 
     // Modal should be open
-    expect(screen.getByText('Add Keyword')).toBeInTheDocument()
+    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
 
     // Click Cancel
     fireEvent.click(screen.getByText('Cancel'))
 
     // Wait for the modal to close
     await waitFor(() => {
-      expect(screen.queryByText('Add Keyword')).not.toBeInTheDocument()
+      expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
     })
   })
 
@@ -246,7 +246,7 @@ describe('KeywordTree', () => {
 
     const contextMenu = screen.getByRole('menu')
     const editOption = screen.getByText('Edit')
-    const addOption = screen.getByText('Add')
+    const addOption = screen.getByText('Add Narrower')
     const deleteOption = screen.getByText('Delete')
 
     contextMenu.focus()
@@ -299,7 +299,7 @@ describe('KeywordTree', () => {
 
     const contextMenu = screen.getByRole('menu')
     const editOption = screen.getByText('Edit')
-    const addOption = screen.getByText('Add')
+    const addOption = screen.getByText('Add Narrower')
     const deleteOption = screen.getByText('Delete')
 
     contextMenu.focus()
@@ -441,10 +441,10 @@ describe('KeywordTree', () => {
     fireEvent.contextMenu(screen.getByText('Child 1'))
 
     // Click 'Add' in the context menu
-    await user.click(screen.getByText('Add'))
+    await user.click(screen.getByText('Add Narrower'))
 
     // Check if the modal is open
-    expect(screen.getByText('Add Keyword')).toBeInTheDocument()
+    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
 
     // Type new keyword
     await user.type(screen.getByPlaceholderText('Enter Keyword'), 'Cancelled Child')
@@ -453,7 +453,7 @@ describe('KeywordTree', () => {
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
     // Check if the modal is closed
-    expect(screen.queryByText('Add Keyword')).not.toBeInTheDocument()
+    expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
 
     // Check that the new child was not added
     expect(screen.queryByText('Cancelled Child')).not.toBeInTheDocument()
@@ -468,10 +468,10 @@ describe('KeywordTree', () => {
     fireEvent.contextMenu(screen.getByText('Child 1'))
 
     // Click 'Add' in the context menu
-    await user.click(screen.getByText('Add'))
+    await user.click(screen.getByText('Add Narrower'))
 
     // Check if the modal is open
-    expect(screen.getByText('Add Keyword')).toBeInTheDocument()
+    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
 
     // Don't type anything (leave input empty)
 
@@ -479,7 +479,7 @@ describe('KeywordTree', () => {
     await user.click(screen.getByRole('button', { name: 'Add' }))
 
     // Check that the modal is still open (add was not performed)
-    expect(screen.getByText('Add Keyword')).toBeInTheDocument()
+    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
 
     // Close the modal
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
@@ -496,10 +496,10 @@ describe('KeywordTree', () => {
     fireEvent.contextMenu(screen.getByText('Child 1'))
 
     // Click 'Add' in the context menu
-    await user.click(screen.getByText('Add'))
+    await user.click(screen.getByText('Add Narrower'))
 
     // Check if the modal is open
-    expect(screen.getByText('Add Keyword')).toBeInTheDocument()
+    expect(screen.getByText('Add Narrower')).toBeInTheDocument()
 
     // Type new keyword
     await user.type(screen.getByPlaceholderText('Enter Keyword'), 'New Child')
@@ -509,7 +509,7 @@ describe('KeywordTree', () => {
 
     // Check if the modal is closed
     await waitFor(() => {
-      expect(screen.queryByText('Add Keyword')).not.toBeInTheDocument()
+      expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
     })
 
     // Wait for any asynchronous updates

--- a/static/src/js/components/KeywordTreeContextMenu/KeywordTreeContextMenu.jsx
+++ b/static/src/js/components/KeywordTreeContextMenu/KeywordTreeContextMenu.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import React, { useState } from 'react'
 
 import './KeywordTreeContextMenu.scss'
 
@@ -102,7 +102,6 @@ export const KeywordTreeContextMenu = ({
             }
             onKeyDown={
               (e) => {
-                console.log('KeyDown event triggered', e.key)
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault()
                   option.action()

--- a/static/src/js/components/KeywordTreeContextMenu/__tests__/KeywordTreeContextMenu.test.jsx
+++ b/static/src/js/components/KeywordTreeContextMenu/__tests__/KeywordTreeContextMenu.test.jsx
@@ -13,7 +13,7 @@ import {
 } from 'vitest'
 import { KeywordTreeContextMenu } from '../KeywordTreeContextMenu'
 
-describe('KeywordTreeContextMenu component', () => {
+describe('KeywordTreeContextMenu', () => {
   const mockOptions = [
     {
       id: 'edit',
@@ -40,161 +40,155 @@ describe('KeywordTreeContextMenu component', () => {
     />
   )
 
-  describe('when rendering and positioning context menu', () => {
-    test('should render the context menu with correct options', () => {
-      renderComponent()
-      expect(screen.getByText('Edit')).toBeDefined()
-      expect(screen.getByText('Delete')).toBeDefined()
-    })
-
-    test('should position the context menu correctly', () => {
-      renderComponent()
-      const menu = screen.getByRole('menu')
-      expect(menu.style.top).toBe('100px')
-      expect(menu.style.left).toBe('100px')
-    })
+  test('renders the context menu with correct options', () => {
+    renderComponent()
+    expect(screen.getByText('Edit')).toBeDefined()
+    expect(screen.getByText('Delete')).toBeDefined()
   })
 
-  describe('when user interacts with context menu', () => {
-    test('should call action and onClose when an option is clicked', () => {
-      renderComponent()
-      fireEvent.click(screen.getByText('Edit'))
-      expect(mockOptions[0].action).toHaveBeenCalled()
-      expect(mockOnClose).toHaveBeenCalled()
-    })
-
-    test('should handle keyboard navigation', () => {
-      renderComponent()
-      const menu = screen.getByRole('menu')
-
-      // Focus the menu
-      fireEvent.focus(menu)
-
-      // Press arrow down
-      fireEvent.keyDown(menu, { key: 'ArrowDown' })
-      expect(screen.getByText('Edit').classList.contains('focused')).toBe(true)
-
-      // Press arrow down again
-      fireEvent.keyDown(menu, { key: 'ArrowDown' })
-      expect(screen.getByText('Delete').classList.contains('focused')).toBe(true)
-
-      // Press arrow up
-      fireEvent.keyDown(menu, { key: 'ArrowUp' })
-      expect(screen.getByText('Edit').classList.contains('focused')).toBe(true)
-    })
-
-    test('should select option with Enter key', () => {
-      renderComponent()
-      const menu = screen.getByRole('menu')
-
-      fireEvent.focus(menu)
-      fireEvent.keyDown(menu, { key: 'ArrowDown' })
-      fireEvent.keyDown(menu, { key: 'Enter' })
-
-      expect(mockOptions[0].action).toHaveBeenCalled()
-      expect(mockOnClose).toHaveBeenCalled()
-    })
-
-    test('closes menu with Escape key', () => {
-      renderComponent()
-      const menu = screen.getByRole('menu')
-
-      fireEvent.keyDown(menu, { key: 'Escape' })
-      expect(mockOnClose).toHaveBeenCalled()
-    })
-
-    test('should select option with Enter or Space key on individual menu item', async () => {
-      const user = userEvent.setup()
-
-      const mockPreventDefault = vi.fn()
-      const originalPreventDefault = Event.prototype.preventDefault
-      Event.prototype.preventDefault = mockPreventDefault
-
-      renderComponent()
-      const editOption = screen.getByText('Edit')
-
-      // Test Enter key
-      await user.type(editOption, '{Enter}')
-
-      expect(mockPreventDefault).toHaveBeenCalled()
-      expect(mockOptions[0].action).toHaveBeenCalled()
-      expect(mockOnClose).toHaveBeenCalled()
-
-      // Reset mocks
-      mockPreventDefault.mockClear()
-      mockOptions[0].action.mockClear()
-      mockOnClose.mockClear()
-
-      // Test Space key
-      await user.type(editOption, ' ')
-
-      expect(mockPreventDefault).toHaveBeenCalled()
-      expect(mockOptions[0].action).toHaveBeenCalled()
-      expect(mockOnClose).toHaveBeenCalled()
-
-      // Restore original preventDefault
-      Event.prototype.preventDefault = originalPreventDefault
-    })
+  test('positions the context menu correctly', () => {
+    renderComponent()
+    const menu = screen.getByRole('menu')
+    expect(menu.style.top).toBe('100px')
+    expect(menu.style.left).toBe('100px')
   })
 
-  describe('when user interacts using mouse or keys', () => {
-    test('should reset hovered state on mouse leave', () => {
-      render(
-        <KeywordTreeContextMenu
-          x={100}
-          y={100}
-          onClose={mockOnClose}
-          options={mockOptions}
-          forwardedRef={mockRef}
-        />
-      )
+  test('calls action and onClose when an option is clicked', () => {
+    renderComponent()
+    fireEvent.click(screen.getByText('Edit'))
+    expect(mockOptions[0].action).toHaveBeenCalled()
+    expect(mockOnClose).toHaveBeenCalled()
+  })
 
-      const menuContainer = screen.getByRole('menu')
-      const editOption = screen.getByText('Edit')
+  test('handles keyboard navigation', () => {
+    renderComponent()
+    const menu = screen.getByRole('menu')
 
-      // Simulate mouse enter on an option
-      fireEvent.mouseEnter(editOption)
-      expect(editOption).toHaveClass('hovered')
+    // Focus the menu
+    fireEvent.focus(menu)
 
-      // Simulate mouse leave on the entire menu
-      fireEvent.mouseLeave(menuContainer)
+    // Press arrow down
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(screen.getByText('Edit').classList.contains('focused')).toBe(true)
 
-      // Check that the hovered class is removed
-      expect(editOption).not.toHaveClass('hovered')
+    // Press arrow down again
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(screen.getByText('Delete').classList.contains('focused')).toBe(true)
+
+    // Press arrow up
+    fireEvent.keyDown(menu, { key: 'ArrowUp' })
+    expect(screen.getByText('Edit').classList.contains('focused')).toBe(true)
+  })
+
+  test('selects option with Enter key', () => {
+    renderComponent()
+    const menu = screen.getByRole('menu')
+
+    fireEvent.focus(menu)
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    fireEvent.keyDown(menu, { key: 'Enter' })
+
+    expect(mockOptions[0].action).toHaveBeenCalled()
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  test('closes menu with Escape key', () => {
+    renderComponent()
+    const menu = screen.getByRole('menu')
+
+    fireEvent.keyDown(menu, { key: 'Escape' })
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  test('selects option with Enter or Space key on individual menu item', async () => {
+    const user = userEvent.setup()
+
+    const mockPreventDefault = vi.fn()
+    const originalPreventDefault = Event.prototype.preventDefault
+    Event.prototype.preventDefault = mockPreventDefault
+
+    renderComponent()
+    const editOption = screen.getByText('Edit')
+
+    // Test Enter key
+    await user.type(editOption, '{Enter}')
+
+    expect(mockPreventDefault).toHaveBeenCalled()
+    expect(mockOptions[0].action).toHaveBeenCalled()
+    expect(mockOnClose).toHaveBeenCalled()
+
+    // Reset mocks
+    mockPreventDefault.mockClear()
+    mockOptions[0].action.mockClear()
+    mockOnClose.mockClear()
+
+    // Test Space key
+    await user.type(editOption, ' ')
+
+    expect(mockPreventDefault).toHaveBeenCalled()
+    expect(mockOptions[0].action).toHaveBeenCalled()
+    expect(mockOnClose).toHaveBeenCalled()
+
+    // Restore original preventDefault
+    Event.prototype.preventDefault = originalPreventDefault
+  })
+
+  test('resets hovered state on mouse leave', () => {
+    render(
+      <KeywordTreeContextMenu
+        x={100}
+        y={100}
+        onClose={mockOnClose}
+        options={mockOptions}
+        forwardedRef={mockRef}
+      />
+    )
+
+    const menuContainer = screen.getByRole('menu')
+    const editOption = screen.getByText('Edit')
+
+    // Simulate mouse enter on an option
+    fireEvent.mouseEnter(editOption)
+    expect(editOption).toHaveClass('hovered')
+
+    // Simulate mouse leave on the entire menu
+    fireEvent.mouseLeave(menuContainer)
+
+    // Check that the hovered class is removed
+    expect(editOption).not.toHaveClass('hovered')
+  })
+
+  test('does not change state for unhandled keys', () => {
+    render(
+      <KeywordTreeContextMenu
+        x={100}
+        y={100}
+        onClose={mockOnClose}
+        options={mockOptions}
+        forwardedRef={mockRef}
+      />
+    )
+
+    const menuContainer = screen.getByRole('menu')
+
+    // Spy on console.log to check if any unexpected logging occurs
+    const consoleSpy = vi.spyOn(console, 'log')
+
+    // Trigger an unhandled key event
+    fireEvent.keyDown(menuContainer, { key: 'A' })
+
+    // Verify that onClose was not called
+    expect(mockOnClose).not.toHaveBeenCalled()
+
+    // Verify that no options were activated
+    mockOptions.forEach((option) => {
+      expect(option.action).not.toHaveBeenCalled()
     })
 
-    test('should not change state for unhandled keys', () => {
-      render(
-        <KeywordTreeContextMenu
-          x={100}
-          y={100}
-          onClose={mockOnClose}
-          options={mockOptions}
-          forwardedRef={mockRef}
-        />
-      )
+    // Verify that no unexpected console logs occurred
+    expect(consoleSpy).not.toHaveBeenCalled()
 
-      const menuContainer = screen.getByRole('menu')
-
-      // Spy on console.log to check if any unexpected logging occurs
-      const consoleSpy = vi.spyOn(console, 'log')
-
-      // Trigger an unhandled key event
-      fireEvent.keyDown(menuContainer, { key: 'A' })
-
-      // Verify that onClose was not called
-      expect(mockOnClose).not.toHaveBeenCalled()
-
-      // Verify that no options were activated
-      mockOptions.forEach((option) => {
-        expect(option.action).not.toHaveBeenCalled()
-      })
-
-      // Verify that no unexpected console logs occurred
-      expect(consoleSpy).not.toHaveBeenCalled()
-
-      // Clean up the spy
-      consoleSpy.mockRestore()
-    })
+    // Clean up the spy
+    consoleSpy.mockRestore()
   })
 })

--- a/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.jsx
+++ b/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.jsx
@@ -40,7 +40,16 @@ import './KeywordTreeCustomNode.scss'
  * />
  */
 export const KeywordTreeCustomNode = ({
-  node, style, dragHandle, onDelete, searchTerm, setContextMenu, onToggle, onEdit, onNodeClick, handleAdd
+  node,
+  style,
+  dragHandle,
+  onDelete,
+  searchTerm,
+  setContextMenu,
+  onToggle,
+  onEdit,
+  onNodeClick,
+  handleAdd
 }) => {
   const [isHovered, setIsHovered] = useState(false)
   const handleTriangleClick = (e) => {

--- a/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.jsx
+++ b/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import React, { useState } from 'react'
 
 import './KeywordTreeCustomNode.scss'
 
@@ -11,44 +11,36 @@ import './KeywordTreeCustomNode.scss'
  *
  * @component
  * @param {Object} props
- * @param {Function|Object} props.dragHandle - Ref or function for drag handle
- * @param {Function} props.handleAdd - Callback function to add a child node
  * @param {Object} props.node - The node data object
+ * @param {Object} props.style - Inline styles for the node
+ * @param {Function|Object} props.dragHandle - Ref or function for drag handle
  * @param {Function} props.onDelete - Callback function to delete a node
+ * @param {Function} props.setContextMenu - Function to set the context menu
+ * @param {Function} props.onToggle - Callback function to toggle node expansion
  * @param {Function} props.onEdit - Callback function to edit a node
  * @param {Function} props.onNodeClick - Callback function for node click
- * @param {Function} props.onToggle - Callback function to toggle node expansion
- * @param {Function} props.setContextMenu - Function to set the context menu
- * @param {Object} props.style - Inline styles for the node
+ * @param {Function} props.handleAdd - Callback function to add a child node
  *
  * @example
  * <CustomNode
- *   dragHandle={dragHandleRef}
- *   handleAdd={(parentId) => console.log('Add child to', parentId)}
  *   node={{
  *     id: '1',
  *     data: { title: 'Node 1', children: [] },
  *     isOpen: false,
  *     toggle: () => {}
  *   }}
+ *   style={{}}
+ *   dragHandle={dragHandleRef}
  *   onDelete={(id) => console.log('Delete node', id)}
+ *   setContextMenu={(menu) => setContextMenu(menu)}
+ *   onToggle={(node) => node.toggle()}
  *   onEdit={(id) => console.log('Edit node', id)}
  *   onNodeClick={(id) => console.log('Click on node', id)}
- *   onToggle={(node) => node.toggle()}
- *   setContextMenu={(menu) => setContextMenu(menu)}
- *   style={{}}
+ *   handleAdd={(parentId) => console.log('Add child to', parentId)}
  * />
  */
 export const KeywordTreeCustomNode = ({
-  dragHandle,
-  handleAdd,
-  node,
-  onDelete,
-  onEdit,
-  onNodeClick,
-  onToggle,
-  setContextMenu,
-  style
+  node, style, dragHandle, onDelete, searchTerm, setContextMenu, onToggle, onEdit, onNodeClick, handleAdd
 }) => {
   const [isHovered, setIsHovered] = useState(false)
   const handleTriangleClick = (e) => {
@@ -80,6 +72,36 @@ export const KeywordTreeCustomNode = ({
       ]
     }
     setContextMenu(newContextMenu)
+  }
+
+  let backgroundColor = 'transparent'
+  if (node.isSelected) {
+    backgroundColor = '#99ccff'
+  } else if (isHovered) {
+    backgroundColor = '#cce5ff'
+  }
+
+  const highlightSearchTerm = (text, term) => {
+    if (!term) {
+      // Return the original text if there is no search term
+      return text
+    }
+
+    // Define a regular expression to match the search term, case-insensitive
+    const regex = new RegExp(`(${term})`, 'gi')
+    // Split the text by the search term regex
+    const parts = text.split(regex)
+
+    // Map over each part, applying <strong> tags to the matched term parts
+    return parts.map((part, index) => {
+      const key = `${part}-${index}` // This still uses index but further distinguished with text content
+
+      if (regex.test(part)) {
+        return <strong key={key}>{part}</strong>
+      }
+
+      return part
+    })
   }
 
   return (
@@ -130,11 +152,11 @@ export const KeywordTreeCustomNode = ({
           className="keyword-tree__node-text"
           style={
             {
-              backgroundColor: isHovered ? '#cce5ff' : 'transparent'
+              backgroundColor
             }
           }
         >
-          {node.data.title}
+          {highlightSearchTerm(node.data.title, searchTerm)}
         </span>
       </div>
     </div>
@@ -148,29 +170,32 @@ const NodeShape = {
 NodeShape.children = PropTypes.arrayOf(PropTypes.shape(NodeShape))
 
 KeywordTreeCustomNode.propTypes = {
-  dragHandle: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) })
-  ]),
-  handleAdd: PropTypes.func.isRequired,
   node: PropTypes.shape({
     data: PropTypes.shape({
       title: PropTypes.string.isRequired,
       children: NodeShape.children
     }).isRequired,
     isOpen: PropTypes.bool.isRequired,
+    isSelected: PropTypes.bool.isRequired,
     toggle: PropTypes.func.isRequired,
     id: PropTypes.string.isRequired
   }).isRequired,
+  style: PropTypes.shape({}),
+  dragHandle: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+  ]),
   onDelete: PropTypes.func.isRequired,
+  searchTerm: PropTypes.string,
+  setContextMenu: PropTypes.func.isRequired,
+  onToggle: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
   onNodeClick: PropTypes.func.isRequired,
-  onToggle: PropTypes.func.isRequired,
-  setContextMenu: PropTypes.func.isRequired,
-  style: PropTypes.shape({})
+  handleAdd: PropTypes.func.isRequired
 }
 
 KeywordTreeCustomNode.defaultProps = {
-  dragHandle: null,
-  style: {}
+  searchTerm: null,
+  style: {},
+  dragHandle: null
 }

--- a/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.scss
+++ b/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.scss
@@ -18,15 +18,15 @@
   }
 
   &__icon-button {
+    align-items: center;
+    background: none;
+    block-size: 24px;
+    border: none;
+    cursor: pointer;
     display: flex;
     inline-size: 24px;
-    block-size: 24px;
-    align-items: center;
     justify-content: center;
     padding: 0 5px;
-    border: none;
-    background: none;
-    cursor: pointer;
   }
 
   &__triangle-icon {

--- a/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.scss
+++ b/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.scss
@@ -18,21 +18,21 @@
   }
 
   &__icon-button {
-    align-items: center;
     background: none;
-    block-size: 24px;
+    display: flex;                 
+    align-items: center;
+    justify-content: center;       
     border: none;
-    cursor: pointer;
-    display: flex;
+    block-size: 24px;
     inline-size: 24px;
-    justify-content: center;
+    cursor: pointer;
     padding: 0 5px;
   }
 
   &__triangle-icon {
-    padding-block-start: 6px;
-    font-size: 25px;
+    font-size: 25px;               
     line-height: 1;
+    padding-block-start: 6px;
   }
 
   &__caret-icon {
@@ -40,9 +40,9 @@
   }
 
   &__text-wrapper {
+    align-items: center;           
     display: flex;
     block-size: 100%;
-    align-items: center;
   }
 
   &__node-text {

--- a/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.scss
+++ b/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.scss
@@ -14,13 +14,13 @@
   &__icon-wrapper {
     display: flex;
     align-items: center;
-    padding-bottom: 6px;
+    padding-block-end: 6px;
   }
 
   &__icon-button {
     display: flex;
-    width: 24px;
-    height: 24px;
+    inline-size: 24px;
+    block-size: 24px;
     align-items: center;
     justify-content: center;
     padding: 0 5px;
@@ -30,7 +30,7 @@
   }
 
   &__triangle-icon {
-    padding-top: 6px;
+    padding-block-start: 6px;
     font-size: 25px;
     line-height: 1;
   }
@@ -41,7 +41,7 @@
 
   &__text-wrapper {
     display: flex;
-    height: 100%;
+    block-size: 100%;
     align-items: center;
   }
 

--- a/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.scss
+++ b/static/src/js/components/KeywordTreeCustomNode/KeywordTreeCustomNode.scss
@@ -18,15 +18,15 @@
   }
 
   &__icon-button {
-    background: none;
     display: flex;                 
     align-items: center;
-    justify-content: center;       
+    justify-content: center;
+    padding: 0 5px;       
     border: none;
+    background: none;
     block-size: 24px;
-    inline-size: 24px;
     cursor: pointer;
-    padding: 0 5px;
+    inline-size: 24px;
   }
 
   &__triangle-icon {
@@ -39,9 +39,9 @@
     font-size: 0.60em;
   }
 
-  &__text-wrapper {
-    align-items: center;           
+  &__text-wrapper {           
     display: flex;
+    align-items: center;
     block-size: 100%;
   }
 

--- a/static/src/js/components/KeywordTreeCustomNode/__tests__/KeywordTreeCustomNode.test.jsx
+++ b/static/src/js/components/KeywordTreeCustomNode/__tests__/KeywordTreeCustomNode.test.jsx
@@ -8,7 +8,7 @@ import {
 import { vi } from 'vitest'
 import { KeywordTreeCustomNode } from '../KeywordTreeCustomNode'
 
-describe('KeywordTreeCustomNode component', () => {
+describe('KeywordTreeCustomNode', () => {
   const defaultProps = {
     node: {
       id: '1',
@@ -28,191 +28,186 @@ describe('KeywordTreeCustomNode component', () => {
     onNodeClick: vi.fn(),
     handleAdd: vi.fn()
   }
-  describe('When rendering', () => {
-    test('should render node title correctly', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      expect(screen.getByText('Node 1')).toBeInTheDocument()
-    })
 
-    test('should render caret-down icon when node is open', () => {
-      const nodeWithChildren = {
-        ...defaultProps.node,
-        isOpen: true,
-        data: {
-          ...defaultProps.node.data,
-          children: [{
-            id: 'child1',
-            title: 'Child 1'
-          }]
-        }
-      }
-      render(<KeywordTreeCustomNode {...defaultProps} node={nodeWithChildren} />)
-
-      const toggleButton = screen.getByRole('button', { name: /Toggle Node 1/i })
-
-      expect(toggleButton).toHaveClass('keyword-tree__triangle-icon')
-      expect(toggleButton).toHaveTextContent('') // The button should be empty (icon is not text)
-
-      const caretIcon = within(toggleButton).getByRole('img', { hidden: true })
-      expect(caretIcon).toHaveClass('fa-caret-down', 'keyword-tree__caret-icon')
-    })
-
-    test('should render caret-right icon when node is closed', () => {
-      const nodeWithChildren = {
-        ...defaultProps.node,
-        data: {
-          ...defaultProps.node.data,
-          children: [{
-            id: 'child1',
-            title: 'Child 1'
-          }]
-        }
-      }
-      render(<KeywordTreeCustomNode {...defaultProps} node={nodeWithChildren} />)
-
-      const toggleButton = screen.getByRole('button', { name: /Toggle Node 1/i })
-
-      expect(toggleButton).toHaveClass('keyword-tree__triangle-icon')
-      expect(toggleButton).toHaveTextContent('') // The button should be empty (icon is not text)
-
-      const caretIcon = within(toggleButton).getByRole('img', { hidden: true })
-      expect(caretIcon).toHaveClass('fa-caret-right', 'keyword-tree__caret-icon')
-    })
-
-    test('should not render toggle button for nodes without children', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      expect(screen.queryByRole('button', { name: /Toggle Node 1/i })).not.toBeInTheDocument()
-    })
+  test('renders node title correctly', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    expect(screen.getByText('Node 1')).toBeInTheDocument()
   })
 
-  describe('when interactions', () => {
-    test('should call onToggle when triangle icon is clicked', () => {
-      const nodeWithChildren = {
-        ...defaultProps.node,
-        data: {
-          ...defaultProps.node.data,
-          children: [{
-            id: 'child1',
-            title: 'Child 1'
-          }]
-        }
+  test('calls onToggle when triangle icon is clicked', () => {
+    const nodeWithChildren = {
+      ...defaultProps.node,
+      data: {
+        ...defaultProps.node.data,
+        children: [{
+          id: 'child1',
+          title: 'Child 1'
+        }]
       }
-      render(<KeywordTreeCustomNode {...defaultProps} node={nodeWithChildren} />)
+    }
+    render(<KeywordTreeCustomNode {...defaultProps} node={nodeWithChildren} />)
 
-      const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
-      const triangleIcon = within(nodeContent).getByRole('button', { name: /Toggle Node 1/i })
+    const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
+    const triangleIcon = within(nodeContent).getByRole('button', { name: /Toggle Node 1/i })
 
-      fireEvent.click(triangleIcon)
-      expect(defaultProps.onToggle).toHaveBeenCalledWith(nodeWithChildren)
-    })
-
-    test('should call onNodeClick when node is clicked', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
-      fireEvent.click(nodeContent)
-      expect(defaultProps.onNodeClick).toHaveBeenCalledWith('1')
-    })
-
-    test('should show context menu on right click', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
-      fireEvent.contextMenu(nodeContent)
-      expect(defaultProps.setContextMenu).toHaveBeenCalled()
-    })
-
-    test('should change background color on hover', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
-      const nodeText = within(nodeContent).getByText('Node 1')
-
-      // Check initial state (not hovered)
-      expect(window.getComputedStyle(nodeText).backgroundColor).not.toBe('rgb(204, 229, 255)')
-
-      // Hover
-      fireEvent.mouseEnter(nodeContent)
-      expect(window.getComputedStyle(nodeText).backgroundColor).toBe('rgb(204, 229, 255)')
-
-      // Un-hover
-      fireEvent.mouseLeave(nodeContent)
-      expect(window.getComputedStyle(nodeText).backgroundColor).not.toBe('rgb(204, 229, 255)')
-    })
-
-    test('should call onNodeClick when Enter key is pressed', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
-      fireEvent.keyDown(nodeContent, { key: 'Enter' })
-      expect(defaultProps.onNodeClick).toHaveBeenCalledWith('1')
-    })
-
-    test('should call onNodeClick when Space key is pressed', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
-      fireEvent.keyDown(nodeContent, { key: ' ' })
-      expect(defaultProps.onNodeClick).toHaveBeenCalledWith('1')
-    })
-
-    test('should not call onNodeClick for other key presses', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
-      fireEvent.keyDown(nodeContent, { key: 'A' })
-      expect(defaultProps.onNodeClick).not.toHaveBeenCalled()
-    })
+    fireEvent.click(triangleIcon)
+    expect(defaultProps.onToggle).toHaveBeenCalledWith(nodeWithChildren)
   })
 
-  describe('when rendering Context Menu', () => {
-    test('should render correct context menu options', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
-      fireEvent.contextMenu(nodeContent)
+  test('calls onNodeClick when node is clicked', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
+    fireEvent.click(nodeContent)
+    expect(defaultProps.onNodeClick).toHaveBeenCalledWith('1')
+  })
 
-      expect(defaultProps.setContextMenu).toHaveBeenCalledWith(
-        expect.objectContaining({
-          options: expect.arrayContaining([
-            expect.objectContaining({
-              id: 'edit',
-              label: 'Edit'
-            }),
-            expect.objectContaining({
-              id: 'add-child',
-              label: 'Add Narrower'
-            }),
-            expect.objectContaining({
-              id: 'delete',
-              label: 'Delete'
-            })
-          ])
-        })
-      )
-    })
+  test('shows context menu on right click', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
+    fireEvent.contextMenu(nodeContent)
+    expect(defaultProps.setContextMenu).toHaveBeenCalled()
+  })
 
-    test('should call onEdit when click on context menu edit', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
-      fireEvent.contextMenu(nodeContent)
+  test('changes background color on hover', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
+    const nodeText = within(nodeContent).getByText('Node 1')
 
-      const editAction = defaultProps.setContextMenu.mock.calls[0][0].options.find((option) => option.id === 'edit').action
-      editAction()
-      expect(defaultProps.onEdit).toHaveBeenCalledWith('1')
-    })
+    // Check initial state (not hovered)
+    expect(window.getComputedStyle(nodeText).backgroundColor).not.toBe('rgb(204, 229, 255)')
 
-    test('should call handleAdd when click on context menu add narrower', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
-      fireEvent.contextMenu(nodeContent)
+    // Hover
+    fireEvent.mouseEnter(nodeContent)
+    expect(window.getComputedStyle(nodeText).backgroundColor).toBe('rgb(204, 229, 255)')
 
-      const addChildAction = defaultProps.setContextMenu.mock.calls[0][0].options.find((option) => option.id === 'add-child').action
-      addChildAction()
-      expect(defaultProps.handleAdd).toHaveBeenCalledWith('1')
-    })
+    // Un-hover
+    fireEvent.mouseLeave(nodeContent)
+    expect(window.getComputedStyle(nodeText).backgroundColor).not.toBe('rgb(204, 229, 255)')
+  })
 
-    test('should call onDelete when click on context menu delete', () => {
-      render(<KeywordTreeCustomNode {...defaultProps} />)
-      const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
-      fireEvent.contextMenu(nodeContent)
+  test('renders caret-down icon when node is open', () => {
+    const nodeWithChildren = {
+      ...defaultProps.node,
+      isOpen: true,
+      data: {
+        ...defaultProps.node.data,
+        children: [{
+          id: 'child1',
+          title: 'Child 1'
+        }]
+      }
+    }
+    render(<KeywordTreeCustomNode {...defaultProps} node={nodeWithChildren} />)
 
-      const deleteAction = defaultProps.setContextMenu.mock.calls[0][0].options.find((option) => option.id === 'delete').action
-      deleteAction()
-      expect(defaultProps.onDelete).toHaveBeenCalledWith('1')
-    })
+    const toggleButton = screen.getByRole('button', { name: /Toggle Node 1/i })
+
+    expect(toggleButton).toHaveClass('keyword-tree__triangle-icon')
+    expect(toggleButton).toHaveTextContent('') // The button should be empty (icon is not text)
+
+    const caretIcon = within(toggleButton).getByRole('img', { hidden: true })
+    expect(caretIcon).toHaveClass('fa-caret-down', 'keyword-tree__caret-icon')
+  })
+
+  test('renders caret-right icon when node is closed', () => {
+    const nodeWithChildren = {
+      ...defaultProps.node,
+      data: {
+        ...defaultProps.node.data,
+        children: [{
+          id: 'child1',
+          title: 'Child 1'
+        }]
+      }
+    }
+    render(<KeywordTreeCustomNode {...defaultProps} node={nodeWithChildren} />)
+
+    const toggleButton = screen.getByRole('button', { name: /Toggle Node 1/i })
+
+    expect(toggleButton).toHaveClass('keyword-tree__triangle-icon')
+    expect(toggleButton).toHaveTextContent('') // The button should be empty (icon is not text)
+
+    const caretIcon = within(toggleButton).getByRole('img', { hidden: true })
+    expect(caretIcon).toHaveClass('fa-caret-right', 'keyword-tree__caret-icon')
+  })
+
+  test('does not render toggle button for nodes without children', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    expect(screen.queryByRole('button', { name: /Toggle Node 1/i })).not.toBeInTheDocument()
+  })
+
+  test('calls onNodeClick when Enter key is pressed', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
+    fireEvent.keyDown(nodeContent, { key: 'Enter' })
+    expect(defaultProps.onNodeClick).toHaveBeenCalledWith('1')
+  })
+
+  test('calls onNodeClick when Space key is pressed', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
+    fireEvent.keyDown(nodeContent, { key: ' ' })
+    expect(defaultProps.onNodeClick).toHaveBeenCalledWith('1')
+  })
+
+  test('does not call onNodeClick for other key presses', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
+    fireEvent.keyDown(nodeContent, { key: 'A' })
+    expect(defaultProps.onNodeClick).not.toHaveBeenCalled()
+  })
+
+  test('renders correct context menu options', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
+    fireEvent.contextMenu(nodeContent)
+
+    expect(defaultProps.setContextMenu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'edit',
+            label: 'Edit'
+          }),
+          expect.objectContaining({
+            id: 'add-child',
+            label: 'Add Narrower'
+          }),
+          expect.objectContaining({
+            id: 'delete',
+            label: 'Delete'
+          })
+        ])
+      })
+    )
+  })
+
+  test('context menu edit option calls onEdit', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
+    fireEvent.contextMenu(nodeContent)
+
+    const editAction = defaultProps.setContextMenu.mock.calls[0][0].options.find((option) => option.id === 'edit').action
+    editAction()
+    expect(defaultProps.onEdit).toHaveBeenCalledWith('1')
+  })
+
+  test('context menu add-child option calls handleAdd', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
+    fireEvent.contextMenu(nodeContent)
+
+    const addChildAction = defaultProps.setContextMenu.mock.calls[0][0].options.find((option) => option.id === 'add-child').action
+    addChildAction()
+    expect(defaultProps.handleAdd).toHaveBeenCalledWith('1')
+  })
+
+  test('context menu delete option calls onDelete', () => {
+    render(<KeywordTreeCustomNode {...defaultProps} />)
+    const nodeContent = screen.getByRole('button', { name: /Keyword: Node 1/i })
+    fireEvent.contextMenu(nodeContent)
+
+    const deleteAction = defaultProps.setContextMenu.mock.calls[0][0].options.find((option) => option.id === 'delete').action
+    deleteAction()
+    expect(defaultProps.onDelete).toHaveBeenCalledWith('1')
   })
 })

--- a/static/src/js/components/KeywordTreeCustomNode/__tests__/KeywordTreeCustomNode.test.jsx
+++ b/static/src/js/components/KeywordTreeCustomNode/__tests__/KeywordTreeCustomNode.test.jsx
@@ -210,4 +210,51 @@ describe('KeywordTreeCustomNode', () => {
     deleteAction()
     expect(defaultProps.onDelete).toHaveBeenCalledWith('1')
   })
+
+  describe('when a search pattern is provided', () => {
+    describe('when a match occurs', () => {
+      test('should highlight matched search term in node title', () => {
+        const propsWithSearchTerm = {
+          ...defaultProps,
+          searchTerm: 'Node'
+        }
+        render(<KeywordTreeCustomNode {...propsWithSearchTerm} />)
+        
+        const highlightedText = screen.getByText((content, element) => {
+          return element.tagName.toLowerCase() === 'strong' && content === 'Node'
+        })
+
+        expect(highlightedText).toBeInTheDocument()
+      })
+    })
+    describe('when a match does not occur', () => {
+      test('renders node title without changes', () => {
+        const propsWithNoMatchTerm = {
+          ...defaultProps,
+          searchTerm: 'NoMatch'
+        }
+        render(<KeywordTreeCustomNode {...propsWithNoMatchTerm} />)
+
+        const regularText = screen.getByText('Node 1')
+
+        expect(regularText).toBeInTheDocument()
+        expect(regularText.tagName.toLowerCase()).not.toBe('strong')
+      })
+    })
+    describe('when search term is empty', () => {
+      test('should render node title without changes', () => {
+        const propsWithEmptySearchTerm = {
+          ...defaultProps,
+          searchTerm: ''
+        }
+        render(<KeywordTreeCustomNode {...propsWithEmptySearchTerm} />)
+
+        const regularText = screen.getByText('Node 1')
+
+        expect(regularText).toBeInTheDocument()
+        expect(regularText.tagName.toLowerCase()).not.toBe('strong')
+      })  
+    })
+  })
+
 })

--- a/static/src/js/components/KeywordTreeCustomNode/__tests__/KeywordTreeCustomNode.test.jsx
+++ b/static/src/js/components/KeywordTreeCustomNode/__tests__/KeywordTreeCustomNode.test.jsx
@@ -219,14 +219,13 @@ describe('KeywordTreeCustomNode', () => {
           searchTerm: 'Node'
         }
         render(<KeywordTreeCustomNode {...propsWithSearchTerm} />)
-        
-        const highlightedText = screen.getByText((content, element) => {
-          return element.tagName.toLowerCase() === 'strong' && content === 'Node'
-        })
+
+        const highlightedText = screen.getByText((content, element) => element.tagName.toLowerCase() === 'strong' && content === 'Node')
 
         expect(highlightedText).toBeInTheDocument()
       })
     })
+
     describe('when a match does not occur', () => {
       test('renders node title without changes', () => {
         const propsWithNoMatchTerm = {
@@ -241,6 +240,7 @@ describe('KeywordTreeCustomNode', () => {
         expect(regularText.tagName.toLowerCase()).not.toBe('strong')
       })
     })
+
     describe('when search term is empty', () => {
       test('should render node title without changes', () => {
         const propsWithEmptySearchTerm = {
@@ -253,8 +253,7 @@ describe('KeywordTreeCustomNode', () => {
 
         expect(regularText).toBeInTheDocument()
         expect(regularText.tagName.toLowerCase()).not.toBe('strong')
-      })  
+      })
     })
   })
-
 })

--- a/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.jsx
+++ b/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.jsx
@@ -2,16 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import './KeywordTreePlaceHolder.scss'
-/**
- * KeywordTreePlaceHolder Component
- *
- * This component renders a placeholder message for the keyword tree.
- * It's typically used when the keyword tree is empty or loading.
- *
- * @param {Object} props - The component props
- * @param {string} props.message - The message to display in the placeholder
- * @returns {React.Element} A div containing the placeholder message
- */
+
 export const KeywordTreePlaceHolder = ({ message }) => (
   <div className="keyword-tree-placeholder">
     {message}

--- a/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.jsx
+++ b/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.jsx
@@ -1,5 +1,5 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 
 import './KeywordTreePlaceHolder.scss'
 

--- a/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
+++ b/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
@@ -4,8 +4,8 @@
 
 .keyword-tree-placeholder {
   display: flex;
-  width: 100%;
-  height: 300px;
+  inline-size: 100%;
+  block-size: 300px;
   align-items: center;
   justify-content: center;
   border: 1px solid $gray-300;

--- a/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
+++ b/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
@@ -4,10 +4,10 @@
 
 .keyword-tree-placeholder {
   align-items: center;
-  block-size: 300px;
-  border-radius: 4px;
-  border: 1px solid $gray-300;
   display: flex;
-  inline-size: 100%;
+  border: 1px solid $gray-300;
+  border-radius: 4px;
+  block-size: 300px;
   justify-content: center;
+  inline-size: 100%;
 }

--- a/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
+++ b/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
@@ -3,11 +3,11 @@
 @import '../../../css/vendor/bootstrap/variables';
 
 .keyword-tree-placeholder {
+  align-items: center;
+  block-size: 300px;
+  border-radius: 4px;
+  border: 1px solid $gray-300;
   display: flex;
   inline-size: 100%;
-  block-size: 300px;
-  align-items: center;
   justify-content: center;
-  border: 1px solid $gray-300;
-  border-radius: 4px;
 }

--- a/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
+++ b/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
@@ -3,11 +3,11 @@
 @import '../../../css/vendor/bootstrap/variables';
 
 .keyword-tree-placeholder {
-  align-items: center;
   display: flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid $gray-300;
   border-radius: 4px;
   block-size: 300px;
-  justify-content: center;
   inline-size: 100%;
 }

--- a/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
+++ b/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
@@ -1,4 +1,6 @@
-@import '../../../../css/vendor/bootstrap/variables';
+@use "sass:map";
+
+@import '../../../css/vendor/bootstrap/variables';
 
 .keyword-tree-placeholder {
   display: flex;

--- a/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
+++ b/static/src/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder.scss
@@ -1,6 +1,4 @@
-@use "sass:map";
-
-@import '../../../css/vendor/bootstrap/variables';
+@import '../../../../css/vendor/bootstrap/variables';
 
 .keyword-tree-placeholder {
   display: flex;

--- a/static/src/js/components/KeywordTreePlaceHolder/__tests__/KeywordTreePlaceHolder.test.jsx
+++ b/static/src/js/components/KeywordTreePlaceHolder/__tests__/KeywordTreePlaceHolder.test.jsx
@@ -8,21 +8,19 @@ import {
 import { KeywordTreePlaceHolder } from '../KeywordTreePlaceHolder'
 
 describe('KeywordTreePlaceholder component', () => {
-  describe('when rendering', () => {
-    test('should display the provided message', () => {
-      const testMessage = 'Test placeholder message'
-      render(<KeywordTreePlaceHolder message={testMessage} />)
+  test('renders with the provided message', () => {
+    const testMessage = 'Test placeholder message'
+    render(<KeywordTreePlaceHolder message={testMessage} />)
 
-      const placeholderElement = screen.getByText(testMessage)
-      expect(placeholderElement).toBeTruthy()
-      expect(placeholderElement).toHaveClass('keyword-tree-placeholder')
-    })
+    const placeholderElement = screen.getByText(testMessage)
+    expect(placeholderElement).toBeTruthy()
+    expect(placeholderElement).toHaveClass('keyword-tree-placeholder')
+  })
 
-    test('should apply correct CSS classes', () => {
-      render(<KeywordTreePlaceHolder message="Test message" />)
+  test('applies correct CSS classes', () => {
+    render(<KeywordTreePlaceHolder message="Test message" />)
 
-      const placeholderElement = screen.getByText('Test message')
-      expect(placeholderElement).toHaveClass('keyword-tree-placeholder')
-    })
+    const placeholderElement = screen.getByText('Test message')
+    expect(placeholderElement).toHaveClass('keyword-tree-placeholder')
   })
 })

--- a/static/src/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector.jsx
+++ b/static/src/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector.jsx
@@ -100,9 +100,7 @@ const KmsConceptSchemeSelector = ({ version, defaultScheme, onSchemeSelect }) =>
 
 KmsConceptSchemeSelector.propTypes = {
   defaultScheme: PropTypes.shape({
-    description: PropTypes.string,
-    maxLength: PropTypes.number,
-    type: PropTypes.string
+    name: PropTypes.string
   }),
   version: PropTypes.shape({
     version: PropTypes.string,
@@ -111,7 +109,7 @@ KmsConceptSchemeSelector.propTypes = {
   onSchemeSelect: PropTypes.func
 }
 
-KmsConceptSchemeSelector.defaultProps = {  
+KmsConceptSchemeSelector.defaultProps = {
   defaultScheme: null,
   version: null,
   onSchemeSelect: () => {}

--- a/static/src/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector.jsx
+++ b/static/src/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector.jsx
@@ -99,7 +99,11 @@ const KmsConceptSchemeSelector = ({ version, defaultScheme, onSchemeSelect }) =>
 }
 
 KmsConceptSchemeSelector.propTypes = {
-  defaultScheme: PropTypes.string,
+  defaultScheme: PropTypes.shape({
+    description: PropTypes.string,
+    maxLength: PropTypes.number,
+    type: PropTypes.string
+  }),
   version: PropTypes.shape({
     version: PropTypes.string,
     version_type: PropTypes.string
@@ -107,7 +111,7 @@ KmsConceptSchemeSelector.propTypes = {
   onSchemeSelect: PropTypes.func
 }
 
-KmsConceptSchemeSelector.defaultProps = {
+KmsConceptSchemeSelector.defaultProps = {  
   defaultScheme: null,
   version: null,
   onSchemeSelect: () => {}

--- a/static/src/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector.jsx
+++ b/static/src/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector.jsx
@@ -1,8 +1,7 @@
-import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
+import React, { useEffect, useState } from 'react'
 import Select from 'react-select'
-import Row from 'react-bootstrap/Row'
-import Col from 'react-bootstrap/Col'
+
 import getKmsConceptSchemes from '@/js/utils/getKmsConceptSchemes'
 
 /**
@@ -15,7 +14,7 @@ import getKmsConceptSchemes from '@/js/utils/getKmsConceptSchemes'
  * @param {string} props.version - The version of KMS to fetch schemes for
  * @param {function} props.onSchemeSelect - Callback function triggered when a scheme is selected
  */
-const KmsConceptSchemeSelector = ({ version, onSchemeSelect }) => {
+const KmsConceptSchemeSelector = ({ version, defaultScheme, onSchemeSelect }) => {
   // State for storing the list of schemes
   const [schemes, setSchemes] = useState([])
   // State for storing the currently selected scheme
@@ -55,14 +54,12 @@ const KmsConceptSchemeSelector = ({ version, onSchemeSelect }) => {
 
         // Select the first option
         if (options.length > 0) {
-          const firstOption = options[0]
-          setSelectedScheme(firstOption)
-          onSchemeSelect({
-            name: firstOption.value,
-            longName: firstOption.label,
-            updateDate: firstOption.updateDate,
-            csvHeaders: firstOption.csvHeaders
-          })
+          if (defaultScheme) {
+            const matchingScheme = options.find((option) => option.value === defaultScheme?.name)
+            if (matchingScheme) {
+              setSelectedScheme(matchingScheme)
+            }
+          }
         }
 
         setLoading(false)
@@ -91,23 +88,18 @@ const KmsConceptSchemeSelector = ({ version, onSchemeSelect }) => {
   }
 
   return (
-    <Row className="mb-4">
-      <Col>
-        <div className="rounded p-3">
-          <Select
-            isLoading={loading}
-            options={schemes}
-            value={selectedScheme}
-            onChange={handleChange}
-            placeholder="Loading schemes..."
-          />
-        </div>
-      </Col>
-    </Row>
+    <Select
+      isLoading={loading}
+      options={schemes}
+      value={selectedScheme ?? defaultScheme}
+      onChange={handleChange}
+      placeholder="Select scheme..."
+    />
   )
 }
 
 KmsConceptSchemeSelector.propTypes = {
+  defaultScheme: PropTypes.string,
   version: PropTypes.shape({
     version: PropTypes.string,
     version_type: PropTypes.string
@@ -116,6 +108,7 @@ KmsConceptSchemeSelector.propTypes = {
 }
 
 KmsConceptSchemeSelector.defaultProps = {
+  defaultScheme: null,
   version: null,
   onSchemeSelect: () => {}
 }

--- a/static/src/js/components/KmsConceptSchemeSelector/__tests__/KmsConceptSchemeSelector.test.jsx
+++ b/static/src/js/components/KmsConceptSchemeSelector/__tests__/KmsConceptSchemeSelector.test.jsx
@@ -36,7 +36,7 @@ describe('KmsConceptSchemeSelector', () => {
   describe('when component is initially rendered', () => {
     test('should display loading state', () => {
       render(<KmsConceptSchemeSelector version={mockVersion} onSchemeSelect={mockOnSchemeSelect} />)
-      expect(screen.getByText('Loading schemes...')).toBeInTheDocument()
+      expect(screen.getByText('Select scheme...')).toBeInTheDocument()
     })
   })
 
@@ -76,33 +76,6 @@ describe('KmsConceptSchemeSelector', () => {
 
       expect(getKmsConceptSchemes).toHaveBeenCalledWith(mockVersion)
     })
-
-    test('should select first scheme by default and call onSchemeSelect', async () => {
-      const mockSchemes = [
-        {
-          name: 'Scheme 1',
-          updateDate: '2023-01-01',
-          csvHeaders: ['header1', 'header2']
-        },
-        {
-          name: 'Scheme 2',
-          updateDate: '2023-01-02',
-          csvHeaders: ['header3', 'header4']
-        }
-      ]
-      getKmsConceptSchemes.mockResolvedValue({ schemes: mockSchemes })
-
-      render(<KmsConceptSchemeSelector version={mockVersion} onSchemeSelect={mockOnSchemeSelect} />)
-
-      await waitFor(() => {
-        expect(mockOnSchemeSelect).toHaveBeenCalledWith({
-          name: 'Scheme 1',
-          longName: 'Scheme 1',
-          updateDate: '2023-01-01',
-          csvHeaders: ['header1', 'header2']
-        })
-      })
-    })
   })
 
   describe('when user selects a new scheme', () => {
@@ -123,12 +96,29 @@ describe('KmsConceptSchemeSelector', () => {
 
       render(<KmsConceptSchemeSelector version={mockVersion} onSchemeSelect={mockOnSchemeSelect} />)
 
+      // Open the dropdown
+      const selectElement = screen.getByRole('combobox')
+      await userEvent.click(selectElement)
+
+      // Assert options are in the document
       await waitFor(() => {
-        expect(screen.getByText('Scheme 1')).toBeInTheDocument()
+        expect(screen.getByText('Select scheme...')).toBeInTheDocument()
       })
 
-      await userEvent.click(screen.getByText('Scheme 1'))
-      await userEvent.click(screen.getByText('Scheme 2'))
+      // Wait for options to appear
+      await waitFor(() => {
+        const option1 = screen.getByRole('option', { name: 'Scheme 1' })
+        expect(option1).toBeInTheDocument()
+      })
+
+      // Select the first option
+      const option1 = screen.getByText('Scheme 1')
+      await userEvent.click(option1)
+
+      // Reopen dropdown and select 'Scheme 2'
+      await userEvent.click(selectElement)
+      const option2 = screen.getByRole('option', { name: 'Scheme 2' })
+      await userEvent.click(option2)
 
       expect(mockOnSchemeSelect).toHaveBeenCalledWith({
         name: 'Scheme 2',
@@ -150,7 +140,7 @@ describe('KmsConceptSchemeSelector', () => {
         expect(console.error).toHaveBeenCalledWith('Error fetching schemes:', expect.any(Error))
       })
 
-      expect(screen.getByText('Loading schemes...')).toBeInTheDocument()
+      expect(screen.getByText('Select scheme...')).toBeInTheDocument()
     })
   })
 
@@ -172,7 +162,7 @@ describe('KmsConceptSchemeSelector', () => {
         />
       )
       await waitFor(() => {
-        expect(screen.getByText('Scheme 1')).toBeInTheDocument()
+        expect(screen.getByText('Select scheme...')).toBeInTheDocument()
       })
 
       rerender(<KmsConceptSchemeSelector version={null} onSchemeSelect={mockOnSchemeSelect} />)
@@ -180,7 +170,7 @@ describe('KmsConceptSchemeSelector', () => {
       await waitFor(() => {})
 
       expect(screen.queryByText('Scheme 1')).toBeNull()
-      expect(screen.getByText('Loading schemes...')).toBeInTheDocument()
+      expect(screen.getByText('Select scheme...')).toBeInTheDocument()
       expect(getKmsConceptSchemes).toHaveBeenCalledTimes(1)
     })
   })
@@ -208,8 +198,12 @@ describe('KmsConceptSchemeSelector', () => {
 
       render(<KmsConceptSchemeSelector version={mockVersion} onSchemeSelect={mockOnSchemeSelect} />)
 
+      const selectElement = screen.getByRole('combobox')
+      await userEvent.click(selectElement)
+
       await waitFor(() => {
-        expect(screen.queryByText('Loading schemes...')).not.toBeInTheDocument()
+        const options = screen.getAllByRole('option')
+        expect(options.length).toBe(3)
       })
 
       expect(screen.getByText('A Scheme')).toBeInTheDocument()
@@ -224,13 +218,6 @@ describe('KmsConceptSchemeSelector', () => {
       expect(dropdownOptions[0]).toHaveTextContent('A Scheme')
       expect(dropdownOptions[1]).toHaveTextContent('B Scheme')
       expect(dropdownOptions[2]).toHaveTextContent('C Scheme')
-
-      expect(mockOnSchemeSelect).toHaveBeenCalledWith({
-        name: 'A Scheme',
-        longName: 'A Scheme',
-        updateDate: '2023-01-02',
-        csvHeaders: ['header3', 'header4']
-      })
     })
   })
 
@@ -257,8 +244,12 @@ describe('KmsConceptSchemeSelector', () => {
 
       render(<KmsConceptSchemeSelector version={mockVersion} onSchemeSelect={mockOnSchemeSelect} />)
 
+      const selectElement = screen.getByRole('combobox')
+      await userEvent.click(selectElement)
+
       await waitFor(() => {
-        expect(screen.queryByText('Loading schemes...')).not.toBeInTheDocument()
+        const options = screen.getAllByRole('option')
+        expect(options.length).toBe(3)
       })
 
       expect(screen.getByText('A Scheme')).toBeInTheDocument()
@@ -287,35 +278,6 @@ describe('KmsConceptSchemeSelector', () => {
 
       expect(mockOnSchemeSelect).not.toHaveBeenCalled()
     })
-
-    test('should select first option when schemes are loaded', async () => {
-      const mockSchemes = [
-        {
-          name: 'Scheme 1',
-          updateDate: '2023-01-01',
-          csvHeaders: ['header1']
-        },
-        {
-          name: 'Scheme 2',
-          updateDate: '2023-01-02',
-          csvHeaders: ['header2']
-        }
-      ]
-      getKmsConceptSchemes.mockResolvedValue({ schemes: mockSchemes })
-
-      render(<KmsConceptSchemeSelector version={mockVersion} onSchemeSelect={mockOnSchemeSelect} />)
-
-      await waitFor(() => {
-        expect(screen.getByText('Scheme 1')).toBeInTheDocument()
-      })
-
-      expect(mockOnSchemeSelect).toHaveBeenCalledWith({
-        name: 'Scheme 1',
-        longName: 'Scheme 1',
-        updateDate: '2023-01-01',
-        csvHeaders: ['header1']
-      })
-    })
   })
 
   describe('when onSchemeSelect prop is not provided', () => {
@@ -343,7 +305,7 @@ describe('KmsConceptSchemeSelector', () => {
 
       // Check if the correct option is selected
       await waitFor(() => {
-        expect(screen.getByText('Scheme 1')).toBeInTheDocument()
+        expect(screen.getByText('Select scheme...')).toBeInTheDocument()
       })
 
       // Attempt to change the selected scheme
@@ -385,8 +347,13 @@ describe('KmsConceptSchemeSelector', () => {
           onSchemeSelect={mockOnSchemeSelect}
         />
       )
+
+      let selectElement = screen.getByRole('combobox')
+      await userEvent.click(selectElement)
+
       await waitFor(() => {
-        expect(screen.getByText('Initial Scheme')).toBeInTheDocument()
+        const options = screen.getAllByRole('option')
+        expect(options.length).toBe(1)
       })
 
       getKmsConceptSchemes.mockResolvedValueOnce({ schemes: updatedMockSchemes })
@@ -402,6 +369,15 @@ describe('KmsConceptSchemeSelector', () => {
         />
       )
 
+      selectElement = screen.getByRole('combobox')
+
+      await userEvent.click(selectElement)
+
+      await waitFor(() => {
+        const options = screen.getAllByRole('option')
+        expect(options.length).toBe(1)
+      })
+
       await waitFor(() => {
         expect(screen.getByText('Updated Scheme')).toBeInTheDocument()
       })
@@ -409,12 +385,36 @@ describe('KmsConceptSchemeSelector', () => {
       expect(getKmsConceptSchemes).toHaveBeenCalledTimes(2)
       expect(getKmsConceptSchemes).toHaveBeenNthCalledWith(1, mockVersion)
       expect(getKmsConceptSchemes).toHaveBeenNthCalledWith(2, updatedVersion)
+    })
+  })
 
-      expect(mockOnSchemeSelect).toHaveBeenCalledWith({
-        name: 'Updated Scheme',
-        longName: 'Updated Scheme',
-        updateDate: '2023-01-02',
-        csvHeaders: ['header2']
+  describe('when defaultScheme matches an option', () => {
+    test('should select the default scheme initially', async () => {
+      const mockSchemes = [
+        {
+          name: 'Scheme 1',
+          updateDate: '2023-01-01',
+          csvHeaders: ['header1', 'header2']
+        },
+        {
+          name: 'Scheme 2',
+          updateDate: '2023-01-02',
+          csvHeaders: ['header3', 'header4']
+        }
+      ]
+      getKmsConceptSchemes.mockResolvedValue({ schemes: mockSchemes })
+
+      render(
+        <KmsConceptSchemeSelector
+          version={mockVersion}
+          defaultScheme={{ name: 'Scheme 1' }}
+          onSchemeSelect={mockOnSchemeSelect}
+        />
+      )
+
+      await waitFor(() => {
+        const selectElement = screen.getByText('Scheme 1')
+        expect(selectElement).toBeInTheDocument()
       })
     })
   })

--- a/static/src/js/components/KmsConceptSchemeSelector/__tests__/KmsConceptSchemeSelector.test.jsx
+++ b/static/src/js/components/KmsConceptSchemeSelector/__tests__/KmsConceptSchemeSelector.test.jsx
@@ -1,12 +1,14 @@
-import React from 'react'
 import {
   render,
   screen,
   waitFor
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import React from 'react'
 import { vi } from 'vitest'
+
 import getKmsConceptSchemes from '@/js/utils/getKmsConceptSchemes'
+
 import KmsConceptSchemeSelector from '../KmsConceptSchemeSelector'
 
 vi.mock('@/js/utils/getKmsConceptSchemes')

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
@@ -11,13 +11,21 @@ import KmsConceptSchemeSelector from '@/js/components/KmsConceptSchemeSelector/K
 import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
 
 import './KmsConceptSelectionEditModal.scss'
+import { KeywordTreePlaceHolder } from '@/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder'
 
-const TreePlaceholder = ({ message }) => (
-  <div className="kms-concept-selection-edit-modal__tree-placeholder">
-    {message}
-  </div>
-)
-
+/**
+ * KmsConceptSelectionEditModal component provides an interface to edit keyword selections
+ * within a modal. It allows users to select a scheme, search for keywords, and apply their changes.
+ *
+ * @param {Object} props - React component props.
+ * @param {boolean} props.show - Determines if the modal is visible.
+ * @param {Function} props.toggleModal - Function to toggle the modal visibility.
+ * @param {string} props.uuid - UUID of the selected keyword.
+ * @param {Object} props.version - Object containing version details like version and version_type.
+ * @param {Object} props.scheme - Object containing scheme details.
+ * @param {Function} props.handleAcceptChanges - Callback function when changes are accepted.
+ * @returns {JSX.Element} The complete modal component for editing keyword selections.
+ */
 export const KmsConceptSelectionEditModal = ({
   show,
   toggleModal,
@@ -107,7 +115,7 @@ export const KmsConceptSelectionEditModal = ({
 
   const renderTree = () => {
     if (isTreeLoading) {
-      return <TreePlaceholder message="Loading..." />
+      return <KeywordTreePlaceHolder message="Loading..." />
     }
 
     const schemeSelectorId = selectedScheme?.name
@@ -157,7 +165,7 @@ export const KmsConceptSelectionEditModal = ({
               onNodeClick={onHandleSelectKeyword}
               openAll={!!searchPatternApplied && searchPatternApplied.trim() !== ''}
             />
-          ) : <TreePlaceholder message={treeMessage} />
+          ) : <KeywordTreePlaceHolder message={treeMessage} />
         }
       </div>
     )
@@ -185,10 +193,6 @@ export const KmsConceptSelectionEditModal = ({
       }
     />
   )
-}
-
-TreePlaceholder.propTypes = {
-  message: PropTypes.string.isRequired
 }
 
 KmsConceptSelectionEditModal.propTypes = {

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
@@ -132,7 +132,7 @@ export const KmsConceptSelectionEditModal = ({
             Scheme:
           </label>
           <KmsConceptSchemeSelector
-            defaultScheme={scheme}
+            defaultScheme={selectedScheme || scheme}
             id={uuid}
             key={uuid}
             onSchemeSelect={onSchemeSelect}

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
@@ -29,12 +29,12 @@ import {
  * @returns {JSX.Element} The complete modal component for editing keyword selections.
  */
 export const KmsConceptSelectionEditModal = ({
+  handleAcceptChanges,
+  scheme,
   show,
   toggleModal,
   uuid,
-  version,
-  scheme,
-  handleAcceptChanges
+  version
 }) => {
   const [treeData, setTreeData] = useState(null)
   const [selectedScheme, setSelectedScheme] = useState(scheme)
@@ -132,21 +132,21 @@ export const KmsConceptSelectionEditModal = ({
             Scheme:
           </label>
           <KmsConceptSchemeSelector
-            key={uuid}
-            id={uuid}
-            version={version}
             defaultScheme={scheme}
+            id={uuid}
+            key={uuid}
             onSchemeSelect={onSchemeSelect}
+            version={version}
           />
         </div>
         <div className="kms-concept-selection-edit-modal__tree-wrapper">
           <input
-            type="text"
-            placeholder="Search by Pattern or UUID"
             className="kms-concept-selection-edit-modal__search-input"
-            value={searchPattern}
             onChange={onHandleSearchInputChange}
             onKeyDown={onHandleKeyDown}
+            placeholder="Search by Pattern or UUID"
+            type="text"
+            value={searchPattern}
           />
           <button
             type="button"
@@ -159,13 +159,13 @@ export const KmsConceptSelectionEditModal = ({
         {
           treeData ? (
             <KeywordTree
-              key={`${uuid}`}
               data={treeData}
+              key={`${uuid}`}
+              onNodeClick={onHandleSelectKeyword}
+              openAll={!!searchPatternApplied && searchPatternApplied.trim() !== ''}
               searchTerm={searchPatternApplied}
               selectedNodeId={uuid}
               showContextMenu={false}
-              onNodeClick={onHandleSelectKeyword}
-              openAll={!!searchPatternApplied && searchPatternApplied.trim() !== ''}
             />
           ) : <KeywordTreePlaceHolder message={treeMessage} />
         }
@@ -198,15 +198,15 @@ export const KmsConceptSelectionEditModal = ({
 }
 
 KmsConceptSelectionEditModal.propTypes = {
-  uuid: PropTypes.string.isRequired,
-  show: PropTypes.bool.isRequired,
-  toggleModal: PropTypes.func.isRequired,
-  version: PropTypes.shape({
-    version: PropTypes.string,
-    version_type: PropTypes.string
-  }).isRequired,
+  handleAcceptChanges: PropTypes.func.isRequired,
   scheme: PropTypes.shape({
     name: PropTypes.string
   }).isRequired,
-  handleAcceptChanges: PropTypes.func.isRequired
+  show: PropTypes.bool.isRequired,
+  toggleModal: PropTypes.func.isRequired,
+  uuid: PropTypes.string.isRequired,
+  version: PropTypes.shape({
+    version: PropTypes.string,
+    version_type: PropTypes.string
+  }).isRequired
 }

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
@@ -53,6 +53,8 @@ export const KmsConceptSelectionEditModal = ({
       } finally {
         setIsTreeLoading(false)
       }
+    } else {
+      setTreeMessage('Select a version and scheme to load the tree')
     }
   }
 
@@ -60,8 +62,6 @@ export const KmsConceptSelectionEditModal = ({
     if (version && selectedScheme) {
       setTreeMessage('Loading...')
       fetchTreeData(version, selectedScheme, searchPatternApplied)
-    } else {
-      setTreeMessage('Select a version and scheme to load the tree')
     }
   }, [show, version, selectedScheme, searchPatternApplied])
 
@@ -110,7 +110,7 @@ export const KmsConceptSelectionEditModal = ({
       return <TreePlaceholder message="Loading..." />
     }
 
-    const schemeSelectorId = selectedScheme.name
+    const schemeSelectorId = selectedScheme?.name
 
     return (
       <div>

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
@@ -11,7 +11,9 @@ import KmsConceptSchemeSelector from '@/js/components/KmsConceptSchemeSelector/K
 import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
 
 import './KmsConceptSelectionEditModal.scss'
-import { KeywordTreePlaceHolder } from '@/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder'
+import {
+  KeywordTreePlaceHolder
+} from '@/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder'
 
 /**
  * KmsConceptSelectionEditModal component provides an interface to edit keyword selections

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
@@ -1,0 +1,206 @@
+import PropTypes from 'prop-types'
+import React, {
+  useCallback,
+  useEffect,
+  useState
+} from 'react'
+
+import CustomModal from '@/js/components/CustomModal/CustomModal'
+import { KeywordTree } from '@/js/components/KeywordTree/KeywordTree'
+import KmsConceptSchemeSelector from '@/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector'
+import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
+
+import './KmsConceptSelectionEditModal.scss'
+
+const TreePlaceholder = ({ message }) => (
+  <div className="kms-concept-selection-edit-modal__tree-placeholder">
+    {message}
+  </div>
+)
+
+export const KmsConceptSelectionEditModal = ({
+  show,
+  toggleModal,
+  uuid,
+  version,
+  scheme,
+  handleAcceptChanges
+}) => {
+  const [treeData, setTreeData] = useState(null)
+  const [selectedScheme, setSelectedScheme] = useState(scheme)
+  const [selectedKeyword, setSelectedKeyword] = useState(uuid)
+  const [isTreeLoading, setIsTreeLoading] = useState(false)
+  const [treeMessage, setTreeMessage] = useState('')
+  const [searchPattern, setSearchPattern] = useState('')
+  const [searchPatternApplied, setSearchPatternApplied] = useState('')
+
+  const fetchTreeData = async () => {
+    if (version && scheme) {
+      setIsTreeLoading(true)
+
+      try {
+        const data = await getKmsKeywordTree(version, selectedScheme, searchPatternApplied)
+        if (data) {
+          setTreeData(data)
+        } else {
+          setTreeData(null)
+          setTreeMessage('No results.')
+        }
+      } catch (error) {
+        console.error('Error fetching keyword tree:', error)
+        setTreeData(null)
+        setTreeMessage('Failed to load the tree. Please try again.')
+      } finally {
+        setIsTreeLoading(false)
+      }
+    }
+  }
+
+  useEffect(() => {
+    if (version && selectedScheme) {
+      setTreeMessage('Loading...')
+      fetchTreeData(version, selectedScheme, searchPatternApplied)
+    } else {
+      setTreeMessage('Select a version and scheme to load the tree')
+    }
+  }, [show, version, selectedScheme, searchPatternApplied])
+
+  const onSchemeSelect = useCallback((schemeInfo) => {
+    setSelectedScheme(schemeInfo)
+    setTreeData(null)
+  }, [])
+
+  useEffect(() => {
+    if (show) {
+      setTreeMessage('Loading...')
+      fetchTreeData(version, selectedScheme, searchPatternApplied)
+    }
+  }, [show])
+
+  const onHandleSelectKeyword = (value) => {
+    setSelectedKeyword(value)
+  }
+
+  const onHandleAcceptChanges = () => {
+    handleAcceptChanges(selectedKeyword)
+    toggleModal(false)
+  }
+
+  // New function to handle search input change
+  const onHandleSearchInputChange = (event) => {
+    setSearchPattern(event.target.value)
+
+    if (event.target.value === '') {
+      setSearchPatternApplied('')
+    }
+  }
+
+  const onHandleApplyFilteredSearch = () => {
+    setSearchPatternApplied(searchPattern)
+  }
+
+  const onHandleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      setSearchPatternApplied(searchPattern)
+    }
+  }
+
+  const renderTree = () => {
+    if (isTreeLoading) {
+      return <TreePlaceholder message="Loading..." />
+    }
+
+    const schemeSelectorId = selectedScheme.name
+
+    return (
+      <div>
+        <div className="kms-concept-selection-edit-modal__scheme-selector">
+          <label
+            htmlFor={schemeSelectorId}
+            className="kms-concept-selection-edit-modal__label"
+          >
+            Scheme:
+          </label>
+          <KmsConceptSchemeSelector
+            key={uuid}
+            id={uuid}
+            version={version}
+            defaultScheme={scheme}
+            onSchemeSelect={onSchemeSelect}
+          />
+        </div>
+        <div className="kms-concept-selection-edit-modal__tree-wrapper">
+          <input
+            type="text"
+            placeholder="Search by Pattern or UUID"
+            className="kms-concept-selection-edit-modal__search-input"
+            value={searchPattern}
+            onChange={onHandleSearchInputChange}
+            onKeyDown={onHandleKeyDown}
+          />
+          <button
+            type="button"
+            className="kms-concept-selection-edit-modal__apply-button"
+            onClick={onHandleApplyFilteredSearch}
+          >
+            Apply
+          </button>
+        </div>
+        {
+          treeData ? (
+            <KeywordTree
+              key={`${uuid}`}
+              data={treeData}
+              searchTerm={searchPatternApplied}
+              selectedNodeId={uuid}
+              showContextMenu={false}
+              onNodeClick={onHandleSelectKeyword}
+              openAll={!!searchPatternApplied && searchPatternApplied.trim() !== ''}
+            />
+          ) : <TreePlaceholder message={treeMessage} />
+        }
+      </div>
+    )
+  }
+
+  return (
+    <CustomModal
+      header="Edit Keyword"
+      message={renderTree()}
+      show={show}
+      toggleModal={toggleModal}
+      actions={
+        [
+          {
+            label: 'Cancel',
+            variant: 'secondary',
+            onClick: () => { toggleModal(false) }
+          },
+          {
+            label: 'Accept',
+            variant: 'primary',
+            onClick: onHandleAcceptChanges
+          }
+        ]
+      }
+    />
+  )
+}
+
+TreePlaceholder.propTypes = {
+  message: PropTypes.string.isRequired
+}
+
+KmsConceptSelectionEditModal.propTypes = {
+  uuid: PropTypes.string.isRequired,
+  show: PropTypes.bool.isRequired,
+  toggleModal: PropTypes.func.isRequired,
+  version: PropTypes.shape({
+    version: PropTypes.string,
+    version_type: PropTypes.string
+  }).isRequired,
+  scheme: PropTypes.shape({
+    name: PropTypes.string
+  }).isRequired,
+  handleAcceptChanges: PropTypes.func.isRequired
+}

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.scss
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.scss
@@ -1,12 +1,13 @@
 @use "sass:map";
+
 @import '../../../css/vendor/bootstrap/variables';
 
 .kms-concept-selection-edit-modal {
   &__search-input {
-    border-radius: 4px;
-    border: 1px solid #ccc;
     inline-size: 80%;
     padding: 8px;
+    border: 1px solid #ccc;      
+    border-radius: 4px;          
 
     &:focus {
       border-color: #007bff;
@@ -15,8 +16,8 @@
   }
 
   &__scheme-selector {
+    display: flex;                
     align-items: center;
-    display: flex;
     padding-block-end: 8px;
   }
 
@@ -26,22 +27,22 @@
   }
 
   &__tree-wrapper {
+    display: flex;                
     align-items: center;
-    display: flex;
     margin-block-end: 12px;
   }
 
   &__tree-placeholder {
+    display: flex;                
     align-items: center;
-    block-size: 300px;
-    border-radius: 4px;
-    border: 1px solid $gray-300;
-    display: flex;
+    justify-content: center;      
     inline-size: 100%;
-    justify-content: center;
+    border-radius: 4px;           
+    border: 1px solid $gray-300;  
+    block-size: 300px;
   }
 
   &__apply-button {
-    margin-inline-start: 10px; // Add spacing to the left of the button
+    margin-inline-start: 10px; 
   }
 }

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.scss
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.scss
@@ -4,10 +4,10 @@
 
 .kms-concept-selection-edit-modal {
   &__search-input {
-    inline-size: 80%;
     padding: 8px;
     border: 1px solid #ccc;      
-    border-radius: 4px;          
+    border-radius: 4px;
+    inline-size: 80%;          
 
     &:focus {
       border-color: #007bff;
@@ -35,11 +35,11 @@
   &__tree-placeholder {
     display: flex;                
     align-items: center;
-    justify-content: center;      
+    justify-content: center;           
+    border: 1px solid $gray-300;
+    border-radius: 4px;  
+    block-size: 300px;      
     inline-size: 100%;
-    border-radius: 4px;           
-    border: 1px solid $gray-300;  
-    block-size: 300px;
   }
 
   &__apply-button {

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.scss
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.scss
@@ -2,12 +2,11 @@
 @import '../../../css/vendor/bootstrap/variables';
 
 .kms-concept-selection-edit-modal {
-
   &__search-input {
+    border-radius: 4px;
+    border: 1px solid #ccc;
     inline-size: 80%;
     padding: 8px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
 
     &:focus {
       border-color: #007bff;
@@ -16,30 +15,30 @@
   }
 
   &__scheme-selector {
-    display: flex;
     align-items: center;
+    display: flex;
     padding-block-end: 8px;
   }
 
   &__label {
-    padding-inline-end: 8px;
     font-weight: bold;
+    padding-inline-end: 8px;
   }
 
   &__tree-wrapper {
-    margin-block-end: 12px;
-    display: flex;
     align-items: center;
+    display: flex;
+    margin-block-end: 12px;
   }
 
   &__tree-placeholder {
+    align-items: center;
+    block-size: 300px;
+    border-radius: 4px;
+    border: 1px solid $gray-300;
     display: flex;
     inline-size: 100%;
-    block-size: 300px;
-    align-items: center;
     justify-content: center;
-    border: 1px solid $gray-300;
-    border-radius: 4px;
   }
 
   &__apply-button {

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.scss
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.scss
@@ -1,0 +1,48 @@
+@use "sass:map";
+@import '../../../css/vendor/bootstrap/variables';
+
+.kms-concept-selection-edit-modal {
+
+  &__search-input {
+    inline-size: 80%;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+
+    &:focus {
+      border-color: #007bff;
+      outline: none;
+    }
+  }
+
+  &__scheme-selector {
+    display: flex;
+    align-items: center;
+    padding-block-end: 8px;
+  }
+
+  &__label {
+    padding-inline-end: 8px;
+    font-weight: bold;
+  }
+
+  &__tree-wrapper {
+    margin-block-end: 12px;
+    display: flex;
+    align-items: center;
+  }
+
+  &__tree-placeholder {
+    display: flex;
+    inline-size: 100%;
+    block-size: 300px;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid $gray-300;
+    border-radius: 4px;
+  }
+
+  &__apply-button {
+    margin-inline-start: 10px; // Add spacing to the left of the button
+  }
+}

--- a/static/src/js/components/KmsConceptSelectionEditModal/__tests__/KmsConceptSelectionEditModal.test.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/__tests__/KmsConceptSelectionEditModal.test.jsx
@@ -1,0 +1,236 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import PropTypes from 'prop-types'
+import React from 'react'
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest'
+
+import {
+  KmsConceptSelectionEditModal
+} from '@/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal'
+import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
+
+vi.mock('@/js/components/KeywordTree/KeywordTree', () => {
+  const MockKeywordTree = ({ onNodeClick }) => (
+    <button
+      type="button"
+      data-testid="keyword-tree"
+      onClick={() => onNodeClick('mock-uuid')}
+    >
+      Mock Keyword Tree
+    </button>
+  )
+
+  MockKeywordTree.propTypes = {
+    onNodeClick: PropTypes.func.isRequired
+  }
+
+  return { KeywordTree: MockKeywordTree }
+})
+
+vi.mock('@/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector', () => {
+  const MockKmsConceptSchemeSelector = ({ onSchemeSelect }) => (
+    <select
+      data-testid="scheme-selector"
+      onChange={() => onSchemeSelect({ name: 'New Scheme' })}
+    >
+      <option>Select a scheme</option>
+      <option value="new-scheme">New Scheme</option>
+    </select>
+  )
+
+  MockKmsConceptSchemeSelector.propTypes = {
+    onSchemeSelect: PropTypes.func.isRequired
+  }
+
+  return { default: MockKmsConceptSchemeSelector }
+})
+
+vi.mock('@/js/utils/getKmsKeywordTree', () => ({
+  default: vi.fn(() => Promise.resolve([{ id: 'mock-tree-data' }]))
+}))
+
+describe('KmsConceptSelectionEditModal', () => {
+  const defaultProps = {
+    show: true,
+    toggleModal: vi.fn(),
+    uuid: 'test-uuid',
+    version: {
+      version: '1.0',
+      version_type: 'published'
+    },
+    scheme: { name: 'Test Scheme' },
+    handleAcceptChanges: vi.fn()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  describe('when the modal appears', () => {
+    it('renders the header', async () => {
+      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+      const modalHeader = await screen.findByText('Edit Keyword')
+      expect(modalHeader).toBeInTheDocument()
+    })
+
+    it('renders the scheme selector', async () => {
+      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+      await waitFor(() => {
+        expect(screen.getByTestId('scheme-selector')).toBeTruthy()
+      })
+    })
+
+    it('renders the keyword tree', async () => {
+      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+      await waitFor(() => {
+        expect(screen.getByTestId('keyword-tree')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('when the modal is hidden', () => {
+    it('does not render the modal', async () => {
+      render(<KmsConceptSelectionEditModal {...defaultProps} show={false} />)
+      await waitFor(() => {
+        expect(screen.queryByTestId('custom-modal')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when user selects a scheme', () => {
+    it('shows tree is loading', async () => {
+      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+      const schemeSelector = await screen.findByTestId('scheme-selector')
+      fireEvent.change(schemeSelector)
+      await waitFor(() => {
+        expect(screen.getByText('Loading...')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('when user accept changes', () => {
+    it('responds with the uuid of the selected keyword', async () => {
+      const handleAcceptChangesMock = vi.fn()
+      const props = {
+        ...defaultProps,
+        handleAcceptChanges: handleAcceptChangesMock
+      }
+
+      render(<KmsConceptSelectionEditModal {...props} />)
+
+      await waitFor(async () => {
+        const keywordTree = screen.getByTestId('keyword-tree')
+        await userEvent.click(keywordTree)
+      })
+
+      // Find and click the Accept button
+      const acceptButton = screen.getByText('Accept')
+      await userEvent.click(acceptButton)
+
+      // Check if handleAcceptChanges was called with the new keyword value
+      expect(handleAcceptChangesMock).toHaveBeenCalledWith('mock-uuid')
+    })
+  })
+
+  describe('when user cancels changes', () => {
+    it('closes the modal', async () => {
+      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+      await waitFor(async () => {
+        const cancelButton = screen.getByText('Cancel')
+        await userEvent.click(cancelButton)
+        expect(defaultProps.toggleModal).toHaveBeenCalledWith(false)
+      })
+    })
+  })
+
+  describe('when the user searches', () => {
+    it('fetches the tree and includes search term when apply button is pressed', async () => {
+      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+      const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
+      fireEvent.change(searchInput, { target: { value: 'test search' } })
+      const applyButton = screen.getByText('Apply')
+      fireEvent.click(applyButton)
+      await waitFor(() => {
+        expect(getKmsKeywordTree).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'test search')
+      })
+    })
+
+    it('fetch the tree and includes search term when enter button is pressed', async () => {
+      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+      const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
+      fireEvent.change(searchInput, { target: { value: 'test search' } })
+      fireEvent.keyDown(searchInput, { key: 'Enter' })
+      await waitFor(() => {
+        expect(getKmsKeywordTree).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'test search')
+      })
+    })
+
+    it('shows no results when fetch returns null', async () => {
+      vi.mocked(getKmsKeywordTree).mockResolvedValue(null)
+      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+      const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
+      await userEvent.type(searchInput, 'test pattern')
+      const applyButton = screen.getByText('Apply')
+      await userEvent.click(applyButton)
+      await waitFor(() => {
+        expect(screen.getByText('No results.')).toBeInTheDocument()
+      })
+    })
+
+    it('handles fetch errors', async () => {
+      vi.mocked(getKmsKeywordTree).mockRejectedValue(new Error('Fetch error'))
+      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load the tree. Please try again.')).toBeInTheDocument()
+      })
+    })
+
+    it('user clears search box', async () => {
+      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+      const textInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
+      fireEvent.change(textInput, { target: { value: 'test pattern' } })
+      fireEvent.change(textInput, { target: { value: '' } })
+      await waitFor(() => {
+        expect(getKmsKeywordTree).toHaveBeenCalledWith(expect.anything(), expect.anything(), '')
+      })
+    })
+  })
+
+  describe('when no version is provided', () => {
+    it('displays correct message', async () => {
+      const propsWithoutVersion = {
+        ...defaultProps,
+        version: null
+      }
+      render(<KmsConceptSelectionEditModal {...propsWithoutVersion} />)
+      await waitFor(() => {
+        expect(screen.getByText('Select a version and scheme to load the tree')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when no scheme is provided', () => {
+    it('displays correct message', async () => {
+      const propsWithoutScheme = {
+        ...defaultProps,
+        scheme: null
+      }
+      render(<KmsConceptSelectionEditModal {...propsWithoutScheme} />)
+      await waitFor(() => {
+        expect(screen.getByText('Select a version and scheme to load the tree')).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/static/src/js/components/KmsConceptSelectionEditModal/__tests__/KmsConceptSelectionEditModal.test.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/__tests__/KmsConceptSelectionEditModal.test.jsx
@@ -11,7 +11,6 @@ import {
   beforeEach,
   describe,
   expect,
-  it,
   vi
 } from 'vitest'
 
@@ -177,6 +176,7 @@ describe('KmsConceptSelectionEditModal', () => {
         })
       })
     })
+
     describe('when enter is pressed', () => {
       test('should fetch the tree and includes search term', async () => {
         render(<KmsConceptSelectionEditModal {...defaultProps} />)
@@ -188,6 +188,7 @@ describe('KmsConceptSelectionEditModal', () => {
         })
       })
     })
+
     describe('when fetch returns no results', () => {
       test('should show no results', async () => {
         vi.mocked(getKmsKeywordTree).mockResolvedValue(null)
@@ -199,7 +200,7 @@ describe('KmsConceptSelectionEditModal', () => {
         await waitFor(() => {
           expect(screen.getByText('No results.')).toBeInTheDocument()
         })
-      })  
+      })
     })
 
     test('should handle fetch errors', async () => {

--- a/static/src/js/components/KmsConceptSelectionEditModal/__tests__/KmsConceptSelectionEditModal.test.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/__tests__/KmsConceptSelectionEditModal.test.jsx
@@ -79,20 +79,20 @@ describe('KmsConceptSelectionEditModal', () => {
   })
 
   describe('when the modal appears', () => {
-    it('renders the header', async () => {
+    test('should render the header', async () => {
       render(<KmsConceptSelectionEditModal {...defaultProps} />)
       const modalHeader = await screen.findByText('Edit Keyword')
       expect(modalHeader).toBeInTheDocument()
     })
 
-    it('renders the scheme selector', async () => {
+    test('should render the scheme selector', async () => {
       render(<KmsConceptSelectionEditModal {...defaultProps} />)
       await waitFor(() => {
         expect(screen.getByTestId('scheme-selector')).toBeTruthy()
       })
     })
 
-    it('renders the keyword tree', async () => {
+    test('should render the keyword tree', async () => {
       render(<KmsConceptSelectionEditModal {...defaultProps} />)
       await waitFor(() => {
         expect(screen.getByTestId('keyword-tree')).toBeTruthy()
@@ -101,7 +101,7 @@ describe('KmsConceptSelectionEditModal', () => {
   })
 
   describe('when the modal is hidden', () => {
-    it('does not render the modal', async () => {
+    test('should not show the modal', async () => {
       render(<KmsConceptSelectionEditModal {...defaultProps} show={false} />)
       await waitFor(() => {
         expect(screen.queryByTestId('custom-modal')).not.toBeInTheDocument()
@@ -110,7 +110,7 @@ describe('KmsConceptSelectionEditModal', () => {
   })
 
   describe('when user selects a scheme', () => {
-    it('shows tree is loading', async () => {
+    test('shows tree is loading', async () => {
       render(<KmsConceptSelectionEditModal {...defaultProps} />)
       const schemeSelector = await screen.findByTestId('scheme-selector')
       fireEvent.change(schemeSelector)
@@ -118,10 +118,19 @@ describe('KmsConceptSelectionEditModal', () => {
         expect(screen.getByText('Loading...')).toBeTruthy()
       })
     })
+
+    test('should render tree when a scheme is selected', async () => {
+      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+      const schemeSelector = await screen.findByTestId('scheme-selector')
+      fireEvent.change(schemeSelector)
+      await waitFor(() => {
+        expect(screen.getByTestId('keyword-tree')).toBeTruthy()
+      })
+    })
   })
 
   describe('when user accept changes', () => {
-    it('responds with the uuid of the selected keyword', async () => {
+    test('should responds with the uuid of the selected keyword', async () => {
       const handleAcceptChangesMock = vi.fn()
       const props = {
         ...defaultProps,
@@ -145,7 +154,7 @@ describe('KmsConceptSelectionEditModal', () => {
   })
 
   describe('when user cancels changes', () => {
-    it('closes the modal', async () => {
+    test('should close the modal', async () => {
       render(<KmsConceptSelectionEditModal {...defaultProps} />)
       await waitFor(async () => {
         const cancelButton = screen.getByText('Cancel')
@@ -156,40 +165,44 @@ describe('KmsConceptSelectionEditModal', () => {
   })
 
   describe('when the user searches', () => {
-    it('fetches the tree and includes search term when apply button is pressed', async () => {
-      render(<KmsConceptSelectionEditModal {...defaultProps} />)
-      const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
-      fireEvent.change(searchInput, { target: { value: 'test search' } })
-      const applyButton = screen.getByText('Apply')
-      fireEvent.click(applyButton)
-      await waitFor(() => {
-        expect(getKmsKeywordTree).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'test search')
+    describe('when apply button is pressed', () => {
+      test('should fetch the tree and includes search term', async () => {
+        render(<KmsConceptSelectionEditModal {...defaultProps} />)
+        const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
+        fireEvent.change(searchInput, { target: { value: 'test search' } })
+        const applyButton = screen.getByText('Apply')
+        fireEvent.click(applyButton)
+        await waitFor(() => {
+          expect(getKmsKeywordTree).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'test search')
+        })
       })
     })
-
-    it('fetch the tree and includes search term when enter button is pressed', async () => {
-      render(<KmsConceptSelectionEditModal {...defaultProps} />)
-      const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
-      fireEvent.change(searchInput, { target: { value: 'test search' } })
-      fireEvent.keyDown(searchInput, { key: 'Enter' })
-      await waitFor(() => {
-        expect(getKmsKeywordTree).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'test search')
+    describe('when enter is pressed', () => {
+      test('should fetch the tree and includes search term', async () => {
+        render(<KmsConceptSelectionEditModal {...defaultProps} />)
+        const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
+        fireEvent.change(searchInput, { target: { value: 'test search' } })
+        fireEvent.keyDown(searchInput, { key: 'Enter' })
+        await waitFor(() => {
+          expect(getKmsKeywordTree).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'test search')
+        })
       })
     })
-
-    it('shows no results when fetch returns null', async () => {
-      vi.mocked(getKmsKeywordTree).mockResolvedValue(null)
-      render(<KmsConceptSelectionEditModal {...defaultProps} />)
-      const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
-      await userEvent.type(searchInput, 'test pattern')
-      const applyButton = screen.getByText('Apply')
-      await userEvent.click(applyButton)
-      await waitFor(() => {
-        expect(screen.getByText('No results.')).toBeInTheDocument()
-      })
+    describe('when fetch returns no results', () => {
+      test('should show no results', async () => {
+        vi.mocked(getKmsKeywordTree).mockResolvedValue(null)
+        render(<KmsConceptSelectionEditModal {...defaultProps} />)
+        const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
+        await userEvent.type(searchInput, 'test pattern')
+        const applyButton = screen.getByText('Apply')
+        await userEvent.click(applyButton)
+        await waitFor(() => {
+          expect(screen.getByText('No results.')).toBeInTheDocument()
+        })
+      })  
     })
 
-    it('handles fetch errors', async () => {
+    test('should handle fetch errors', async () => {
       vi.mocked(getKmsKeywordTree).mockRejectedValue(new Error('Fetch error'))
       render(<KmsConceptSelectionEditModal {...defaultProps} />)
       await waitFor(() => {
@@ -197,7 +210,7 @@ describe('KmsConceptSelectionEditModal', () => {
       })
     })
 
-    it('user clears search box', async () => {
+    test('should handling clearing the search box', async () => {
       render(<KmsConceptSelectionEditModal {...defaultProps} />)
       const textInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
       fireEvent.change(textInput, { target: { value: 'test pattern' } })
@@ -209,7 +222,7 @@ describe('KmsConceptSelectionEditModal', () => {
   })
 
   describe('when no version is provided', () => {
-    it('displays correct message', async () => {
+    test('displays correct message', async () => {
       const propsWithoutVersion = {
         ...defaultProps,
         version: null
@@ -222,7 +235,7 @@ describe('KmsConceptSelectionEditModal', () => {
   })
 
   describe('when no scheme is provided', () => {
-    it('displays correct message', async () => {
+    test('displays correct message', async () => {
       const propsWithoutScheme = {
         ...defaultProps,
         scheme: null

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
@@ -47,6 +47,7 @@ const KmsConceptSelectionWidget = ({
   const [keywordLabel, setKeywordLabel] = useState('')
   const [fullPath, setFullPath] = useState('')
   const [showEditModal, setShowEditModal] = useState(false)
+  const [error, setError] = useState('')
   const inputScrollRef = useRef(null)
   const focusRef = useRef(null)
 
@@ -68,8 +69,10 @@ const KmsConceptSelectionWidget = ({
         fullPaths = fullPaths.map((path) => path.replaceAll('|', ' > '))
         setKeywordLabel(lastField)
         setFullPath(fullPaths.join('\n'))
-      } catch (error) {
-        console.error('Error fetching versions:', error)
+      } catch (errorObj) {
+        console.log('error=', errorObj)
+        console.error(`Error fetching keyword for ${value}`, errorObj)
+        setError(`Error fetching keyword for ${value}`)
       }
     }
 
@@ -113,6 +116,14 @@ const KmsConceptSelectionWidget = ({
         />
       </div>
 
+      {
+        error && (
+          <div className="alert alert-danger kms-concept-selection-widget__compact-alert" role="alert">
+            {error}
+          </div>
+        )
+      }
+      {' '}
       <KmsConceptSelectionEditModal
         uuid={value}
         version={version}

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
@@ -18,20 +18,22 @@ import CustomWidgetWrapper from '../CustomWidgetWrapper/CustomWidgetWrapper'
 import './KmsConceptSelectionWidget.scss'
 
 /**
- * KmsConceptSelectionWidget
- * @typedef {Object} KmsConceptSelectionWidget
- * @property {Boolean} disable A boolean value to disable the selection widget
- * @property {String} id The id of the widget.
- * @property {String} label The label of the widget.
- * @property {Boolean} onBlur Should blur a field.
- * @property {Function} onChange A callback function triggered when the concept uuid changes
- * @property {Object} registry An Object that has all the props that are in registry.
- * @property {Boolean} required Is the KmsConceptSelectionWidget field required
- * @property {Object} schema A UMM Schema for the widget being previewed.
- * @property {Object} uiSchema A uiSchema for the field being shown.
- * @property {String} value A concept uuid saved to the draft.
+ * KmsConceptSelectionWidget component for selecting and editing keyword concepts
+ * within a user interface. It uses a modal to allow keyword selection and then
+ * displays the selected keyword and its full path.
+ *
+ * @component
+ * @param {Object} props - Component properties.
+ * @param {string} props.id - Unique identifier for the widget.
+ * @param {string} props.label - Label displayed for the widget.
+ * @param {Function} props.onChange - Callback function to handle changes.
+ * @param {Object} props.registry - Contains form context information.
+ * @param {boolean} [props.required=false] - Specifies if the field is required.
+ * @param {Object} props.schema - Schema containing field constraints.
+ * @param {Object} props.uiSchema - UI schema allowing customization of display.
+ * @param {string|number} [props.value=''] - Current value of the widget.
+ * @returns {JSX.Element} The rendered component.
  */
-
 const KmsConceptSelectionWidget = ({
   id,
   label,
@@ -80,6 +82,7 @@ const KmsConceptSelectionWidget = ({
 
   return (
     <CustomWidgetWrapper
+      id={id}
       key={`${id}-${value}`}
       charactersUsed={value?.length}
       description={description}

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
@@ -70,7 +70,6 @@ const KmsConceptSelectionWidget = ({
         setKeywordLabel(lastField)
         setFullPath(fullPaths.join('\n'))
       } catch (errorObj) {
-        console.log('error=', errorObj)
         console.error(`Error fetching keyword for ${value}`, errorObj)
         setError(`Error fetching keyword for ${value}`)
       }

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
@@ -76,7 +76,9 @@ const KmsConceptSelectionWidget = ({
       }
     }
 
-    fetchFullPaths()
+    if (value !== null && value.trim() !== '') {
+      fetchFullPaths()
+    }
   }, [value])
 
   const toggleEditModal = (nextState) => {

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
@@ -1,0 +1,175 @@
+import { startCase } from 'lodash-es'
+import PropTypes from 'prop-types'
+import React, {
+  useEffect,
+  useRef,
+  useState
+} from 'react'
+import { FaPencilAlt } from 'react-icons/fa'
+
+import Button from '@/js/components/Button/Button'
+import {
+  KmsConceptSelectionEditModal
+} from '@/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal'
+import { getKmsConceptFullPaths } from '@/js/utils/getKmsConceptFullPaths'
+
+import shouldFocusField from '../../utils/shouldFocusField'
+import CustomWidgetWrapper from '../CustomWidgetWrapper/CustomWidgetWrapper'
+
+import './KmsConceptSelectionWidget.scss'
+
+/**
+ * KmsConceptSelectionWidget
+ * @typedef {Object} KmsConceptSelectionWidget
+ * @property {Boolean} disable A boolean value to disable the selection widget
+ * @property {String} id The id of the widget.
+ * @property {String} label The label of the widget.
+ * @property {Boolean} onBlur Should blur a field.
+ * @property {Function} onChange A callback function triggered when the concept uuid changes
+ * @property {Object} registry An Object that has all the props that are in registry.
+ * @property {Boolean} required Is the KmsConceptSelectionWidget field required
+ * @property {Object} schema A UMM Schema for the widget being previewed.
+ * @property {Object} uiSchema A uiSchema for the field being shown.
+ * @property {String} value A concept uuid saved to the draft.
+ */
+
+const KmsConceptSelectionWidget = ({
+  id,
+  label,
+  onChange,
+  registry,
+  required,
+  schema,
+  uiSchema,
+  value
+}) => {
+  const [keywordLabel, setKeywordLabel] = useState('')
+  const [fullPath, setFullPath] = useState('')
+  const [showEditModal, setShowEditModal] = useState(false)
+  const inputScrollRef = useRef(null)
+  const focusRef = useRef(null)
+
+  const { formContext } = registry
+  const { focusField, version, scheme } = formContext
+
+  const { maxLength, description } = schema
+
+  let title = startCase(label.split(/-/)[0])
+  if (uiSchema['ui:title']) {
+    title = uiSchema['ui:title']
+  }
+
+  const shouldFocus = shouldFocusField(focusField, id)
+
+  useEffect(() => {
+    if (shouldFocus) {
+      inputScrollRef.current?.scrollIntoView({ behavior: 'smooth' })
+      focusRef.current?.focus()
+    }
+  }, [shouldFocus])
+
+  useEffect(() => {
+    const fetchFullPaths = async () => {
+      try {
+        let fullPaths = await getKmsConceptFullPaths(value)
+        const lastField = fullPaths[0].split('|').pop()
+        fullPaths = fullPaths.map((path) => path.replaceAll('|', ' > '))
+        setKeywordLabel(lastField)
+        setFullPath(fullPaths.join('\n'))
+      } catch (error) {
+        console.error('Error fetching versions:', error)
+      }
+    }
+
+    fetchFullPaths()
+  }, [value])
+
+  const toggleEditModal = (nextState) => {
+    setShowEditModal(nextState)
+  }
+
+  return (
+    <CustomWidgetWrapper
+      key={`${id}-${value}`}
+      charactersUsed={value?.length}
+      description={description}
+      label={label}
+      maxLength={maxLength}
+      required={required}
+      scrollRef={inputScrollRef}
+      title={title}
+    >
+      <div className="kms-concept-selection-widget__container">
+        <span
+          key={`${id}-${value}`}
+          className="kms-concept-selection-widget__label"
+          id={id}
+          ref={focusRef}
+          title={fullPath || 'No full path available'}
+        >
+          {keywordLabel || 'No value set'}
+        </span>
+        <Button
+          className="kms-concept-selection-widget__edit-button"
+          Icon={FaPencilAlt}
+          iconTitle="Pencil icon to edit"
+          naked
+          onClick={() => setShowEditModal(true)}
+          size="sm"
+        />
+      </div>
+
+      <KmsConceptSelectionEditModal
+        uuid={value}
+        version={version}
+        scheme={scheme}
+        show={showEditModal}
+        toggleModal={toggleEditModal}
+        handleAcceptChanges={
+          (uuidValue) => {
+            onChange(uuidValue)
+          }
+        }
+      />
+    </CustomWidgetWrapper>
+  )
+}
+
+KmsConceptSelectionWidget.defaultProps = {
+  value: '',
+  required: false
+}
+
+KmsConceptSelectionWidget.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  registry: PropTypes.shape({
+    formContext: PropTypes.shape({
+      focusField: PropTypes.string,
+      setFocusField: PropTypes.func,
+      version: PropTypes.shape({
+        version: PropTypes.string,
+        version_type: PropTypes.string
+      }).isRequired,
+      scheme: PropTypes.shape({
+        name: PropTypes.string
+      }).isRequired
+    }).isRequired
+  }).isRequired,
+  required: PropTypes.bool,
+  schema: PropTypes.shape({
+    description: PropTypes.string,
+    maxLength: PropTypes.number,
+    type: PropTypes.string
+  }).isRequired,
+  uiSchema: PropTypes.shape({
+    'ui:title': PropTypes.string
+  }).isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ])
+}
+
+export default KmsConceptSelectionWidget

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
@@ -13,7 +13,6 @@ import {
 } from '@/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal'
 import { getKmsConceptFullPaths } from '@/js/utils/getKmsConceptFullPaths'
 
-import shouldFocusField from '../../utils/shouldFocusField'
 import CustomWidgetWrapper from '../CustomWidgetWrapper/CustomWidgetWrapper'
 
 import './KmsConceptSelectionWidget.scss'
@@ -50,7 +49,7 @@ const KmsConceptSelectionWidget = ({
   const focusRef = useRef(null)
 
   const { formContext } = registry
-  const { focusField, version, scheme } = formContext
+  const { version, scheme } = formContext
 
   const { maxLength, description } = schema
 
@@ -58,15 +57,6 @@ const KmsConceptSelectionWidget = ({
   if (uiSchema['ui:title']) {
     title = uiSchema['ui:title']
   }
-
-  const shouldFocus = shouldFocusField(focusField, id)
-
-  useEffect(() => {
-    if (shouldFocus) {
-      inputScrollRef.current?.scrollIntoView({ behavior: 'smooth' })
-      focusRef.current?.focus()
-    }
-  }, [shouldFocus])
 
   useEffect(() => {
     const fetchFullPaths = async () => {
@@ -110,6 +100,7 @@ const KmsConceptSelectionWidget = ({
           {keywordLabel || 'No value set'}
         </span>
         <Button
+          title="Edit Keyword"
           className="kms-concept-selection-widget__edit-button"
           Icon={FaPencilAlt}
           iconTitle="Pencil icon to edit"

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.scss
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.scss
@@ -1,0 +1,43 @@
+.kms-concept-selection-widget {
+  &__container {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1; // Match your design requirement
+  }
+
+  &__label {
+    margin-inline-end: 8px;
+    font-size: 14px;
+    color: #333; // You can use a consistent color palette here
+  }
+
+  &__edit-button {
+    padding-inline-start: 5px;
+    margin: 0;
+    color: #007bff; // Blue color for the icon
+    background: none;
+    border: none;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    transition: color 0.2s ease-in-out; // Smooth transition for color change
+   
+    &:hover,
+    &:focus {
+      color: #0056b3; // Darker blue on hover/focus
+    }
+  }
+
+  &__input {
+    inline-size: 80%; // Ensure consistency in sizing
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    transition: border-color 0.2s ease;
+
+    &:focus {
+      border-color: #007bff;
+      outline: none;
+    }
+  }
+}

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.scss
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.scss
@@ -14,11 +14,11 @@
   &__edit-button {
     display: inline-flex;          
     align-items: center;
-    background: none;
-    border: none;                  
+    border: none;
+    margin: 0;
+    background: none;                  
     color: #007bff; 
     cursor: pointer;
-    margin: 0;
     padding-inline-start: 5px;
     transition: color 0.2s ease-in-out; 
    
@@ -28,11 +28,11 @@
     }
   }
 
-  &__input {
+  &__input { 
+    padding: 8px;
     border: 1px solid #ccc;       
     border-radius: 4px;
-    inline-size: 80%; 
-    padding: 8px;                    
+    inline-size: 80%;                    
     transition: border-color 0.2s ease;
 
     &:focus {

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.scss
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.scss
@@ -1,38 +1,38 @@
 .kms-concept-selection-widget {
   &__container {
+    display: inline-flex;          
     align-items: center;
-    display: inline-flex;
-    line-height: 1; // Match your design requirement
+    line-height: 1;
   }
 
   &__label {
-    color: #333; // You can use a consistent color palette here
+    color: #333; 
     font-size: 14px;
     margin-inline-end: 8px;
   }
 
   &__edit-button {
+    display: inline-flex;          
     align-items: center;
     background: none;
-    border: none;
-    color: #007bff; // Blue color for the icon
+    border: none;                  
+    color: #007bff; 
     cursor: pointer;
-    display: inline-flex;
     margin: 0;
     padding-inline-start: 5px;
-    transition: color 0.2s ease-in-out; // Smooth transition for color change
+    transition: color 0.2s ease-in-out; 
    
     &:hover,
     &:focus {
-      color: #0056b3; // Darker blue on hover/focus
+      color: #0056b3; 
     }
   }
 
   &__input {
+    border: 1px solid #ccc;       
     border-radius: 4px;
-    border: 1px solid #ccc;
-    inline-size: 80%; // Ensure consistency in sizing
-    padding: 8px;
+    inline-size: 80%; 
+    padding: 8px;                    
     transition: border-color 0.2s ease;
 
     &:focus {

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.scss
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.scss
@@ -40,4 +40,10 @@
       outline: none;
     }
   }
+
+  &__compact-alert {
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;  
+    margin-block-end: 0.5rem;
+  }
 }

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.scss
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.scss
@@ -1,25 +1,25 @@
 .kms-concept-selection-widget {
   &__container {
-    display: inline-flex;
     align-items: center;
+    display: inline-flex;
     line-height: 1; // Match your design requirement
   }
 
   &__label {
-    margin-inline-end: 8px;
-    font-size: 14px;
     color: #333; // You can use a consistent color palette here
+    font-size: 14px;
+    margin-inline-end: 8px;
   }
 
   &__edit-button {
-    padding-inline-start: 5px;
-    margin: 0;
-    color: #007bff; // Blue color for the icon
+    align-items: center;
     background: none;
     border: none;
+    color: #007bff; // Blue color for the icon
     cursor: pointer;
     display: inline-flex;
-    align-items: center;
+    margin: 0;
+    padding-inline-start: 5px;
     transition: color 0.2s ease-in-out; // Smooth transition for color change
    
     &:hover,
@@ -29,10 +29,10 @@
   }
 
   &__input {
+    border-radius: 4px;
+    border: 1px solid #ccc;
     inline-size: 80%; // Ensure consistency in sizing
     padding: 8px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
     transition: border-color 0.2s ease;
 
     &:focus {

--- a/static/src/js/components/KmsConceptSelectionWidget/__tests__/KMSConceptSelectionWidget.test.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/__tests__/KMSConceptSelectionWidget.test.jsx
@@ -151,21 +151,18 @@ describe('KmsConceptSelectionWidget', () => {
     })
   })
 
-  describe('when the user encounted network error', () => {
-    test('should handle errors thrown by getKmsConceptFullPaths gracefully', async () => {
-      getKmsConceptFullPaths.mockRejectedValueOnce(new Error('Failed to fetch full paths'))
+  describe('when the user encounters a network error', () => {
+    test('should handle errors by adding a notification', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      vi.spyOn(console, 'log').mockImplementation(() => {})
 
-      // Mock console.error to suppress error logs
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      getKmsConceptFullPaths.mockRejectedValue(new Error('Failed to fetch full paths'))
 
       renderComponent()
 
       await waitFor(() => {
-        expect(consoleErrorSpy).toHaveBeenCalledWith('Error fetching versions:', expect.any(Error))
+        expect(screen.getByRole('alert')).toHaveTextContent('Error fetching keyword for test-uuid')
       })
-
-      // Restore the original implementation of console.error
-      consoleErrorSpy.mockRestore()
     })
   })
 })

--- a/static/src/js/components/KmsConceptSelectionWidget/__tests__/KMSConceptSelectionWidget.test.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/__tests__/KMSConceptSelectionWidget.test.jsx
@@ -1,0 +1,158 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Button } from 'react-bootstrap'
+import {
+  beforeEach,
+  describe,
+  it,
+  vi
+} from 'vitest'
+
+import KmsConceptSelectionWidget from '@/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget'
+import { getKmsConceptFullPaths } from '@/js/utils/getKmsConceptFullPaths'
+
+// Mock the `getKmsConceptFullPaths` and Button components
+vi.mock('@/js/utils/getKmsConceptFullPaths')
+
+vi.mock('react-icons/fa', () => ({
+  FaPencilAlt: () => <svg data-testid="pencil-icon" />,
+  FaInfoCircle: () => <svg data-testid="info-circle" />,
+  FaTimes: () => <svg data-testid="times" />
+}))
+
+vi.mock('@/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal', () => {
+  const KmsConceptSelectionEditModal = ({ show, handleAcceptChanges, toggleModal }) => (
+    show ? (
+      <div>
+        <p>Handle Change Modal</p>
+        <Button onClick={() => handleAcceptChanges('new-uuid')}>Accept Change</Button>
+        {/* Add a button to simulate modal close using toggleModal */}
+        <Button onClick={() => toggleModal(false)}>Cancel</Button>
+      </div>
+    ) : null
+  )
+
+  KmsConceptSelectionEditModal.propTypes = {
+    show: PropTypes.bool.isRequired,
+    handleAcceptChanges: PropTypes.func.isRequired,
+    toggleModal: PropTypes.func.isRequired
+  }
+
+  return { KmsConceptSelectionEditModal }
+})
+
+describe('KmsConceptSelectionWidget', () => {
+  beforeEach(() => {
+    getKmsConceptFullPaths.mockClear()
+    getKmsConceptFullPaths.mockResolvedValue(['ScienceKeywords | ATMOSPHERE | TORNADOES'])
+  })
+
+  const renderComponent = (props = {}) => render(
+    <KmsConceptSelectionWidget
+      id="test-id"
+      label="Test Label"
+      onChange={vi.fn()}
+      registry={
+        {
+          formContext: {
+            focusField: null,
+            version: {
+              version: '1',
+              version_type: 'draft'
+            },
+            scheme: { name: 'sciencekeywords' }
+          }
+        }
+      }
+      schema={
+        {
+          description: 'Description',
+          maxLength: 255
+        }
+      }
+      uiSchema={{ 'ui:title': 'UI Title' }}
+      value="test-uuid"
+      {...props}
+    />
+  )
+
+  describe('when a user first loads the page', () => {
+    it('should render the page', async () => {
+      renderComponent()
+      await waitFor(() => {
+        expect(screen.getByText(/tornadoes/i)).toBeInTheDocument()
+      })
+    })
+
+    it('should fetch and display the correct full path', async () => {
+      renderComponent()
+      expect(getKmsConceptFullPaths).toHaveBeenCalledWith('test-uuid')
+      await waitFor(async () => {
+        expect(await screen.findByText('TORNADOES')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when a user clicks the edit icon', () => {
+    it('should open the edit modal', () => {
+      renderComponent()
+      const button = screen.getByRole('button', { name: /edit/i })
+      fireEvent.click(button)
+      expect(screen.getByText('Handle Change Modal')).toBeInTheDocument()
+    })
+
+    it('should toggle the edit modal state correctly', async () => {
+      renderComponent()
+
+      // Open the modal
+      const editButton = screen.getByRole('button', { name: /edit/i })
+      fireEvent.click(editButton)
+      expect(screen.getByText('Handle Change Modal')).toBeInTheDocument()
+
+      // Simulate clicking the custom cancel button in the modal
+      const cancelButton = screen.getByRole('button', { name: /cancel/i })
+      fireEvent.click(cancelButton)
+
+      // Wait for the modal to no longer be in the document
+      await waitFor(() => {
+        expect(screen.queryByText('Handle Change Modal')).toBeNull()
+      })
+    })
+  })
+
+  describe('when a user accepts changes', () => {
+    it('should call onChange when accepting changes from the modal', () => {
+      const onChangeMock = vi.fn()
+      renderComponent({ onChange: onChangeMock })
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+      fireEvent.click(screen.getByText('Accept Change'))
+
+      expect(onChangeMock).toHaveBeenCalledWith('new-uuid')
+    })
+  })
+
+  describe('error handling in fetchFullPaths', () => {
+    it('should handle errors thrown by getKmsConceptFullPaths gracefully', async () => {
+      getKmsConceptFullPaths.mockRejectedValueOnce(new Error('Failed to fetch full paths'))
+
+      // Spy on console.error
+      const consoleErrorSpy = vi.spyOn(console, 'error')
+
+      renderComponent()
+
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Error fetching versions:', expect.any(Error))
+      })
+
+      // Restore the console.error after the test
+      consoleErrorSpy.mockRestore()
+    })
+  })
+})

--- a/static/src/js/components/KmsConceptSelectionWidget/__tests__/KMSConceptSelectionWidget.test.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/__tests__/KMSConceptSelectionWidget.test.jsx
@@ -10,7 +10,6 @@ import { Button } from 'react-bootstrap'
 import {
   beforeEach,
   describe,
-  it,
   vi
 } from 'vitest'
 
@@ -97,6 +96,7 @@ describe('KmsConceptSelectionWidget', () => {
         expect(await screen.findByText('TORNADOES')).toBeInTheDocument()
       })
     })
+
     test('should show the full path as a title attribute', async () => {
       renderComponent()
       expect(getKmsConceptFullPaths).toHaveBeenCalledWith('test-uuid')
@@ -104,7 +104,7 @@ describe('KmsConceptSelectionWidget', () => {
         const keywordElement = screen.getByText(/tornadoes/i)
         const expectedTitle = /ScienceKeywords\s*>\s*ATMOSPHERE\s*>\s*TORNADOES/
         expect(keywordElement).toHaveAttribute('title', expect.stringMatching(expectedTitle))
-      })    
+      })
     })
   })
 
@@ -154,16 +154,16 @@ describe('KmsConceptSelectionWidget', () => {
   describe('when the user encounted network error', () => {
     test('should handle errors thrown by getKmsConceptFullPaths gracefully', async () => {
       getKmsConceptFullPaths.mockRejectedValueOnce(new Error('Failed to fetch full paths'))
-  
+
       // Mock console.error to suppress error logs
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-  
+
       renderComponent()
-  
+
       await waitFor(() => {
         expect(consoleErrorSpy).toHaveBeenCalledWith('Error fetching versions:', expect.any(Error))
       })
-  
+
       // Restore the original implementation of console.error
       consoleErrorSpy.mockRestore()
     })

--- a/static/src/js/components/KmsConceptVersionSelector/KmsConceptVersionSelector.jsx
+++ b/static/src/js/components/KmsConceptVersionSelector/KmsConceptVersionSelector.jsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import Select from 'react-select'
-import Row from 'react-bootstrap/Row'
+import React, { useEffect, useState } from 'react'
 import Col from 'react-bootstrap/Col'
+import Row from 'react-bootstrap/Row'
+import Select from 'react-select'
+
 import getKmsConceptVersions from '@/js/utils/getKmsConceptVersions'
 
 /**
@@ -90,19 +91,13 @@ const KmsConceptVersionSelector = ({ onVersionSelect }) => {
   }
 
   return (
-    <Row className="mb-4">
-      <Col>
-        <div className="rounded p-3">
-          <Select
-            isLoading={loading}
-            options={versions}
-            value={selectedVersion}
-            onChange={handleChange}
-            placeholder="Loading versions..."
-          />
-        </div>
-      </Col>
-    </Row>
+    <Select
+      isLoading={loading}
+      options={versions}
+      value={selectedVersion}
+      onChange={handleChange}
+      placeholder="Loading versions..."
+    />
   )
 }
 

--- a/static/src/js/components/KmsConceptVersionSelector/KmsConceptVersionSelector.jsx
+++ b/static/src/js/components/KmsConceptVersionSelector/KmsConceptVersionSelector.jsx
@@ -1,7 +1,5 @@
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
-import Col from 'react-bootstrap/Col'
-import Row from 'react-bootstrap/Row'
 import Select from 'react-select'
 
 import getKmsConceptVersions from '@/js/utils/getKmsConceptVersions'

--- a/static/src/js/components/KmsConceptVersionSelector/__tests__/KmsConceptVersionSelector.test.jsx
+++ b/static/src/js/components/KmsConceptVersionSelector/__tests__/KmsConceptVersionSelector.test.jsx
@@ -1,13 +1,15 @@
-import React from 'react'
 import {
+  fireEvent,
   render,
   screen,
-  fireEvent,
   waitFor
 } from '@testing-library/react'
-import { vi } from 'vitest'
 import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { vi } from 'vitest'
+
 import getKmsConceptVersions from '@/js/utils/getKmsConceptVersions'
+
 import KmsConceptVersionSelector from '../KmsConceptVersionSelector'
 
 vi.mock('@/js/utils/getKmsConceptVersions')

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -44,7 +44,8 @@ const Layout = ({ className, displayNav }) => {
     ummC,
     ummS,
     ummT,
-    ummV
+    ummV,
+    ummVis
   } = getUmmVersionsConfig()
 
   const { env, displayProdWarning } = getApplicationConfig()
@@ -185,6 +186,20 @@ const Layout = ({ className, displayNav }) => {
                                   },
                                   {
                                     to: '/drafts/tools',
+                                    title: 'Drafts'
+                                  }
+                                ]
+                              },
+                              {
+                                title: 'Visualizations',
+                                version: `v${ummVis}`,
+                                children: [
+                                  {
+                                    to: '/visualizations',
+                                    title: 'All Visualizations'
+                                  },
+                                  {
+                                    to: '/drafts/visualizations',
                                     title: 'Drafts'
                                   }
                                 ]

--- a/static/src/js/components/Layout/__tests__/Layout.test.jsx
+++ b/static/src/js/components/Layout/__tests__/Layout.test.jsx
@@ -26,7 +26,8 @@ const setup = (loggedIn) => {
     ummC: 'mock-umm-c',
     ummS: 'mock-umm-s',
     ummT: 'mock-umm-t',
-    ummV: 'mock-umm-v'
+    ummV: 'mock-umm-v',
+    ummVis: 'mock-umm-vis'
   }))
 
   vi.setSystemTime('2024-01-01')
@@ -157,6 +158,20 @@ describe('Layout component', () => {
             ]
           },
           {
+            title: 'Visualizations',
+            version: 'vmock-umm-vis',
+            children: [
+              {
+                title: 'All Visualizations',
+                to: '/visualizations'
+              },
+              {
+                title: 'Drafts',
+                to: '/drafts/visualizations'
+              }
+            ]
+          },
+          {
             title: 'Order Options',
             children: [
               {
@@ -273,6 +288,20 @@ describe('Layout component', () => {
                 {
                   to: '/drafts/tools',
                   title: 'Drafts'
+                }
+              ]
+            },
+            {
+              title: 'Visualizations',
+              version: 'vmock-umm-vis',
+              children: [
+                {
+                  title: 'All Visualizations',
+                  to: '/visualizations'
+                },
+                {
+                  title: 'Drafts',
+                  to: '/drafts/visualizations'
                 }
               ]
             },

--- a/static/src/js/constants/conceptTypeDraftsQueries.js
+++ b/static/src/js/constants/conceptTypeDraftsQueries.js
@@ -2,12 +2,14 @@ import { GET_SERVICE_DRAFTS } from '../operations/queries/getServiceDrafts'
 import { GET_TOOL_DRAFTS } from '../operations/queries/getToolDrafts'
 import { GET_VARIABLE_DRAFTS } from '../operations/queries/getVariableDrafts'
 import { GET_COLLECTION_DRAFTS } from '../operations/queries/getCollectionDrafts'
+import { GET_VISUALIZATION_DRAFTS } from '../operations/queries/getVisualizationDrafts'
 
 const conceptTypeDraftsQueries = {
   Collection: GET_COLLECTION_DRAFTS,
   Service: GET_SERVICE_DRAFTS,
   Tool: GET_TOOL_DRAFTS,
-  Variable: GET_VARIABLE_DRAFTS
+  Variable: GET_VARIABLE_DRAFTS,
+  Visualization: GET_VISUALIZATION_DRAFTS
 }
 
 export default conceptTypeDraftsQueries

--- a/static/src/js/constants/conceptTypeQueries.js
+++ b/static/src/js/constants/conceptTypeQueries.js
@@ -8,6 +8,7 @@ import { GET_TOOL } from '@/js/operations/queries/getTool'
 import { GET_TOOLS } from '@/js/operations/queries/getTools'
 import { GET_VARIABLE } from '@/js/operations/queries/getVariable'
 import { GET_VARIABLES } from '@/js/operations/queries/getVariables'
+import { GET_VISUALIZATIONS } from '@/js/operations/queries/getVisualizations'
 
 const conceptTypeQueries = {
   Collection: GET_COLLECTION,
@@ -19,7 +20,8 @@ const conceptTypeQueries = {
   Tool: GET_TOOL,
   Tools: GET_TOOLS,
   Variable: GET_VARIABLE,
-  Variables: GET_VARIABLES
+  Variables: GET_VARIABLES,
+  Visualizations: GET_VISUALIZATIONS
 }
 
 export default conceptTypeQueries

--- a/static/src/js/constants/conceptTypes.js
+++ b/static/src/js/constants/conceptTypes.js
@@ -9,7 +9,8 @@ const conceptTypes = {
   Tool: 'Tool',
   Tools: 'Tools',
   Variable: 'Variable',
-  Variables: 'Variables'
+  Variables: 'Variables',
+  Visualizations: 'Visualizations'
 }
 
 export default conceptTypes

--- a/static/src/js/constants/redirectsMap/redirectsMap.js
+++ b/static/src/js/constants/redirectsMap/redirectsMap.js
@@ -7,11 +7,13 @@ const REDIRECTS = {
   manage_variables: 'variables',
   manage_services: 'services',
   manage_tools: 'tools',
+  manage_visualizations: 'visualizations',
   manage_cmr: 'collections',
   tool_drafts: 'drafts/tools',
   service_drafts: 'drafts/services',
   collection_drafts: 'drafts/collections',
-  variable_drafts: 'drafts/variables'
+  variable_drafts: 'drafts/variables',
+  visualization_drafts: 'drafts/visualizations'
 }
 
 export default REDIRECTS

--- a/static/src/js/constants/typeParamToHumanizedStringMap.js
+++ b/static/src/js/constants/typeParamToHumanizedStringMap.js
@@ -2,7 +2,8 @@ const typeParamToHumanizedStringMap = {
   collections: 'collection',
   services: 'service',
   tools: 'tool',
-  variables: 'variable'
+  variables: 'variable',
+  visualizations: 'visualization'
 }
 
 export default typeParamToHumanizedStringMap

--- a/static/src/js/constants/urlValueToConceptStringMap.js
+++ b/static/src/js/constants/urlValueToConceptStringMap.js
@@ -3,7 +3,8 @@ const urlValueTypeToConceptTypeStringMap = {
   collections: 'Collection',
   tools: 'Tool',
   services: 'Service',
-  cmr: 'CMR'
+  cmr: 'CMR',
+  visualizations: 'Visualization'
 }
 
 export default urlValueTypeToConceptTypeStringMap

--- a/static/src/js/operations/queries/getVisualizationDrafts.js
+++ b/static/src/js/operations/queries/getVisualizationDrafts.js
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client'
+
+export const GET_VISUALIZATION_DRAFTS = gql`
+  query VaisualizationDrafts($params: DraftsInput) {
+    drafts(params: $params) {
+      count
+      items {
+        conceptId
+        providerId
+        revisionDate
+        ummMetadata
+        previewMetadata {
+          ... on Visualization {
+            conceptId
+            name
+            title
+          }
+        }
+      }
+    }
+  }
+`

--- a/static/src/js/operations/queries/getVisualizations.js
+++ b/static/src/js/operations/queries/getVisualizations.js
@@ -1,0 +1,17 @@
+import { gql } from '@apollo/client'
+
+export const GET_VISUALIZATIONS = gql`
+  query GetVisualizations($params: VisualizationsInput) {
+    visualizations(params: $params) {
+      count
+      items {
+        conceptId
+        revisionId
+        name
+        title
+        providerId
+        revisionDate
+      }
+    }
+  }
+`

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -27,33 +27,6 @@ import createFormDataFromRdf from '@/js/utils/createFormDataFromRdf'
 
 import './KeywordManagerPage.scss'
 
-const KeywordManagerPageHeader = () => (
-  <PageHeader
-    breadcrumbs={
-      [
-        {
-          label: 'Keyword Manager',
-          to: '/keywords',
-          active: true
-        }
-      ]
-    }
-    pageType="secondary"
-    primaryActions={
-      [
-        {
-          icon: FaPlus,
-          iconTitle: 'A plus icon',
-          title: 'Publish New Keyword Version',
-          to: 'new',
-          variant: 'success'
-        }
-      ]
-    }
-    title="Keyword Manager"
-  />
-)
-
 const KeywordManagerPage = () => {
   const [showError, setShowError] = useState(null)
   const [isLoading, setIsLoading] = useState(false)

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -5,8 +5,7 @@ import React, {
   useEffect
 } from 'react'
 import { FaPlus } from 'react-icons/fa'
-import { Button } from 'react-bootstrap'
-import Modal from 'react-bootstrap/Modal'
+import { Modal, Button } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 
 import { getApplicationConfig } from 'sharedUtils/getConfig'

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -1,29 +1,28 @@
 import React, {
-  useState,
   useCallback,
-  useEffect
+  useEffect,
+  useState
 } from 'react'
+import { Col, Row } from 'react-bootstrap'
 import { FaPlus } from 'react-icons/fa'
 
-import { getApplicationConfig } from 'sharedUtils/getConfig'
-
+import CustomModal from '@/js/components/CustomModal/CustomModal'
 import ErrorBanner from '@/js/components/ErrorBanner/ErrorBanner'
 import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
 import KeywordForm from '@/js/components/KeywordForm/KeywordForm'
+import { KeywordTree } from '@/js/components/KeywordTree/KeywordTree'
+import {
+  KeywordTreePlaceHolder
+} from '@/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder'
 import KmsConceptSchemeSelector from '@/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector'
 import KmsConceptVersionSelector from '@/js/components/KmsConceptVersionSelector/KmsConceptVersionSelector'
 import MetadataPreviewPlaceholder from '@/js/components/MetadataPreviewPlaceholder/MetadataPreviewPlaceholder'
 import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
-import KeywordTree from '@/js/components/KeywordTree/KeywordTree'
-import CustomModal from '@/js/components/CustomModal/CustomModal'
-import {
-  KeywordTreePlaceHolder
-} from '@/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder'
-
-import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
-import errorLogger from '@/js/utils/errorLogger'
 import createFormDataFromRdf from '@/js/utils/createFormDataFromRdf'
+import errorLogger from '@/js/utils/errorLogger'
+import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
+import { getApplicationConfig } from 'sharedUtils/getConfig'
 
 import './KeywordManagerPage.scss'
 
@@ -92,7 +91,7 @@ const KeywordManagerPage = () => {
     }
   }
 
-  const handleNodeDoubleClick = useCallback((nodeId) => {
+  const handleNodeClick = useCallback((nodeId) => {
     handleShowKeyword(nodeId)
   }, [handleShowKeyword])
 
@@ -165,7 +164,13 @@ const KeywordManagerPage = () => {
     }
 
     if (selectedKeywordData) {
-      return <KeywordForm initialData={selectedKeywordData} />
+      return (
+        <KeywordForm
+          initialData={selectedKeywordData}
+          version={selectedVersion}
+          scheme={selectedScheme}
+        />
+      )
     }
 
     return null
@@ -181,9 +186,8 @@ const KeywordManagerPage = () => {
         <KeywordTree
           key={`${selectedVersion?.version}-${selectedScheme?.name}`}
           data={treeData}
-          onNodeDoubleClick={handleNodeDoubleClick}
+          onNodeClick={handleNodeClick}
           onNodeEdit={handleShowKeyword}
-          selectedScheme={selectedScheme?.name}
         />
       )
     }
@@ -231,7 +235,13 @@ const KeywordManagerPage = () => {
           >
             Version:
           </label>
-          <KmsConceptVersionSelector onVersionSelect={onVersionSelect} id="version-selector" />
+          <Row className="mb-4">
+            <Col>
+              <div className="rounded p-3">
+                <KmsConceptVersionSelector onVersionSelect={onVersionSelect} id="version-selector" />
+              </div>
+            </Col>
+          </Row>
           <label
             htmlFor="scheme-selector"
             className="keyword-manager-page__scheme-selector-label"
@@ -239,12 +249,18 @@ const KeywordManagerPage = () => {
             Scheme:
           </label>
           <div className="keyword-manager-page__scheme-selector-wrapper">
-            <KmsConceptSchemeSelector
-              version={selectedVersion}
-              onSchemeSelect={onSchemeSelect}
-              key={selectedVersion?.version}
-              id="scheme-selector"
-            />
+            <Row className="mb-4">
+              <Col>
+                <div className="rounded p-3">
+                  <KmsConceptSchemeSelector
+                    version={selectedVersion}
+                    onSchemeSelect={onSchemeSelect}
+                    key={selectedVersion?.version}
+                    id="scheme-selector"
+                  />
+                </div>
+              </Col>
+            </Row>
           </div>
         </div>
       </ErrorBoundary>

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -1,5 +1,4 @@
 import React, {
-  Suspense,
   useState,
   useCallback,
   useEffect
@@ -11,14 +10,12 @@ import { getApplicationConfig } from 'sharedUtils/getConfig'
 
 import ErrorBanner from '@/js/components/ErrorBanner/ErrorBanner'
 import ErrorBoundary from '@/js/components/ErrorBoundary/ErrorBoundary'
-import LoadingTable from '@/js/components/LoadingTable/LoadingTable'
 import KeywordForm from '@/js/components/KeywordForm/KeywordForm'
 import KmsConceptSchemeSelector from '@/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector'
 import KmsConceptVersionSelector from '@/js/components/KmsConceptVersionSelector/KmsConceptVersionSelector'
 import MetadataPreviewPlaceholder from '@/js/components/MetadataPreviewPlaceholder/MetadataPreviewPlaceholder'
 import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
-import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
 import KeywordTree from '@/js/components/KeywordTree/KeywordTree'
 import CustomModal from '@/js/components/CustomModal/CustomModal'
 
@@ -217,6 +214,7 @@ const KeywordManagerPage = () => {
           data={treeData}
           onNodeDoubleClick={handleNodeDoubleClick}
           onNodeEdit={handleShowKeyword}
+          selectedScheme={selectedScheme?.name}
         />
       )
     }
@@ -257,31 +255,29 @@ const KeywordManagerPage = () => {
       }
     >
       <ErrorBoundary>
-        <Suspense fallback={<LoadingTable />}>
-          <div className="keyword-manager-page__selector-container">
-            <label
-              htmlFor="version-selector"
-              className="keyword-manager-page__selector-label"
-            >
-              Version:
-            </label>
-            <KmsConceptVersionSelector onVersionSelect={onVersionSelect} id="version-selector" />
-            <label
-              htmlFor="scheme-selector"
-              className="keyword-manager-page__scheme-selector-label"
-            >
-              Scheme:
-            </label>
-            <div className="keyword-manager-page__scheme-selector-wrapper">
-              <KmsConceptSchemeSelector
-                version={selectedVersion}
-                onSchemeSelect={onSchemeSelect}
-                key={selectedVersion?.version}
-                id="scheme-selector"
-              />
-            </div>
+        <div className="keyword-manager-page__selector-container">
+          <label
+            htmlFor="version-selector"
+            className="keyword-manager-page__selector-label"
+          >
+            Version:
+          </label>
+          <KmsConceptVersionSelector onVersionSelect={onVersionSelect} id="version-selector" />
+          <label
+            htmlFor="scheme-selector"
+            className="keyword-manager-page__scheme-selector-label"
+          >
+            Scheme:
+          </label>
+          <div className="keyword-manager-page__scheme-selector-wrapper">
+            <KmsConceptSchemeSelector
+              version={selectedVersion}
+              onSchemeSelect={onSchemeSelect}
+              key={selectedVersion?.version}
+              id="scheme-selector"
+            />
           </div>
-        </Suspense>
+        </div>
       </ErrorBoundary>
       <div className="keyword-manager-page__content">
         <ErrorBoundary>

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -5,7 +5,6 @@ import React, {
   useEffect
 } from 'react'
 import { FaPlus } from 'react-icons/fa'
-import { Modal, Button } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 
 import { getApplicationConfig } from 'sharedUtils/getConfig'
@@ -21,6 +20,7 @@ import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
 import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
 import KeywordTree from '@/js/components/KeywordTree/KeywordTree'
+import CustomModal from '@/js/components/CustomModal/CustomModal'
 
 import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
 import errorLogger from '@/js/utils/errorLogger'
@@ -180,7 +180,7 @@ const KeywordManagerPage = () => {
    * Closes the warning modal
    */
   const handleCloseWarning = () => setShowWarning(false)
-  // Modal actions for the warning modal
+
   const warningModalActions = [
     {
       label: 'OK',
@@ -188,10 +188,7 @@ const KeywordManagerPage = () => {
       onClick: handleCloseWarning
     }
   ]
-  /**
-   * Renders the content based on the current state
-   * @returns {JSX.Element} The rendered content
-   */
+
   const renderContent = () => {
     if (isLoading) {
       return <MetadataPreviewPlaceholder />
@@ -299,20 +296,13 @@ const KeywordManagerPage = () => {
         </ErrorBoundary>
       </div>
 
-      <Modal show={showWarning} onHide={handleCloseWarning}>
-        <Modal.Header>
-          <Modal.Title>Warning</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          You are now viewing the live published keyword version. Changes made
-          to this version will show up on the website right away.
-        </Modal.Body>
-        <Modal.Footer>
-          <Button variant="primary" onClick={handleCloseWarning}>
-            OK
-          </Button>
-        </Modal.Footer>
-      </Modal>
+      <CustomModal
+        show={showWarning}
+        toggleModal={() => setShowWarning(false)}
+        header="Warning"
+        message="You are now viewing the live published keyword version. Changes made to this version will show up on the website right away."
+        actions={warningModalActions}
+      />
     </Page>
   )
 }

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -27,6 +27,8 @@ import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
 import errorLogger from '@/js/utils/errorLogger'
 import createFormDataFromRdf from '@/js/utils/createFormDataFromRdf'
 
+import './KeywordManagerPage.scss'
+
 const KeywordManagerPageHeader = () => (
   <PageHeader
     breadcrumbs={
@@ -55,19 +57,7 @@ const KeywordManagerPageHeader = () => (
 )
 
 const TreePlaceholder = ({ message }) => (
-  <div style={
-    {
-      width: '40%',
-      maxWidth: '40%',
-      height: '300px', // Adjust as needed
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      border: '1px solid #ccc',
-      borderRadius: '4px'
-    }
-  }
-  >
+  <div className="keyword-manager-page__tree-placeholder">
     {message}
   </div>
 )
@@ -271,40 +261,21 @@ const KeywordManagerPage = () => {
     >
       <ErrorBoundary>
         <Suspense fallback={<LoadingTable />}>
-
-          <div style={
-            {
-              display: 'flex',
-              alignItems: 'center',
-              marginBottom: '20px'
-            }
-          }
-          >
+          <div className="keyword-manager-page__selector-container">
             <label
               htmlFor="version-selector"
-              style={
-                {
-                  marginRight: '10px',
-                  marginBottom: '25px'
-                }
-              }
+              className="keyword-manager-page__selector-label"
             >
               Version:
             </label>
             <KmsConceptVersionSelector onVersionSelect={onVersionSelect} id="version-selector" />
             <label
               htmlFor="scheme-selector"
-              style={
-                {
-                  marginLeft: '20px',
-                  marginRight: '10px',
-                  marginBottom: '25px'
-                }
-              }
+              className="keyword-manager-page__scheme-selector-label"
             >
               Scheme:
             </label>
-            <div style={{ width: '300px' }}>
+            <div className="keyword-manager-page__scheme-selector-wrapper">
               <KmsConceptSchemeSelector
                 version={selectedVersion}
                 onSchemeSelect={onSchemeSelect}
@@ -313,44 +284,16 @@ const KeywordManagerPage = () => {
               />
             </div>
           </div>
-
         </Suspense>
       </ErrorBoundary>
-      <div style={
-        {
-          display: 'flex',
-          flexWrap: 'wrap'
-        }
-      }
-      >
+      <div className="keyword-manager-page__content">
         <ErrorBoundary>
-          <div style={
-            {
-              width: '40%',
-              maxWidth: '40%',
-              overflowX: 'auto',
-              padding: '10px',
-              borderRadius: '4px',
-              border: '1px solid #ccc',
-              alignSelf: 'flex-start',
-              maxHeight: '80vh',
-              overflowY: 'auto'
-            }
-          }
-          >
+          <div className="keyword-manager-page__tree-container">
             {renderTree()}
           </div>
         </ErrorBoundary>
         <ErrorBoundary>
-          <div style={
-            {
-              flexBasis: '58.33%',
-              maxWidth: '58.33%',
-              padding: '0 15px 0 40px',
-              minHeight: '300px'
-            }
-          }
-          >
+          <div className="keyword-manager-page__form-container">
             {renderContent()}
           </div>
         </ErrorBoundary>
@@ -370,7 +313,6 @@ const KeywordManagerPage = () => {
           </Button>
         </Modal.Footer>
       </Modal>
-
     </Page>
   )
 }

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -4,7 +4,6 @@ import React, {
   useEffect
 } from 'react'
 import { FaPlus } from 'react-icons/fa'
-import PropTypes from 'prop-types'
 
 import { getApplicationConfig } from 'sharedUtils/getConfig'
 
@@ -18,6 +17,9 @@ import Page from '@/js/components/Page/Page'
 import PageHeader from '@/js/components/PageHeader/PageHeader'
 import KeywordTree from '@/js/components/KeywordTree/KeywordTree'
 import CustomModal from '@/js/components/CustomModal/CustomModal'
+import {
+  KeywordTreePlaceHolder
+} from '@/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder'
 
 import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
 import errorLogger from '@/js/utils/errorLogger'
@@ -50,12 +52,6 @@ const KeywordManagerPageHeader = () => (
     }
     title="Keyword Manager"
   />
-)
-
-const TreePlaceholder = ({ message }) => (
-  <div className="keyword-manager-page__tree-placeholder">
-    {message}
-  </div>
 )
 
 const KeywordManagerPage = () => {
@@ -204,7 +200,7 @@ const KeywordManagerPage = () => {
 
   const renderTree = () => {
     if (isTreeLoading) {
-      return <TreePlaceholder message="Loading..." />
+      return <KeywordTreePlaceHolder message="Loading..." />
     }
 
     if (treeData) {
@@ -219,7 +215,7 @@ const KeywordManagerPage = () => {
       )
     }
 
-    return <TreePlaceholder message={treeMessage} />
+    return <KeywordTreePlaceHolder message={treeMessage} />
   }
 
   return (
@@ -301,10 +297,6 @@ const KeywordManagerPage = () => {
       />
     </Page>
   )
-}
-
-TreePlaceholder.propTypes = {
-  message: PropTypes.string.isRequired
 }
 
 export default KeywordManagerPage

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -139,6 +139,7 @@ const KeywordManagerPage = () => {
       } catch (error) {
         console.error('Error fetching keyword tree:', error)
         setTreeData(null)
+        setTreeMessage('Failed to load the tree. Please try again.')
       } finally {
         setIsTreeLoading(false)
       }
@@ -209,7 +210,7 @@ const KeywordManagerPage = () => {
 
   const renderTree = () => {
     if (isTreeLoading) {
-      return <TreePlaceholder message="Loading tree..." />
+      return <TreePlaceholder message="Loading..." />
     }
 
     if (treeData) {

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.scss
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.scss
@@ -47,14 +47,4 @@
   &__scheme-selector-wrapper {
     width: 300px;
   }
-
-  &__tree-placeholder {
-    display: flex;
-    width: 100%;
-    height: 300px;
-    align-items: center;
-    justify-content: center;
-    border: 1px solid $gray-300;
-    border-radius: 4px;
-  }
 }

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.scss
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.scss
@@ -2,6 +2,15 @@
 
 @import '../../../css/vendor/bootstrap/variables';
 
+$md-breakpoint: map.get($grid-breakpoints, "md");
+
+@mixin md-down {
+  // stylelint-disable-next-line media-query-no-invalid
+  @media (max-width: #{$md-breakpoint}) {
+    @content;
+  }
+}
+
 .keyword-manager-page {
   &__content {
     display: flex;
@@ -11,20 +20,20 @@
   &__tree-container {
     width: 40%;
     max-width: 40%;
-    overflow-x: auto;
-    padding: 10px;
-    border-radius: 4px;
-    border: 1px solid $gray-300;
-    align-self: flex-start;
     max-height: 80vh;
+    align-self: flex-start;
+    padding: 10px;
+    border: 1px solid $gray-300;
+    border-radius: 4px;
+    overflow-x: auto;
     overflow-y: auto;
   }
 
   &__form-container {
-    flex-basis: 58.33%;
     max-width: 58.33%;
-    padding: 0 15px 0 40px;
     min-height: 300px;
+    flex-basis: 58.33%;
+    padding: 0 15px 0 40px;
   }
 
   &__selector-container {
@@ -39,9 +48,9 @@
   }
 
   &__scheme-selector-label {
-    margin-left: 20px;
     margin-right: 10px;
     margin-bottom: 25px;
+    margin-left: 20px;
   }
 
   &__scheme-selector-wrapper {
@@ -49,19 +58,16 @@
   }
 
   &__tree-placeholder {
+    display: flex;
     width: 100%;
     height: 300px;
-    display: flex;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
     border: 1px solid $gray-300;
     border-radius: 4px;
   }
-}
 
-
-@media (max-width: map.get($grid-breakpoints, "md")) {
-  .keyword-manager-page {
+  @include md-down {
     &__tree-container,
     &__form-container {
       width: 100%;
@@ -69,7 +75,7 @@
     }
 
     &__form-container {
-      padding: 15px 0 0 0;
+      padding: 15px 0 0;
     }
   }
 }

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.scss
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.scss
@@ -11,20 +11,20 @@
   &__tree-container {
     width: 40%;
     max-width: 40%;
-    max-height: 80vh;
-    align-self: flex-start;
-    padding: 10px;
-    border: 1px solid $gray-300;
-    border-radius: 4px;
     overflow-x: auto;
+    padding: 10px;
+    border-radius: 4px;
+    border: 1px solid $gray-300;
+    align-self: flex-start;
+    max-height: 80vh;
     overflow-y: auto;
   }
 
   &__form-container {
-    max-width: 58.33%;
-    min-height: 300px;
     flex-basis: 58.33%;
+    max-width: 58.33%;
     padding: 0 15px 0 40px;
+    min-height: 300px;
   }
 
   &__selector-container {
@@ -39,12 +39,37 @@
   }
 
   &__scheme-selector-label {
+    margin-left: 20px;
     margin-right: 10px;
     margin-bottom: 25px;
-    margin-left: 20px;
   }
 
   &__scheme-selector-wrapper {
     width: 300px;
+  }
+
+  &__tree-placeholder {
+    width: 100%;
+    height: 300px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid $gray-300;
+    border-radius: 4px;
+  }
+}
+
+
+@media (max-width: map.get($grid-breakpoints, "md")) {
+  .keyword-manager-page {
+    &__tree-container,
+    &__form-container {
+      width: 100%;
+      max-width: 100%;
+    }
+
+    &__form-container {
+      padding: 15px 0 0 0;
+    }
   }
 }

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.scss
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.scss
@@ -2,15 +2,6 @@
 
 @import '../../../css/vendor/bootstrap/variables';
 
-$md-breakpoint: map.get($grid-breakpoints, "md");
-
-@mixin md-down {
-  // stylelint-disable-next-line media-query-no-invalid
-  @media (max-width: #{$md-breakpoint}) {
-    @content;
-  }
-}
-
 .keyword-manager-page {
   &__content {
     display: flex;
@@ -65,17 +56,5 @@ $md-breakpoint: map.get($grid-breakpoints, "md");
     justify-content: center;
     border: 1px solid $gray-300;
     border-radius: 4px;
-  }
-
-  @include md-down {
-    &__tree-container,
-    &__form-container {
-      width: 100%;
-      max-width: 100%;
-    }
-
-    &__form-container {
-      padding: 15px 0 0;
-    }
   }
 }

--- a/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
+++ b/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
@@ -280,6 +280,33 @@ describe('KeywordManagerPage component', () => {
       expect(versionSelector).toHaveValue('3.0')
     })
 
+    test('closes warning modal when toggleModal is called', async () => {
+      const { user } = setup()
+
+      // Select a published version to trigger the warning modal
+      await waitFor(() => {
+        expect(screen.getByTestId('version-selector')).toBeInTheDocument()
+      })
+
+      const versionSelector = screen.getByTestId('version-selector')
+      await user.selectOptions(versionSelector, '3.0')
+
+      // Check if the warning modal is shown
+      await waitFor(() => {
+        expect(screen.getByTestId('custom-modal')).toBeInTheDocument()
+      })
+
+      // Find and click the close button
+      const closeButton = screen.getByTestId('modal-close')
+      await user.click(closeButton)
+
+      // Check if the modal is closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('custom-modal')).not.toBeInTheDocument()
+      })
+    })
+  })
+
   describe('KmsConceptSchemeSelector', () => {
     test('renders the scheme selector next to the version selector', async () => {
       setup()

--- a/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
+++ b/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
@@ -16,19 +16,18 @@ import KeywordManagerPage from '../KeywordManagerPage'
 vi.mock('@/js/utils/getKmsKeywordTree')
 
 vi.mock('@/js/components/KeywordTree/KeywordTree', () => ({
-  __esModule: true,
-  default: ({ data, onNodeDoubleClick }) => {
-    if (!data) {
+  KeywordTree: vi.fn((props) => {
+    if (!props.data) {
       return null
     }
 
     return (
       <div data-testid="keyword-tree">
-        <pre>{JSON.stringify(data, null, 2)}</pre>
-        <button type="button" onClick={() => onNodeDoubleClick('test-node-id')}>Double Click Node</button>
+        <pre>{JSON.stringify(props.data, null, 2)}</pre>
+        <button type="button" onClick={() => props.onNodeClick('test-node-id')}>Click Node</button>
       </div>
     )
-  }
+  })
 }))
 
 vi.mock('sharedUtils/getConfig')
@@ -478,7 +477,7 @@ describe('KeywordManagerPage component', () => {
       expect(screen.queryByTestId('keyword-tree')).not.toBeInTheDocument()
     })
 
-    test('calls handleShowKeyword and createFormDataFromRdf when a node is double-clicked', async () => {
+    test('calls handleShowKeyword and createFormDataFromRdf when a node is clicked', async () => {
       const mockCreateFormDataFromRdf = vi.fn().mockReturnValue({})
       vi.spyOn(createFormDataFromRdfModule, 'default').mockImplementation(mockCreateFormDataFromRdf)
 
@@ -509,9 +508,9 @@ describe('KeywordManagerPage component', () => {
         expect(screen.getByTestId('keyword-tree')).toBeInTheDocument()
       })
 
-      // Simulate double-click on a node
-      const doubleClickButton = screen.getByText('Double Click Node')
-      await user.click(doubleClickButton)
+      // Simulate click on a node
+      const clickButton = screen.getByText('Click Node')
+      await user.click(clickButton)
 
       // Wait for the fetch to be called
       await waitFor(() => {
@@ -554,9 +553,9 @@ describe('KeywordManagerPage component', () => {
         expect(screen.getByTestId('keyword-tree')).toBeInTheDocument()
       })
 
-      // Simulate double-click on a node
-      const doubleClickButton = screen.getByText('Double Click Node')
-      await user.click(doubleClickButton)
+      // Simulate click on a node
+      const clickButton = screen.getByText('Click Node')
+      await user.click(clickButton)
 
       // Wait for the error message to appear
       await waitFor(() => {

--- a/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
+++ b/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
@@ -450,5 +450,51 @@ describe('KeywordManagerPage component', () => {
       // Ensure the tree is not rendered
       expect(screen.queryByTestId('keyword-tree')).not.toBeInTheDocument()
     })
+
+    test('calls handleShowKeyword and createFormDataFromRdf when a node is double-clicked', async () => {
+      const mockCreateFormDataFromRdf = vi.fn().mockReturnValue({})
+      vi.spyOn(createFormDataFromRdfModule, 'default').mockImplementation(mockCreateFormDataFromRdf)
+  
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('<rdf:RDF></rdf:RDF>')
+      })
+  
+      const { user } = setup()
+  
+      // Select version and scheme
+      await waitFor(() => {
+        expect(screen.getByTestId('version-selector')).toBeInTheDocument()
+      })
+  
+      const versionSelector = screen.getByTestId('version-selector')
+      await user.selectOptions(versionSelector, '2.0')
+  
+      await waitFor(() => {
+        expect(screen.getByTestId('scheme-selector')).toBeInTheDocument()
+      })
+  
+      const schemeSelector = screen.getByTestId('scheme-selector')
+      await user.selectOptions(schemeSelector, 'scheme1')
+  
+      // Wait for the tree to load
+      await waitFor(() => {
+        expect(screen.getByTestId('keyword-tree')).toBeInTheDocument()
+      })
+  
+      // Simulate double-click on a node
+      const doubleClickButton = screen.getByText('Double Click Node')
+      await user.click(doubleClickButton)
+  
+      // Wait for the fetch to be called
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/concept/test-node-id'))
+      })
+  
+      // Verify that createFormDataFromRdf was called with the fetched RDF data
+      await waitFor(() => {
+        expect(mockCreateFormDataFromRdf).toHaveBeenCalledWith('<rdf:RDF></rdf:RDF>')
+      })
+    })
   })
 })

--- a/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
+++ b/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
@@ -496,5 +496,48 @@ describe('KeywordManagerPage component', () => {
         expect(mockCreateFormDataFromRdf).toHaveBeenCalledWith('<rdf:RDF></rdf:RDF>')
       })
     })
+
+    test('shows error message when fetching keyword data fails', async () => {
+      // Mock fetch to return a non-OK response
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found'
+      })
+
+      const { user } = setup()
+
+      // Select version and scheme
+      await waitFor(() => {
+        expect(screen.getByTestId('version-selector')).toBeInTheDocument()
+      })
+
+      const versionSelector = screen.getByTestId('version-selector')
+      await user.selectOptions(versionSelector, '2.0')
+
+      await waitFor(() => {
+        expect(screen.getByTestId('scheme-selector')).toBeInTheDocument()
+      })
+
+      const schemeSelector = screen.getByTestId('scheme-selector')
+      await user.selectOptions(schemeSelector, 'scheme1')
+
+      // Wait for the tree to load
+      await waitFor(() => {
+        expect(screen.getByTestId('keyword-tree')).toBeInTheDocument()
+      })
+
+      // Simulate double-click on a node
+      const doubleClickButton = screen.getByText('Double Click Node')
+      await user.click(doubleClickButton)
+
+      // Wait for the error message to appear
+      await waitFor(() => {
+        expect(screen.getByText('HTTP error! status: 404')).toBeInTheDocument()
+      })
+
+      // Ensure that the KeywordForm is not rendered
+      expect(screen.queryByTestId('keyword-form')).not.toBeInTheDocument()
+    })
   })
 })

--- a/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
+++ b/static/src/js/pages/KeywordManagerPage/__tests__/KeywordManagerPage.test.jsx
@@ -454,43 +454,43 @@ describe('KeywordManagerPage component', () => {
     test('calls handleShowKeyword and createFormDataFromRdf when a node is double-clicked', async () => {
       const mockCreateFormDataFromRdf = vi.fn().mockReturnValue({})
       vi.spyOn(createFormDataFromRdfModule, 'default').mockImplementation(mockCreateFormDataFromRdf)
-  
+
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,
         text: () => Promise.resolve('<rdf:RDF></rdf:RDF>')
       })
-  
+
       const { user } = setup()
-  
+
       // Select version and scheme
       await waitFor(() => {
         expect(screen.getByTestId('version-selector')).toBeInTheDocument()
       })
-  
+
       const versionSelector = screen.getByTestId('version-selector')
       await user.selectOptions(versionSelector, '2.0')
-  
+
       await waitFor(() => {
         expect(screen.getByTestId('scheme-selector')).toBeInTheDocument()
       })
-  
+
       const schemeSelector = screen.getByTestId('scheme-selector')
       await user.selectOptions(schemeSelector, 'scheme1')
-  
+
       // Wait for the tree to load
       await waitFor(() => {
         expect(screen.getByTestId('keyword-tree')).toBeInTheDocument()
       })
-  
+
       // Simulate double-click on a node
       const doubleClickButton = screen.getByText('Double Click Node')
       await user.click(doubleClickButton)
-  
+
       // Wait for the fetch to be called
       await waitFor(() => {
         expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/concept/test-node-id'))
       })
-  
+
       // Verify that createFormDataFromRdf was called with the fetched RDF data
       await waitFor(() => {
         expect(mockCreateFormDataFromRdf).toHaveBeenCalledWith('<rdf:RDF></rdf:RDF>')

--- a/static/src/js/pages/SearchList/SearchList.jsx
+++ b/static/src/js/pages/SearchList/SearchList.jsx
@@ -79,6 +79,15 @@ const SearchList = ({ limit }) => {
     }
   }
 
+  if (formattedType === conceptTypes.Visualizations) {
+    params = {
+      limit,
+      offset,
+      provider: providerParam,
+      sortKey: sortKeyParam
+    }
+  }
+
   const { data } = useSuspenseQuery(conceptTypeQueries[formattedType], {
     variables: {
       params
@@ -111,18 +120,28 @@ const SearchList = ({ limit }) => {
   const buildEllipsisLinkCell = useCallback((cellData, rowData) => {
     const { conceptId } = rowData
 
+    let newCellData = cellData
+
+    if (!newCellData && conceptType === 'visualizations') newCellData = '<Blank Short Name>'
+
     return (
       <EllipsisLink to={`/${conceptType}/${conceptId}`}>
-        {cellData}
+        {newCellData}
       </EllipsisLink>
     )
   }, [conceptType])
 
-  const buildEllipsisTextCell = useCallback((cellData) => (
-    <EllipsisText>
-      {cellData}
-    </EllipsisText>
-  ), [])
+  const buildEllipsisTextCell = useCallback((cellData) => {
+    let newCellData = cellData
+
+    if (!newCellData && conceptType === 'visualizations') newCellData = '<Blank Long Name>'
+
+    return (
+      <EllipsisText>
+        {newCellData}
+      </EllipsisText>
+    )
+  }, [])
 
   const buildTagCell = useCallback((cellData, rowData) => {
     const tagCount = getTagCount(cellData)
@@ -204,6 +223,42 @@ const SearchList = ({ limit }) => {
           dataAccessorFn: buildTagCell,
           dataKey: 'tagDefinitions',
           title: 'Tags'
+        },
+        {
+          align: 'end',
+          className: 'col-auto text-nowrap',
+          dataAccessorFn: (cellData) => moment.utc(cellData).format(DATE_FORMAT),
+          dataKey: 'revisionDate',
+          sortFn,
+          title: 'Last Modified (UTC)'
+        }
+      ]
+    }
+
+    if (formattedType === conceptTypes.Visualizations) {
+      return [
+        {
+          className: 'col-auto',
+          dataAccessorFn: buildEllipsisLinkCell,
+          dataKey: 'name',
+          sortFn,
+          title: 'Short Name'
+        },
+        {
+          className: 'col-auto',
+          dataAccessorFn: buildEllipsisTextCell,
+          dataKey: 'title',
+          // To be completed in MMT-4023
+          // SortFn,
+          // sortKey: 'title',
+          title: 'Long Name'
+        },
+        {
+          align: 'center',
+          className: 'col-auto text-nowrap',
+          dataKey: 'providerId',
+          sortFn,
+          title: 'Provider'
         },
         {
           align: 'end',

--- a/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
+++ b/static/src/js/pages/SearchList/__tests__/SearchList.test.jsx
@@ -22,7 +22,8 @@ import {
   singlePageServicesSearch,
   singlePageToolsSearch,
   singlePageToolsSearchWithProvider,
-  singlePageVariablesSearch
+  singlePageVariablesSearch,
+  singlePageVisualizationsSearch
 } from './__mocks__/searchResults'
 
 import SearchList from '../SearchList'
@@ -457,6 +458,54 @@ describe('SearchPage component', () => {
         expect(row1Cells[1].textContent).toBe('Variable Long Name 1')
         expect(row1Cells[2].textContent).toBe('TESTPROV')
         expect(row1Cells[3].textContent).toBe('Thursday, November 30, 2023 12:00 AM')
+      })
+    })
+  })
+
+  describe('when searching for visualizations', () => {
+    beforeEach(() => {
+      setup([singlePageVisualizationsSearch], {}, ['/visualizations'])
+    })
+
+    describe('while the request is loading', () => {
+      test('renders the headers', async () => {
+        expect(screen.getByText('Loading...')).toBeInTheDocument()
+
+        const table = await screen.findByRole('table')
+
+        const tableRows = within(table).getAllByRole('row')
+
+        expect(tableRows.length).toEqual(3)
+
+        expect(within(table).getAllByRole('columnheader')[1].textContent).toContain('Long Name')
+        expect(within(table).getAllByRole('columnheader')[2].textContent).toContain('Provider')
+        expect(within(table).getAllByRole('columnheader')[3].textContent).toContain('Last Modified')
+      })
+    })
+
+    describe('when the request has loaded', () => {
+      test('renders the data', async () => {
+        expect(screen.getByText('Loading...')).toBeInTheDocument()
+
+        const table = await screen.findByRole('table')
+
+        const tableRows = within(table).getAllByRole('row')
+
+        expect(tableRows.length).toEqual(3)
+
+        const row1Cells = within(tableRows[1]).queryAllByRole('cell')
+        const row2Cells = within(tableRows[2]).queryAllByRole('cell')
+
+        expect(row1Cells).toHaveLength(4)
+        expect(row1Cells[0].textContent).toBe('Visualization Name 1')
+        expect(row1Cells[1].textContent).toBe('Visualization Long Name 1')
+        expect(row1Cells[2].textContent).toBe('TESTPROV')
+        expect(row1Cells[3].textContent).toBe('Monday, April 28, 2025 3:13 PM')
+        expect(row2Cells).toHaveLength(4)
+        expect(row2Cells[0].textContent).toBe('<Blank Short Name>')
+        expect(row2Cells[1].textContent).toBe('<Blank Long Name>')
+        expect(row2Cells[2].textContent).toBe('TESTPROV')
+        expect(row2Cells[3].textContent).toBe('Monday, April 28, 2025 3:13 PM')
       })
     })
   })

--- a/static/src/js/pages/SearchList/__tests__/__mocks__/searchResults.js
+++ b/static/src/js/pages/SearchList/__tests__/__mocks__/searchResults.js
@@ -1,8 +1,9 @@
+import { GET_COLLECTIONS } from '@/js/operations/queries/getCollections'
+import { GET_SERVICES } from '@/js/operations/queries/getServices'
+import { GET_TOOLS } from '@/js/operations/queries/getTools'
+import { GET_VARIABLES } from '@/js/operations/queries/getVariables'
+import { GET_VISUALIZATIONS } from '@/js/operations/queries/getVisualizations'
 import { GraphQLError } from 'graphql'
-import { GET_COLLECTIONS } from '../../../../operations/queries/getCollections'
-import { GET_SERVICES } from '../../../../operations/queries/getServices'
-import { GET_VARIABLES } from '../../../../operations/queries/getVariables'
-import { GET_TOOLS } from '../../../../operations/queries/getTools'
 
 export const singlePageCollectionSearch = {
   request: {
@@ -778,6 +779,45 @@ export const singlePageToolsSearchWithProvider = {
             revisionDate: '2023-11-30 00:00:00',
             revisionId: '1',
             userId: 'admin'
+          }
+        ]
+      }
+    }
+  }
+}
+
+export const singlePageVisualizationsSearch = {
+  request: {
+    query: GET_VISUALIZATIONS,
+    variables: {
+      params: {
+        limit: 25,
+        offset: 0,
+        provider: null,
+        sortKey: null
+      }
+    }
+  },
+  result: {
+    data: {
+      visualizations: {
+        count: 2,
+        items: [
+          {
+            conceptId: 'VIS000000001-TESTPROV',
+            name: 'Visualization Name 1',
+            title: 'Visualization Long Name 1',
+            providerId: 'TESTPROV',
+            revisionId: '1',
+            revisionDate: '2025-04-28T15:13:10.461Z'
+          },
+          {
+            conceptId: 'VIS000000002-TESTPROV',
+            name: '',
+            title: '',
+            providerId: 'TESTPROV',
+            revisionId: '1',
+            revisionDate: '2025-04-28T15:13:10.461Z'
           }
         ]
       }

--- a/static/src/js/pages/SearchPage/SearchPage.jsx
+++ b/static/src/js/pages/SearchPage/SearchPage.jsx
@@ -209,6 +209,18 @@ const SearchBar = () => {
  *   <SearchPageHeader />
  * )
  */
+
+// Remove this in MMT-4023
+const renderSearchBar = () => {
+  const { type: searchTypeFromPath } = useParams()
+  // Don't render SearchBar for Visualizations
+  if (searchTypeFromPath.toLowerCase() === 'visualizations') {
+    return null
+  }
+
+  return <SearchBar />
+}
+
 const SearchPageHeader = () => {
   const { type: conceptType } = useParams()
 
@@ -216,9 +228,7 @@ const SearchPageHeader = () => {
     <PageHeader
       title={`All ${capitalize(getHumanizedNameFromTypeParam(conceptType))}s`}
       pageType="secondary"
-      beforeActions={(
-        <SearchBar />
-      )}
+      beforeActions={renderSearchBar()}
       breadcrumbs={
         [
           {

--- a/static/src/js/schemas/uiSchemas/keywords/editKeyword.js
+++ b/static/src/js/schemas/uiSchemas/keywords/editKeyword.js
@@ -89,8 +89,7 @@ const editKeywordsUiSchema = {
     'ui:disabled': true
   },
   BroaderKeyword: {
-    'ui:widget': KmsConceptSelectionWidget,
-    'ui:title': 'Keyword'
+    'ui:widget': KmsConceptSelectionWidget
   },
   NarrowerKeywords: {
     items: {

--- a/static/src/js/schemas/uiSchemas/keywords/editKeyword.js
+++ b/static/src/js/schemas/uiSchemas/keywords/editKeyword.js
@@ -1,6 +1,7 @@
 import CustomSelectWidget from '@/js/components/CustomSelectWidget/CustomSelectWidget'
 import CustomTextareaWidget from '@/js/components/CustomTextareaWidget/CustomTextareaWidget'
 import CustomTextWidget from '@/js/components/CustomTextWidget/CustomTextWidget'
+import KmsConceptSelectionWidget from '@/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget'
 
 const editKeywordsUiSchema = {
   'ui:submitButtonOptions': {
@@ -88,7 +89,7 @@ const editKeywordsUiSchema = {
     'ui:disabled': true
   },
   BroaderKeyword: {
-    'ui:widget': CustomTextWidget
+    'ui:widget': KmsConceptSelectionWidget
   },
   NarrowerKeywords: {
     items: {
@@ -102,10 +103,10 @@ const editKeywordsUiSchema = {
             }
           }
         ]
+      },
+      NarrowerUUID: {
+        'ui:widget': KmsConceptSelectionWidget
       }
-    },
-    NarrowerUUID: {
-      'ui:widget': CustomTextWidget
     }
   },
   PreferredLabel: {
@@ -194,8 +195,7 @@ const editKeywordsUiSchema = {
         'ui:widget': CustomSelectWidget
       },
       UUID: {
-        'ui:widget': CustomTextWidget,
-        'ui:readonly': true
+        'ui:widget': KmsConceptSelectionWidget
       }
     }
   },

--- a/static/src/js/schemas/uiSchemas/keywords/editKeyword.js
+++ b/static/src/js/schemas/uiSchemas/keywords/editKeyword.js
@@ -89,7 +89,8 @@ const editKeywordsUiSchema = {
     'ui:disabled': true
   },
   BroaderKeyword: {
-    'ui:widget': KmsConceptSelectionWidget
+    'ui:widget': KmsConceptSelectionWidget,
+    'ui:title': 'Keyword'
   },
   NarrowerKeywords: {
     items: {
@@ -105,7 +106,8 @@ const editKeywordsUiSchema = {
         ]
       },
       NarrowerUUID: {
-        'ui:widget': KmsConceptSelectionWidget
+        'ui:widget': KmsConceptSelectionWidget,
+        'ui:title': 'Keyword'
       }
     }
   },
@@ -195,7 +197,8 @@ const editKeywordsUiSchema = {
         'ui:widget': CustomSelectWidget
       },
       UUID: {
-        'ui:widget': KmsConceptSelectionWidget
+        'ui:widget': KmsConceptSelectionWidget,
+        'ui:title': 'Keyword'
       }
     }
   },

--- a/static/src/js/utils/__tests__/getKmsConceptFullPaths.test.js
+++ b/static/src/js/utils/__tests__/getKmsConceptFullPaths.test.js
@@ -1,0 +1,48 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest'
+
+import { getKmsConceptFullPaths } from '@/js/utils/getKmsConceptFullPaths'
+
+// Mocking fetch
+global.fetch = vi.fn(() => Promise.resolve({
+  ok: true,
+  text: () => Promise.resolve(`
+      <FullPaths>
+        <FullPath xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:string">Chained Operations</FullPath>
+      </FullPaths>
+    `)
+}))
+
+describe('getKmsConceptFullPaths', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    fetch.mockClear()
+  })
+
+  it('should fetch and return full paths from KMS', async () => {
+    const value = 'test-uuid'
+    const expectedResult = ['Chained Operations']
+
+    const result = await getKmsConceptFullPaths(value)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining(`/concept_fullpaths/concept_uuid/${value}`), { method: 'GET' })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it('should throw an error if fetch fails', async () => {
+    fetch.mockImplementationOnce(() => Promise.resolve({
+      ok: false,
+      status: 404
+    }))
+
+    await expect(getKmsConceptFullPaths('bad-uuid')).rejects.toThrow('getConceptFullPaths HTTP error! status: 404')
+  })
+})

--- a/static/src/js/utils/__tests__/getKmsConceptSchemes.test.js
+++ b/static/src/js/utils/__tests__/getKmsConceptSchemes.test.js
@@ -1,12 +1,14 @@
 import {
-  describe,
-  test,
-  expect,
-  vi,
+  afterEach,
   beforeEach,
-  afterEach
+  describe,
+  expect,
+  test,
+  vi
 } from 'vitest'
+
 import { getApplicationConfig } from 'sharedUtils/getConfig'
+
 import getKmsConceptSchemes from '../getKmsConceptSchemes'
 
 vi.mock('sharedUtils/getConfig', () => ({

--- a/static/src/js/utils/__tests__/getKmsKeywordTree.test.js
+++ b/static/src/js/utils/__tests__/getKmsKeywordTree.test.js
@@ -344,4 +344,31 @@ describe('getKmsKeywordTree', () => {
       })
     })
   })
+
+  describe('when providing a search pattern', () => {
+    test('should append search pattern to the endpoint URL', async () => {
+      const mockResponse = {
+        tree: {
+          treeData: [{ children: [{}] }]
+        }
+      }
+  
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse)
+      })
+  
+      const searchPattern = 'someSearchPattern'
+      await getKmsKeywordTree(
+        { version: '21.0', version_type: 'draft' },
+        { name: 'idnnode' },
+        searchPattern
+      )
+  
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://example.com/tree/concept_scheme/idnnode?version=21.0&filter=someSearchPattern',
+        { method: 'GET' }
+      )
+    })
+  })
 })

--- a/static/src/js/utils/__tests__/getKmsKeywordTree.test.js
+++ b/static/src/js/utils/__tests__/getKmsKeywordTree.test.js
@@ -153,7 +153,7 @@ describe('getKmsKeywordTree', () => {
     })
   })
 
-  describe('when edge cases', () => {
+  describe('edge cases', () => {
     test('should handle empty tree', async () => {
       const mockResponse = {
         tree: {
@@ -239,7 +239,7 @@ describe('getKmsKeywordTree', () => {
     })
   })
 
-  describe('when handling version', () => {
+  describe('version handling', () => {
     test('should use version number for non-published versions', async () => {
       global.fetch.mockResolvedValueOnce({
         ok: true,
@@ -258,7 +258,7 @@ describe('getKmsKeywordTree', () => {
     })
   })
 
-  describe('when handling scheme', () => {
+  describe('scheme handling', () => {
     test('should use the correct scheme name in the URL', async () => {
       global.fetch.mockResolvedValueOnce({
         ok: true,
@@ -274,7 +274,7 @@ describe('getKmsKeywordTree', () => {
     })
   })
 
-  describe('when handling response structure', () => {
+  describe('response structure', () => {
     test('should handle deeply nested tree structures', async () => {
       const mockResponse = {
         tree: {

--- a/static/src/js/utils/__tests__/getKmsKeywordTree.test.js
+++ b/static/src/js/utils/__tests__/getKmsKeywordTree.test.js
@@ -352,19 +352,22 @@ describe('getKmsKeywordTree', () => {
           treeData: [{ children: [{}] }]
         }
       }
-  
+
       global.fetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockResponse)
       })
-  
+
       const searchPattern = 'someSearchPattern'
       await getKmsKeywordTree(
-        { version: '21.0', version_type: 'draft' },
+        {
+          version: '21.0',
+          version_type: 'draft'
+        },
         { name: 'idnnode' },
         searchPattern
       )
-  
+
       expect(global.fetch).toHaveBeenCalledWith(
         'http://example.com/tree/concept_scheme/idnnode?version=21.0&filter=someSearchPattern',
         { method: 'GET' }

--- a/static/src/js/utils/getKmsConceptFullPaths.js
+++ b/static/src/js/utils/getKmsConceptFullPaths.js
@@ -1,0 +1,37 @@
+import { XMLParser } from 'fast-xml-parser'
+import { castArray } from 'lodash-es'
+
+import { getApplicationConfig } from 'sharedUtils/getConfig'
+
+const getKmsConceptFullPaths = async (value) => {
+  const { kmsHost } = getApplicationConfig()
+  try {
+    // Fetch data from KMS server
+    const response = await fetch(`${kmsHost}/concept_fullpaths/concept_uuid/${value}`, {
+      method: 'GET'
+    })
+
+    if (!response.ok) {
+      throw new Error(`getConceptFullPaths HTTP error! status: ${response.status}`)
+    }
+
+    const xmlText = await response.text()
+
+    // Parse XML to JavaScript object
+    const parser = new XMLParser({
+      ignoreAttributes: false,
+      attributeNamePrefix: '@_'
+    })
+    const result = parser.parse(xmlText)
+
+    // Ensure we always have an array of FullPath objects
+    const fullPaths = castArray(result.FullPaths.FullPath)
+
+    return fullPaths.map((path) => (path['#text']))
+  } catch (error) {
+    console.error('Error fetching KMS concept schemes:', error)
+    throw error
+  }
+}
+
+export { getKmsConceptFullPaths }

--- a/static/src/js/utils/getKmsConceptFullPaths.js
+++ b/static/src/js/utils/getKmsConceptFullPaths.js
@@ -3,6 +3,15 @@ import { castArray } from 'lodash-es'
 
 import { getApplicationConfig } from 'sharedUtils/getConfig'
 
+/**
+ * Fetches the full path(s) for a given KMS concept UUID and returns them as an array of strings.
+ *
+ * @async
+ * @function getKmsConceptFullPaths
+ * @param {string} value - The UUID of the KMS concept whose full paths are to be fetched.
+ * @returns {Promise<string[]>} A promise that resolves to an array of full paths as strings.
+ * @throws Will throw an error if the fetch operation or XML parsing fails.
+ */
 const getKmsConceptFullPaths = async (value) => {
   const { kmsHost } = getApplicationConfig()
   try {

--- a/static/src/js/utils/getKmsConceptSchemes.js
+++ b/static/src/js/utils/getKmsConceptSchemes.js
@@ -1,4 +1,5 @@
 import { XMLParser } from 'fast-xml-parser'
+
 import { getApplicationConfig } from 'sharedUtils/getConfig'
 
 /**

--- a/static/src/js/utils/getKmsKeywordTree.js
+++ b/static/src/js/utils/getKmsKeywordTree.js
@@ -1,5 +1,10 @@
 import { getApplicationConfig } from 'sharedUtils/getConfig'
 
+/**
+ * Recursively adds unique IDs to each node in the tree.
+ * @param {Object} node - The node to process.
+ * @returns {Object} A new node with added ID.
+ */
 const addIdsToNodes = (node) => {
   const newNode = {
     ...node,
@@ -12,6 +17,25 @@ const addIdsToNodes = (node) => {
   return newNode
 }
 
+/**
+ * Fetches the keyword tree from the KMS server and processes it.
+ * @param {Object} version - The version object containing version information.
+ * @param {Object} scheme - The scheme object containing the scheme name.
+ * @returns {Promise<Object>} A promise that resolves to the processed keyword tree.
+ * @throws {Error} If there's an error fetching or processing the tree.
+ *
+ * @example
+ * // Usage example
+ * const version = { version: '1.0', version_type: 'draft' };
+ * const scheme = { name: 'MyScheme' };
+ *
+ * try {
+ *   const keywordTree = await getKmsKeywordTree(version, scheme);
+ *   console.log(keywordTree);
+ * } catch (error) {
+ *   console.error('Failed to get keyword tree:', error);
+ * }
+ */
 const getKmsKeywordTree = async (version, scheme) => {
   const { kmsHost } = getApplicationConfig()
   try {
@@ -21,7 +45,7 @@ const getKmsKeywordTree = async (version, scheme) => {
       versionParam = 'published'
     }
 
-    const schemeParam = scheme.name
+    const schemeParam = encodeURIComponent(scheme.name)
 
     // Fetch data from KMS server
     const response = await fetch(`${kmsHost}/tree/concept_scheme/${schemeParam}?version=${versionParam}`, {

--- a/static/src/js/utils/getKmsKeywordTree.js
+++ b/static/src/js/utils/getKmsKeywordTree.js
@@ -1,10 +1,5 @@
 import { getApplicationConfig } from 'sharedUtils/getConfig'
 
-/**
- * Recursively adds unique IDs to each node in the tree.
- * @param {Object} node - The node to process.
- * @returns {Object} A new node with added ID.
- */
 const addIdsToNodes = (node) => {
   const newNode = {
     ...node,
@@ -17,25 +12,6 @@ const addIdsToNodes = (node) => {
   return newNode
 }
 
-/**
- * Fetches the keyword tree from the KMS server and processes it.
- * @param {Object} version - The version object containing version information.
- * @param {Object} scheme - The scheme object containing the scheme name.
- * @returns {Promise<Object>} A promise that resolves to the processed keyword tree.
- * @throws {Error} If there's an error fetching or processing the tree.
- *
- * @example
- * // Usage example
- * const version = { version: '1.0', version_type: 'draft' };
- * const scheme = { name: 'MyScheme' };
- *
- * try {
- *   const keywordTree = await getKmsKeywordTree(version, scheme);
- *   console.log(keywordTree);
- * } catch (error) {
- *   console.error('Failed to get keyword tree:', error);
- * }
- */
 const getKmsKeywordTree = async (version, scheme) => {
   const { kmsHost } = getApplicationConfig()
   try {
@@ -45,7 +21,7 @@ const getKmsKeywordTree = async (version, scheme) => {
       versionParam = 'published'
     }
 
-    const schemeParam = encodeURIComponent(scheme.name)
+    const schemeParam = scheme.name
 
     // Fetch data from KMS server
     const response = await fetch(`${kmsHost}/tree/concept_scheme/${schemeParam}?version=${versionParam}`, {


### PR DESCRIPTION
# Overview

### What is the feature?

Support a custom widget for selecting a keyword from the form page.

### What is the Solution?

Added a custom widget component that provides a tree for a user to search for keyword and select it.  The selection will then populate the form page.   You can also filter by concept scheme.   The placeholder text mentions you can filter by UUID, but that is coming in the next ticket, as will require a KMS change.

### What areas of the application does this impact?

Keyword Mange Form

# Testing

Select a keyword from the tree, so the form displays.
Next to each keyword should be a pencil icon, indicating you can edit that keyword.  Note the tree will open to the selected keyword.
Click it and a modal will display.
Try finding a keyword by searching by pattern, selecting it, and hitting accept.   The form should now contain your selection.    Note when you search, the tree now auto expands all nodes and highlights the search word.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
