### PR TITLE
MMT-4028: Removing Visualizations Toggle

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -19,8 +19,6 @@ config="`jq '.application.cmrHost = $newValue' --arg newValue $bamboo_CMR_HOST <
 config="`jq '.application.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
 config="`jq '.application.gkrHost = $newValue' --arg newValue $bamboo_GKR_HOST <<< $config`"
 config="`jq '.application.kmsHost = $newValue' --arg newValue $bamboo_KMS_HOST <<< $config`"
-# Remove in MMT-4028
-config="`jq '.application.showVisualizations = ($newValue | tostring)' --arg newValue $bamboo_SHOW_VISUALIZATIONS <<< $config`"
 config="`jq '.application.cookieDomain = $newValue' --arg newValue $bamboo_COOKIE_DOMAIN <<< $config`"
 config="`jq '.application.displayProdWarning = $newValue' --arg newValue $bamboo_DISPLAY_PROD_WARNING <<< $config`"
 config="`jq '.application.tokenValidTime = $newValue' --arg newValue $bamboo_JWT_VALID_TIME <<< $config`"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@apollo/client": "^3.8.5",
-        "@edsc/metadata-preview": "^1.4.0-beta.2",
+        "@edsc/metadata-preview": "^1.4.0",
         "@node-saml/node-saml": "^4.0.5",
         "@rjsf/core": "^5.15.0",
         "@rjsf/utils": "^5.15.0",
@@ -4232,9 +4232,9 @@
       }
     },
     "node_modules/@edsc/metadata-preview": {
-      "version": "1.4.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@edsc/metadata-preview/-/metadata-preview-1.4.0-beta.2.tgz",
-      "integrity": "sha512-dSLfVZxt5iSSGXW33Y9xyUXAXc1p+X/n0D0WfAUmLlkCuFDQ0OUHLcnt1PNERVEn01a+IS/IQ+zVG+TYT5gIdQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@edsc/metadata-preview/-/metadata-preview-1.4.0.tgz",
+      "integrity": "sha512-dBMFzFaUTEmqiCaZ5zMYK0+jurCAWRu/lSGOkX1Spu9xO0B2hvOAZZAhIrG7Lonm4anvRL6dmY41AVD3srUNQQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.5",
-    "@edsc/metadata-preview": "^1.4.0-beta.2",
+    "@edsc/metadata-preview": "^1.4.0",
     "@node-saml/node-saml": "^4.0.5",
     "@rjsf/core": "^5.15.0",
     "@rjsf/utils": "^5.15.0",

--- a/static/src/js/components/Layout/Layout.jsx
+++ b/static/src/js/components/Layout/Layout.jsx
@@ -48,8 +48,7 @@ const Layout = ({ className, displayNav }) => {
     ummVis
   } = getUmmVersionsConfig()
 
-  // Remove showVisualizations in MMT-4028
-  const { env, displayProdWarning, showVisualizations } = getApplicationConfig()
+  const { env, displayProdWarning } = getApplicationConfig()
 
   const { user } = useAuthContext()
 
@@ -191,8 +190,7 @@ const Layout = ({ className, displayNav }) => {
                                   }
                                 ]
                               },
-                              // Remove in MMT-4028
-                              ...((showVisualizations === 'true') ? [{
+                              {
                                 title: 'Visualizations',
                                 version: `v${ummVis}`,
                                 children: [
@@ -205,7 +203,7 @@ const Layout = ({ className, displayNav }) => {
                                     title: 'Drafts'
                                   }
                                 ]
-                              }] : []),
+                              },
                               {
                                 title: 'Order Options',
                                 children: [


### PR DESCRIPTION
# Overview

### What is the feature?

Users in any environment can see Visualizations in the primary navigation bar
Bamboo env var is removed and the parsing of it in the deployment script/code is removed
Update @edsc/metadata-preview package

### What is the Solution?

Removed showVisualizaitons logic from Layout and bamboo config. Updated edsc/cmr-preview to 1.4.0

### What areas of the application does this impact?

List impacted areas.

# Testing

### Reproduction steps

- **Environment for testing: SIT
- **Collection to test with: Any

1. Ensure that Visualizations Navigation shows up
2. Under All Visualizations, click on a published record and make sure all the fields show up in the Access preview
3. Do the same for Drafts

### Attachments

<img width="1711" alt="Screenshot 2025-06-17 at 9 56 30 AM" src="https://github.com/user-attachments/assets/25286bb0-d3c5-498a-9285-6b9074eef3e6" />

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
