### PR TITLE
MMT-4048: Concept Selection Widget needs to include version when retrieving concept full path.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16694,15 +16694,44 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18736,6 +18765,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -18946,12 +18989,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -19013,9 +19054,10 @@
       "peer": true
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -20833,11 +20875,18 @@
       }
     },
     "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
@@ -21117,21 +21166,40 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stdin": {
@@ -21303,11 +21371,12 @@
       "dev": true
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -21454,9 +21523,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -22708,11 +22778,12 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -24224,6 +24295,15 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -26604,18 +26684,51 @@
       }
     },
     "node_modules/pbkdf2": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+      "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
+      "license": "MIT",
       "dependencies": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "~1.1.3",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "=2.0.1",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.11",
+        "to-buffer": "^1.2.0"
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/create-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/hash-base": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/ripemd160": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "node_modules/peek-readable": {
@@ -31511,9 +31624,18 @@
       }
     },
     "node_modules/to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+      "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -31844,13 +31966,14 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.13"
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -34056,14 +34179,17 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
@@ -66,7 +66,7 @@ const KmsConceptSelectionWidget = ({
     const fetchFullPaths = async () => {
       try {
         const params = {
-          conceptId: value,
+          uuid: value,
           version: getVersionName(version)
         }
         let fullPaths = await getKmsConceptFullPaths(params)

--- a/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/KmsConceptSelectionWidget.jsx
@@ -13,7 +13,7 @@ import {
   KmsConceptSelectionEditModal
 } from '@/js/components/KmsConceptSelectionEditModal/KmsConceptSelectionEditModal'
 import { getKmsConceptFullPaths } from '@/js/utils/getKmsConceptFullPaths'
-
+import { getVersionName } from '@/js/utils/getVersionName'
 import CustomWidgetWrapper from '../CustomWidgetWrapper/CustomWidgetWrapper'
 
 import './KmsConceptSelectionWidget.scss'
@@ -65,7 +65,11 @@ const KmsConceptSelectionWidget = ({
   useEffect(() => {
     const fetchFullPaths = async () => {
       try {
-        let fullPaths = await getKmsConceptFullPaths(value)
+        const params = {
+          conceptId: value,
+          version: getVersionName(version)
+        }
+        let fullPaths = await getKmsConceptFullPaths(params)
         const lastField = fullPaths[0].split('|').pop()
         fullPaths = fullPaths.map((path) => path.replaceAll('|', ' > '))
         setKeywordLabel(lastField)

--- a/static/src/js/components/KmsConceptSelectionWidget/__tests__/KMSConceptSelectionWidget.test.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/__tests__/KMSConceptSelectionWidget.test.jsx
@@ -91,7 +91,11 @@ describe('KmsConceptSelectionWidget', () => {
 
     test('should fetch and display the correct keyword', async () => {
       renderComponent()
-      expect(getKmsConceptFullPaths).toHaveBeenCalledWith('test-uuid')
+      expect(getKmsConceptFullPaths).toHaveBeenCalledWith({
+        conceptId: 'test-uuid',
+        version: '1'
+      })
+
       await waitFor(async () => {
         expect(await screen.findByText('TORNADOES')).toBeInTheDocument()
       })
@@ -99,7 +103,11 @@ describe('KmsConceptSelectionWidget', () => {
 
     test('should show the full path as a title attribute', async () => {
       renderComponent()
-      expect(getKmsConceptFullPaths).toHaveBeenCalledWith('test-uuid')
+      expect(getKmsConceptFullPaths).toHaveBeenCalledWith({
+        conceptId: 'test-uuid',
+        version: '1'
+      })
+
       await waitFor(() => {
         const keywordElement = screen.getByText(/tornadoes/i)
         const expectedTitle = /ScienceKeywords\s*>\s*ATMOSPHERE\s*>\s*TORNADOES/

--- a/static/src/js/components/KmsConceptSelectionWidget/__tests__/KMSConceptSelectionWidget.test.jsx
+++ b/static/src/js/components/KmsConceptSelectionWidget/__tests__/KMSConceptSelectionWidget.test.jsx
@@ -92,7 +92,7 @@ describe('KmsConceptSelectionWidget', () => {
     test('should fetch and display the correct keyword', async () => {
       renderComponent()
       expect(getKmsConceptFullPaths).toHaveBeenCalledWith({
-        conceptId: 'test-uuid',
+        uuid: 'test-uuid',
         version: '1'
       })
 
@@ -104,7 +104,7 @@ describe('KmsConceptSelectionWidget', () => {
     test('should show the full path as a title attribute', async () => {
       renderComponent()
       expect(getKmsConceptFullPaths).toHaveBeenCalledWith({
-        conceptId: 'test-uuid',
+        uuid: 'test-uuid',
         version: '1'
       })
 

--- a/static/src/js/utils/__tests__/getKmsConceptFullPaths.test.js
+++ b/static/src/js/utils/__tests__/getKmsConceptFullPaths.test.js
@@ -30,10 +30,10 @@ describe('getKmsConceptFullPaths', () => {
   })
 
   it('should fetch and return full paths from KMS without version', async () => {
-    const conceptId = 'test-uuid'
+    const uuid = 'test-uuid'
     const expectedResult = ['Chained Operations']
 
-    const result = await getKmsConceptFullPaths({ conceptId })
+    const result = await getKmsConceptFullPaths({ uuid })
 
     expect(fetch).toHaveBeenCalledTimes(1)
     expect(fetch).toHaveBeenCalledWith('http://example.com/concept_fullpaths/concept_uuid/test-uuid', { method: 'GET' })
@@ -42,12 +42,12 @@ describe('getKmsConceptFullPaths', () => {
   })
 
   it('should fetch and return full paths from KMS with version', async () => {
-    const conceptId = 'test-uuid'
+    const uuid = 'test-uuid'
     const version = '1.0'
     const expectedResult = ['Chained Operations']
 
     const result = await getKmsConceptFullPaths({
-      conceptId,
+      uuid,
       version
     })
 
@@ -77,10 +77,10 @@ describe('getKmsConceptFullPaths', () => {
       `)
     }))
 
-    const conceptId = 'multi-path-uuid'
+    const uuid = 'multi-path-uuid'
     const expectedResult = ['Path 1', 'Path 2']
 
-    const result = await getKmsConceptFullPaths({ conceptId })
+    const result = await getKmsConceptFullPaths({ uuid })
 
     expect(result).toEqual(expectedResult)
   })

--- a/static/src/js/utils/__tests__/getKmsConceptFullPaths.test.js
+++ b/static/src/js/utils/__tests__/getKmsConceptFullPaths.test.js
@@ -8,6 +8,11 @@ import {
 
 import { getKmsConceptFullPaths } from '@/js/utils/getKmsConceptFullPaths'
 
+// Mock getApplicationConfig
+vi.mock('sharedUtils/getConfig', () => ({
+  getApplicationConfig: vi.fn(() => ({ kmsHost: 'http://example.com' }))
+}))
+
 // Mocking fetch
 global.fetch = vi.fn(() => Promise.resolve({
   ok: true,
@@ -21,18 +26,33 @@ global.fetch = vi.fn(() => Promise.resolve({
 describe('getKmsConceptFullPaths', () => {
   beforeEach(() => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
-
     fetch.mockClear()
   })
 
-  it('should fetch and return full paths from KMS', async () => {
-    const value = 'test-uuid'
+  it('should fetch and return full paths from KMS without version', async () => {
+    const conceptId = 'test-uuid'
     const expectedResult = ['Chained Operations']
 
-    const result = await getKmsConceptFullPaths(value)
+    const result = await getKmsConceptFullPaths({ conceptId })
 
     expect(fetch).toHaveBeenCalledTimes(1)
-    expect(fetch).toHaveBeenCalledWith(expect.stringContaining(`/concept_fullpaths/concept_uuid/${value}`), { method: 'GET' })
+    expect(fetch).toHaveBeenCalledWith('http://example.com/concept_fullpaths/concept_uuid/test-uuid', { method: 'GET' })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it('should fetch and return full paths from KMS with version', async () => {
+    const conceptId = 'test-uuid'
+    const version = '1.0'
+    const expectedResult = ['Chained Operations']
+
+    const result = await getKmsConceptFullPaths({
+      conceptId,
+      version
+    })
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith('http://example.com/concept_fullpaths/concept_uuid/test-uuid?version=1.0', { method: 'GET' })
 
     expect(result).toEqual(expectedResult)
   })
@@ -43,6 +63,25 @@ describe('getKmsConceptFullPaths', () => {
       status: 404
     }))
 
-    await expect(getKmsConceptFullPaths('bad-uuid')).rejects.toThrow('getConceptFullPaths HTTP error! status: 404')
+    await expect(getKmsConceptFullPaths({ conceptId: 'bad-uuid' })).rejects.toThrow('getConceptFullPaths HTTP error! status: 404')
+  })
+
+  it('should handle multiple full paths', async () => {
+    fetch.mockImplementationOnce(() => Promise.resolve({
+      ok: true,
+      text: () => Promise.resolve(`
+        <FullPaths>
+          <FullPath xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:string">Path 1</FullPath>
+          <FullPath xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:string">Path 2</FullPath>
+        </FullPaths>
+      `)
+    }))
+
+    const conceptId = 'multi-path-uuid'
+    const expectedResult = ['Path 1', 'Path 2']
+
+    const result = await getKmsConceptFullPaths({ conceptId })
+
+    expect(result).toEqual(expectedResult)
   })
 })

--- a/static/src/js/utils/getKmsConceptFullPaths.js
+++ b/static/src/js/utils/getKmsConceptFullPaths.js
@@ -9,7 +9,7 @@ import { getApplicationConfig } from 'sharedUtils/getConfig'
  * @async
  * @function getKmsConceptFullPaths
  * @param {Object} params - The parameters for the function.
- * @param {string} params.conceptId - The UUID of the KMS concept whose full paths are to be fetched.
+ * @param {string} params.uuid - The UUID of the KMS concept whose full paths are to be fetched.
  * @param {string|null} [params.version] - Optional. The version of the concept to fetch. If not provided, the latest version is used.
  * @returns {Promise<string[]>} A promise that resolves to an array of full paths as strings.
  * @throws Will throw an error if the fetch operation or XML parsing fails.
@@ -21,10 +21,10 @@ import { getApplicationConfig } from 'sharedUtils/getConfig'
  * // Usage example
  * async function fetchConceptPaths() {
  *   try {
- *     const conceptId = '123e4567-e89b-12d3-a456-426614174000';
+ *     const uuid = '123e4567-e89b-12d3-a456-426614174000';
  *     const version = '1.0'; // Optional, can be omitted
  *
- *     const paths = await getKmsConceptFullPaths({ conceptId, version });
+ *     const paths = await getKmsConceptFullPaths({ uuid, version });
  *
  *     console.log('Concept full paths:', paths);
  *     // Example output: ['Root > Category > Subcategory > Concept']
@@ -36,11 +36,11 @@ import { getApplicationConfig } from 'sharedUtils/getConfig'
  * // Call the function
  * fetchConceptPaths();
  */
-const getKmsConceptFullPaths = async ({ conceptId, version }) => {
+const getKmsConceptFullPaths = async ({ uuid, version }) => {
   const { kmsHost } = getApplicationConfig()
   try {
     // Construct the base URL
-    let url = `${kmsHost}/concept_fullpaths/concept_uuid/${conceptId}`
+    let url = `${kmsHost}/concept_fullpaths/concept_uuid/${uuid}`
 
     // Add version parameter only if version is not null
     if (version) {

--- a/static/src/js/utils/getKmsConceptFullPaths.js
+++ b/static/src/js/utils/getKmsConceptFullPaths.js
@@ -8,15 +8,47 @@ import { getApplicationConfig } from 'sharedUtils/getConfig'
  *
  * @async
  * @function getKmsConceptFullPaths
- * @param {string} value - The UUID of the KMS concept whose full paths are to be fetched.
+ * @param {Object} params - The parameters for the function.
+ * @param {string} params.conceptId - The UUID of the KMS concept whose full paths are to be fetched.
+ * @param {string|null} [params.version] - Optional. The version of the concept to fetch. If not provided, the latest version is used.
  * @returns {Promise<string[]>} A promise that resolves to an array of full paths as strings.
  * @throws Will throw an error if the fetch operation or XML parsing fails.
+ *
+ * @example
+ * // Import the function
+ * import { getKmsConceptFullPaths } from './getKmsConceptFullPaths';
+ *
+ * // Usage example
+ * async function fetchConceptPaths() {
+ *   try {
+ *     const conceptId = '123e4567-e89b-12d3-a456-426614174000';
+ *     const version = '1.0'; // Optional, can be omitted
+ *
+ *     const paths = await getKmsConceptFullPaths({ conceptId, version });
+ *
+ *     console.log('Concept full paths:', paths);
+ *     // Example output: ['Root > Category > Subcategory > Concept']
+ *   } catch (error) {
+ *     console.error('Error fetching concept paths:', error);
+ *   }
+ * }
+ *
+ * // Call the function
+ * fetchConceptPaths();
  */
-const getKmsConceptFullPaths = async (value) => {
+const getKmsConceptFullPaths = async ({ conceptId, version }) => {
   const { kmsHost } = getApplicationConfig()
   try {
+    // Construct the base URL
+    let url = `${kmsHost}/concept_fullpaths/concept_uuid/${conceptId}`
+
+    // Add version parameter only if version is not null
+    if (version) {
+      url += `?version=${version}`
+    }
+
     // Fetch data from KMS server
-    const response = await fetch(`${kmsHost}/concept_fullpaths/concept_uuid/${value}`, {
+    const response = await fetch(url, {
       method: 'GET'
     })
 


### PR DESCRIPTION
# Overview

### What is the feature?

Widget needs to use version to fetch concept full path. Without version, getting new concept full path in draft results in error because getKmsConceptFullPaths can't find it in published version.

### What is the Solution?

Pass version as parameter for kms call in getKmsConceptFullPaths.

Also fix 1 critical vulnerabilities pbkdf2 

### What areas of the application does this impact?

Concept Selection Widget in keyword form.

# Testing

Add a new narrower keyword. Save it. Pick another keyword to edit, choose the new keyword as broader or narrower, hit save, see attachment for error shown. Fixed version (this branch) should not show that error.

### Attachments

<img width="1368" alt="Screenshot 2025-07-01 at 5 59 31 PM" src="https://github.com/user-attachments/assets/6ccf0b04-6ddf-46b0-a8f8-a9da10cd142e" />


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
