### PR TITLE
MMT-4069: Fixing dropdown z-index and englarging more actions icon

### DIFF
--- a/static/src/js/components/CustomToggle/CustomToggle.jsx
+++ b/static/src/js/components/CustomToggle/CustomToggle.jsx
@@ -33,6 +33,7 @@ const CustomToggle = React.forwardRef(
       Icon={FaEllipsisV}
       iconTitle="A vertical ellipsis icon"
       ref={ref}
+      size="lg"
       onClick={
         (e) => {
           e.preventDefault()

--- a/static/src/js/schemas/uiSchemas/GroupSearch.js
+++ b/static/src/js/schemas/uiSchemas/GroupSearch.js
@@ -21,7 +21,10 @@ const groupSearchUiSchema = {
                 {
                   'ui:col': {
                     md: 4,
-                    children: ['providers']
+                    children: ['providers'],
+                    style: {
+                      zIndex: 9999
+                    }
                   }
                 },
                 {
@@ -33,7 +36,10 @@ const groupSearchUiSchema = {
                 {
                   'ui:col': {
                     md: 4,
-                    children: ['members']
+                    children: ['members'],
+                    style: {
+                      zIndex: 9999
+                    }
                   }
                 }
               ]


### PR DESCRIPTION
# Overview

### What is the feature?

Fixing the dropdown issue in groups after searching a second time. Also enlarging the "more actions" icon

### What is the Solution?

Adjusted the z-index of the dropdown and enlarged the icon.

### What areas of the application does this impact?

React MMT

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

Go to Groups and select a provider then select submit.
Now go to select a provider again and notice that the drop-down menu is not obscured by the table. 

Select a collection and view the more actions icon. MAke sure its size is inline with with Edit/Delete/Clone buttons

### Attachments
<img width="946" height="728" alt="Screenshot 2025-09-04 at 6 16 01 PM" src="https://github.com/user-attachments/assets/24a21055-62c4-44ef-bf80-366fd2bb1eb2" />


<img width="474" height="315" alt="Screenshot 2025-09-04 at 6 12 48 PM" src="https://github.com/user-attachments/assets/60227b45-9343-433b-834d-a24167e9e355" />

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
