### PR TITLE
MMT-4006: User can add new narrower keyword

### DIFF
--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -25,6 +25,7 @@ import './KeywordTree.scss'
  * @param {Object|Array} props.data - The initial tree data structure
  * @param {Function} props.onNodeClick - Callback function when a node is clicked
  * @param {Function} props.onNodeEdit - Callback function when a node is edited
+ * @param {Function} props.onAddNarrower - Callback function when a narrower keyword is added
  *
  * @example
  * const treeData = [
@@ -57,16 +58,21 @@ import './KeywordTree.scss'
  *   console.log('Node edit requested:', nodeId);
  * };
  *
+ * const handleAddNarrower = (parentId, newChild) => {
+ *   console.log('New narrower added:', newChild, 'to parent:', parentId);
+ * };
+ *
  * return (
  *   <KeywordTree
  *     data={treeData}
  *     onNodeClick={handleNodeClick}
  *     onNodeEdit={handleNodeEdit}
+ *     onAddNarrower={handleAddNarrower}
  *   />
  * );
  */
 export const KeywordTree = ({
-  data, onNodeClick, onNodeEdit
+  data, onAddNarrower, onNodeClick, onNodeEdit
 }) => {
   const [treeData, setTreeData] = useState(Array.isArray(data) ? data : [data])
   const treeRef = useRef(null)
@@ -163,6 +169,9 @@ export const KeywordTree = ({
           parentNode.toggle()
         }
       }
+
+      // Notify the parent component about the new keyword
+      onAddNarrower(addNarrowerParentId, newChild)
 
       setShowAddNarrowerPopup(false)
       setNewNarrowerTitle('')
@@ -269,6 +278,7 @@ KeywordTree.propTypes = {
     PropTypes.shape(NodeShape),
     PropTypes.arrayOf(PropTypes.shape(NodeShape))
   ]).isRequired,
+  onAddNarrower: PropTypes.func.isRequired,
   onNodeClick: PropTypes.func.isRequired,
   onNodeEdit: PropTypes.func.isRequired
 }

--- a/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
+++ b/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
@@ -39,6 +39,7 @@ describe('KeywordTree component', () => {
 
   const mockOnNodeClick = vi.fn()
   const mockOnNodeEdit = vi.fn()
+  const mockOnAddNarrower = vi.fn()
   let consoleErrorSpy
 
   beforeAll(() => {
@@ -58,6 +59,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -70,6 +72,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -83,6 +86,7 @@ describe('KeywordTree component', () => {
           data={[]}
           onNodeClick={vi.fn()}
           onNodeEdit={vi.fn()}
+          onAddNarrower={vi.fn()}
         />
       )
 
@@ -103,6 +107,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -139,6 +144,7 @@ describe('KeywordTree component', () => {
           data={dataWithGrandchildren}
           onNodeClick={vi.fn()}
           onNodeEdit={vi.fn()}
+          onAddNarrower={vi.fn()}
         />
       )
 
@@ -181,6 +187,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -194,6 +201,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -243,6 +251,7 @@ describe('KeywordTree component', () => {
           data={nestedData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -273,6 +282,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -286,6 +296,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -302,6 +313,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -321,6 +333,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -345,6 +358,9 @@ describe('KeywordTree component', () => {
       await waitFor(() => {
         expect(screen.getByText('New Child')).toBeInTheDocument()
       })
+
+      // Check if onAddNarrower was called
+      expect(mockOnAddNarrower).toHaveBeenCalled()
     })
 
     test('should close "Add Narrower" modal when Cancel is clicked', async () => {
@@ -353,6 +369,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -380,6 +397,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -422,6 +440,7 @@ describe('KeywordTree component', () => {
           data={collapsedData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -451,6 +470,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -489,6 +509,7 @@ describe('KeywordTree component', () => {
           data={longTitleData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -503,6 +524,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -524,6 +546,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -545,6 +568,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -581,6 +605,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -635,6 +660,7 @@ describe('KeywordTree component', () => {
           data={dataWithLeafNodes}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -684,6 +710,7 @@ describe('KeywordTree component', () => {
           data={dataWithEmptyChildren}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 
@@ -696,6 +723,7 @@ describe('KeywordTree component', () => {
           data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
         />
       )
 

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -74,6 +74,18 @@ const KeywordManagerPage = () => {
       setIsLoading(false)
     }
   }, [selectedVersion])
+
+  const handleAddNarrower = useCallback((parentId, newKeyword) => {
+    // Create a new keyword data structure for the form
+    const newKeywordData = {
+      KeywordUUID: newKeyword.id,
+      PreferredLabel: newKeyword.title,
+      BroaderKeyword: parentId
+    }
+
+    // Update the selected keyword data with the new keyword
+    setSelectedKeywordData(newKeywordData)
+  }, [])
   /**
    * Handles the click event on a tree node
    * @param {string} nodeId - The id of the clicked node
@@ -162,7 +174,16 @@ const KeywordManagerPage = () => {
     }
 
     if (selectedKeywordData) {
-      return <KeywordForm initialData={selectedKeywordData} />
+      return (
+        <KeywordForm
+          initialData={selectedKeywordData}
+          onFormDataChange={
+            (newFormData) => {
+              setSelectedKeywordData(newFormData)
+            }
+          }
+        />
+      )
     }
 
     return null
@@ -184,6 +205,7 @@ const KeywordManagerPage = () => {
           data={treeData}
           onNodeClick={handleNodeClick}
           onNodeEdit={handleShowKeyword}
+          onAddNarrower={handleAddNarrower}
         />
       )
     }

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -177,11 +177,6 @@ const KeywordManagerPage = () => {
       return (
         <KeywordForm
           initialData={selectedKeywordData}
-          onFormDataChange={
-            (newFormData) => {
-              setSelectedKeywordData(newFormData)
-            }
-          }
         />
       )
     }


### PR DESCRIPTION
# Overview

### What is the feature?

User can add new narrower keyword

### What is the Solution?

Add new context menu item 'Add Narrower' to add new keyword.

### What areas of the application does this impact?

The keyword tree and the form. The form will show the new keyword's detail for user to edit.

# Testing

Right click on a keyword on the tree, click 'Add Narrower', new keyword should show up in the form.

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
