### PR TITLE
MMT-3967: Adding FED DAP code

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
     </script>
     <% } %>
     <!-- End Google Tag Manager -->
+    <script async type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DHS&pga4=G-SXHX7M2NBE"></script>
   </head>
   <body class="h-100 d-flex flex-column is-loading">
     <!-- Google Tag Manager (noscript) -->


### PR DESCRIPTION
# Overview

### What is the feature?

The Fed DAP script (Federal Digital Analytics Program) serves the General Services Administration (GSA), and is required for all public facing federal websites. Basically it allows federal agencies to track metrics through the GSA analytics property. It’s the same google dashboard but for all government agencies.

### What is the Solution?

Add Fed DAP script to header of index.html

### What areas of the application does this impact?

index.html

# Testing

### Reproduction steps

- **Environment for testing:local
- **Collection to test with:**

1. Open the Network tab, remove any filters, should see a call to Universal-Analytics-Fedartion-Min.js

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
