### PR TITLE
MMT-4035: Increasing initial retrieval limit to 500 for groups

### DIFF
--- a/static/src/js/components/GroupPermissionSelect/GroupPermissionSelect.jsx
+++ b/static/src/js/components/GroupPermissionSelect/GroupPermissionSelect.jsx
@@ -143,7 +143,7 @@ const GroupPermissionSelectComponent = ({
     value: item.id,
     label: item.name,
     provider: item.tag
-  }))
+  })).sort((a, b) => a.label.localeCompare(b.label))
 
   // Include "All RegisterUser" and "All Guest" in the initial options
   const additionalOptions = [

--- a/static/src/js/components/GroupPermissionSelect/GroupPermissionSelect.jsx
+++ b/static/src/js/components/GroupPermissionSelect/GroupPermissionSelect.jsx
@@ -129,7 +129,8 @@ const GroupPermissionSelectComponent = ({
     skip: providerIds.length === 0,
     variables: {
       params: {
-        tags: providerIds
+        tags: providerIds,
+        limit: 500
       }
     }
   })

--- a/static/src/js/components/GroupPermissionSelect/__tests__/GroupPermissionSelect.test.jsx
+++ b/static/src/js/components/GroupPermissionSelect/__tests__/GroupPermissionSelect.test.jsx
@@ -31,7 +31,12 @@ const setup = ({
       [{
         request: {
           query: GET_GROUPS,
-          variables: { params: { tags: ['MMT_1', 'MMT_2'] } }
+          variables: {
+            params: {
+              tags: ['MMT_1', 'MMT_2'],
+              limit: 500
+            }
+          }
         },
         result: {
           data: {

--- a/static/src/js/components/PermissionForm/__tests__/PermissionForm.test.jsx
+++ b/static/src/js/components/PermissionForm/__tests__/PermissionForm.test.jsx
@@ -81,7 +81,12 @@ const setup = ({
         {
           request: {
             query: GET_GROUPS,
-            variables: { params: { tags: ['MMT_1', 'MMT_2'] } }
+            variables: {
+              params: {
+                tags: ['MMT_1', 'MMT_2'],
+                limit: 500
+              }
+            }
           },
           result: {
             data: {


### PR DESCRIPTION
# Overview

### What is the feature?

Currently the initial group list is limited to 20 groups. This fix increases the initial group list to 500.

### What is the Solution?

Increasing the initial group list to 500

### What areas of the application does this impact?

React MMT when creating new permissions.

# Testing

### Reproduction steps

- **Environment for testing: SIT**
- **Collection to test with:**

1. Use React MMT in SIT and create a new permission at https://mmt.sit.earthdata.nasa.gov/permissions/new
2. At the bottom of the page under "Group Permissions" click on one of the drop downs. Make sure it lists more than 20 options (not including "All guest users" or "All registered users"). 

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.
<img width="364" alt="Screenshot 2025-06-02 at 9 56 58 PM" src="https://github.com/user-attachments/assets/bb018fd1-5438-4150-a5bf-6200e414053e" />

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
