### PR TITLE
MMT-4080: As a MMT user, if I remove all selected collections and save, it should not default to all collections.

### DIFF
--- a/static/src/js/schemas/collectionPermission.js
+++ b/static/src/js/schemas/collectionPermission.js
@@ -41,21 +41,31 @@ const collectionPermission = {
       oneOf: [
         {
           title: 'All Collections',
+          type: 'object',
           properties: {
             allCollection: {
               title: 'All Collections',
-              type: 'string',
-              default: true
+              type: 'boolean',
+              const: true
             }
-          }
+          },
+          required: ['allCollection']
         },
         {
-          title: 'Selected Collection',
+          title: 'Selected Collections',
+          type: 'object',
           properties: {
+            allCollection: {
+              title: 'All Collections',
+              type: 'boolean',
+              const: false
+            },
             selectedCollections: {
-              description: 'Entry Title of the collection'
+              type: 'object',
+              description: 'Entry Titles of the selected collections'
             }
-          }
+          },
+          required: ['allCollection', 'selectedCollections']
         }
       ]
     },

--- a/static/src/js/schemas/uiSchemas/collectionPermission.js
+++ b/static/src/js/schemas/uiSchemas/collectionPermission.js
@@ -29,7 +29,7 @@ const collectionPermissionUiSchema = {
                 {
                   'ui:col': {
                     style: {
-                      marginTop: '-10px'
+                      marginTop: '-15px'
                     },
                     md: 4,
                     children: ['accessPermission']
@@ -151,13 +151,19 @@ const collectionPermissionUiSchema = {
                 'ui:row': [
                   {
                     'ui:col': {
-                      md: 4,
+                      style: {
+                        marginTop: '-10px'
+                      },
+                      md: 5,
                       children: ['collection']
                     }
                   },
                   {
                     'ui:col': {
-                      md: 4,
+                      style: {
+                        marginTop: '-10px'
+                      },
+                      md: 5,
                       children: ['granule']
                     }
                   }


### PR DESCRIPTION
# Overview

### What is the feature?

When a user removes all collections from their selected collection list, it should not default to all collections, but no collections.

### What is the Solution?

TBD

### What areas of the application does this impact?

Collection Permissions

# Testing

TBD

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
