### PR TITLE
MMT-4054: As a user, I can enter related identifiers and citation metadata

### DIFF
--- a/static/src/js/schemas/otherSchemasCitSchema.js
+++ b/static/src/js/schemas/otherSchemasCitSchema.js
@@ -61,13 +61,17 @@ const otherSchemasCitSchema = {
           RelatedIdentifier: {
             type: 'string',
             description: 'The identifier for related resource',
-            examples: ['10.5067/ABC123XYZ', '978-3-16-148410-0']
+            examples: ['10.5067/ABC123XYZ', '978-3-16-148410-0'],
+            minLength: 1,
+            maxLength: 1024
           },
           RelatedResolutionAuthority: {
             type: 'string',
             format: 'uri',
             description: 'URI used to resolve the related identifier',
-            examples: ['https://doi.org']
+            examples: ['https://doi.org'],
+            minLength: 1,
+            maxLength: 1024
           }
         }
       }
@@ -81,12 +85,16 @@ const otherSchemasCitSchema = {
         Title: {
           type: 'string',
           description: 'Title of the resource',
-          examples: ['Air quality during three covid-19 lockdown phases']
+          examples: ['Air quality during three covid-19 lockdown phases'],
+          minLength: 1,
+          maxLength: 1024
         },
         Year: {
           type: 'integer',
           description: 'Year when resource was published',
-          examples: [2022]
+          examples: [2022],
+          minLength: 1,
+          maxLength: 256
         },
         Type: {
           type: 'string',
@@ -104,17 +112,23 @@ const otherSchemasCitSchema = {
               ORCID: {
                 type: 'string',
                 description: 'ORCID identifier of the author',
-                examples: ['0009-0004-9235-1891']
+                examples: ['0009-0004-9235-1891'],
+                minLength: 1,
+                maxLength: 512
               },
               Given: {
                 type: 'string',
                 description: 'Given name of the author',
-                examples: ['Abdelfettah']
+                examples: ['Abdelfettah'],
+                minLength: 1,
+                maxLength: 256
               },
               Family: {
                 type: 'string',
                 description: 'Family name of the author',
-                examples: ['Benchrif']
+                examples: ['Benchrif'],
+                minLength: 1,
+                maxLength: 256
               },
               Sequence: {
                 type: 'string',
@@ -127,37 +141,51 @@ const otherSchemasCitSchema = {
         },
         Publisher: {
           type: 'string',
-          description: 'Name of the resource publisher'
+          description: 'Name of the resource publisher',
+          minLength: 1,
+          maxLength: 1024
         },
         Container: {
           type: 'string',
           description: 'Journal name for journal articles, conference name for proceedings, book name for book chapters',
-          examples: ['Sustainable Cities and Society']
+          examples: ['Sustainable Cities and Society'],
+          minLength: 1,
+          maxLength: 1024
         },
         Volume: {
           type: 'string',
           description: 'The journal volume of journal article',
-          examples: ['84']
+          examples: ['84'],
+          minLength: 1,
+          maxLength: 1024
         },
         Number: {
           type: 'string',
           description: 'The issue of a journal article or number of technical report',
-          examples: ['1']
+          examples: ['1'],
+          minLength: 1,
+          maxLength: 256
         },
         Pages: {
           type: 'string',
           description: 'Page numbers, separated either by commas or double-hyphens',
-          examples: ['100-110']
+          examples: ['100-110'],
+          minLength: 1,
+          maxLength: 256
         },
         Address: {
           type: 'string',
           description: 'The address where the book was published, or thesis or report were created',
-          examples: ['Cham, Switzerland']
+          examples: ['Cham, Switzerland'],
+          minLength: 1,
+          maxLength: 1024
         },
         Institution: {
           type: 'string',
           description: 'Name of institution where the thesis or report were created',
-          examples: ['Stanford University']
+          examples: ['Stanford University'],
+          minLength: 1,
+          maxLength: 1024
         }
       }
     },

--- a/static/src/js/schemas/uiSchemas/citations/citationMetadata.js
+++ b/static/src/js/schemas/uiSchemas/citations/citationMetadata.js
@@ -88,8 +88,6 @@ const citationMetadataUiSchema = {
                     }
                   },
                   {
-                    'ui:group-classname': 'h2-title',
-                    'ui:group': 'Addition Information',
                     'ui:col': {
                       md: 12,
                       children: ['Address']

--- a/static/src/js/schemas/uiSchemas/citations/citationMetadata.js
+++ b/static/src/js/schemas/uiSchemas/citations/citationMetadata.js
@@ -1,0 +1,124 @@
+const citationMetadataUiSchema = {
+  'ui:heading-level': 'h3',
+  'ui:field': 'layout',
+  'ui:layout_grid': {
+    'ui:row': [
+      {
+        'ui:group': 'Citation Metadata',
+        'ui:required': false,
+        'ui:col': {
+          md: 12,
+          children: [
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['CitationMetadata']
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  CitationMetadata: {
+    'ui:heading-level': 'lead',
+    'ui:field': 'layout',
+    'ui:layout_grid': {
+      'ui:row': [
+        {
+          'ui:col': {
+            md: 12,
+            children: [
+              {
+                'ui:row': [
+                  {
+                    'ui:group-classname': 'h2-title',
+                    'ui:group': 'Basic Information',
+                    'ui:col': {
+                      md: 12,
+                      children: ['Title']
+                    }
+                  },
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['Year']
+                    }
+                  },
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['Type']
+                    }
+                  },
+                  {
+                    'ui:group-classname': 'h2-title',
+                    'ui:group': 'Publication Details',
+                    'ui:col': {
+                      md: 12,
+                      children: ['Publisher']
+                    }
+                  },
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['Container']
+                    }
+                  },
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['Volume']
+                    }
+                  },
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['Number']
+                    }
+                  },
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['Pages']
+                    }
+                  },
+                  {
+                    'ui:group-classname': 'h2-title',
+                    'ui:group': 'Addition Information',
+                    'ui:col': {
+                      md: 12,
+                      children: ['Address']
+                    }
+                  },
+                  {
+                    'ui:col': {
+                      md: 12,
+                      children: ['Institution']
+                    }
+                  },
+                  {
+                    'ui:group-classname': 'h2-title',
+                    'ui:group': 'Authorship',
+                    'ui:col': {
+                      md: 12,
+                      children: ['Author']
+                    }
+                  }
+
+                ]
+              }
+
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+export default citationMetadataUiSchema

--- a/static/src/js/schemas/uiSchemas/citations/index.js
+++ b/static/src/js/schemas/uiSchemas/citations/index.js
@@ -1,9 +1,13 @@
+import relatedIdentifiersUiSchema from '@/js/schemas/uiSchemas/citations/relatedIdentifiers'
+import citationMetadataUiSchema from '@/js/schemas/uiSchemas/citations/citationMetadata'
 import citationInformationUiSchema from './citationInformation'
 import citationScienceKeywordsUiSchema from './citationScienceKeywordsUiSchema'
 
 const citationUiSchema = {
   'citation-information': citationInformationUiSchema,
-  'science-keywords': citationScienceKeywordsUiSchema
+  'science-keywords': citationScienceKeywordsUiSchema,
+  'related-identifiers': relatedIdentifiersUiSchema,
+  'citation-metadata': citationMetadataUiSchema
 }
 
 export default citationUiSchema

--- a/static/src/js/schemas/uiSchemas/citations/index.js
+++ b/static/src/js/schemas/uiSchemas/citations/index.js
@@ -1,13 +1,13 @@
-import relatedIdentifiersUiSchema from '@/js/schemas/uiSchemas/citations/relatedIdentifiers'
 import citationMetadataUiSchema from '@/js/schemas/uiSchemas/citations/citationMetadata'
+import relatedIdentifiersUiSchema from '@/js/schemas/uiSchemas/citations/relatedIdentifiers'
 import citationInformationUiSchema from './citationInformation'
 import citationScienceKeywordsUiSchema from './citationScienceKeywordsUiSchema'
 
 const citationUiSchema = {
   'citation-information': citationInformationUiSchema,
-  'science-keywords': citationScienceKeywordsUiSchema,
+  'citation-metadata': citationMetadataUiSchema,
   'related-identifiers': relatedIdentifiersUiSchema,
-  'citation-metadata': citationMetadataUiSchema
+  'science-keywords': citationScienceKeywordsUiSchema
 }
 
 export default citationUiSchema

--- a/static/src/js/schemas/uiSchemas/citations/relatedIdentifiers.js
+++ b/static/src/js/schemas/uiSchemas/citations/relatedIdentifiers.js
@@ -1,0 +1,36 @@
+const relatedIdentifiersUiSchema = {
+  'ui:heading-level': 'h3',
+  'ui:field': 'layout',
+  'ui:layout_grid': {
+    'ui:row': [
+      {
+        'ui:group': 'Related Identifiers',
+        'ui:required': false,
+        'ui:col': {
+          md: 12,
+          children: [
+            {
+              'ui:row': [
+                {
+                  'ui:col': {
+                    md: 12,
+                    children: ['RelatedIdentifiers']
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  RelatedIdentifiers: {
+    items: {
+      RelatedResolutionAuthority: {
+        'ui:widget': 'TextWidget'
+      }
+    }
+  }
+}
+
+export default relatedIdentifiersUiSchema


### PR DESCRIPTION
# Overview

### What is the feature?

Update MMT to support entering related identifiers and citation metadata.

### What is the Solution?

Most of the changes were just changing ui schemas.   I took a little bit of liberty with breaking out the citation details into sections just to improve the look of the form.  

### What areas of the application does this impact?

Entering citation details.

# Testing

Verify each form has all the fields as specified in the schema.
Verify no issues when filling out the form.

### Attachments

<img width="1178" height="704" alt="Screenshot 2025-08-01 at 11 01 46 AM" src="https://github.com/user-attachments/assets/f1738966-a346-4ad5-8d5c-d4991fe89e9e" />
<img width="1390" height="793" alt="Screenshot 2025-08-01 at 11 02 41 AM" src="https://github.com/user-attachments/assets/22b06df7-2855-4442-8933-5d328d9c2d7e" />

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
