### PR TITLE
MMT-4065: Make searching for groups require a provider

### DIFF
--- a/static/src/js/components/CustomMultiSelectWidget/CustomMultiSelectWidget.jsx
+++ b/static/src/js/components/CustomMultiSelectWidget/CustomMultiSelectWidget.jsx
@@ -44,7 +44,6 @@ const CustomMultiSelectWidget = ({
   const { items } = schema
   const { schemaUtils } = registry
   const retrievedSchema = schemaUtils.retrieveSchema(items)
-  const requiredUI = uiSchema['ui:required']
 
   const multiSelectScrollRef = useRef(null)
   const focusRef = useRef(null)
@@ -124,7 +123,7 @@ const CustomMultiSelectWidget = ({
       description={description}
       id={id}
       label={label}
-      required={required || requiredUI}
+      required={required}
       scrollRef={multiSelectScrollRef}
       title={title}
     >
@@ -178,7 +177,6 @@ CustomMultiSelectWidget.propTypes = {
     enum: PropTypes.arrayOf(PropTypes.string)
   }).isRequired,
   uiSchema: PropTypes.shape({
-    'ui:required': PropTypes.bool,
     'ui:title': PropTypes.string
   }),
   value: PropTypes.arrayOf(PropTypes.string)

--- a/static/src/js/components/GroupList/GroupList.jsx
+++ b/static/src/js/components/GroupList/GroupList.jsx
@@ -228,7 +228,7 @@ const GroupList = ({ isAdminPage }) => {
           !providers ? (
             <Alert variant="info" className="mb-4">
               <FaQuestionCircle className="me-2 small" />
-              Please select a provider
+              Required fields not selected
             </Alert>
           ) : (
             <ControlledPaginatedContent

--- a/static/src/js/components/GroupList/__tests__/GroupList.test.jsx
+++ b/static/src/js/components/GroupList/__tests__/GroupList.test.jsx
@@ -145,7 +145,7 @@ describe('GroupList', () => {
         }]
       })
 
-      expect(await screen.findByText('Please select a provider')).toBeInTheDocument()
+      expect(await screen.findByText('Required fields not selected')).toBeInTheDocument()
     })
   })
 

--- a/static/src/js/schemas/groupSearch.js
+++ b/static/src/js/schemas/groupSearch.js
@@ -34,7 +34,7 @@ const groupSearch = {
       }
     }
   },
-  required: []
+  required: ['providers']
 }
 
 export default groupSearch

--- a/static/src/js/schemas/uiSchemas/GroupSearch.js
+++ b/static/src/js/schemas/uiSchemas/GroupSearch.js
@@ -21,13 +21,13 @@ const groupSearchUiSchema = {
                 {
                   'ui:col': {
                     md: 4,
-                    children: ['name']
+                    children: ['providers']
                   }
                 },
                 {
                   'ui:col': {
                     md: 4,
-                    children: ['providers']
+                    children: ['name']
                   }
                 },
                 {
@@ -44,7 +44,6 @@ const groupSearchUiSchema = {
     ]
   },
   providers: {
-    'ui:required': true,
     'ui:widget': CustomMultiSelectWidget
   },
   members: {


### PR DESCRIPTION
# Overview

### What is the feature?

Make searching for groups require a provider to overcome a vulnerability fixed in previous GQL ticket

### What is the Solution?

Made providers a required field in the UI only so that admin page still validates and disabled the submit button until a provider is selected. Created an info alert banner upon page load that prompts users to select a provider.

### What areas of the application does this impact?

GroupList
GroupSearchForm
Had to edit CustomMultiSelectWidget to accept ui:required

# Testing

### Reproduction steps

- **Environment for testing: any
- **Collection to test with:**

1. Go to /groups and make sure the submit button is disabled until you select a provider. Delete provider and click submit again. 
2. Go to admin/groups and make sure the page works as expected. 

### Attachments
<img width="1667" height="413" alt="Screenshot 2025-07-29 at 9 57 21 AM" src="https://github.com/user-attachments/assets/59c97e6d-7cb8-49a2-8655-6d75f6d03a3f" />

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
