### PR TITLE
MMT-4055: Adding ability to restore previous Citation revisions

### DIFF
--- a/static/src/js/constants/restoreRevisionMutations.js
+++ b/static/src/js/constants/restoreRevisionMutations.js
@@ -1,3 +1,4 @@
+import { RESTORE_CITATION_REVISION } from '../operations/mutations/restoreCitationRevision'
 import { RESTORE_COLLECTION_REVISION } from '../operations/mutations/restoreCollectionRevision'
 import { RESTORE_SERVICE_REVISION } from '../operations/mutations/restoreServiceRevision'
 import { RESTORE_TOOL_REVISION } from '../operations/mutations/restoreToolRevision'
@@ -7,6 +8,7 @@ import {
 } from '../operations/mutations/restoreVisualizationRevision'
 
 const restoreRevisionMutations = {
+  Citation: RESTORE_CITATION_REVISION,
   Collection: RESTORE_COLLECTION_REVISION,
   Service: RESTORE_SERVICE_REVISION,
   Tool: RESTORE_TOOL_REVISION,

--- a/static/src/js/operations/mutations/restoreCitationRevision.js
+++ b/static/src/js/operations/mutations/restoreCitationRevision.js
@@ -1,0 +1,21 @@
+import { gql } from '@apollo/client'
+
+export const RESTORE_CITATION_REVISION = gql`
+  mutation RestoreCitationRevision (
+    $conceptId: String!
+    $revisionId: String!
+  ) {
+    restoreCitationRevision (
+      conceptId: $conceptId
+      revisionId: $revisionId
+    ) {
+      conceptId
+      revisionId
+    }
+  }
+`
+// Example Variables:
+// {
+//   "conceptId": "CIT1200000098-MMT_2",
+//   "revisionId": "1"
+// }


### PR DESCRIPTION
# Overview

### What is the feature?

Adding ability to review past revisions of a Citation and restore a previous revision.

### What is the Solution?

Adding the restore Citation Revision mutation.

### What areas of the application does this impact?

MMT

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

View a Citation (or create a citation if none are present) Click on the 3 dots to pull the drop down and click on View Revisions. If there is only 1 Revision, then make an edit and save it so that there are multiple revisions (You can change the name so its easy to tell what changed.).
On the Revisions page, check that "Revert to this revision" is shown on the previous revisions. You can click the "Revert to this revision" link and ensure that a new Published revision gets created. Verify that the published revision is the same as the one you wanted.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.
<img width="1755" height="836" alt="Screenshot 2025-08-18 at 10 32 43 PM" src="https://github.com/user-attachments/assets/4f645930-720c-4f70-a36e-12f4894c2e52" />

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
