### PR TITLE
MMT-4050-1: BUG FIX to the BUG FIX: When clicking publish, users may receive an intermittent error claiming previewMetadata returns null

### DIFF
--- a/static/src/js/utils/__tests__/checkForCMRFetchDraftLag.test.js
+++ b/static/src/js/utils/__tests__/checkForCMRFetchDraftLag.test.js
@@ -7,9 +7,15 @@ describe('checkForCMRFetchDraftLag', () => {
     })
   })
 
-  describe('when the fetched revision Id does not match expected revision Id', () => {
+  describe('when the fetched revision Id is less than the expected revision Id, indicating a cmr lag', () => {
     test('throws error', () => {
       expect(() => checkForCMRFetchDraftLag('1', '2')).toThrow('Delay in CMR has been detected. Refresh the page in order to see latest revision')
+    })
+  })
+
+  describe('when the fetched revision Id is greater than the expected revision Id, indicating a draft has been published', () => {
+    test('throws error', () => {
+      expect(() => checkForCMRFetchDraftLag('2', '1')).not.toThrow('Delay in CMR has been detected. Refresh the page in order to see latest revision')
     })
   })
 })

--- a/static/src/js/utils/checkForCMRFetchDraftLag.js
+++ b/static/src/js/utils/checkForCMRFetchDraftLag.js
@@ -5,7 +5,7 @@
  */
 
 const checkForCMRFetchDraftLag = (fetchedRevisionId, expectedRevisionId) => {
-  if ((fetchedRevisionId && expectedRevisionId) && (fetchedRevisionId !== expectedRevisionId)) {
+  if ((fetchedRevisionId && expectedRevisionId) && (fetchedRevisionId < expectedRevisionId)) {
     throw new Error('Delay in CMR has been detected. Refresh the page in order to see latest revision')
   }
 }


### PR DESCRIPTION
# Overview

### What is the feature?

This original issue has been solved. Upon testing we discovered an additional issue where if a user clicks 'save and continue' then 'save and publish' they would then receive an error saying that a cmr lag has been detected. 

### What is the Solution?

there is a file called checkForCmrFetchDraftLag which looks at the expected revision Id (comes from the params which are bumped up everytime a user saves) and compares that to the fetched revision id that comes back from CMR. 

BEFORE, the file was checking to see if those two values matched or did not match. If they did not match, then throw an error. 

NOW, the file checks to see if the fetched revision id is less than the expected revision id. This will always be the case when looking for a cmr draft lag. 

In this particular scenario, when a use clicks save & continue, a new draft with a new revision id is ingested AND the revision id in the url is bumped then checkForCmrFetchDraftLag is initiated. But then when a user when to click save and publish, the new draft with a new revision id was ingested but the revision id in the url was NOT bumped, so when checkForCmrFetchDraftLag was initiated, it thought there was a lag. 

Changed the logic from !== to <

### What areas of the application does this impact?

checkForCmrFetchDraftLag

# Testing

### Reproduction steps

1. Grab a published record, edit, save & continue, then click save & publish. It should publish without issue. 
2. Do this multiple times and do any other combination of save options you can think of to break it. 

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
