### PR TITLE
MMT-4018: As a user, I can filter the navigation tree by a pattern search

### DIFF
--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -8,7 +8,7 @@ import React, {
 import { Tree } from 'react-arborist'
 import CustomModal from '@/js/components/CustomModal/CustomModal'
 import PropTypes from 'prop-types'
-import { Form } from 'react-bootstrap'
+import { Button, Form } from 'react-bootstrap'
 import { v4 as uuidv4 } from 'uuid'
 import {
   KeywordTreeContextMenu
@@ -274,13 +274,13 @@ const KeywordTreeComponent = forwardRef(({
           ref={searchInputRef}
           defaultValue={searchPattern}
         />
-        <button
+        <Button
           type="button"
           className="kms-concept-selection-edit-modal__apply-button"
           onClick={onHandleApplyFilteredSearch}
         >
           Apply
-        </button>
+        </Button>
       </div>
 
       <Tree

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -97,7 +97,11 @@ const KeywordTreeComponent = forwardRef(({
     if (selectedVersion && selectedScheme) {
       setIsTreeLoading(true)
       try {
-        const kmsTree = castArray(await getKmsKeywordTree(selectedVersion, selectedScheme, searchPattern))
+        const kmsTree = castArray(await getKmsKeywordTree(
+          selectedVersion,
+          selectedScheme,
+          searchPattern
+        ))
         setTreeData(kmsTree)
       } catch (error) {
         console.error('Error fetching keyword tree:', error)

--- a/static/src/js/components/KeywordTree/KeywordTree.jsx
+++ b/static/src/js/components/KeywordTree/KeywordTree.jsx
@@ -29,34 +29,16 @@ import { castArray } from 'lodash-es'
  * It uses react-arborist for the tree structure and provides context menu functionality.
  *
  * @component
- * @param {Object|Array} props.data - The initial tree data structure
+ * @param {Function} props.onAddNarrower - Callback function when a narrower keyword is added
  * @param {Function} props.onNodeClick - Callback function when a node is clicked
  * @param {Function} props.onNodeEdit - Callback function when a node is edited
- * @param {Function} props.onAddNarrower - Callback function when a narrower keyword is added
+ * @param {string} props.selectedNodeId - ID of the currently selected node
+ * @param {boolean} props.showContextMenu - Whether to show the context menu
+ * @param {boolean} props.openAll - Whether to open all nodes in the tree
+ * @param {Object} props.selectedVersion - The selected version object
+ * @param {Object} props.selectedScheme - The selected scheme object
  *
  * @example
- * const treeData = [
- *   {
- *     id: '1',
- *     key: '1',
- *     title: 'Root',
- *     children: [
- *       {
- *         id: '2',
- *         key: '2',
- *         title: 'Child 1',
- *         children: []
- *       },
- *       {
- *         id: '3',
- *         key: '3',
- *         title: 'Child 2',
- *         children: []
- *       }
- *     ]
- *   }
- * ];
- *
  * const handleNodeClick = (nodeId) => {
  *   console.log('Node clicked:', nodeId);
  * };
@@ -71,10 +53,14 @@ import { castArray } from 'lodash-es'
  *
  * return (
  *   <KeywordTree
- *     data={treeData}
  *     onNodeClick={handleNodeClick}
  *     onNodeEdit={handleNodeEdit}
  *     onAddNarrower={handleAddNarrower}
+ *     selectedNodeId="1"
+ *     showContextMenu={true}
+ *     openAll={false}
+ *     selectedVersion={{...}}
+ *     selectedScheme={{...}}
  *   />
  * );
  */

--- a/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
+++ b/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
@@ -114,6 +114,51 @@ describe('KeywordTree component', () => {
         expect(screen.getByText(/Failed to load the tree/i)).toBeInTheDocument()
       }, { timeout: 3000 })
     })
+
+    test('should set tree data to null when refreshTree is called without version and scheme', async () => {
+      const mockOnNodeClick = vi.fn()
+      const mockTreeData = [{
+        id: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValueOnce(mockTreeData)
+
+      const { rerender } = render(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          selectedVersion={{ id: 'v1' }}
+          selectedScheme={{ id: 's1' }}
+        />
+      )
+
+      // Wait for the initial render with data
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
+
+      // Clear the selected version and scheme and call refreshTree
+      const ref = { current: null }
+      rerender(
+        <KeywordTree
+          ref={ref}
+          onNodeClick={mockOnNodeClick}
+          selectedVersion={null}
+          selectedScheme={null}
+        />
+      )
+
+      // Call refreshTree directly
+      await ref.current.refreshTree()
+
+      // Check that the tree data has been cleared
+      await waitFor(() => {
+        expect(screen.queryByText('Root')).not.toBeInTheDocument()
+      })
+
+      // Verify that the placeholder message is shown
+      expect(screen.getByText('Select a version and scheme to load the tree')).toBeInTheDocument()
+    })
   })
 
   describe('when searching', () => {

--- a/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
+++ b/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
@@ -3,116 +3,289 @@ import {
   render,
   fireEvent,
   screen,
-  within,
-  waitFor
+  waitFor,
+  within
 } from '@testing-library/react'
 import {
   describe,
   test,
   expect,
-  vi
+  vi,
+  beforeEach
 } from 'vitest'
+import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
 import { KeywordTree } from '../KeywordTree'
 
-describe('KeywordTree component', () => {
-  const mockData = [
-    {
-      id: '1',
-      key: '1',
-      title: 'Root',
-      children: [
-        {
-          id: '2',
-          key: '2',
-          title: 'Child 1',
-          children: []
-        },
-        {
-          id: '3',
-          key: '3',
-          title: 'Child 2',
-          children: []
-        }
-      ]
-    }
-  ]
+// Mock the getKmsKeywordTree function
+vi.mock('@/js/utils/getKmsKeywordTree')
 
+const mockData = [
+  {
+    id: '1',
+    key: '1',
+    title: 'Root',
+    children: [
+      {
+        id: '2',
+        key: '2',
+        title: 'Child 1',
+        children: []
+      },
+      {
+        id: '3',
+        key: '3',
+        title: 'Child 2',
+        children: []
+      }
+    ]
+  }
+]
+
+describe('KeywordTree component', () => {
   const mockOnNodeClick = vi.fn()
   const mockOnNodeEdit = vi.fn()
   const mockOnAddNarrower = vi.fn()
-  let consoleErrorSpy
+  const mockSelectedVersion = { id: 'v1' }
+  const mockSelectedScheme = { id: 's1' }
 
-  beforeAll(() => {
-    // Suppress console.error for all tests in this file
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
-  afterAll(() => {
-    // Restore console.error after all tests
-    consoleErrorSpy.mockRestore()
-  })
-
-  describe('when rendering', () => {
-    test('should render KeywordTree component', () => {
-      render(
-        <KeywordTree
-          data={mockData}
-          onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
-        />
-      )
-
-      expect(screen.getByText('Root')).toBeTruthy()
+  describe('when rendering tree', () => {
+    test('should render placeholder when no version or scheme selected', () => {
+      render(<KeywordTree onNodeClick={mockOnNodeClick} />)
+      expect(screen.getByText('Select a version and scheme to load the tree')).toBeInTheDocument()
     })
 
-    test('should expand root node on initial render', () => {
+    test('should render loading state when fetching tree data', async () => {
+      getKmsKeywordTree.mockResolvedValueOnce([])
       render(
         <KeywordTree
-          data={mockData}
           onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
         />
       )
 
-      expect(screen.getByText('Child 1')).toBeTruthy()
-      expect(screen.getByText('Child 2')).toBeTruthy()
-    })
-
-    test('should handle empty data gracefully', () => {
-      render(
-        <KeywordTree
-          data={[]}
-          onNodeClick={vi.fn()}
-          onNodeEdit={vi.fn()}
-          onAddNarrower={vi.fn()}
-        />
-      )
-
-      // Check if the tree container is rendered
-      const treeContainer = screen.getByRole('tree')
-      expect(treeContainer).toBeInTheDocument()
-
-      // Check that no nodes are rendered
-      const nodes = screen.queryAllByRole('button', { name: /Keyword:/i })
-      expect(nodes).toHaveLength(0)
+      await waitFor(() => {
+        expect(screen.getByText('Loading...')).toBeInTheDocument()
+      })
     })
   })
 
-  describe('when node interaction', () => {
-    test('should call onNodeClick when a node is clicked', () => {
+  describe('when fetching tree', () => {
+    test('should fetch tree data when version and scheme are selected', async () => {
+      const mockTreeData = [{
+        id: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValueOnce(mockTreeData)
+
       render(
         <KeywordTree
-          data={mockData}
           onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
         />
       )
 
-      fireEvent.click(screen.getByText('Child 1'))
-      expect(mockOnNodeClick).toHaveBeenCalledWith('2')
+      await waitFor(() => {
+        expect(getKmsKeywordTree).toHaveBeenCalledWith(mockSelectedVersion, mockSelectedScheme, '')
+      })
+
+      expect(screen.getByText('Root')).toBeInTheDocument()
+    })
+
+    test('should handle error when fetching tree data fails', async () => {
+      getKmsKeywordTree.mockRejectedValueOnce(new Error('Fetch error'))
+
+      render(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(/Failed to load the tree/i)).toBeInTheDocument()
+      }, { timeout: 3000 })
+    })
+  })
+
+  describe('when searching', () => {
+    test('should update search pattern when apply button is clicked', async () => {
+      const mockTreeData = [{
+        id: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
+      render(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
+
+      const searchInput = screen.getByPlaceholderText('Search by Pattern or UUID')
+      const applyButton = screen.getByText('Apply')
+
+      fireEvent.change(searchInput, { target: { value: 'test' } })
+      fireEvent.click(applyButton)
+
+      await waitFor(() => {
+        expect(getKmsKeywordTree).toHaveBeenCalledWith(mockSelectedVersion, mockSelectedScheme, 'test')
+      })
+    })
+
+    test('should update search pattern when Enter key is pressed', async () => {
+      const mockTreeData = [{
+        id: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
+      render(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
+
+      const searchInput = screen.getByPlaceholderText('Search by Pattern or UUID')
+
+      fireEvent.change(searchInput, { target: { value: 'test' } })
+      fireEvent.keyDown(searchInput, {
+        key: 'Enter',
+        code: 'Enter'
+      })
+
+      await waitFor(() => {
+        expect(getKmsKeywordTree).toHaveBeenCalledWith(mockSelectedVersion, mockSelectedScheme, 'test')
+      })
+    })
+
+    test('should clear search pattern when input is cleared', async () => {
+      const mockTreeData = [{
+        id: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
+      render(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
+
+      const searchInput = screen.getByPlaceholderText('Search by Pattern or UUID')
+
+      fireEvent.change(searchInput, { target: { value: 'test' } })
+      fireEvent.click(screen.getByText('Apply'))
+
+      await waitFor(() => {
+        expect(getKmsKeywordTree).toHaveBeenCalledWith(mockSelectedVersion, mockSelectedScheme, 'test')
+      })
+
+      fireEvent.change(searchInput, { target: { value: '' } })
+
+      await waitFor(() => {
+        expect(getKmsKeywordTree).toHaveBeenCalledWith(mockSelectedVersion, mockSelectedScheme, '')
+      })
+    })
+
+    test('should clear search pattern when input is cleared', async () => {
+      const mockTreeData = [{
+        id: '1',
+        key: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
+      render(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+        />
+      )
+
+      // Wait for the component to render
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
+
+      const searchInput = screen.getByPlaceholderText('Search by Pattern or UUID')
+
+      // Set an initial search pattern
+      fireEvent.change(searchInput, { target: { value: 'test' } })
+
+      // Clear the input
+      fireEvent.change(searchInput, { target: { value: '' } })
+
+      // Verify that getKmsKeywordTree is called with an empty string
+      await waitFor(() => {
+        expect(getKmsKeywordTree).toHaveBeenCalledWith(mockSelectedVersion, mockSelectedScheme, '')
+      })
+    })
+  })
+
+  describe('when clicking on nodes in tree', () => {
+    test('should call onNodeClick when a node is clicked', async () => {
+      const mockTreeData = [{
+        id: '1',
+        key: '1',
+        title: 'Root',
+        children: [{
+          id: '2',
+          key: '2',
+          title: 'Child',
+          children: []
+        }]
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
+      render(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Child')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Child'))
+
+      await waitFor(() => {
+        expect(mockOnNodeClick).toHaveBeenCalledWith('2')
+      })
     })
 
     test('should toggle node expansion when clicked', async () => {
@@ -139,14 +312,23 @@ describe('KeywordTree component', () => {
         }
       ]
 
+      // Mock the getKmsKeywordTree to return our test data
+      getKmsKeywordTree.mockResolvedValue(dataWithGrandchildren)
+
       render(
         <KeywordTree
-          data={dataWithGrandchildren}
           onNodeClick={vi.fn()}
           onNodeEdit={vi.fn()}
           onAddNarrower={vi.fn()}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
         />
       )
+
+      // Wait for the initial render
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
 
       // Find the root node
       const rootNode = screen.getByRole('button', { name: /Keyword: Root/i })
@@ -181,32 +363,53 @@ describe('KeywordTree component', () => {
       })
     })
 
-    test('should handle node click on leaf nodes', () => {
+    test('should handle node click on leaf nodes', async () => {
+      getKmsKeywordTree.mockResolvedValue(mockData)
+
       render(
         <KeywordTree
-          data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
           onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
         />
       )
+
+      await waitFor(() => {
+        expect(screen.getByText('Child 1')).toBeInTheDocument()
+      })
 
       fireEvent.click(screen.getByText('Child 1'))
       expect(mockOnNodeClick).toHaveBeenCalledWith('2')
     })
 
-    test('should handle node click on parent nodes', () => {
+    test('should handle node click on parent nodes', async () => {
+      const mockTreeData = [{
+        id: '1',
+        key: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
       render(
         <KeywordTree
-          data={mockData}
           onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
         />
       )
 
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
+
       fireEvent.click(screen.getByText('Root'))
-      expect(mockOnNodeClick).toHaveBeenCalledWith('1')
+
+      await waitFor(() => {
+        expect(mockOnNodeClick).toHaveBeenCalledWith('1')
+      })
     })
 
     test('should handle rapid expansion and collapse of nodes', async () => {
@@ -246,14 +449,21 @@ describe('KeywordTree component', () => {
         }
       ]
 
+      getKmsKeywordTree.mockResolvedValue(nestedData)
+
       render(
         <KeywordTree
-          data={nestedData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
           onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
         />
       )
+
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
 
       const parent1Node = screen.getByText('Parent 1')
       const parent2Node = screen.getByText('Parent 2')
@@ -270,290 +480,340 @@ describe('KeywordTree component', () => {
       expect(screen.getByText('Parent 2')).toBeInTheDocument()
 
       // Check if child nodes are not visible (as parents should be collapsed after the last click)
-      expect(screen.queryByText('Child 1')).not.toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.queryByText('Child 1')).not.toBeInTheDocument()
+      })
+
       expect(screen.queryByText('Child 2')).not.toBeInTheDocument()
     })
   })
 
-  describe('when context menu', () => {
-    test('should display context menu when right click', () => {
+  describe('when showing context menu', () => {
+    test('should display context menu on right-click', async () => {
+      const mockTreeData = [{
+        id: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
       render(
         <KeywordTree
-          data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
           onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+          showContextMenu
         />
       )
 
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-      expect(screen.getByRole('menu')).toBeTruthy()
-    })
-
-    test('should close context menu when clicking outside', () => {
-      render(
-        <KeywordTree
-          data={mockData}
-          onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
-        />
-      )
-
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-      expect(screen.getByRole('menu')).toBeTruthy()
-
-      fireEvent.mouseDown(document.body)
-      expect(screen.queryByRole('menu')).toBeFalsy()
-    })
-
-    test('should handles multiple context menu opens without clicking', () => {
-      render(
-        <KeywordTree
-          data={mockData}
-          onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
-        />
-      )
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
 
       fireEvent.contextMenu(screen.getByText('Root'))
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-      fireEvent.contextMenu(screen.getByText('Child 2'))
 
-      // Only the last context menu should be open
-      expect(screen.getAllByRole('menu')).toHaveLength(1)
+      expect(screen.getByRole('menu')).toBeInTheDocument()
+    })
+
+    test('should not display context menu when showContextMenu is false', async () => {
+      const mockTreeData = [{
+        id: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
+      render(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+          showContextMenu={false}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
+
+      fireEvent.contextMenu(screen.getByText('Root'))
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    })
+
+    test('should close context menu when clicking outside', async () => {
+      const mockTreeData = [{
+        id: '1',
+        key: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
+      render(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+          showContextMenu
+        />
+      )
+
+      // Wait for the tree to render
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
+
+      // Open the context menu
+      fireEvent.contextMenu(screen.getByText('Root'))
+
+      // Verify that the context menu is open
+      expect(screen.getByRole('menu')).toBeInTheDocument()
+
+      // Click outside the context menu
+      fireEvent.mouseDown(document.body)
+
+      // Verify that the context menu is closed
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      })
     })
   })
 
-  describe('when adding nodes', () => {
-    test('should close "Add Narrower" modal when Cancel is clicked', async () => {
+  describe('when adding a narrower', () => {
+    test('should open Add Narrower modal when selected from context menu', async () => {
+      const mockTreeData = [{
+        id: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
       render(
         <KeywordTree
-          data={mockData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
           onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+          showContextMenu
         />
       )
 
-      // Open context menu
-      fireEvent.contextMenu(screen.getByText('Root'))
-
-      // Click "Add Narrower" option
-      fireEvent.click(screen.getByText('Add Narrower'))
-
-      // Check if modal is open
-      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-      // Click "Cancel" button
-      fireEvent.click(screen.getByText('Cancel'))
-
-      // Check if modal is closed
       await waitFor(() => {
-        expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
+        expect(screen.getByText('Root')).toBeInTheDocument()
       })
-    })
 
-    test('should handle adding a node with empty title', async () => {
-      render(
-        <KeywordTree
-          data={mockData}
-          onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
-        />
-      )
-
-      // Open context menu
       fireEvent.contextMenu(screen.getByText('Root'))
-      // Click "Add Narrower" option
       fireEvent.click(screen.getByText('Add Narrower'))
 
-      // Check if modal is open
-      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-      // Don't enter any title (leave it empty)
-
-      // Click "Add" button
-      fireEvent.click(screen.getByText('Add'))
-
-      // Check if modal is still open (because empty title should not be added)
       expect(screen.getByText('Add Narrower')).toBeInTheDocument()
     })
 
-    test('should handle nodes with very long titles', async () => {
-      const longTitleData = [
-        {
-          id: '1',
-          key: '1',
-          title: 'Root',
-          children: [
-            {
-              id: '2',
-              key: '2',
-              title: 'This is a very long title that might cause issues with layout or display',
-              children: []
-            }
-          ]
-        }
-      ]
+    test('should call onAddNarrower when adding a new narrower keyword', async () => {
+      const mockTreeData = [{
+        id: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
 
       render(
         <KeywordTree
-          data={longTitleData}
           onNodeClick={mockOnNodeClick}
           onNodeEdit={mockOnNodeEdit}
           onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+          showContextMenu
         />
       )
 
-      expect(screen.getByText('This is a very long title that might cause issues with layout or display')).toBeInTheDocument()
-    })
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
 
-    test('should add a new narrower keyword when confirmed', async () => {
-      render(
-        <KeywordTree
-          data={mockData}
-          onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
-        />
-      )
-
-      // Open context menu for Root
       fireEvent.contextMenu(screen.getByText('Root'))
-
-      // Click "Add Narrower" option
       fireEvent.click(screen.getByText('Add Narrower'))
 
-      // Check if modal is open
-      expect(screen.getByText('Add Narrower')).toBeInTheDocument()
-
-      // Enter new keyword title
       const input = screen.getByPlaceholderText('Enter Keyword')
       fireEvent.change(input, { target: { value: 'New Keyword' } })
-
-      // Click "Add" button
       fireEvent.click(screen.getByText('Add'))
 
-      // Check if onAddNarrower was called with correct arguments
+      expect(mockOnAddNarrower).toHaveBeenCalledWith('1', expect.objectContaining({
+        title: 'New Keyword',
+        children: []
+      }))
+    })
+
+    test('should close Add Narrower modal when cancelled', async () => {
+      const mockTreeData = [{
+        id: '1',
+        title: 'Root',
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
+      render(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+          showContextMenu
+        />
+      )
+
       await waitFor(() => {
-        expect(mockOnAddNarrower).toHaveBeenCalledWith('1', expect.objectContaining({
-          title: 'New Keyword',
-          children: []
-        }))
+        expect(screen.getByText('Root')).toBeInTheDocument()
       })
 
-      // Check if modal is closed
+      fireEvent.contextMenu(screen.getByText('Root'))
+      fireEvent.click(screen.getByText('Add Narrower'))
+
+      fireEvent.click(screen.getByText('Cancel'))
+
       await waitFor(() => {
         expect(screen.queryByText('Add Narrower')).not.toBeInTheDocument()
       })
     })
   })
 
-  describe('when editing and deleting nodes', () => {
-    test('deletes a node when "Delete" is used', async () => {
-      render(
-        <KeywordTree
-          data={mockData}
-          onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
-        />
-      )
-
-      // Open context menu for Child 1
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-
-      // Click "Delete" option
-      fireEvent.click(screen.getByText('Delete'))
-
-      // Check if node is deleted
-      await waitFor(() => {
-        expect(screen.queryByText('Child 1')).not.toBeInTheDocument()
-      })
-    })
-
-    test('should edit a node when "Edit" is used', () => {
-      render(
-        <KeywordTree
-          data={mockData}
-          onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
-        />
-      )
-
-      // Open context menu for Child 1
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-
-      // Click "Edit" option
-      fireEvent.click(screen.getByText('Edit'))
-
-      // Check if onNodeEdit was called with correct id
-      expect(mockOnNodeEdit).toHaveBeenCalledWith('2')
-    })
-  })
-
-  describe('when edge cases and performance', () => {
-    test('should handle nodes with empty children array', () => {
-      const dataWithEmptyChildren = [
+  describe('when expanding tree', () => {
+    test('should open all nodes when openAll prop is true', async () => {
+      const mockTreeData = [
         {
           id: '1',
-          key: '1',
           title: 'Root',
           children: [
             {
               id: '2',
-              key: '2',
-              title: 'Node with empty children',
-              children: []
+              title: 'Parent',
+              children: [{
+                id: '3',
+                title: 'Child',
+                children: []
+              }]
             }
           ]
         }
       ]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
 
       render(
         <KeywordTree
-          data={dataWithEmptyChildren}
           onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+          openAll
         />
       )
 
-      expect(screen.getByText('Node with empty children')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByText('Root')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('Parent')).toBeInTheDocument()
+      expect(screen.getByText('Child')).toBeInTheDocument()
     })
 
-    test('should handle very large number of operations without crashing', async () => {
+    test('should open parents of selected node when selectedNodeId is provided', async () => {
+      const mockTreeData = [
+        {
+          id: '1',
+          title: 'Root',
+          children: [
+            {
+              id: '2',
+              title: 'Parent',
+              children: [{
+                id: '3',
+                title: 'Child',
+                children: []
+              }]
+            }
+          ]
+        }
+      ]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
       render(
         <KeywordTree
-          data={mockData}
           onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+          selectedNodeId="3"
         />
       )
 
-      const root = screen.getByText('Root')
-
-      // Perform a large number of expand/collapse operations
-      for (let i = 0; i < 1000; i += 1) {
-        fireEvent.click(root)
-      }
-
-      // The component should still be responsive after many operations
-      fireEvent.click(root)
       await waitFor(() => {
-        expect(screen.getByText('Child 1')).toBeInTheDocument()
+        expect(screen.getByText('Root')).toBeInTheDocument()
       })
+
+      expect(screen.getByText('Parent')).toBeInTheDocument()
+      expect(screen.getByText('Child')).toBeInTheDocument()
     })
   })
 
-  describe('When opening the tree', () => {
-    const treeData = [
-      {
+  describe('when refreshing tree', () => {
+    test('should refresh tree when refreshTree is called', async () => {
+      const mockTreeData1 = [{
+        id: '1',
+        key: '1',
+        title: 'Root 1',
+        children: []
+      }]
+      const mockTreeData2 = [{
+        id: '2',
+        key: '2',
+        title: 'Root 2',
+        children: []
+      }]
+
+      getKmsKeywordTree.mockResolvedValueOnce(mockTreeData1)
+      getKmsKeywordTree.mockResolvedValueOnce(mockTreeData2)
+
+      const { rerender } = render(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Root 1')).toBeInTheDocument()
+      })
+
+      rerender(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          selectedVersion={
+            {
+              ...mockSelectedVersion,
+              id: 'v2'
+            }
+          }
+          selectedScheme={mockSelectedScheme}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Root 2')).toBeInTheDocument()
+      }, { timeout: 3000 })
+
+      expect(screen.queryByText('Root 1')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when deleting a node', () => {
+    test('should remove a node when handleDelete is called', async () => {
+      const mockTreeData = [{
         id: '1',
         key: '1',
         title: 'Root',
@@ -561,91 +821,145 @@ describe('KeywordTree component', () => {
           {
             id: '2',
             key: '2',
-            title: 'Node 2',
+            title: 'Child 1',
+            children: []
+          },
+          {
+            id: '3',
+            key: '3',
+            title: 'Child 2',
             children: [
               {
-                id: '3',
-                key: '3',
-                title: 'Node 3',
+                id: '4',
+                key: '4',
+                title: 'Grandchild',
                 children: []
               }
             ]
           }
         ]
-      }
-    ]
-    test('should open all nodes when openAll is true', async () => {
-      render(
+      }]
+
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
+      const { rerender } = render(
         <KeywordTree
-          data={treeData}
-          onNodeClick={vi.fn()}
-          onNodeEdit={vi.fn()}
-          openAll
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
         />
       )
 
+      // Wait for the tree to render
       await waitFor(() => {
-        expect(screen.getByText('Node 3')).toBeVisible()
+        expect(screen.getByText('Root')).toBeInTheDocument()
       })
 
-      expect(screen.getByText('Root')).toBeVisible()
-      expect(screen.getByText('Node 3')).toBeVisible()
-    })
+      expect(screen.getByText('Child 1')).toBeInTheDocument()
+      expect(screen.getByText('Child 2')).toBeInTheDocument()
 
-    test('should scroll to selected node when selectedNodeId is provided', async () => {
-      render(
+      // Expand 'Child 2' to reveal 'Grandchild'
+      const child2Toggle = screen.getByRole('button', { name: /Toggle Child 2/i })
+      fireEvent.click(child2Toggle)
+
+      // Now check for 'Grandchild'
+      await waitFor(() => {
+        expect(screen.getByText('Grandchild')).toBeInTheDocument()
+      })
+
+      // Simulate deleting 'Child 1'
+      fireEvent.contextMenu(screen.getByText('Child 1'))
+      fireEvent.click(screen.getByText('Delete'))
+
+      // Re-render to reflect changes
+      rerender(
         <KeywordTree
-          data={treeData}
-          onNodeClick={vi.fn()}
-          onNodeEdit={vi.fn()}
-          selectedNodeId="2"
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
         />
       )
 
+      // Check if 'Child 1' is removed
       await waitFor(() => {
-        expect(screen.getByText('Node 2')).toBeVisible()
+        expect(screen.queryByText('Child 1')).not.toBeInTheDocument()
       })
 
-      expect(screen.getByText('Node 2')).toBeVisible()
-      expect(screen.queryByText('Node 3')).not.toBeInTheDocument()
+      // Check if other nodes still exist
+      expect(screen.getByText('Root')).toBeInTheDocument()
+      expect(screen.getByText('Child 2')).toBeInTheDocument()
+      expect(screen.getByText('Grandchild')).toBeInTheDocument()
+
+      // Simulate deleting 'Child 2'
+      fireEvent.contextMenu(screen.getByText('Child 2'))
+      fireEvent.click(screen.getByText('Delete'))
+
+      // Re-render to reflect changes
+      rerender(
+        <KeywordTree
+          onNodeClick={mockOnNodeClick}
+          onNodeEdit={mockOnNodeEdit}
+          onAddNarrower={mockOnAddNarrower}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
+        />
+      )
+
+      // Check if 'Child 2' and its child 'Grandchild' are removed
+      await waitFor(() => {
+        expect(screen.queryByText('Child 2')).not.toBeInTheDocument()
+      })
+
+      expect(screen.queryByText('Grandchild')).not.toBeInTheDocument()
+
+      // Check if 'Root' still exists
+      expect(screen.getByText('Root')).toBeInTheDocument()
     })
   })
 
-  describe('when showing/hiding context menu', () => {
-    test('should not display context menu when showContextMenu is false', () => {
+  describe('Edge cases', () => {
+    test('should handle empty tree data', async () => {
+      getKmsKeywordTree.mockResolvedValue([])
+
       render(
         <KeywordTree
-          data={mockData}
           onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
-          showContextMenu={false}
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
         />
       )
 
-      // Attempt to open context menu
-      fireEvent.contextMenu(screen.getByText('Child 1'))
+      await waitFor(() => {
+        expect(screen.getByRole('tree')).toBeInTheDocument()
+      })
 
-      // Verify that the context menu is not in the document
-      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      expect(screen.queryByRole('treeitem')).not.toBeInTheDocument()
     })
 
-    test('should display context menu when showContextMenu is true', () => {
+    test('should handle very long node titles', async () => {
+      const longTitle = 'A'.repeat(100)
+      const mockTreeData = [{
+        id: '1',
+        title: longTitle,
+        children: []
+      }]
+      getKmsKeywordTree.mockResolvedValue(mockTreeData)
+
       render(
         <KeywordTree
-          data={mockData}
           onNodeClick={mockOnNodeClick}
-          onNodeEdit={mockOnNodeEdit}
-          onAddNarrower={mockOnAddNarrower}
-          showContextMenu
+          selectedVersion={mockSelectedVersion}
+          selectedScheme={mockSelectedScheme}
         />
       )
 
-      // Open context menu
-      fireEvent.contextMenu(screen.getByText('Child 1'))
-
-      // Verify that the context menu is in the document
-      expect(screen.getByRole('menu')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByText(longTitle)).toBeInTheDocument()
+      })
     })
   })
 })

--- a/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
+++ b/static/src/js/components/KeywordTree/__tests__/KeywordTree.test.jsx
@@ -116,7 +116,6 @@ describe('KeywordTree component', () => {
     })
 
     test('should set tree data to null when refreshTree is called without version and scheme', async () => {
-      const mockOnNodeClick = vi.fn()
       const mockTreeData = [{
         id: '1',
         title: 'Root',
@@ -229,42 +228,6 @@ describe('KeywordTree component', () => {
     test('should clear search pattern when input is cleared', async () => {
       const mockTreeData = [{
         id: '1',
-        title: 'Root',
-        children: []
-      }]
-      getKmsKeywordTree.mockResolvedValue(mockTreeData)
-
-      render(
-        <KeywordTree
-          onNodeClick={mockOnNodeClick}
-          selectedVersion={mockSelectedVersion}
-          selectedScheme={mockSelectedScheme}
-        />
-      )
-
-      await waitFor(() => {
-        expect(screen.getByText('Root')).toBeInTheDocument()
-      })
-
-      const searchInput = screen.getByPlaceholderText('Search by Pattern or UUID')
-
-      fireEvent.change(searchInput, { target: { value: 'test' } })
-      fireEvent.click(screen.getByText('Apply'))
-
-      await waitFor(() => {
-        expect(getKmsKeywordTree).toHaveBeenCalledWith(mockSelectedVersion, mockSelectedScheme, 'test')
-      })
-
-      fireEvent.change(searchInput, { target: { value: '' } })
-
-      await waitFor(() => {
-        expect(getKmsKeywordTree).toHaveBeenCalledWith(mockSelectedVersion, mockSelectedScheme, '')
-      })
-    })
-
-    test('should clear search pattern when input is cleared', async () => {
-      const mockTreeData = [{
-        id: '1',
         key: '1',
         title: 'Root',
         children: []
@@ -312,6 +275,7 @@ describe('KeywordTree component', () => {
           children: []
         }]
       }]
+
       getKmsKeywordTree.mockResolvedValue(mockTreeData)
 
       render(

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React, {
   useCallback,
-  useEffect,
   useState,
   useRef
 } from 'react'
@@ -9,12 +8,8 @@ import React, {
 import CustomModal from '@/js/components/CustomModal/CustomModal'
 import { KeywordTree } from '@/js/components/KeywordTree/KeywordTree'
 import KmsConceptSchemeSelector from '@/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector'
-import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
 
 import './KmsConceptSelectionEditModal.scss'
-import {
-  KeywordTreePlaceHolder
-} from '@/js/components/KeywordTreePlaceHolder/KeywordTreePlaceHolder'
 
 /**
  * KmsConceptSelectionEditModal component provides an interface to edit keyword selections
@@ -37,56 +32,13 @@ export const KmsConceptSelectionEditModal = ({
   uuid,
   version
 }) => {
-  const [treeData, setTreeData] = useState(null)
   const [selectedScheme, setSelectedScheme] = useState(scheme)
   const [selectedKeyword, setSelectedKeyword] = useState(uuid)
-  const [isTreeLoading, setIsTreeLoading] = useState(false)
-  const [treeMessage, setTreeMessage] = useState('')
-  const [searchPattern, setSearchPattern] = useState('')
-  const searchInputRef = useRef(null)
-
-  const fetchTreeData = async () => {
-    if (version && scheme) {
-      setIsTreeLoading(true)
-
-      try {
-        const data = await getKmsKeywordTree(version, selectedScheme, searchPattern)
-        if (data) {
-          setTreeData(data)
-        } else {
-          setTreeData(null)
-          setTreeMessage('No results.')
-        }
-      } catch (error) {
-        console.error('Error fetching keyword tree:', error)
-        setTreeData(null)
-        setTreeMessage('Failed to load the tree. Please try again.')
-      } finally {
-        setIsTreeLoading(false)
-      }
-    } else {
-      setTreeMessage('Select a version and scheme to load the tree')
-    }
-  }
-
-  useEffect(() => {
-    if (version && selectedScheme) {
-      setTreeMessage('Loading...')
-      fetchTreeData(version, selectedScheme, searchPattern)
-    }
-  }, [show, version, selectedScheme, searchPattern])
+  const keywordTreeRef = useRef(null)
 
   const onSchemeSelect = useCallback((schemeInfo) => {
     setSelectedScheme(schemeInfo)
-    setTreeData(null)
   }, [])
-
-  useEffect(() => {
-    if (show) {
-      setTreeMessage('Loading...')
-      fetchTreeData(version, selectedScheme, searchPattern)
-    }
-  }, [show])
 
   const onHandleSelectKeyword = (value) => {
     setSelectedKeyword(value)
@@ -97,28 +49,7 @@ export const KmsConceptSelectionEditModal = ({
     toggleModal(false)
   }
 
-  // New function to handle search input change
-  const onHandleSearchInputChange = (event) => {
-    if (event.target.value === '') {
-      setSearchPattern('')
-    }
-  }
-
-  const onHandleApplyFilteredSearch = () => {
-    setSearchPattern(searchInputRef.current.value)
-  }
-
-  const onHandleKeyDown = (event) => {
-    if (event.key === 'Enter') {
-      setSearchPattern(searchInputRef.current.value)
-    }
-  }
-
   const renderTree = () => {
-    if (isTreeLoading) {
-      return <KeywordTreePlaceHolder message="Loading..." />
-    }
-
     const schemeSelectorId = selectedScheme?.name
 
     return (
@@ -138,37 +69,15 @@ export const KmsConceptSelectionEditModal = ({
             version={version}
           />
         </div>
-        <div className="kms-concept-selection-edit-modal__tree-wrapper">
-          <input
-            className="kms-concept-selection-edit-modal__search-input"
-            onChange={onHandleSearchInputChange}
-            onKeyDown={onHandleKeyDown}
-            placeholder="Search by Pattern or UUID"
-            type="text"
-            ref={searchInputRef}
-            defaultValue={searchPattern}
-          />
-          <button
-            type="button"
-            className="kms-concept-selection-edit-modal__apply-button"
-            onClick={onHandleApplyFilteredSearch}
-          >
-            Apply
-          </button>
-        </div>
-        {
-          treeData ? (
-            <KeywordTree
-              data={treeData}
-              key={`${uuid}`}
-              onNodeClick={onHandleSelectKeyword}
-              openAll={!!searchPattern && searchPattern.trim() !== ''}
-              searchTerm={searchPattern}
-              selectedNodeId={uuid}
-              showContextMenu={false}
-            />
-          ) : <KeywordTreePlaceHolder message={treeMessage} />
-        }
+        <KeywordTree
+          ref={keywordTreeRef}
+          key={`${version?.version}-${selectedScheme?.name}`}
+          onNodeClick={onHandleSelectKeyword}
+          selectedNodeId={uuid}
+          showContextMenu={false}
+          selectedScheme={selectedScheme}
+          selectedVersion={version}
+        />
       </div>
     )
   }

--- a/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal.jsx
@@ -12,17 +12,40 @@ import KmsConceptSchemeSelector from '@/js/components/KmsConceptSchemeSelector/K
 import './KmsConceptSelectionEditModal.scss'
 
 /**
- * KmsConceptSelectionEditModal component provides an interface to edit keyword selections
- * within a modal. It allows users to select a scheme, search for keywords, and apply their changes.
+ * KmsConceptSelectionEditModal Component
  *
- * @param {Object} props - React component props.
- * @param {boolean} props.show - Determines if the modal is visible.
- * @param {Function} props.toggleModal - Function to toggle the modal visibility.
- * @param {string} props.uuid - UUID of the selected keyword.
- * @param {Object} props.version - Object containing version details like version and version_type.
- * @param {Object} props.scheme - Object containing scheme details.
- * @param {Function} props.handleAcceptChanges - Callback function when changes are accepted.
- * @returns {JSX.Element} The complete modal component for editing keyword selections.
+ * This component provides a modal interface for editing keyword selections.
+ * It allows users to select a scheme, view a keyword tree, and choose a specific keyword.
+ *
+ * Features:
+ * - Scheme selection using KmsConceptSchemeSelector
+ * - Keyword tree visualization and selection using KeywordTree
+ * - Ability to accept or cancel changes
+ *
+ * @component
+ * @param {Object} props
+ * @param {Function} props.handleAcceptChanges - Callback function when changes are accepted
+ * @param {Object} props.scheme - Object containing scheme details (e.g., {name: string})
+ * @param {boolean} props.show - Controls the visibility of the modal
+ * @param {Function} props.toggleModal - Function to toggle the modal's visibility
+ * @param {string} props.uuid - UUID of the initially selected keyword
+ * @param {Object} props.version - Object containing version details (e.g., {version: string, version_type: string})
+ *
+ * @example
+ * const handleAcceptChanges = (selectedKeyword) => {
+ *   console.log('Selected keyword:', selectedKeyword);
+ * };
+ *
+ * return (
+ *   <KmsConceptSelectionEditModal
+ *     handleAcceptChanges={handleAcceptChanges}
+ *     scheme={{name: 'Example Scheme'}}
+ *     show={true}
+ *     toggleModal={(show) => setShowModal(show)}
+ *     uuid="example-uuid"
+ *     version={{version: '1.0', version_type: 'draft'}}
+ *   />
+ * );
  */
 export const KmsConceptSelectionEditModal = ({
   handleAcceptChanges,

--- a/static/src/js/components/KmsConceptSelectionEditModal/__tests__/KmsConceptSelectionEditModal.test.jsx
+++ b/static/src/js/components/KmsConceptSelectionEditModal/__tests__/KmsConceptSelectionEditModal.test.jsx
@@ -1,250 +1,245 @@
+import React from 'react'
+
 import {
-  fireEvent,
+  describe,
+  test,
+  expect,
+  vi,
+  beforeEach
+} from 'vitest'
+import {
   render,
   screen,
+  within,
   waitFor
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import PropTypes from 'prop-types'
-import React from 'react'
-import {
-  beforeEach,
-  describe,
-  expect,
-  vi
-} from 'vitest'
+import { KmsConceptSelectionEditModal } from '../KmsConceptSelectionEditModal'
 
-import {
-  KmsConceptSelectionEditModal
-} from '@/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal'
-import getKmsKeywordTree from '@/js/utils/getKmsKeywordTree'
+vi.mock('@/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector', () => ({
+  default: vi.fn().mockImplementation(({ defaultScheme }) => (
+    <select data-testid="mock-scheme-selector">
+      <option value={defaultScheme.name}>{defaultScheme.name}</option>
+      <option value="New Scheme">New Scheme</option>
+    </select>
+  ))
+}))
 
 vi.mock('@/js/components/KeywordTree/KeywordTree', () => {
-  const MockKeywordTree = ({ onNodeClick }) => (
-    <button
-      type="button"
-      data-testid="keyword-tree"
-      onClick={() => onNodeClick('mock-uuid')}
-    >
-      Mock Keyword Tree
-    </button>
-  )
+  const MockKeywordTree = React.forwardRef(({ onNodeClick }, ref) => {
+    const handleInteraction = () => onNodeClick('new-keyword-id')
+
+    return (
+      <div
+        ref={ref}
+        data-testid="mock-keyword-tree"
+        onClick={handleInteraction}
+        onKeyDown={
+          (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              handleInteraction()
+            }
+          }
+        }
+        role="button"
+        tabIndex={0}
+      >
+        Mocked KeywordTree
+      </div>
+    )
+  })
 
   MockKeywordTree.propTypes = {
     onNodeClick: PropTypes.func.isRequired
   }
 
+  MockKeywordTree.displayName = 'MockKeywordTree'
+
   return { KeywordTree: MockKeywordTree }
 })
 
-vi.mock('@/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector', () => {
-  const MockKmsConceptSchemeSelector = ({ onSchemeSelect }) => (
-    <select
-      data-testid="scheme-selector"
-      onChange={() => onSchemeSelect({ name: 'New Scheme' })}
-    >
-      <option>Select a scheme</option>
-      <option value="new-scheme">New Scheme</option>
-    </select>
-  )
-
-  MockKmsConceptSchemeSelector.propTypes = {
-    onSchemeSelect: PropTypes.func.isRequired
-  }
-
-  return { default: MockKmsConceptSchemeSelector }
-})
-
 vi.mock('@/js/utils/getKmsKeywordTree', () => ({
-  default: vi.fn(() => Promise.resolve([{ id: 'mock-tree-data' }]))
+  default: vi.fn().mockResolvedValue({
+    ok: true,
+    data: {
+      id: 'root',
+      children: [
+        {
+          id: 'child1',
+          label: 'Child 1'
+        },
+        {
+          id: 'child2',
+          label: 'Child 2'
+        }
+      ]
+    }
+  })
+}))
+
+vi.mock('@/js/components/KmsConceptSchemeSelector/KmsConceptSchemeSelector', () => ({
+  default: vi.fn().mockImplementation(({ defaultScheme, onSchemeSelect }) => (
+    <select
+      data-testid="mock-scheme-selector"
+      onChange={
+        (e) => onSchemeSelect({
+          id: e.target.value,
+          name: e.target.value
+        })
+      }
+    >
+      <option value={defaultScheme.name}>{defaultScheme.name}</option>
+      <option value="New Scheme">New Scheme</option>
+    </select>
+  ))
 }))
 
 describe('KmsConceptSelectionEditModal', () => {
-  const defaultProps = {
+  const mockProps = {
+    handleAcceptChanges: vi.fn(),
+    scheme: {
+      id: 'scheme1',
+      name: 'Test Scheme'
+    },
     show: true,
     toggleModal: vi.fn(),
     uuid: 'test-uuid',
     version: {
       version: '1.0',
       version_type: 'published'
-    },
-    scheme: { name: 'Test Scheme' },
-    handleAcceptChanges: vi.fn()
+    }
   }
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
-  describe('when the modal appears', () => {
-    test('should render the header', async () => {
-      render(<KmsConceptSelectionEditModal {...defaultProps} />)
-      const modalHeader = await screen.findByText('Select Concept')
-      expect(modalHeader).toBeInTheDocument()
-    })
-
-    test('should render the scheme selector', async () => {
-      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+  describe('when showing the modal', () => {
+    test('should renders the modal when show is true', async () => {
+      render(<KmsConceptSelectionEditModal {...mockProps} />)
       await waitFor(() => {
-        expect(screen.getByTestId('scheme-selector')).toBeTruthy()
+        expect(screen.getByText('Select Concept')).toBeInTheDocument()
       })
     })
 
-    test('should render the keyword tree', async () => {
-      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+    test('should not render the modal when show is false', async () => {
+      render(<KmsConceptSelectionEditModal {...mockProps} show={false} />)
       await waitFor(() => {
-        expect(screen.getByTestId('keyword-tree')).toBeTruthy()
+        expect(screen.queryByText('Select Concept')).not.toBeInTheDocument()
       })
     })
   })
 
-  describe('when the modal is hidden', () => {
-    test('should not show the modal', async () => {
-      render(<KmsConceptSelectionEditModal {...defaultProps} show={false} />)
+  describe('when selecting a scheme', () => {
+    test('renders the scheme selector', async () => {
+      render(<KmsConceptSelectionEditModal {...mockProps} />)
+
+      // Wait for the modal to appear
+      const modal = await screen.findByRole('dialog')
+
+      // Find the scheme selector label
+      const schemeLabel = within(modal).getByText('Scheme:')
+
+      // Find the scheme selector (combobox)
+      const schemeSelector = within(modal).getByRole('combobox')
+
+      // Check if the label has the correct class
+      expect(schemeLabel).toHaveClass('kms-concept-selection-edit-modal__label')
+
+      // Check if the scheme selector exists
+      expect(schemeSelector).toBeInTheDocument()
+
+      // Check if the options are present in the scheme selector
+      expect(within(schemeSelector).getByRole('option', { name: 'Test Scheme' })).toBeInTheDocument()
+      expect(within(schemeSelector).getByRole('option', { name: 'New Scheme' })).toBeInTheDocument()
+
+      // Check if the container class exists (without directly accessing nodes)
+      const containerElement = screen.getByText((content, element) => element.classList.contains('kms-concept-selection-edit-modal__scheme-selector')
+           && element.textContent.includes('Scheme:'))
+      expect(containerElement).toBeInTheDocument()
+    })
+
+    test('should update selected scheme when a new scheme is selected', async () => {
+      render(<KmsConceptSelectionEditModal {...mockProps} />)
       await waitFor(() => {
-        expect(screen.queryByTestId('custom-modal')).not.toBeInTheDocument()
+        const schemeSelector = screen.getByRole('combobox')
+        expect(schemeSelector).toBeInTheDocument()
       })
+
+      // Note: This part might need to be adjusted based on how your KmsConceptSchemeSelector is implemented
+      const schemeSelector = screen.getByRole('combobox')
+      await userEvent.selectOptions(schemeSelector, 'New Scheme')
+      expect(schemeSelector).toHaveValue('New Scheme')
     })
   })
 
-  describe('when user selects a scheme', () => {
-    test('shows tree is loading', async () => {
-      render(<KmsConceptSelectionEditModal {...defaultProps} />)
-      const schemeSelector = await screen.findByTestId('scheme-selector')
-      fireEvent.change(schemeSelector)
-      await waitFor(() => {
-        expect(screen.getByText('Loading...')).toBeTruthy()
-      })
+  describe('when handling callback functions', () => {
+    test('should update selected scheme when onSchemeSelect is called', async () => {
+      const { rerender } = render(<KmsConceptSelectionEditModal {...mockProps} />)
+
+      // Wait for the component to render
+      await screen.findByRole('dialog')
+
+      // Get the scheme selector
+      const schemeSelector = screen.getByTestId('mock-scheme-selector')
+
+      // Simulate selecting a new scheme
+      await userEvent.selectOptions(schemeSelector, 'New Scheme')
+
+      // Re-render the component to reflect the state change
+      rerender(<KmsConceptSelectionEditModal {...mockProps} />)
+
+      // Check if the new scheme is selected
+      expect(schemeSelector).toHaveValue('New Scheme')
+
+      // Check if Accept button now uses the new scheme
+      await userEvent.click(screen.getByText('Accept'))
+      expect(mockProps.handleAcceptChanges).toHaveBeenCalledWith('test-uuid') // This should still be 'test-uuid' as we haven't changed the keyword
     })
 
-    test('should render tree when a scheme is selected', async () => {
-      render(<KmsConceptSelectionEditModal {...defaultProps} />)
-      const schemeSelector = await screen.findByTestId('scheme-selector')
-      fireEvent.change(schemeSelector)
-      await waitFor(() => {
-        expect(screen.getByTestId('keyword-tree')).toBeTruthy()
-      })
+    test('should update selected keyword when onHandleSelectKeyword is called', async () => {
+      render(<KmsConceptSelectionEditModal {...mockProps} />)
+
+      // Wait for the component to render
+      await screen.findByRole('dialog')
+
+      // Get the mock keyword tree
+      const mockKeywordTree = screen.getByTestId('mock-keyword-tree')
+
+      // Simulate selecting a new keyword
+      await userEvent.click(mockKeywordTree)
+
+      // Check if handleAcceptChanges is called with the new keyword when Accept is clicked
+      await userEvent.click(screen.getByText('Accept'))
+
+      // This now checks if handleAcceptChanges is called with the new keyword ID
+      expect(mockProps.handleAcceptChanges).toHaveBeenCalledWith('new-keyword-id')
     })
   })
 
-  describe('when user accept changes', () => {
-    test('should responds with the uuid of the selected keyword', async () => {
-      const handleAcceptChangesMock = vi.fn()
-      const props = {
-        ...defaultProps,
-        handleAcceptChanges: handleAcceptChangesMock
-      }
-
-      render(<KmsConceptSelectionEditModal {...props} />)
-
-      await waitFor(async () => {
-        const keywordTree = screen.getByTestId('keyword-tree')
-        await userEvent.click(keywordTree)
-      })
-
-      // Find and click the Accept button
-      const acceptButton = screen.getByText('Accept')
-      await userEvent.click(acceptButton)
-
-      // Check if handleAcceptChanges was called with the new keyword value
-      expect(handleAcceptChangesMock).toHaveBeenCalledWith('mock-uuid')
-    })
-  })
-
-  describe('when user cancels changes', () => {
-    test('should close the modal', async () => {
-      render(<KmsConceptSelectionEditModal {...defaultProps} />)
-      await waitFor(async () => {
+  describe('when interacting with buttons in the modal', () => {
+    test('should toggleModal when Cancel button is clicked', async () => {
+      render(<KmsConceptSelectionEditModal {...mockProps} />)
+      await waitFor(() => {
         const cancelButton = screen.getByText('Cancel')
-        await userEvent.click(cancelButton)
-        expect(defaultProps.toggleModal).toHaveBeenCalledWith(false)
+        expect(cancelButton).toBeInTheDocument()
       })
-    })
-  })
 
-  describe('when the user searches', () => {
-    describe('when apply button is pressed', () => {
-      test('should fetch the tree and includes search term', async () => {
-        render(<KmsConceptSelectionEditModal {...defaultProps} />)
-        const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
-        fireEvent.change(searchInput, { target: { value: 'test search' } })
-        const applyButton = screen.getByText('Apply')
-        fireEvent.click(applyButton)
-        await waitFor(() => {
-          expect(getKmsKeywordTree).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'test search')
-        })
-      })
+      await userEvent.click(screen.getByText('Cancel'))
+      expect(mockProps.toggleModal).toHaveBeenCalledWith(false)
     })
 
-    describe('when enter is pressed', () => {
-      test('should fetch the tree and includes search term', async () => {
-        render(<KmsConceptSelectionEditModal {...defaultProps} />)
-        const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
-        fireEvent.change(searchInput, { target: { value: 'test search' } })
-        fireEvent.keyDown(searchInput, { key: 'Enter' })
-        await waitFor(() => {
-          expect(getKmsKeywordTree).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'test search')
-        })
-      })
-    })
-
-    describe('when fetch returns no results', () => {
-      test('should show no results', async () => {
-        vi.mocked(getKmsKeywordTree).mockResolvedValue(null)
-        render(<KmsConceptSelectionEditModal {...defaultProps} />)
-        const searchInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
-        await userEvent.type(searchInput, 'test pattern')
-        const applyButton = screen.getByText('Apply')
-        await userEvent.click(applyButton)
-        await waitFor(() => {
-          expect(screen.getByText('No results.')).toBeInTheDocument()
-        })
-      })
-    })
-
-    test('should handle fetch errors', async () => {
-      vi.mocked(getKmsKeywordTree).mockRejectedValue(new Error('Fetch error'))
-      render(<KmsConceptSelectionEditModal {...defaultProps} />)
+    test('should call handleAcceptChanges and toggleModal when Accept button is clicked', async () => {
+      render(<KmsConceptSelectionEditModal {...mockProps} />)
       await waitFor(() => {
-        expect(screen.getByText('Failed to load the tree. Please try again.')).toBeInTheDocument()
+        const acceptButton = screen.getByText('Accept')
+        expect(acceptButton).toBeInTheDocument()
       })
-    })
 
-    test('should handling clearing the search box', async () => {
-      render(<KmsConceptSelectionEditModal {...defaultProps} />)
-      const textInput = await screen.findByPlaceholderText('Search by Pattern or UUID')
-      fireEvent.change(textInput, { target: { value: 'test pattern' } })
-      fireEvent.change(textInput, { target: { value: '' } })
-      await waitFor(() => {
-        expect(getKmsKeywordTree).toHaveBeenCalledWith(expect.anything(), expect.anything(), '')
-      })
-    })
-  })
-
-  describe('when no version is provided', () => {
-    test('displays correct message', async () => {
-      const propsWithoutVersion = {
-        ...defaultProps,
-        version: null
-      }
-      render(<KmsConceptSelectionEditModal {...propsWithoutVersion} />)
-      await waitFor(() => {
-        expect(screen.getByText('Select a version and scheme to load the tree')).toBeInTheDocument()
-      })
-    })
-  })
-
-  describe('when no scheme is provided', () => {
-    test('displays correct message', async () => {
-      const propsWithoutScheme = {
-        ...defaultProps,
-        scheme: null
-      }
-      render(<KmsConceptSelectionEditModal {...propsWithoutScheme} />)
-      await waitFor(() => {
-        expect(screen.getByText('Select a version and scheme to load the tree')).toBeInTheDocument()
-      })
+      await userEvent.click(screen.getByText('Accept'))
+      expect(mockProps.handleAcceptChanges).toHaveBeenCalledWith('test-uuid')
+      expect(mockProps.toggleModal).toHaveBeenCalledWith(false)
     })
   })
 })

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -157,7 +157,6 @@ const KeywordManagerPage = () => {
   }, [selectedVersion])
 
   const handleAddNarrower = useCallback((parentId, newKeyword) => {
-    console.log('GOT ', parentId, newKeyword)
     // Create a new keyword data structure for the form
     const newKeywordData = {
       KeywordUUID: newKeyword.id,

--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -35,9 +35,32 @@ import './KeywordManagerPage.scss'
 /**
  * KeywordManagerPage Component
  *
- * This component represents the main page for managing keywords.
- * It allows users to select keyword versions and schemes, view and interact with a keyword tree,
- * and manage individual keywords.
+ * This component represents the main page for managing keywords in a hierarchical structure.
+ * It provides functionality to:
+ * - Select and view different versions of keyword sets
+ * - Choose specific keyword schemes within a version
+ * - View and interact with a hierarchical keyword tree
+ * - Add, edit, and manage individual keywords
+ * - Publish new versions of keyword sets
+ *
+ * The page layout includes:
+ * - Version and scheme selectors
+ * - A keyword tree view
+ * - A form for viewing and editing keyword details
+ * - Modals for warnings and publishing new versions
+ *
+ * Key features:
+ * - Integration with KMS (Knowledge Management System) for keyword data
+ * - Real-time updates of the keyword tree upon modifications
+ * - Version control and publishing capabilities
+ * - Error handling and loading states
+ *
+ * @component
+ *
+ * @example
+ * return (
+ *   <KeywordManagerPage />
+ * )
  */
 const KeywordManagerPage = () => {
   const [showError, setShowError] = useState(null)

--- a/static/src/js/schemas/uiSchemas/keywords/editKeyword.js
+++ b/static/src/js/schemas/uiSchemas/keywords/editKeyword.js
@@ -196,13 +196,13 @@ const editKeywordsUiSchema = {
         'ui:row': [
           {
             'ui:col': {
-              md: 4,
+              md: 6,
               children: ['RelationshipType']
             }
           },
           {
             'ui:col': {
-              md: 8,
+              md: 6,
               children: ['UUID']
             }
           }

--- a/static/src/js/schemas/umm/keywordSchema.js
+++ b/static/src/js/schemas/umm/keywordSchema.js
@@ -101,7 +101,7 @@ const keywordSchema = {
   definitions: {
     LabelTypeEnum: {
       type: 'string',
-      enum: ['Primary', 'Alternate', 'Abbreviation', 'Outdated']
+      enum: ['primary', 'alternate', 'abbreviation', 'outdated']
     },
     RelationshipTypeEnum: {
       type: 'string',

--- a/static/src/js/utils/convertFormDataToRdf.js
+++ b/static/src/js/utils/convertFormDataToRdf.js
@@ -33,8 +33,14 @@ export const convertFormDataToRdf = (formData, userNote, scheme, uid) => {
 
   const createNewChangeNote = () => {
     const currentDate = new Date().toISOString().split('T')[0]
+    const userIdPart = uid ? `User Id=${uid}` : ''
+    const parts = [
+      `Date=${currentDate}`,
+      userIdPart,
+      `User Note=${userNote.trim()}`
+    ].filter(Boolean)
 
-    return `Date=${currentDate} User Id=${uid} User Note=${userNote.trim()}`
+    return parts.join(' ')
   }
 
   // Construct the RDF object structure


### PR DESCRIPTION
# Overview

### What is the feature?

Tree now supports the ability to filter by a pattern search, as well as UUID.

### What is the Solution?

Added a text box to the top of the tree to allow filtering the tree by pattern.   Refactored a large part of the code to put most of the logic now in KeywordTree, before it was scattered in multiple places (Keyword Page, Edit Modal, etc.).    The tree is now responsible for fetching data, now has a hook that can be called for refreshing the tree, etc.  

### What areas of the application does this impact?

Main Page
Edit Modal when editing a keyword.

# Testing

From the main page, try searching for a keyword and editing it.
From the form page, try editing a keyword, make sure nothing broke there.

# Attachments

![Screenshot 2025-05-29 at 10 09 02 AM](https://github.com/user-attachments/assets/b6d20709-de67-4924-bc9f-b5970431a4ff)


# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
