### PR TITLE
MMT-3991b: Updating temporalExtent to Temporal Extents for the graphql visualization query

### DIFF
--- a/static/src/js/operations/queries/getVisualization.js
+++ b/static/src/js/operations/queries/getVisualization.js
@@ -20,7 +20,7 @@ export const GET_VISUALIZATION = gql`
       spatialExtent
       specification
       subtitle
-      temporalExtent
+      temporalExtents
       title
       ummMetadata
       visualizationType

--- a/static/src/js/operations/queries/getVisualizationDraft.js
+++ b/static/src/js/operations/queries/getVisualizationDraft.js
@@ -27,7 +27,7 @@ export const VISUALIZATION_DRAFT = gql`
           spatialExtent
           specification
           subtitle
-          temporalExtent
+          temporalExtents
           title
           ummMetadata
           visualizationType


### PR DESCRIPTION
# Overview

### What is the feature?

GQL had a change to field where temporalExtent became temporalExtents. Made that change here so that MMT-3991 can be fully tested

### What is the Solution?

adding an s

### What areas of the application does this impact?

visualization queries

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Spin up environment and make sure that we can make calls to published and draft visualization

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
