### PR TITLE
MMT-4053: As a user, I can enter citation information and science keywords

### DIFF
--- a/static/src/js/components/DraftList/DraftList.jsx
+++ b/static/src/js/components/DraftList/DraftList.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 import { FaFileDownload } from 'react-icons/fa'
 import { useParams } from 'react-router-dom'
@@ -117,7 +117,7 @@ const DraftList = () => {
   // For 'generic' schemas as opposed to umm
   const genericColumns = [
     {
-      dataKey: 'previewMetadata.name',
+      dataKey: 'ummMetadata.Name',
       title: 'Name',
       className: 'col-auto',
       dataAccessorFn: buildPrimaryEllipsisLink

--- a/static/src/js/operations/queries/getCitationDraft.js
+++ b/static/src/js/operations/queries/getCitationDraft.js
@@ -18,7 +18,7 @@ export const CITATION_DRAFT = gql`
           conceptId
           identifier
           identifierType
-          name
+          pageTitle: name
           nativeId
           providerId
           relatedIdentifiers

--- a/static/src/js/schemas/uiSchemas/citations/citationInformation.js
+++ b/static/src/js/schemas/uiSchemas/citations/citationInformation.js
@@ -1,0 +1,72 @@
+const citationInformationUiSchema = {
+  'ui:heading-level': 'h3',
+  'ui:field': 'layout',
+  'ui:layout_grid': {
+    'ui:row': [
+      {
+        'ui:group': 'Citation Information',
+        'ui:required': true,
+        'ui:col': {
+          md: 12,
+          children: [
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['Identifier']
+                  }
+                }
+              ]
+            },
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['IdentifierType']
+                  }
+                }
+              ]
+            },
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['Name']
+                  }
+                }
+              ]
+            },
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['Abstract']
+                  }
+                }
+              ]
+            },
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['ResolutionAuthority']
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  Abstract: {
+    'ui:widget': 'textarea'
+  }
+}
+
+export default citationInformationUiSchema

--- a/static/src/js/schemas/uiSchemas/citations/citationScienceKeywordsUiSchema.js
+++ b/static/src/js/schemas/uiSchemas/citations/citationScienceKeywordsUiSchema.js
@@ -1,0 +1,37 @@
+const citationScienceKeywordsUiSchema = {
+  'ui:heading-level': 'h3',
+  'ui:field': 'layout',
+  'ui:layout_grid': {
+    'ui:row': [
+      {
+        'ui:group': 'Science Keywords',
+        'ui:required': true,
+        'ui:col': {
+          md: 12,
+          children: [
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['ScienceKeywords']
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  ScienceKeywords: {
+    'ui:field': 'keywordPicker',
+    'ui:keyword_scheme': 'science_keywords',
+    'ui:picker_title': 'SERVICE KEYWORD',
+    'ui:keyword_scheme_column_names': ['sciencekeywords', 'category', 'topic', 'term', 'variable_level_1', 'variable_level_2', 'variable_level_3'],
+    'ui:filter': 'EARTH SCIENCE',
+    'ui:scheme_values': ['Category', 'Topic', 'Term', 'VariableLevel1', 'VariableLevel2', 'VariableLevel3']
+  }
+}
+
+export default citationScienceKeywordsUiSchema

--- a/static/src/js/schemas/uiSchemas/citations/index.js
+++ b/static/src/js/schemas/uiSchemas/citations/index.js
@@ -1,0 +1,9 @@
+import citationInformationUiSchema from './citationInformation'
+import citationScienceKeywordsUiSchema from './citationScienceKeywordsUiSchema'
+
+const citationUiSchema = {
+  'citation-information': citationInformationUiSchema,
+  'science-keywords': citationScienceKeywordsUiSchema
+}
+
+export default citationUiSchema

--- a/static/src/js/utils/__tests__/getUiSchema.test.js
+++ b/static/src/js/utils/__tests__/getUiSchema.test.js
@@ -1,3 +1,4 @@
+import citationUiSchema from '@/js/schemas/uiSchemas/citations'
 import collectionUiSchema from '@/js/schemas/uiSchemas/collections'
 import serviceUiSchema from '@/js/schemas/uiSchemas/services'
 import toolsUiSchema from '@/js/schemas/uiSchemas/tools'
@@ -34,6 +35,12 @@ describe('getUiSchema', () => {
   describe('when the concept type is visualization-draft', () => {
     test('returns the UMM-VIS schema', () => {
       expect(getUiSchema('Visualization')).toEqual(visualizationUiSchema)
+    })
+  })
+
+  describe('when the concept type is citation-draft', () => {
+    test('returns the UMM-VIS schema', () => {
+      expect(getUiSchema('Citation')).toEqual(citationUiSchema)
     })
   })
 

--- a/static/src/js/utils/getUiSchema.js
+++ b/static/src/js/utils/getUiSchema.js
@@ -1,3 +1,4 @@
+import citationUiSchema from '../schemas/uiSchemas/citations'
 import collectionsUiSchema from '../schemas/uiSchemas/collections'
 import serviceUiSchema from '../schemas/uiSchemas/services'
 import toolsUiSchema from '../schemas/uiSchemas/tools'
@@ -10,6 +11,8 @@ import visualizationUiSchema from '../schemas/uiSchemas/visualizations'
  */
 const getUiSchema = (conceptType) => {
   switch (conceptType) {
+    case 'Citation':
+      return citationUiSchema
     case 'Collection':
       return collectionsUiSchema
     case 'Service':


### PR DESCRIPTION
# Overview

### What is the feature?

As a user, I can enter citation information and science keywords

### What is the Solution?

Adding those uiSchemas

### What areas of the application does this impact?

/citation-information
/science-keywords

# Testing

### Reproduction steps

- **Environment for testing: Any
- **Collection to test with: any

1. Go to a draft and open up Citation Information and Science Keywords. Make sure they look alright.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
