### PR TITLE
MMT-4059: Update cmr-metadata-preview to latest package and integrate those citations previews to MMT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@apollo/client": "^3.8.5",
-        "@edsc/metadata-preview": "^1.5.0",
+        "@edsc/metadata-preview": "^1.5.1",
         "@node-saml/node-saml": "^5.1.0",
         "@rjsf/core": "^5.15.0",
         "@rjsf/utils": "^5.15.0",
@@ -9378,9 +9378,9 @@
       }
     },
     "node_modules/@edsc/metadata-preview": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@edsc/metadata-preview/-/metadata-preview-1.5.0.tgz",
-      "integrity": "sha512-qj5Hws2lm4YdaydQn6/jsO39TLx/+EeFe4OYR9kQa3UQER27kG8SztiFIXFMs7JMV7wSnzBhNOS3l8cDS37Vpw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@edsc/metadata-preview/-/metadata-preview-1.5.1.tgz",
+      "integrity": "sha512-k6OPzYCYWGZonnocc+bQkjlYPaGmkJ1+m+3XTJV1K/GBkTuB6WrvoNC1qjh2EknGMfqYg/ue6YTrA9u0o7lO1w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15636,13 +15636,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
-      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -32911,9 +32911,9 @@
       }
     },
     "node_modules/vite-node/node_modules/vite": {
-      "version": "5.4.19",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -33714,9 +33714,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "5.4.19",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.5",
-    "@edsc/metadata-preview": "^1.5.0",
+    "@edsc/metadata-preview": "^1.5.1",
     "@node-saml/node-saml": "^5.1.0",
     "@rjsf/core": "^5.15.0",
     "@rjsf/utils": "^5.15.0",

--- a/static/src/js/components/MetadataPreview/MetadataPreview.jsx
+++ b/static/src/js/components/MetadataPreview/MetadataPreview.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+  CitationPreview,
   CollectionPreview,
   ServicePreview,
   ToolPreview,
@@ -130,6 +131,16 @@ const MetadataPreview = ({
             <VisualizationPreview
               cmrHost={cmrHost}
               visualization={concept}
+              conceptId={conceptId}
+              conceptType={type}
+            />
+          )
+        }
+        {
+          conceptType === 'Citation' && (
+            <CitationPreview
+              cmrHost={cmrHost}
+              citation={concept}
               conceptId={conceptId}
               conceptType={type}
             />

--- a/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
+++ b/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
@@ -1,4 +1,5 @@
 import {
+  CitationPreview,
   CollectionPreview,
   ServicePreview,
   ToolPreview,
@@ -20,6 +21,7 @@ import ErrorBoundary from '../../ErrorBoundary/ErrorBoundary'
 import conceptTypeDraftQueries from '../../../constants/conceptTypeDraftQueries'
 import conceptTypeQueries from '../../../constants/conceptTypeQueries'
 import {
+  mockCitationDraft,
   mockCollection,
   mockCollectionDraft,
   mockCollectionWithAssociatedVariables,
@@ -302,6 +304,71 @@ describe('MetadataPreview', () => {
       })
 
       expect(VisualizationPreview).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when the conceptType is Citation draft', () => {
+    test('renders a Citation Preview component', async () => {
+      setup({
+        overrideProps: {
+          conceptId: 'CITD0000000-MMT_1',
+          conceptType: 'Citation'
+        },
+        mock: [{
+          request: {
+            query: conceptTypeDraftQueries.Citation,
+            variables: {
+              params: {
+                conceptId: 'CITD0000000-MMT_1',
+                conceptType: 'Citation'
+              },
+              variableParams: null
+            }
+          },
+          result: {
+            data: {
+              draft: mockCitationDraft
+            }
+          }
+        }],
+        initialEntries: '/drafts/citations/CITD0000000-MMT_1'
+      })
+
+      await waitFor(() => {
+        expect(CitationPreview).toHaveBeenCalledWith({
+          cmrHost: 'http://example.com',
+          conceptId: 'CITD0000000-MMT_1',
+          conceptType: 'citation-draft',
+          conceptUrlTemplate: '/{conceptType}/{conceptId}',
+          isPlugin: true,
+          citation: {
+            __typename: 'Citation',
+            abstract: 'This is a randomly generated citation for demonstration purposes. Created at 2025-05-28T18:48:11.453Z.',
+            citationMetadata: {
+              number: '2',
+              publisher: 'Springer Nature',
+              title: 'Archival Earth Science Resource 8 - Research Publication 8',
+              type: 'journal-article',
+              volume: '23'
+            },
+            conceptId: 'CITD1200484992-DEMO_PROV',
+            identifier: 'ark:/13030/tf8p17484-test-2',
+            identifierType: 'ARK',
+            name: 'Archival Earth Science Resource 8',
+            nativeId: 'GQL-113-test',
+            pageTitle: 'Archival Earth Science Resource 8',
+            providerId: 'DEMO_PROV',
+            relatedIdentifiers: [],
+            resolutionAuthority: 'https://n2t.net',
+            revisionDate: '2025-09-03T21:45:49.248Z',
+            revisionId: '2',
+            scienceKeywords: [],
+            userId: 'test.user'
+          }
+        }, {})
+      })
+
+      expect(CitationPreview).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/static/src/js/components/MetadataPreview/__tests__/__mocks__/MatadataPreviewMocks.js
+++ b/static/src/js/components/MetadataPreview/__tests__/__mocks__/MatadataPreviewMocks.js
@@ -3853,3 +3853,40 @@ export const mockVisualizationDraft = {
   visualizationType: 'tiles',
   __typename: 'Visualization'
 }
+
+export const mockCitationDraft = {
+  conceptId: 'CITD0000000-MMT_1',
+  conceptType: 'citation-draft',
+  deleted: false,
+  name: 'Archival Earth Science Resource 8',
+  nativeId: 'GQL-113-test',
+  providerId: 'DEMO_PROV',
+  revisionDate: '2025-09-03T21:45:49.248Z',
+  revisionId: '2',
+  ummMetadata: {},
+  previewMetadata: {
+    abstract: 'This is a randomly generated citation for demonstration purposes. Created at 2025-05-28T18:48:11.453Z.',
+    citationMetadata: {
+      type: 'journal-article',
+      volume: '23',
+      publisher: 'Springer Nature',
+      number: '2',
+      title: 'Archival Earth Science Resource 8 - Research Publication 8'
+    },
+    conceptId: 'CITD1200484992-DEMO_PROV',
+    identifier: 'ark:/13030/tf8p17484-test-2',
+    identifierType: 'ARK',
+    name: 'Archival Earth Science Resource 8',
+    nativeId: 'GQL-113-test',
+    pageTitle: 'Archival Earth Science Resource 8',
+    providerId: 'DEMO_PROV',
+    relatedIdentifiers: [],
+    resolutionAuthority: 'https://n2t.net',
+    revisionDate: '2025-09-03T21:45:49.248Z',
+    revisionId: '2',
+    scienceKeywords: [],
+    userId: 'test.user',
+    __typename: 'Citation'
+  },
+  __typename: 'Citation'
+}

--- a/static/src/js/operations/queries/getCitation.js
+++ b/static/src/js/operations/queries/getCitation.js
@@ -17,7 +17,7 @@ export const GET_CITATION = gql`
       }
       conceptId
       identifier
-      identifierType,
+      identifierType
       name
       pageTitle: name
       nativeId

--- a/static/src/js/operations/queries/getCitation.js
+++ b/static/src/js/operations/queries/getCitation.js
@@ -17,8 +17,8 @@ export const GET_CITATION = gql`
       }
       conceptId
       identifier
-      identifierType
-      name,
+      identifierType,
+      name
       pageTitle: name
       nativeId
       providerId

--- a/static/src/js/operations/queries/getCitationDraft.js
+++ b/static/src/js/operations/queries/getCitationDraft.js
@@ -18,6 +18,7 @@ export const CITATION_DRAFT = gql`
           conceptId
           identifier
           identifierType
+          name
           pageTitle: name
           nativeId
           providerId

--- a/static/src/js/operations/queries/getCollection.js
+++ b/static/src/js/operations/queries/getCollection.js
@@ -10,6 +10,14 @@ export const GET_COLLECTION = gql`
       archiveAndDistributionInformation
       associationDetails
       associatedDois
+      citations {
+        count
+        items {
+          conceptId
+          name
+          type: identifierType
+        }
+      }
       collectionCitations
       collectionProgress
       conceptId

--- a/static/src/js/operations/queries/getVisualization.js
+++ b/static/src/js/operations/queries/getVisualization.js
@@ -8,7 +8,7 @@ export const GET_VISUALIZATION = gql`
       generation
       identifier
       metadataSpecification
-      name,
+      name
       pageTitle: name
       nativeId
       providerId


### PR DESCRIPTION
# Overview

### What is the feature?

Final step. Should do this after all other tickets are complete. Update the
metadata-preview package to account for all new changes and integrate that onto MMT

### What is the Solution?

Bump edsc/cmr-preview to version 1.5.1
Update MetadataPreview
Update getCitation and getCitationDraft to enable breadcrumbs

### What areas of the application does this impact?

MetadataPreview
package.json
graphql queries

# Testing

### Reproduction steps

- **Environment for testing: Any
- **Collection to test with: Any

1. Select a published citation and ensure the information presented in the preview is accurate and not missing fields
2. Do the same for drafts

### Attachments

Published
<img width="1144" height="509" alt="Screenshot 2025-09-30 at 12 12 42 PM" src="https://github.com/user-attachments/assets/07d399f7-d0cc-4f2e-84c1-c2138f677d3c" />

Draft
<img width="1156" height="536" alt="Screenshot 2025-09-30 at 12 13 17 PM" src="https://github.com/user-attachments/assets/07a13c08-cb6d-4208-976a-840444c6d4f7" />

CollectionPreview Update
<img width="1137" height="421" alt="Screenshot 2025-09-30 at 12 39 00 PM" src="https://github.com/user-attachments/assets/74c65ed4-e466-4915-a769-85392b075449" />


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
