### PR TITLE
MMT-4061: Use node.id to call delete keyword

### DIFF
--- a/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
+++ b/static/src/js/pages/KeywordManagerPage/KeywordManagerPage.jsx
@@ -112,10 +112,8 @@ const KeywordManagerPage = () => {
       setIsDeleting(true)
       setDeleteError(null)
       try {
-        // Check if nodeToDelete has a data property, if not use id directly
-        const conceptId = nodeToDelete.data ? nodeToDelete.data.id : nodeToDelete.id
         const params = {
-          conceptId,
+          conceptId: nodeToDelete.id,
           version: getVersionName(selectedVersion),
           token: tokenValue
         }


### PR DESCRIPTION
# Overview

### What is the feature?

User should be able to delete a leaf keyword found per filter from the keyword tree.

### What is the Solution?

Fetch keyword uuid from keyword tree node directly.

### What areas of the application does this impact?

Filter with a pattern to find a leaf keyword and delete it per 'Delete' from it's context menu.

# Testing

Filter with a pattern to find a leaf keyword and delete it per 'Delete' from it's context menu. There should be no 404 error and keyword is deleted.

### Attachments

N/A

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
