### PR TITLE
MMT-4044: Adjusting error message to include message from ingestDraftError

### DIFF
--- a/static/src/js/components/PublishPreview/PublishPreview.jsx
+++ b/static/src/js/components/PublishPreview/PublishPreview.jsx
@@ -154,9 +154,10 @@ const PublishPreviewHeader = () => {
 
   useEffect(() => {
     if (ingestDraftError) {
+      const { message } = ingestDraftError
       errorLogger(ingestDraftError, 'PublishPreview ingestDraftMutation Query')
       addNotification({
-        message: 'Error creating draft',
+        message: `Error creating draft: ${message}`,
         variant: 'danger'
       })
     }

--- a/static/src/js/components/PublishPreview/PublishPreview.jsx
+++ b/static/src/js/components/PublishPreview/PublishPreview.jsx
@@ -155,7 +155,7 @@ const PublishPreviewHeader = () => {
   useEffect(() => {
     if (ingestDraftError) {
       const { message } = ingestDraftError
-      errorLogger(ingestDraftError, 'PublishPreview ingestDraftMutation Query')
+      errorLogger(ingestDraftError, 'PublishPreview: ingestDraftMutation Query')
       addNotification({
         message: `Error creating draft: ${message}`,
         variant: 'danger'

--- a/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.jsx
+++ b/static/src/js/components/PublishPreview/__tests__/PublishPreview.test.jsx
@@ -377,7 +377,7 @@ describe('PublishPreview', () => {
 
       expect(navigateSpy).toHaveBeenCalledTimes(0)
       expect(errorLogger).toHaveBeenCalledTimes(1)
-      expect(errorLogger).toHaveBeenCalledWith(new Error('An error occurred'), 'PublishPreview ingestDraftMutation Query')
+      expect(errorLogger).toHaveBeenCalledWith(new Error('An error occurred'), 'PublishPreview: ingestDraftMutation Query')
     })
   })
 

--- a/static/src/js/components/TemplateForm/TemplateForm.jsx
+++ b/static/src/js/components/TemplateForm/TemplateForm.jsx
@@ -244,10 +244,11 @@ const TemplateForm = () => {
     }
 
     if (ingestDraftError) {
+      const { message } = ingestDraftError
       setLoading(false)
-      errorLogger('Unable to Ingest Draft', 'Collection Association: ingestDraft Mutation')
+      errorLogger(ingestDraftError, 'TemplateForm: ingestDraft Mutation')
       addNotification({
-        message: 'Error removing collection association ',
+        message: `Error creating draft: ${message}`,
         variant: 'danger'
       })
     }

--- a/static/src/js/components/TemplateForm/__tests__/TemplateForm.test.jsx
+++ b/static/src/js/components/TemplateForm/__tests__/TemplateForm.test.jsx
@@ -579,7 +579,7 @@ describe('TemplateForm', () => {
           expect(navigateSpy).toHaveBeenCalledTimes(0)
 
           expect(errorLogger).toHaveBeenCalledTimes(1)
-          expect(errorLogger).toHaveBeenCalledWith('Unable to Ingest Draft', 'Collection Association: ingestDraft Mutation')
+          expect(errorLogger).toHaveBeenCalledWith(new Error('An error occurred'), 'TemplateForm: ingestDraft Mutation')
         })
       })
     })

--- a/static/src/js/components/TemplatePreview/TemplatePreview.jsx
+++ b/static/src/js/components/TemplatePreview/TemplatePreview.jsx
@@ -152,10 +152,11 @@ const TemplatePreview = () => {
     }
 
     if (ingestDraftError) {
+      const { message } = ingestDraftError
       setLoading(false)
-      errorLogger('Unable to Ingest Draft', 'Template Preview: ingestDraft Mutation')
+      errorLogger(ingestDraftError, 'TemplatePreview: ingestDraft Mutation')
       addNotification({
-        message: 'Error removing collection association ',
+        message: `Error creating draft: ${message}`,
         variant: 'danger'
       })
     }

--- a/static/src/js/components/TemplatePreview/__tests__/TemplatePreview.test.jsx
+++ b/static/src/js/components/TemplatePreview/__tests__/TemplatePreview.test.jsx
@@ -426,7 +426,7 @@ describe('TemplatePreview', () => {
         expect(navigateSpy).toHaveBeenCalledTimes(0)
 
         expect(errorLogger).toHaveBeenCalledTimes(1)
-        expect(errorLogger).toHaveBeenCalledWith('Unable to Ingest Draft', 'Template Preview: ingestDraft Mutation')
+        expect(errorLogger).toHaveBeenCalledWith(new Error('An error occurred'), 'TemplatePreview: ingestDraft Mutation')
       })
     })
   })

--- a/static/src/js/operations/mutations/restoreVisualizationRevision.js
+++ b/static/src/js/operations/mutations/restoreVisualizationRevision.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export const RESTORE_VISUALIZATION_REVISION = gql`
-  mutation RestoreVariableRevision (
+  mutation RestoreVisualizationRevision (
     $conceptId: String!
     $revisionId: String!
   ) {


### PR DESCRIPTION
# Overview

### What is the feature?

Adjusting toast message to include specific ingestDraftError message

### What is the Solution?

Adjusting toast message to include specific ingestDraftError message

### What areas of the application does this impact?

When a user doesnt have PROVIDER_CONTEXT read permissions for a provider

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

Ensure the user does not have PROVIDER_CONTEXT read permissions for a provider.
If you need to remove the permission, you can do so but you have to wait about 2 hours to make sure it takes affect.
View a collection for that provider.
Click the Edit button.
You should get the following toast message:
Error creating draft: You do not have PROVIDER_CONTEXT permission to perform that action.

### Attachments
<img width="1036" height="1030" alt="Screenshot 2025-08-28 at 10 41 27 PM" src="https://github.com/user-attachments/assets/49276187-c210-4a29-8f67-2849f410fce5" />

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
