### PR TITLE
MMT-4080: Moved everything into one useEffect

### DIFF
--- a/static/src/js/components/PermissionForm/PermissionForm.jsx
+++ b/static/src/js/components/PermissionForm/PermissionForm.jsx
@@ -213,14 +213,6 @@ const PermissionForm = ({ selectedCollectionsPageSize }) => {
     }
   }, [providerIds])
 
-  useEffect(() => {
-    formData.providers = providerId
-    setFormData((prevFormData) => ({
-      ...prevFormData,
-      providers: providerId
-    }))
-  }, [providerId])
-
   const [createAclMutation] = useMutation(CREATE_ACL)
   const [updateAclMutation] = useMutation(UPDATE_ACL, {
     update: (cache) => {
@@ -307,12 +299,6 @@ const PermissionForm = ({ selectedCollectionsPageSize }) => {
   }, [data])
 
   useEffect(() => {
-    if (conceptId === 'new') {
-      setFormData({ ...initFormState })
-    }
-  }, [conceptId])
-
-  useEffect(() => {
     if (error) {
       throw error
     }
@@ -363,7 +349,6 @@ const PermissionForm = ({ selectedCollectionsPageSize }) => {
 
   // When 'data' is available, this block generates formData using information from the ACL from CMR.
   useEffect(() => {
-    console.log('data is ', data)
     if (data) {
       const { acl } = data
       const {
@@ -518,11 +503,19 @@ const PermissionForm = ({ selectedCollectionsPageSize }) => {
 
         return {
           ...prevFormData,
-          ...updatedFormData
+          ...updatedFormData,
+          providers: providerId // Use the latest providerId
         }
       })
+    } else if (conceptId === 'new') {
+    // Handle the case for new permissions
+      setFormData((prevFormData) => ({
+        ...prevFormData,
+        ...initFormState,
+        providers: providerId
+      }))
     }
-  }, [data])
+  }, [data, providerId, conceptId])
 
   const totalSelectedCollections = () => {
     const {


### PR DESCRIPTION
# Overview

### What is the feature?

There is a useEffect race condition that can happen due to multiple useEffects updating the same form data.

### What is the Solution?

The fix is to merge 3 of these useEffects into a single useEffect.

### What areas of the application does this impact?

Loading of existing permission data into the form.

# Testing

Try modifying a permission, saving, going back in, and repeating that multiple times.  Occasionally it will 
fail to load the fetch data due the initial form data loading over the top of it.   It doesn't happen all the time.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
