### PR TITLE
MMT-3995: As a user, I can edit Visualization Information and Science Keywords

### DIFF
--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -45,6 +45,7 @@ import getFormSchema from '@/js/utils/getFormSchema'
 import getNextFormName from '@/js/utils/getNextFormName'
 import getUiSchema from '@/js/utils/getUiSchema'
 import getUmmSchema from '@/js/utils/getUmmSchema'
+import getUmmVersion from '@/js/utils/getUmmVersion'
 import removeEmpty from '@/js/utils/removeEmpty'
 import toKebabCase from '@/js/utils/toKebabCase'
 
@@ -204,7 +205,7 @@ const MetadataForm = () => {
         nativeId,
         providerId: fetchedMetadataProviderId || providerId,
         // TODO pull this version number from a config
-        ummVersion: '1.0.0'
+        ummVersion: getUmmVersion(derivedConceptType)
       },
       onCompleted: (mutationData) => {
         const { ingestDraft } = mutationData

--- a/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
+++ b/static/src/js/components/MetadataForm/__tests__/MetadataForm.test.jsx
@@ -23,6 +23,7 @@ import * as router from 'react-router'
 import conceptTypeDraftQueries from '@/js/constants/conceptTypeDraftQueries'
 
 import errorLogger from '@/js/utils/errorLogger'
+import getUmmVersion from '@/js/utils/getUmmVersion'
 
 import relatedUrlsUiSchema from '@/js/schemas/uiSchemas/tools/relatedUrls'
 import toolInformationUiSchema from '@/js/schemas/uiSchemas/tools/toolInformation'
@@ -54,6 +55,14 @@ import { INGEST_DRAFT } from '@/js/operations/mutations/ingestDraft'
 import { PUBLISH_DRAFT } from '@/js/operations/mutations/publishDraft'
 
 import MetadataForm from '../MetadataForm'
+
+vi.mock('@/js/hooks/usePublishMutation', () => ({
+  default: vi.fn(() => ({
+    publishMutation: vi.fn(),
+    publishDraft: null,
+    error: null
+  }))
+}))
 
 vi.mock('@rjsf/core', () => ({
   default: vi.fn(({
@@ -580,7 +589,7 @@ describe('MetadataForm', () => {
                 },
                 nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
                 providerId: 'MMT_2',
-                ummVersion: '1.0.0'
+                ummVersion: getUmmVersion('Tool')
               }
             },
             result: {
@@ -629,7 +638,7 @@ describe('MetadataForm', () => {
                 },
                 nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
                 providerId: 'MMT_2',
-                ummVersion: '1.0.0'
+                ummVersion: getUmmVersion('Tool')
               }
             },
             result: {
@@ -675,7 +684,7 @@ describe('MetadataForm', () => {
                 },
                 nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
                 providerId: 'MMT_2',
-                ummVersion: '1.0.0'
+                ummVersion: getUmmVersion('Tool')
               }
             },
             result: {
@@ -800,7 +809,7 @@ describe('MetadataForm', () => {
                 metadata: ummMetadata,
                 nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
                 providerId: 'MMT_2',
-                ummVersion: '1.0.0'
+                ummVersion: getUmmVersion('Tool')
               }
             },
             result: {
@@ -817,7 +826,7 @@ describe('MetadataForm', () => {
               variables: {
                 draftConceptId: 'TD1000000-MMT',
                 nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
-                ummVersion: '1.2.0'
+                ummVersion: getUmmVersion('Tool')
               }
             },
             result: {
@@ -864,7 +873,7 @@ describe('MetadataForm', () => {
                 },
                 nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
                 providerId: 'MMT_2',
-                ummVersion: '1.0.0'
+                ummVersion: getUmmVersion('Tool')
               }
             },
             error: new Error('An error occured')
@@ -928,7 +937,7 @@ describe('MetadataForm', () => {
                 },
                 nativeId: 'MMT_mock-uuid',
                 providerId: 'MMT_1',
-                ummVersion: '1.0.0'
+                ummVersion: getUmmVersion('Collection')
               }
             },
             result: {

--- a/static/src/js/hooks/usePublishMutation.js
+++ b/static/src/js/hooks/usePublishMutation.js
@@ -32,10 +32,13 @@ const usePublishMutation = (queryName) => {
     conceptType,
     nativeId
   ) => {
+    // Can be removed once CMR-10545 is complete
+    const publishNativeId = conceptType === 'Visualization' ? `MMT_${crypto.randomUUID()}` : nativeId
+
     await publishDraftMutation({
       variables: {
         draftConceptId: conceptId,
-        nativeId,
+        nativeId: publishNativeId,
         ummVersion: getUmmVersion(conceptType)
       },
       onCompleted: (getPublishedData) => {

--- a/static/src/js/schemas/uiSchemas/visualizations/index.js
+++ b/static/src/js/schemas/uiSchemas/visualizations/index.js
@@ -1,0 +1,9 @@
+import scienceKeywordsUiSchema from './scienceKeywords'
+import visualizationInformationUiSchema from './visualizationInformation'
+
+const visualizationUiSchema = {
+  'visualization-information': visualizationInformationUiSchema,
+  'science-keywords': scienceKeywordsUiSchema
+}
+
+export default visualizationUiSchema

--- a/static/src/js/schemas/uiSchemas/visualizations/scienceKeywords.js
+++ b/static/src/js/schemas/uiSchemas/visualizations/scienceKeywords.js
@@ -1,0 +1,37 @@
+const scienceKeywordsUiSchema = {
+  'ui:heading-level': 'h3',
+  'ui:field': 'layout',
+  'ui:layout_grid': {
+    'ui:row': [
+      {
+        'ui:group': 'Science Keywords',
+        'ui:required': true,
+        'ui:col': {
+          md: 12,
+          children: [
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['ScienceKeywords']
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  ScienceKeywords: {
+    'ui:field': 'keywordPicker',
+    'ui:keyword_scheme': 'science_keywords',
+    'ui:picker_title': 'SERVICE KEYWORD',
+    'ui:keyword_scheme_column_names': ['sciencekeywords', 'category', 'topic', 'term', 'variable_level_1', 'variable_level_2', 'variable_level_3'],
+    'ui:filter': 'EARTH SCIENCE',
+    'ui:scheme_values': ['Category', 'Topic', 'Term', 'VariableLevel1', 'VariableLevel2', 'VariableLevel3']
+  }
+}
+
+export default scienceKeywordsUiSchema

--- a/static/src/js/schemas/uiSchemas/visualizations/visualizationInformation.js
+++ b/static/src/js/schemas/uiSchemas/visualizations/visualizationInformation.js
@@ -1,0 +1,82 @@
+const visualizationInformationUiSchema = {
+  'ui:heading-level': 'h3',
+  'ui:field': 'layout',
+  'ui:layout_grid': {
+    'ui:row': [
+      {
+        'ui:group': 'Visualization Information',
+        'ui:required': true,
+        'ui:col': {
+          md: 12,
+          children: [
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['Identifier']
+                  }
+                }
+              ]
+            },
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['Name']
+                  }
+                }
+              ]
+            },
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['Title']
+                  }
+                }
+              ]
+            },
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['Subtitle']
+                  }
+                }
+              ]
+            },
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['Description']
+                  }
+                }
+              ]
+            },
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['VisualizationType']
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  Description: {
+    'ui:widget': 'textarea'
+  }
+}
+
+export default visualizationInformationUiSchema

--- a/static/src/js/utils/getUiSchema.js
+++ b/static/src/js/utils/getUiSchema.js
@@ -2,6 +2,7 @@ import collectionsUiSchema from '../schemas/uiSchemas/collections'
 import serviceUiSchema from '../schemas/uiSchemas/services'
 import toolsUiSchema from '../schemas/uiSchemas/tools'
 import variableUiSchema from '../schemas/uiSchemas/variables'
+import visualizationUiSchema from '../schemas/uiSchemas/visualizations'
 
 /**
  * Returns the UI Schema of the provided conceptType
@@ -17,6 +18,8 @@ const getUiSchema = (conceptType) => {
       return toolsUiSchema
     case 'Variable':
       return variableUiSchema
+    case 'Visualization':
+      return visualizationUiSchema
     default:
       return null
   }

--- a/static/src/js/utils/getUmmVersion.js
+++ b/static/src/js/utils/getUmmVersion.js
@@ -16,6 +16,8 @@ const getUmmVersion = (conceptType) => {
       return ummVersion.ummT
     case 'Variable':
       return ummVersion.ummV
+    case 'Visualization':
+      return ummVersion.ummVis
     default:
       return null
   }


### PR DESCRIPTION
# Overview

### What is the feature?

Users can edit Visualization Information.
Users can edit Science Keywords.
Users can use all buttons that are in the form (save, save & continue, save & publish, save & preview)

### What is the Solution?

Adding ummVis to all appropriate areas for it to render within MetadataForms. 

### What areas of the application does this impact?

MetadataForm.js
usePublishMutataion
>> Please note that this file only needs to be changed until CMR-10545 is complete
Also utilzied getUmmVersion in areas where we wanted to use it when it was completed. 

# Testing

### Reproduction steps

- **Environment for testing: SIT
- **Collection to test with: Any

1. Select a Visualization (there's one corrupted file, let me know if you find it. It doesn't work) and click on Visualization Information. It should be styled the way we want it. 
2. Select Science Keywords. It should work as expected. 
3. Select any/all of the Save Options and make sure they work as expected. 

### Attachments

<img width="1397" alt="Screenshot 2025-05-14 at 9 49 35 AM" src="https://github.com/user-attachments/assets/23dc2136-45d8-40d0-a43c-9cdc36143bdd" />
<img width="1398" alt="Screenshot 2025-05-14 at 9 49 52 AM" src="https://github.com/user-attachments/assets/9e9a8c2d-aa92-45c1-9856-1c49a8d9c114" />


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
