### PR TITLE
MMT-4051: When users create a new umm-visualization draft, they are unable to publish it.

### DIFF
--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -154,10 +154,18 @@ const MetadataForm = () => {
   }, [data])
 
   const {
-    nativeId = `MMT_${crypto.randomUUID()}`,
+    nativeId: existingNativeId,
     providerId: fetchedMetadataProviderId,
     ummMetadata = {}
   } = draft || {}
+
+  const nativeId = existingNativeId || (
+    // Add '-draft' to the end of nativeId if it doesn't already end with it.
+    // Can be removed after CMR-10545 is complete
+    derivedConceptType === 'Visualization'
+      ? `MMT_${crypto.randomUUID()}-draft`
+      : `MMT_${crypto.randomUUID()}`
+  )
 
   const schema = getUmmSchema(derivedConceptType)
   const formSections = formConfigurations[derivedConceptType]
@@ -239,7 +247,7 @@ const MetadataForm = () => {
         // even though we will end up navigating to the preview page.  The reason
         // being is because the publish mutation causes the cache to be cleared and as a
         // result the draft is refetched.
-        if (type === saveTypes.save || type === saveTypes.saveAndPublish) {
+        if (type === saveTypes.save) {
           // Navigate to current form? just scroll to top of page instead?
           if (currentSection) navigate(`/drafts/${draftType}/${savedConceptId}/${currentSection}?revisionId=${savedRevisionId}`, { replace: true })
 


### PR DESCRIPTION
# Overview

### What is the feature?

There is an issue where cmr needs a unique nativeId to publish a visualization record.

We previously fixed this in [MMT-3995](https://bugs.earthdata.nasa.gov/browse/MMT-3995) however it does not appear that the fix was applied to newly created drafts. Just need to fix logic so that it's now applied.

Note that this logic will eventually need to come out once [CMR-10545](https://bugs.earthdata.nasa.gov/browse/CMR-10545) is completed. 

### What is the Solution?

Previous logic to add -draft to nativeId was only applied to ingestDraftMutation. It needed to apply to MetadataForm as well. 

### What areas of the application does this impact?

MetadataForm

# Testing

### Reproduction steps

- **Environment for testing: local
- **Collection to test with: Create a new draft

1. Create a new draft in MMT and save. Then click Save & Publish. It should publish now.


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
