### PR TITLE
MMT-4001: Getting more info for visualization associations

### DIFF
--- a/static/src/js/operations/queries/getVisualization.js
+++ b/static/src/js/operations/queries/getVisualization.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export const GET_VISUALIZATION = gql`
-  query GetVisualization ($params: VisualizationInput) {
+  query GetVisualization ($params: VisualizationInput, $collectionsParams: CollectionsInput) {
     visualization (params: $params) {
       conceptId
       description
@@ -17,7 +17,7 @@ export const GET_VISUALIZATION = gql`
       revisions {
         count
       }
-      collections {
+      collections (params: $collectionsParams) {
         count
         items {
           conceptId


### PR DESCRIPTION
# Overview

### What is the feature?

As a user, I can associate visualizations to a collections

### What is the Solution?

Most of the code was already in place. Just needed to modify the gql query to get some additional information so it shows up on the Visualization associations page.

### What areas of the application does this impact?

React MMT

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

Use react MMT to associate a visualization with a collection in which you have permissions to.
Login to React MMT.
Go to Visualizations -> All Visualizations
Select a Visualization for a provider you have access to.
Click on the 3 dot menu and go to Collection Associations.
From here you can click on Add Collection Association and search for a collection.
Complete the steps for searching and adding a collection.
When finished after about 20 sections, refresh the page, you should be able to see your collection association.

I used the following visualization and collections:
https://mmt.sit.earthdata.nasa.gov/visualizations/VIS1200484663-MMT_1
C1200482521-AMD_KOPRI
C1200444618-AMD_USAPDC

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.
<img width="1787" alt="Screenshot 2025-06-08 at 8 29 33 PM" src="https://github.com/user-attachments/assets/c20b50eb-e7be-4757-b4d1-034dbfa161a8" />


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
