### PR TITLE
MMT-4181: Get more variables, citations, services for a collection if needed and collections for a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We can configure some of the layouts for MMT and the endpoints it utilizes this 
 
 ## Fast MMT startup mode
 
-1. Note that this workflow does not require any other services such as cmr, graphdn, or graphql.Start the application against the SIT env to start you will need to have EDL_CLIENT_ID, EDL_PASSWORD` var in your PATH
+1. Note that this workflow does not require any other services such as cmr, graphdb, or graphql.Start the application against the SIT env to start you will need to have EDL_CLIENT_ID, EDL_PASSWORD` var in your PATH
 Note this mode makes startup fast but, if resources in `SIT` are in maintenance or down this won't work
 2. Be cognizant that SIT is a shared env. No "important" data should be used in `SIT` but, we should not unnecessarily start removing data in `SIT` or updating data that seems to be well crafted for a specific purpose. It should not be hard to avoid this problem.
 3. Ensure VPN connection as services are behind `SIT` e.g. `SIT`, URS

--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -27,6 +27,7 @@ config="`jq '.application.cookieDomain = $newValue' --arg newValue $bamboo_COOKI
 config="`jq '.application.displayProdWarning = $newValue' --arg newValue $bamboo_DISPLAY_PROD_WARNING <<< $config`"
 config="`jq '.application.tokenValidTime = $newValue' --arg newValue $bamboo_JWT_VALID_TIME <<< $config`"
 config="`jq '.application.analytics.gtmPropertyId = $newValue' --arg newValue $bamboo_GTM_PROPERTY_ID <<< $config`"
+config="`jq '.application.conceptsResultLimit = $newValue' --arg newValue $bamboo_CONCEPTS_RESULT_LIMIT <<< $config`"
 config="`jq '.edl.host = $newValue' --arg newValue $bamboo_EDL_HOST <<< $config`"
 config="`jq '.edl.uid = $newValue' --arg newValue $bamboo_EDL_UID <<< $config`"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@apollo/client": "^3.8.5",
-        "@edsc/metadata-preview": "^1.5.8",
+        "@edsc/metadata-preview": "^1.5.10",
         "@node-saml/node-saml": "^5.1.0",
         "@rjsf/core": "^5.15.0",
         "@rjsf/utils": "^5.15.0",
@@ -4530,9 +4530,9 @@
       }
     },
     "node_modules/@edsc/metadata-preview": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/@edsc/metadata-preview/-/metadata-preview-1.5.9.tgz",
-      "integrity": "sha512-eC0ayVu9wdHVWbiv6bXZtkqAZm7X7GtH3U4tGuZu8qkpITynVtsoKx1zO56RpzC3jf8jhxvECGUqttp0hFeBgw==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/@edsc/metadata-preview/-/metadata-preview-1.5.10.tgz",
+      "integrity": "sha512-wDCTBlf4eu+t+dEhRS6mPP0aP5yN1TcZa81aFIgZ48y32lFqo+itONxwQX8D8qjStopwRGebmBpz9mPA4wA/rw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.5",
-    "@edsc/metadata-preview": "^1.5.8",
+    "@edsc/metadata-preview": "^1.5.10",
     "@node-saml/node-saml": "^5.1.0",
     "@rjsf/core": "^5.15.0",
     "@rjsf/utils": "^5.15.0",

--- a/static.config.json
+++ b/static.config.json
@@ -24,7 +24,8 @@
         "enabled": false,
         "propertyId": ""
       }
-    }
+    },
+    "conceptsResultLimit": 1000
   },
   "ummVersions": {
     "ummC": "1.18.5",

--- a/static/src/js/components/MetadataPreview/MetadataPreview.jsx
+++ b/static/src/js/components/MetadataPreview/MetadataPreview.jsx
@@ -100,21 +100,14 @@ const MetadataPreview = ({
   let { [conceptKey]: concept } = data || {}
 
   // The following variables are needed when we need to fetch extra variables from a collection
-  const { associationDetails = {} } = concept || {}
-  const { variables = [] } = associationDetails || {}
-  const variableCount = variables.length
-  const allVariableConceptIds = variables.map((variableTmp) => variableTmp.conceptId)
-  const excludeVariableConceptIds = variableItems.map((variableTmp) => variableTmp.conceptId)
-  const variableConceptIds = allVariableConceptIds
-    .filter((variableTmp) => !excludeVariableConceptIds.includes(variableTmp))
   const variables = concept?.associationDetails?.variables ?? []
-const variableCount = variables.length
-const excludeSet = new Set(variableItems.map((v) => v.conceptId))
+  const variableCount = variables.length
+  const excludeSet = new Set(variableItems.map((v) => v.conceptId))
 
-const variableConceptIds = variables
-  .map((v) => v.conceptId)
-  .filter((id) => !excludeSet.has(id))
-  .slice(0, conceptsResultLimitInt)
+  const variableConceptIds = variables
+    .map((v) => v.conceptId)
+    .filter((id) => !excludeSet.has(id))
+    .slice(0, conceptsResultLimitInt)
 
   // Returns a conceptsResultLimitInt-limited set of data until there are no newItems left
   const { loading: varLoading, error: varError } = useQuery(conceptTypeQueries.Variables, {
@@ -146,7 +139,7 @@ const variableConceptIds = variables
   // Display loading banner if we need to load additional variables and it hasn't completed yet
   if (varLoading
     || ((variableCount > conceptsResultLimitInt)
-    && (!varError && variableItems && (variableItems.length < variableCount)))) {
+    && (!varError && (variableItems.length < variableCount)))) {
     return (
       <>
         <div>

--- a/static/src/js/components/MetadataPreview/MetadataPreview.jsx
+++ b/static/src/js/components/MetadataPreview/MetadataPreview.jsx
@@ -45,7 +45,7 @@ const MetadataPreview = ({
 }) => {
   const { cmrHost, conceptsResultLimit } = getApplicationConfig()
 
-  const conceptsResultLimitInt = parseInt(conceptsResultLimit, 10)
+  const conceptsResultLimitInt = parseInt(conceptsResultLimit, 10) || 1000
 
   const { draftType } = useParams()
 

--- a/static/src/js/components/MetadataPreview/MetadataPreview.jsx
+++ b/static/src/js/components/MetadataPreview/MetadataPreview.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   CitationPreview,
   CollectionPreview,
@@ -8,12 +8,14 @@ import {
   VisualizationPreview
 } from '@edsc/metadata-preview'
 import { useParams } from 'react-router'
-import { useSuspenseQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import Col from 'react-bootstrap/Col'
 import PropTypes from 'prop-types'
 import Row from 'react-bootstrap/Row'
-
 import getConceptTypeByDraftConceptId from '@/js/utils/getConceptTypeByDraftConceptId'
+import parseError from '@/js/utils/parseError'
+import LoadingBanner from '../LoadingBanner/LoadingBanner'
+import ErrorBanner from '../ErrorBanner/ErrorBanner'
 
 import conceptTypeDraftQueries from '../../constants/conceptTypeDraftQueries'
 import conceptTypeQueries from '../../constants/conceptTypeQueries'
@@ -41,7 +43,9 @@ const MetadataPreview = ({
   conceptId,
   conceptType
 }) => {
-  const { cmrHost } = getApplicationConfig()
+  const { cmrHost, conceptsResultLimit } = getApplicationConfig()
+
+  const conceptsResultLimitInt = parseInt(conceptsResultLimit, 10)
 
   const { draftType } = useParams()
 
@@ -64,22 +68,95 @@ const MetadataPreview = ({
     }
   }
 
-  const variableParams = (conceptType === 'Collection') ? { limit: 1000 } : null
+  const citationParams = (conceptType === 'Collection') ? { limit: conceptsResultLimitInt } : null
+  const serviceParams = (conceptType === 'Collection') ? { limit: conceptsResultLimitInt } : null
+  const variableParams = (conceptType === 'Collection') ? { limit: conceptsResultLimitInt } : null
+  const collectionsParams = (conceptType !== 'Collection' && !isDraft) ? { limit: conceptsResultLimitInt } : null
 
-  const { data } = useSuspenseQuery(query, {
+  // State variables needed in case we need to fetch more variables for a collection
+  const [variableItems, setVariableItems] = useState([])
+  const [variablesCursor, setVariableCursor] = useState(null)
+
+  const { loading: conceptLoading, error: conceptError, data } = useQuery(query, {
     variables: {
       params,
-      variableParams
+      citationParams,
+      serviceParams,
+      variableParams,
+      collectionsParams
+    },
+    onCompleted: () => {
+      setVariableItems([])
+      setVariableCursor(null)
     }
   })
 
-  let { [conceptKey]: concept } = data
+  let { [conceptKey]: concept } = data || {}
+
+  // The following variables are needed when we need to fetch extra variables from a collection
+  const { associationDetails = {}, variables: metadata = {} } = concept || {};
+  const { count: variableCount } = metadata
+  const { variables = [] } = associationDetails || {}
+  const variableConceptIds = variables.map((variableTmp) => variableTmp.conceptId)
+
+  // Returns a conceptsResultLimitInt-limited set of data and resets the variableCursor until there are no newItems left
+  const { loading: varLoading, error: varError } = useQuery(conceptTypeQueries.Variables, {
+    skip: (!variableConceptIds.length
+      || (variableItems && (variableItems.length >= variableCount)))
+      || variableCount <= conceptsResultLimitInt,
+    variables: {
+      params: {
+        limit: conceptsResultLimitInt,
+        cursor: variablesCursor,
+        conceptId: variableConceptIds
+      }
+    },
+    onCompleted: (responseData) => {
+      const { variables: responseVariables } = responseData
+      const { cursor: newCursor, items: newItems } = responseVariables
+      if (newItems && (newItems.length > 0)) {
+        setVariableItems([...variableItems, ...newItems])
+        setVariableCursor(newCursor)
+      }
+    }
+  })
+
+  // Display loading banner if we need to load additional variables and it hasn't completed yet
+  if (conceptLoading || varLoading
+    || ((variableCount > conceptsResultLimitInt)
+    && (!varError && variableItems && (variableItems.length < variableCount)))) {
+    return (
+      <Row>
+        <LoadingBanner />
+      </Row>
+    )
+  }
+
+  if (conceptError || varError) {
+    const message = parseError(conceptError || varError)
+
+    return (
+      <Row>
+        <ErrorBanner message={message} />
+      </Row>
+    )
+  }
 
   if (isDraft) {
     concept = concept.previewMetadata
   }
 
   const type = isDraft ? `${conceptType.toLowerCase()}-draft` : conceptType.toLowerCase()
+
+  // Replace collection.variables.items if we had to make additional calls to get more variables
+  const newConcept = (conceptType === 'Collection' && variableCount > conceptsResultLimitInt)
+    ? {
+      ...concept,
+      variables: {
+        ...concept.variables,
+        items: variableItems
+      }
+    } : concept
 
   return (
     <Row>
@@ -88,7 +165,7 @@ const MetadataPreview = ({
           conceptType === 'Collection' && (
             <CollectionPreview
               cmrHost={cmrHost}
-              collection={concept}
+              collection={newConcept}
               conceptId={conceptId}
               conceptType={type}
             />

--- a/static/src/js/components/MetadataPreview/MetadataPreview.jsx
+++ b/static/src/js/components/MetadataPreview/MetadataPreview.jsx
@@ -141,16 +141,18 @@ const MetadataPreview = ({
     || ((variableCount > conceptsResultLimitInt)
     && (!varError && variableItems && (variableItems.length < variableCount)))) {
     return (
-      <Row>
-        <Alert>
-          <Alert.Heading>Notice:</Alert.Heading>
-
-          <span className="visually-hidden">{' '}</span>
-
-          <p>This collection has a lot of variables and needs some extra time to load.</p>
-        </Alert>
-        <LoadingBanner />
-      </Row>
+      <>
+        <div>
+          <Alert className="fst-italic fs-6" variant="warning">
+            <i className="eui-icon eui-fa-info-circle" />
+            {' '}
+            This collection has many associated variables that may require extra load time.
+          </Alert>
+        </div>
+        <Row>
+          <LoadingBanner />
+        </Row>
+      </>
     )
   }
 

--- a/static/src/js/components/MetadataPreview/MetadataPreview.jsx
+++ b/static/src/js/components/MetadataPreview/MetadataPreview.jsx
@@ -94,9 +94,9 @@ const MetadataPreview = ({
   let { [conceptKey]: concept } = data || {}
 
   // The following variables are needed when we need to fetch extra variables from a collection
-  const { associationDetails = {}, variables: metadata = {} } = concept || {}
-  const { count: variableCount } = metadata
+  const { associationDetails = {} } = concept || {}
   const { variables = [] } = associationDetails || {}
+  const variableCount = variables.length
   const variableConceptIds = variables.map((variableTmp) => variableTmp.conceptId)
 
   // Returns a conceptsResultLimitInt-limited set of data and resets the variableCursor until there are no newItems left

--- a/static/src/js/components/MetadataPreview/MetadataPreview.jsx
+++ b/static/src/js/components/MetadataPreview/MetadataPreview.jsx
@@ -9,6 +9,7 @@ import {
 } from '@edsc/metadata-preview'
 import { useParams } from 'react-router'
 import { useQuery } from '@apollo/client'
+import Alert from 'react-bootstrap/Alert'
 import Col from 'react-bootstrap/Col'
 import PropTypes from 'prop-types'
 import Row from 'react-bootstrap/Row'
@@ -75,7 +76,6 @@ const MetadataPreview = ({
 
   // State variables needed in case we need to fetch more variables for a collection
   const [variableItems, setVariableItems] = useState([])
-  const [variablesCursor, setVariableCursor] = useState(null)
 
   const { loading: conceptLoading, error: conceptError, data } = useQuery(query, {
     variables: {
@@ -85,9 +85,15 @@ const MetadataPreview = ({
       variableParams,
       collectionsParams
     },
-    onCompleted: () => {
-      setVariableItems([])
-      setVariableCursor(null)
+    onCompleted: (responseData) => {
+      if (conceptType === 'Collection' && !isDraft) {
+        const { collection } = responseData
+        const { variables } = collection
+        const { items } = variables
+        setVariableItems(items)
+      } else {
+        setVariableItems([])
+      }
     }
   })
 
@@ -97,36 +103,52 @@ const MetadataPreview = ({
   const { associationDetails = {} } = concept || {}
   const { variables = [] } = associationDetails || {}
   const variableCount = variables.length
-  const variableConceptIds = variables.map((variableTmp) => variableTmp.conceptId)
+  const allVariableConceptIds = variables.map((variableTmp) => variableTmp.conceptId)
+  const excludeVariableConceptIds = variableItems.map((variableTmp) => variableTmp.conceptId)
+  const variableConceptIds = allVariableConceptIds
+    .filter((variableTmp) => !excludeVariableConceptIds.includes(variableTmp))
+    .slice(0, conceptsResultLimitInt)
 
-  // Returns a conceptsResultLimitInt-limited set of data and resets the variableCursor until there are no newItems left
+  // Returns a conceptsResultLimitInt-limited set of data until there are no newItems left
   const { loading: varLoading, error: varError } = useQuery(conceptTypeQueries.Variables, {
-    skip: (!variableConceptIds.length
-      || (variableItems && (variableItems.length >= variableCount)))
+    skip: (variableItems.length === 0)
+      || (variableItems.length >= variableCount)
       || variableCount <= conceptsResultLimitInt,
     variables: {
       params: {
         limit: conceptsResultLimitInt,
-        cursor: variablesCursor,
         conceptId: variableConceptIds
       }
     },
     onCompleted: (responseData) => {
       const { variables: responseVariables } = responseData
-      const { cursor: newCursor, items: newItems } = responseVariables
-      if (newItems && (newItems.length > 0)) {
-        setVariableItems([...variableItems, ...newItems])
-        setVariableCursor(newCursor)
-      }
+      const { items: newItems } = responseVariables
+      setVariableItems([...variableItems, ...newItems])
     }
   })
 
+  // Display loading banner
+  if (conceptLoading) {
+    return (
+      <Row>
+        <LoadingBanner />
+      </Row>
+    )
+  }
+
   // Display loading banner if we need to load additional variables and it hasn't completed yet
-  if (conceptLoading || varLoading
+  if (varLoading
     || ((variableCount > conceptsResultLimitInt)
     && (!varError && variableItems && (variableItems.length < variableCount)))) {
     return (
       <Row>
+        <Alert>
+          <Alert.Heading>Notice:</Alert.Heading>
+
+          <span className="visually-hidden">{' '}</span>
+
+          <p>This collection has a lot of variables and needs some extra time to load.</p>
+        </Alert>
         <LoadingBanner />
       </Row>
     )

--- a/static/src/js/components/MetadataPreview/MetadataPreview.jsx
+++ b/static/src/js/components/MetadataPreview/MetadataPreview.jsx
@@ -107,7 +107,14 @@ const MetadataPreview = ({
   const excludeVariableConceptIds = variableItems.map((variableTmp) => variableTmp.conceptId)
   const variableConceptIds = allVariableConceptIds
     .filter((variableTmp) => !excludeVariableConceptIds.includes(variableTmp))
-    .slice(0, conceptsResultLimitInt)
+  const variables = concept?.associationDetails?.variables ?? []
+const variableCount = variables.length
+const excludeSet = new Set(variableItems.map((v) => v.conceptId))
+
+const variableConceptIds = variables
+  .map((v) => v.conceptId)
+  .filter((id) => !excludeSet.has(id))
+  .slice(0, conceptsResultLimitInt)
 
   // Returns a conceptsResultLimitInt-limited set of data until there are no newItems left
   const { loading: varLoading, error: varError } = useQuery(conceptTypeQueries.Variables, {

--- a/static/src/js/components/MetadataPreview/MetadataPreview.jsx
+++ b/static/src/js/components/MetadataPreview/MetadataPreview.jsx
@@ -94,7 +94,7 @@ const MetadataPreview = ({
   let { [conceptKey]: concept } = data || {}
 
   // The following variables are needed when we need to fetch extra variables from a collection
-  const { associationDetails = {}, variables: metadata = {} } = concept || {};
+  const { associationDetails = {}, variables: metadata = {} } = concept || {}
   const { count: variableCount } = metadata
   const { variables = [] } = associationDetails || {}
   const variableConceptIds = variables.map((variableTmp) => variableTmp.conceptId)

--- a/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
+++ b/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
@@ -48,6 +48,8 @@ vi.mock('@sharedUtils/getConfig', async () => ({
   }))
 }))
 
+const conceptsResultsLimitInt = 20
+
 const setup = ({
   initialEntries,
   mock,
@@ -484,9 +486,9 @@ describe('MetadataPreview', () => {
                 conceptId: 'CD000000-MMT',
                 conceptType: 'Collection'
               },
-              citationParams: { limit: 20 },
-              serviceParams: { limit: 20 },
-              variableParams: { limit: 20 },
+              citationParams: { limit: conceptsResultsLimitInt },
+              serviceParams: { limit: conceptsResultsLimitInt },
+              variableParams: { limit: conceptsResultsLimitInt },
               collectionsParams: null
             }
           },
@@ -606,9 +608,9 @@ describe('MetadataPreview', () => {
             query: conceptTypeQueries.Collection,
             variables: {
               params: { conceptId: 'C1000000-MMT' },
-              citationParams: { limit: 20 },
-              serviceParams: { limit: 20 },
-              variableParams: { limit: 20 },
+              citationParams: { limit: conceptsResultsLimitInt },
+              serviceParams: { limit: conceptsResultsLimitInt },
+              variableParams: { limit: conceptsResultsLimitInt },
               collectionsParams: null
             }
           },
@@ -651,9 +653,9 @@ describe('MetadataPreview', () => {
             query: conceptTypeQueries.Collection,
             variables: {
               params: { conceptId: 'C1000000-MMT' },
-              citationParams: { limit: 20 },
-              serviceParams: { limit: 20 },
-              variableParams: { limit: 20 },
+              citationParams: { limit: conceptsResultsLimitInt },
+              serviceParams: { limit: conceptsResultsLimitInt },
+              variableParams: { limit: conceptsResultsLimitInt },
               collectionsParams: null
             }
           },
@@ -667,7 +669,7 @@ describe('MetadataPreview', () => {
             query: conceptTypeQueries.Variables,
             variables: {
               params: {
-                limit: 20,
+                limit: conceptsResultsLimitInt,
                 cursor: null,
                 conceptId: ['V100000_MMT']
               }
@@ -683,7 +685,7 @@ describe('MetadataPreview', () => {
             query: conceptTypeQueries.Variables,
             variables: {
               params: {
-                limit: 20,
+                limit: conceptsResultsLimitInt,
                 cursor: 'page-1-cursor',
                 conceptId: ['V100000_MMT']
               }
@@ -728,9 +730,9 @@ describe('MetadataPreview', () => {
             query: conceptTypeQueries.Collection,
             variables: {
               params: { conceptId: 'C1000000-MMT' },
-              citationParams: { limit: 20 },
-              serviceParams: { limit: 20 },
-              variableParams: { limit: 20 },
+              citationParams: { limit: conceptsResultsLimitInt },
+              serviceParams: { limit: conceptsResultsLimitInt },
+              variableParams: { limit: conceptsResultsLimitInt },
               collectionsParams: null
             }
           },
@@ -759,9 +761,9 @@ describe('MetadataPreview', () => {
             query: conceptTypeQueries.Collection,
             variables: {
               params: { conceptId: 'C1000000-MMT' },
-              citationParams: { limit: 20 },
-              serviceParams: { limit: 20 },
-              variableParams: { limit: 20 },
+              citationParams: { limit: conceptsResultsLimitInt },
+              serviceParams: { limit: conceptsResultsLimitInt },
+              variableParams: { limit: conceptsResultsLimitInt },
               collectionsParams: null
             }
           },
@@ -775,7 +777,7 @@ describe('MetadataPreview', () => {
             query: conceptTypeQueries.Variables,
             variables: {
               params: {
-                limit: 20,
+                limit: conceptsResultsLimitInt,
                 cursor: null,
                 conceptId: ['V100000_MMT']
               }

--- a/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
+++ b/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
@@ -33,7 +33,6 @@ import {
   mockServiceDraft,
   mockToolDraft,
   mockVariableDraft,
-  mockVariableList,
   mockVariableList2,
   mockVariableList3,
   mockVisualizationDraft

--- a/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
+++ b/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
@@ -131,53 +131,98 @@ describe('MetadataPreview', () => {
       })
 
       await waitFor(() => {
-        expect(ToolPreview).toHaveBeenCalledWith({
-          cmrHost: 'http://example.com',
-          conceptId: 'TD000000-MMT',
-          conceptType: 'tool-draft',
-          conceptUrlTemplate: '/{conceptType}/{conceptId}',
-          isPlugin: true,
-          tool: {
-            __typename: 'Tool',
-            accessConstraints: null,
-            ancillaryKeywords: null,
-            associationDetails: null,
-            conceptId: 'TD1000000-MMT',
-            contactGroups: null,
-            contactPersons: null,
-            description: null,
-            doi: null,
-            lastUpdatedDate: null,
-            longName: 'Long Name',
-            metadataSpecification: {
-              name: 'UMM-T',
-              url: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.1',
-              version: '1.1'
-            },
-            name: null,
-            nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
-            organizations: null,
-            pageTitle: null,
-            potentialAction: null,
-            quality: null,
-            relatedUrls: null,
-            searchAction: null,
-            supportedBrowsers: null,
-            supportedInputFormats: null,
-            supportedOperatingSystems: null,
-            supportedOutputFormats: null,
-            supportedSoftwareLanguages: null,
-            toolKeywords: null,
-            type: null,
-            url: null,
-            useConstraints: null,
-            version: null,
-            versionDescription: null
-          }
-        }, {})
+        expect(ToolPreview).toHaveBeenCalledTimes(2)
       })
 
-      expect(ToolPreview).toHaveBeenCalledTimes(2)
+      expect(ToolPreview).toHaveBeenNthCalledWith(1, {
+        cmrHost: 'http://example.com',
+        conceptId: 'TD000000-MMT',
+        conceptType: 'tool-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        tool: {
+          __typename: 'Tool',
+          accessConstraints: null,
+          ancillaryKeywords: null,
+          associationDetails: null,
+          conceptId: 'TD1000000-MMT',
+          contactGroups: null,
+          contactPersons: null,
+          description: null,
+          doi: null,
+          lastUpdatedDate: null,
+          longName: 'Long Name',
+          metadataSpecification: {
+            name: 'UMM-T',
+            url: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.1',
+            version: '1.1'
+          },
+          name: null,
+          nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
+          organizations: null,
+          pageTitle: null,
+          potentialAction: null,
+          quality: null,
+          relatedUrls: null,
+          searchAction: null,
+          supportedBrowsers: null,
+          supportedInputFormats: null,
+          supportedOperatingSystems: null,
+          supportedOutputFormats: null,
+          supportedSoftwareLanguages: null,
+          toolKeywords: null,
+          type: null,
+          url: null,
+          useConstraints: null,
+          version: null,
+          versionDescription: null
+        }
+      }, {})
+
+      expect(ToolPreview).toHaveBeenNthCalledWith(2, {
+        cmrHost: 'http://example.com',
+        conceptId: 'TD000000-MMT',
+        conceptType: 'tool-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        tool: {
+          __typename: 'Tool',
+          accessConstraints: null,
+          ancillaryKeywords: null,
+          associationDetails: null,
+          conceptId: 'TD1000000-MMT',
+          contactGroups: null,
+          contactPersons: null,
+          description: null,
+          doi: null,
+          lastUpdatedDate: null,
+          longName: 'Long Name',
+          metadataSpecification: {
+            name: 'UMM-T',
+            url: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.1',
+            version: '1.1'
+          },
+          name: null,
+          nativeId: 'MMT_2331e312-cbbc-4e56-9d6f-fe217464be2c',
+          organizations: null,
+          pageTitle: null,
+          potentialAction: null,
+          quality: null,
+          relatedUrls: null,
+          searchAction: null,
+          supportedBrowsers: null,
+          supportedInputFormats: null,
+          supportedOperatingSystems: null,
+          supportedOutputFormats: null,
+          supportedSoftwareLanguages: null,
+          toolKeywords: null,
+          type: null,
+          url: null,
+          useConstraints: null,
+          version: null,
+          versionDescription: null
+        }
+      }, {})
     })
   })
 
@@ -213,47 +258,86 @@ describe('MetadataPreview', () => {
       })
 
       await waitFor(() => {
-        expect(ServicePreview).toHaveBeenCalledWith({
-          cmrHost: 'http://example.com',
-          conceptId: 'SD000000-MMT',
-          conceptType: 'service-draft',
-          conceptUrlTemplate: '/{conceptType}/{conceptId}',
-          isPlugin: true,
-          service: {
-            __typename: 'Service',
-            accessConstraints: null,
-            ancillaryKeywords: null,
-            associationDetails: null,
-            conceptId: 'SD000000-MMT',
-            contactGroups: null,
-            contactPersons: null,
-            description: null,
-            lastUpdatedDate: null,
-            longName: 'Test long name',
-            maxItemsPerOrder: null,
-            name: 'Service Draft Preview Test',
-            nativeId: 'MMT_88f3c72f-38df-4524-b97c-dce0c8d0b3e7',
-            operationMetadata: null,
-            pageTitle: 'Service Draft Preview Test',
-            providerId: 'MMT_2',
-            relatedUrls: null,
-            serviceKeywords: null,
-            serviceOptions: null,
-            serviceOrganizations: null,
-            serviceQuality: null,
-            supportedInputProjections: null,
-            supportedOutputProjections: null,
-            supportedReformattings: null,
-            type: null,
-            url: null,
-            useConstraints: null,
-            version: 'v.1.0.0',
-            versionDescription: null
-          }
-        }, {})
+        expect(ServicePreview).toHaveBeenCalledTimes(2)
       })
 
-      expect(ServicePreview).toHaveBeenCalledTimes(2)
+      expect(ServicePreview).toHaveBeenNthCalledWith(1, {
+        cmrHost: 'http://example.com',
+        conceptId: 'SD000000-MMT',
+        conceptType: 'service-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        service: {
+          __typename: 'Service',
+          accessConstraints: null,
+          ancillaryKeywords: null,
+          associationDetails: null,
+          conceptId: 'SD000000-MMT',
+          contactGroups: null,
+          contactPersons: null,
+          description: null,
+          lastUpdatedDate: null,
+          longName: 'Test long name',
+          maxItemsPerOrder: null,
+          name: 'Service Draft Preview Test',
+          nativeId: 'MMT_88f3c72f-38df-4524-b97c-dce0c8d0b3e7',
+          operationMetadata: null,
+          pageTitle: 'Service Draft Preview Test',
+          providerId: 'MMT_2',
+          relatedUrls: null,
+          serviceKeywords: null,
+          serviceOptions: null,
+          serviceOrganizations: null,
+          serviceQuality: null,
+          supportedInputProjections: null,
+          supportedOutputProjections: null,
+          supportedReformattings: null,
+          type: null,
+          url: null,
+          useConstraints: null,
+          version: 'v.1.0.0',
+          versionDescription: null
+        }
+      }, {})
+
+      expect(ServicePreview).toHaveBeenNthCalledWith(2, {
+        cmrHost: 'http://example.com',
+        conceptId: 'SD000000-MMT',
+        conceptType: 'service-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        service: {
+          __typename: 'Service',
+          accessConstraints: null,
+          ancillaryKeywords: null,
+          associationDetails: null,
+          conceptId: 'SD000000-MMT',
+          contactGroups: null,
+          contactPersons: null,
+          description: null,
+          lastUpdatedDate: null,
+          longName: 'Test long name',
+          maxItemsPerOrder: null,
+          name: 'Service Draft Preview Test',
+          nativeId: 'MMT_88f3c72f-38df-4524-b97c-dce0c8d0b3e7',
+          operationMetadata: null,
+          pageTitle: 'Service Draft Preview Test',
+          providerId: 'MMT_2',
+          relatedUrls: null,
+          serviceKeywords: null,
+          serviceOptions: null,
+          serviceOrganizations: null,
+          serviceQuality: null,
+          supportedInputProjections: null,
+          supportedOutputProjections: null,
+          supportedReformattings: null,
+          type: null,
+          url: null,
+          useConstraints: null,
+          version: 'v.1.0.0',
+          versionDescription: null
+        }
+      }, {})
     })
   })
 
@@ -288,42 +372,76 @@ describe('MetadataPreview', () => {
       })
 
       await waitFor(() => {
-        expect(VisualizationPreview).toHaveBeenCalledWith({
-          cmrHost: 'http://example.com',
-          conceptId: 'VISD000000-MMT',
-          conceptType: 'visualization-draft',
-          conceptUrlTemplate: '/{conceptType}/{conceptId}',
-          isPlugin: true,
-          visualization: {
-            __typename: 'Visualization',
-            conceptId: 'VISD0000000000-CMR',
-            description: 'Draft test description',
-            generation: {},
-            identifier: 'Extra Data',
-            metadataSpecification: {
-              url: 'https://cdn.earthdata.nasa.gov/umm/visualization/v1.1.0',
-              name: 'Visualization',
-              version: '1.1.0'
-            },
-            pageTitle: 'Creating Test 3',
-            name: 'Creating Test 3',
-            nativeId: 'Visualization-1303',
-            providerId: 'MMT_1',
-            revisionDate: '2025-04-25T17:25:17.825Z',
-            revisionId: '1',
-            scienceKeywords: null,
-            spatialExtent: null,
-            specification: {},
-            subtitle: null,
-            temporalExtents: null,
-            title: 'Draft test title',
-            ummMetadata: null,
-            visualizationType: 'tiles'
-          }
-        }, {})
+        expect(VisualizationPreview).toHaveBeenCalledTimes(2)
       })
 
-      expect(VisualizationPreview).toHaveBeenCalledTimes(2)
+      expect(VisualizationPreview).toHaveBeenNthCalledWith(1, {
+        cmrHost: 'http://example.com',
+        conceptId: 'VISD000000-MMT',
+        conceptType: 'visualization-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        visualization: {
+          __typename: 'Visualization',
+          conceptId: 'VISD0000000000-CMR',
+          description: 'Draft test description',
+          generation: {},
+          identifier: 'Extra Data',
+          metadataSpecification: {
+            url: 'https://cdn.earthdata.nasa.gov/umm/visualization/v1.1.0',
+            name: 'Visualization',
+            version: '1.1.0'
+          },
+          pageTitle: 'Creating Test 3',
+          name: 'Creating Test 3',
+          nativeId: 'Visualization-1303',
+          providerId: 'MMT_1',
+          revisionDate: '2025-04-25T17:25:17.825Z',
+          revisionId: '1',
+          scienceKeywords: null,
+          spatialExtent: null,
+          specification: {},
+          subtitle: null,
+          temporalExtents: null,
+          title: 'Draft test title',
+          ummMetadata: null,
+          visualizationType: 'tiles'
+        }
+      }, {})
+
+      expect(VisualizationPreview).toHaveBeenNthCalledWith(2, {
+        cmrHost: 'http://example.com',
+        conceptId: 'VISD000000-MMT',
+        conceptType: 'visualization-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        visualization: {
+          __typename: 'Visualization',
+          conceptId: 'VISD0000000000-CMR',
+          description: 'Draft test description',
+          generation: {},
+          identifier: 'Extra Data',
+          metadataSpecification: {
+            url: 'https://cdn.earthdata.nasa.gov/umm/visualization/v1.1.0',
+            name: 'Visualization',
+            version: '1.1.0'
+          },
+          pageTitle: 'Creating Test 3',
+          name: 'Creating Test 3',
+          nativeId: 'Visualization-1303',
+          providerId: 'MMT_1',
+          revisionDate: '2025-04-25T17:25:17.825Z',
+          revisionId: '1',
+          scienceKeywords: null,
+          spatialExtent: null,
+          specification: {},
+          subtitle: null,
+          temporalExtents: null,
+          title: 'Draft test title',
+          ummMetadata: null,
+          visualizationType: 'tiles'
+        }
+      }, {})
     })
   })
 
@@ -358,40 +476,72 @@ describe('MetadataPreview', () => {
       })
 
       await waitFor(() => {
-        expect(CitationPreview).toHaveBeenCalledWith({
-          cmrHost: 'http://example.com',
-          conceptId: 'CITD0000000-MMT_1',
-          conceptType: 'citation-draft',
-          conceptUrlTemplate: '/{conceptType}/{conceptId}',
-          isPlugin: true,
-          citation: {
-            __typename: 'Citation',
-            abstract: 'This is a randomly generated citation for demonstration purposes. Created at 2025-05-28T18:48:11.453Z.',
-            citationMetadata: {
-              number: '2',
-              publisher: 'Springer Nature',
-              title: 'Archival Earth Science Resource 8 - Research Publication 8',
-              type: 'journal-article',
-              volume: '23'
-            },
-            conceptId: 'CITD1200484992-DEMO_PROV',
-            identifier: 'ark:/13030/tf8p17484-test-2',
-            identifierType: 'ARK',
-            name: 'Archival Earth Science Resource 8',
-            nativeId: 'GQL-113-test',
-            pageTitle: 'Archival Earth Science Resource 8',
-            providerId: 'DEMO_PROV',
-            relatedIdentifiers: [],
-            resolutionAuthority: 'https://n2t.net',
-            revisionDate: '2025-09-03T21:45:49.248Z',
-            revisionId: '2',
-            scienceKeywords: [],
-            userId: 'test.user'
-          }
-        }, {})
+        expect(CitationPreview).toHaveBeenCalledTimes(2)
       })
 
-      expect(CitationPreview).toHaveBeenCalledTimes(2)
+      expect(CitationPreview).toHaveBeenNthCalledWith(1, {
+        cmrHost: 'http://example.com',
+        conceptId: 'CITD0000000-MMT_1',
+        conceptType: 'citation-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        citation: {
+          __typename: 'Citation',
+          abstract: 'This is a randomly generated citation for demonstration purposes. Created at 2025-05-28T18:48:11.453Z.',
+          citationMetadata: {
+            number: '2',
+            publisher: 'Springer Nature',
+            title: 'Archival Earth Science Resource 8 - Research Publication 8',
+            type: 'journal-article',
+            volume: '23'
+          },
+          conceptId: 'CITD1200484992-DEMO_PROV',
+          identifier: 'ark:/13030/tf8p17484-test-2',
+          identifierType: 'ARK',
+          name: 'Archival Earth Science Resource 8',
+          nativeId: 'GQL-113-test',
+          pageTitle: 'Archival Earth Science Resource 8',
+          providerId: 'DEMO_PROV',
+          relatedIdentifiers: [],
+          resolutionAuthority: 'https://n2t.net',
+          revisionDate: '2025-09-03T21:45:49.248Z',
+          revisionId: '2',
+          scienceKeywords: [],
+          userId: 'test.user'
+        }
+      }, {})
+
+      expect(CitationPreview).toHaveBeenNthCalledWith(2, {
+        cmrHost: 'http://example.com',
+        conceptId: 'CITD0000000-MMT_1',
+        conceptType: 'citation-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        citation: {
+          __typename: 'Citation',
+          abstract: 'This is a randomly generated citation for demonstration purposes. Created at 2025-05-28T18:48:11.453Z.',
+          citationMetadata: {
+            number: '2',
+            publisher: 'Springer Nature',
+            title: 'Archival Earth Science Resource 8 - Research Publication 8',
+            type: 'journal-article',
+            volume: '23'
+          },
+          conceptId: 'CITD1200484992-DEMO_PROV',
+          identifier: 'ark:/13030/tf8p17484-test-2',
+          identifierType: 'ARK',
+          name: 'Archival Earth Science Resource 8',
+          nativeId: 'GQL-113-test',
+          pageTitle: 'Archival Earth Science Resource 8',
+          providerId: 'DEMO_PROV',
+          relatedIdentifiers: [],
+          resolutionAuthority: 'https://n2t.net',
+          revisionDate: '2025-09-03T21:45:49.248Z',
+          revisionId: '2',
+          scienceKeywords: [],
+          userId: 'test.user'
+        }
+      }, {})
     })
   })
 
@@ -427,48 +577,88 @@ describe('MetadataPreview', () => {
       })
 
       await waitFor(() => {
-        expect(VariablePreview).toHaveBeenCalledWith({
-          cmrHost: 'http://example.com',
-          conceptId: 'VD000000-MMT',
-          conceptType: 'variable-draft',
-          conceptUrlTemplate: '/{conceptType}/{conceptId}',
-          isPlugin: true,
-          variable: {
-            __typename: 'Variable',
-            additionalIdentifiers: [
-              {
-                identifier: '213'
-              }
-            ],
-            associationDetails: null,
-            conceptId: 'VD1200000101-MMT_2',
-            dataType: null,
-            definition: 'asdf',
-            dimensions: null,
-            fillValues: null,
-            indexRanges: null,
-            instanceInformation: null,
-            longName: '12',
-            measurementIdentifiers: null,
-            name: 'Testing a Variable association',
-            nativeId: 'MMT_f1a16a66-bc9c-4ba9-bd38-825276522f9e',
-            offset: null,
-            pageTitle: 'Testing a Variable association',
-            relatedUrls: null,
-            samplingIdentifiers: null,
-            scale: null,
-            scienceKeywords: null,
-            sets: null,
-            standardName: null,
-            units: null,
-            validRanges: null,
-            variableSubType: null,
-            variableType: null
-          }
-        }, {})
+        expect(VariablePreview).toHaveBeenCalledTimes(2)
       })
 
-      expect(VariablePreview).toHaveBeenCalledTimes(2)
+      expect(VariablePreview).toHaveBeenNthCalledWith(1, {
+        cmrHost: 'http://example.com',
+        conceptId: 'VD000000-MMT',
+        conceptType: 'variable-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        variable: {
+          __typename: 'Variable',
+          additionalIdentifiers: [
+            {
+              identifier: '213'
+            }
+          ],
+          associationDetails: null,
+          conceptId: 'VD1200000101-MMT_2',
+          dataType: null,
+          definition: 'asdf',
+          dimensions: null,
+          fillValues: null,
+          indexRanges: null,
+          instanceInformation: null,
+          longName: '12',
+          measurementIdentifiers: null,
+          name: 'Testing a Variable association',
+          nativeId: 'MMT_f1a16a66-bc9c-4ba9-bd38-825276522f9e',
+          offset: null,
+          pageTitle: 'Testing a Variable association',
+          relatedUrls: null,
+          samplingIdentifiers: null,
+          scale: null,
+          scienceKeywords: null,
+          sets: null,
+          standardName: null,
+          units: null,
+          validRanges: null,
+          variableSubType: null,
+          variableType: null
+        }
+      }, {})
+
+      expect(VariablePreview).toHaveBeenNthCalledWith(2, {
+        cmrHost: 'http://example.com',
+        conceptId: 'VD000000-MMT',
+        conceptType: 'variable-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        variable: {
+          __typename: 'Variable',
+          additionalIdentifiers: [
+            {
+              identifier: '213'
+            }
+          ],
+          associationDetails: null,
+          conceptId: 'VD1200000101-MMT_2',
+          dataType: null,
+          definition: 'asdf',
+          dimensions: null,
+          fillValues: null,
+          indexRanges: null,
+          instanceInformation: null,
+          longName: '12',
+          measurementIdentifiers: null,
+          name: 'Testing a Variable association',
+          nativeId: 'MMT_f1a16a66-bc9c-4ba9-bd38-825276522f9e',
+          offset: null,
+          pageTitle: 'Testing a Variable association',
+          relatedUrls: null,
+          samplingIdentifiers: null,
+          scale: null,
+          scienceKeywords: null,
+          sets: null,
+          standardName: null,
+          units: null,
+          validRanges: null,
+          variableSubType: null,
+          variableType: null
+        }
+      }, {})
     })
   })
 
@@ -503,97 +693,186 @@ describe('MetadataPreview', () => {
       })
 
       await waitFor(() => {
-        expect(CollectionPreview).toHaveBeenCalledWith({
-          cmrHost: 'http://example.com',
-          conceptId: 'CD000000-MMT',
-          conceptType: 'collection-draft',
-          conceptUrlTemplate: '/{conceptType}/{conceptId}',
-          isPlugin: true,
-          collection: {
-            __typename: 'Collection',
-            abstract: null,
-            accessConstraints: null,
-            additionalAttributes: null,
-            ancillaryKeywords: null,
-            archiveAndDistributionInformation: null,
-            archiveCenter: null,
-            associatedDois: null,
-            associationDetails: null,
-            boxes: null,
-            browseFlag: null,
-            cloudHosted: null,
-            collectionCitations: null,
-            collectionDataType: null,
-            collectionProgress: null,
-            conceptId: 'CD1200000116-MMT_2',
-            consortiums: null,
-            contactGroups: null,
-            contactPersons: null,
-            coordinateSystem: null,
-            dataCenter: null,
-            dataCenters: null,
-            dataDates: null,
-            dataLanguage: null,
-            datasetId: null,
-            directDistributionInformation: null,
-            directoryNames: null,
-            doi: null,
-            hasFormats: null,
-            hasGranules: null,
-            hasSpatialSubsetting: null,
-            hasTemporalSubsetting: null,
-            hasTransforms: null,
-            hasVariables: null,
-            isoTopicCategories: null,
-            lines: null,
-            locationKeywords: null,
-            metadataAssociations: null,
-            metadataDates: null,
-            metadataFormat: null,
-            metadataLanguage: null,
-            nativeDataFormats: null,
-            nativeId: 'MMT_ae383e10-4d28-4f2e-be56-5721573db3dd',
-            onlineAccessFlag: null,
-            organizations: null,
-            originalFormat: null,
-            pageTitle: 'Testing Collection Preview',
-            paleoTemporalCoverages: null,
-            platforms: null,
-            points: null,
-            polygons: null,
-            processingLevel: null,
-            processingLevelId: null,
-            projects: null,
-            provider: null,
-            publicationReferences: null,
-            purpose: null,
-            quality: null,
-            relatedUrls: null,
-            revisionDate: '2024-04-29T21:12:09.999Z',
-            revisionId: '1',
-            scienceKeywords: null,
-            shortName: 'Testing Collection Preview',
-            spatialExtent: null,
-            spatialInformation: null,
-            standardProduct: null,
-            summary: null,
-            tags: null,
-            temporalExtents: null,
-            temporalKeywords: null,
-            tilingIdentificationSystems: null,
-            timeEnd: null,
-            timeStart: null,
-            title: 'Title of Testing Collection Preview',
-            useConstraints: null,
-            version: 'v.1.0.0',
-            versionDescription: null,
-            versionId: null
-          },
-          token: null
-        }, {})
+        expect(CollectionPreview).toHaveBeenCalledTimes(2)
       })
 
-      expect(CollectionPreview).toHaveBeenCalledTimes(2)
+      expect(CollectionPreview).toHaveBeenNthCalledWith(1, {
+        cmrHost: 'http://example.com',
+        conceptId: 'CD000000-MMT',
+        conceptType: 'collection-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        collection: {
+          __typename: 'Collection',
+          abstract: null,
+          accessConstraints: null,
+          additionalAttributes: null,
+          ancillaryKeywords: null,
+          archiveAndDistributionInformation: null,
+          archiveCenter: null,
+          associatedDois: null,
+          associationDetails: null,
+          boxes: null,
+          browseFlag: null,
+          cloudHosted: null,
+          collectionCitations: null,
+          collectionDataType: null,
+          collectionProgress: null,
+          conceptId: 'CD1200000116-MMT_2',
+          consortiums: null,
+          contactGroups: null,
+          contactPersons: null,
+          coordinateSystem: null,
+          dataCenter: null,
+          dataCenters: null,
+          dataDates: null,
+          dataLanguage: null,
+          datasetId: null,
+          directDistributionInformation: null,
+          directoryNames: null,
+          doi: null,
+          hasFormats: null,
+          hasGranules: null,
+          hasSpatialSubsetting: null,
+          hasTemporalSubsetting: null,
+          hasTransforms: null,
+          hasVariables: null,
+          isoTopicCategories: null,
+          lines: null,
+          locationKeywords: null,
+          metadataAssociations: null,
+          metadataDates: null,
+          metadataFormat: null,
+          metadataLanguage: null,
+          nativeDataFormats: null,
+          nativeId: 'MMT_ae383e10-4d28-4f2e-be56-5721573db3dd',
+          onlineAccessFlag: null,
+          organizations: null,
+          originalFormat: null,
+          pageTitle: 'Testing Collection Preview',
+          paleoTemporalCoverages: null,
+          platforms: null,
+          points: null,
+          polygons: null,
+          processingLevel: null,
+          processingLevelId: null,
+          projects: null,
+          provider: null,
+          publicationReferences: null,
+          purpose: null,
+          quality: null,
+          relatedUrls: null,
+          revisionDate: '2024-04-29T21:12:09.999Z',
+          revisionId: '1',
+          scienceKeywords: null,
+          shortName: 'Testing Collection Preview',
+          spatialExtent: null,
+          spatialInformation: null,
+          standardProduct: null,
+          summary: null,
+          tags: null,
+          temporalExtents: null,
+          temporalKeywords: null,
+          tilingIdentificationSystems: null,
+          timeEnd: null,
+          timeStart: null,
+          title: 'Title of Testing Collection Preview',
+          useConstraints: null,
+          version: 'v.1.0.0',
+          versionDescription: null,
+          versionId: null
+        },
+        token: null
+      }, {})
+
+      expect(CollectionPreview).toHaveBeenNthCalledWith(1, {
+        cmrHost: 'http://example.com',
+        conceptId: 'CD000000-MMT',
+        conceptType: 'collection-draft',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        collection: {
+          __typename: 'Collection',
+          abstract: null,
+          accessConstraints: null,
+          additionalAttributes: null,
+          ancillaryKeywords: null,
+          archiveAndDistributionInformation: null,
+          archiveCenter: null,
+          associatedDois: null,
+          associationDetails: null,
+          boxes: null,
+          browseFlag: null,
+          cloudHosted: null,
+          collectionCitations: null,
+          collectionDataType: null,
+          collectionProgress: null,
+          conceptId: 'CD1200000116-MMT_2',
+          consortiums: null,
+          contactGroups: null,
+          contactPersons: null,
+          coordinateSystem: null,
+          dataCenter: null,
+          dataCenters: null,
+          dataDates: null,
+          dataLanguage: null,
+          datasetId: null,
+          directDistributionInformation: null,
+          directoryNames: null,
+          doi: null,
+          hasFormats: null,
+          hasGranules: null,
+          hasSpatialSubsetting: null,
+          hasTemporalSubsetting: null,
+          hasTransforms: null,
+          hasVariables: null,
+          isoTopicCategories: null,
+          lines: null,
+          locationKeywords: null,
+          metadataAssociations: null,
+          metadataDates: null,
+          metadataFormat: null,
+          metadataLanguage: null,
+          nativeDataFormats: null,
+          nativeId: 'MMT_ae383e10-4d28-4f2e-be56-5721573db3dd',
+          onlineAccessFlag: null,
+          organizations: null,
+          originalFormat: null,
+          pageTitle: 'Testing Collection Preview',
+          paleoTemporalCoverages: null,
+          platforms: null,
+          points: null,
+          polygons: null,
+          processingLevel: null,
+          processingLevelId: null,
+          projects: null,
+          provider: null,
+          publicationReferences: null,
+          purpose: null,
+          quality: null,
+          relatedUrls: null,
+          revisionDate: '2024-04-29T21:12:09.999Z',
+          revisionId: '1',
+          scienceKeywords: null,
+          shortName: 'Testing Collection Preview',
+          spatialExtent: null,
+          spatialInformation: null,
+          standardProduct: null,
+          summary: null,
+          tags: null,
+          temporalExtents: null,
+          temporalKeywords: null,
+          tilingIdentificationSystems: null,
+          timeEnd: null,
+          timeStart: null,
+          title: 'Title of Testing Collection Preview',
+          useConstraints: null,
+          version: 'v.1.0.0',
+          versionDescription: null,
+          versionId: null
+        },
+        token: null
+      }, {})
     })
   })
 
@@ -627,18 +906,28 @@ describe('MetadataPreview', () => {
       })
 
       await waitFor(() => {
-        expect(CollectionPreview).toHaveBeenCalledWith({
-          cmrHost: 'http://example.com',
-          conceptId: 'C1000000-MMT',
-          conceptType: 'collection',
-          conceptUrlTemplate: '/{conceptType}/{conceptId}',
-          isPlugin: true,
-          collection: mockCollection,
-          token: null
-        }, {})
+        expect(CollectionPreview).toHaveBeenCalledTimes(2)
       })
 
-      expect(CollectionPreview).toHaveBeenCalledTimes(2)
+      expect(CollectionPreview).toHaveBeenNthCalledWith(1, {
+        cmrHost: 'http://example.com',
+        conceptId: 'C1000000-MMT',
+        conceptType: 'collection',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        collection: mockCollection,
+        token: null
+      }, {})
+
+      expect(CollectionPreview).toHaveBeenNthCalledWith(1, {
+        cmrHost: 'http://example.com',
+        conceptId: 'C1000000-MMT',
+        conceptType: 'collection',
+        conceptUrlTemplate: '/{conceptType}/{conceptId}',
+        isPlugin: true,
+        collection: mockCollection,
+        token: null
+      }, {})
     })
   })
 

--- a/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
+++ b/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
@@ -785,7 +785,7 @@ describe('MetadataPreview', () => {
         token: null
       }, {})
 
-      expect(CollectionPreview).toHaveBeenNthCalledWith(1, {
+      expect(CollectionPreview).toHaveBeenNthCalledWith(2, {
         cmrHost: 'http://example.com',
         conceptId: 'CD000000-MMT',
         conceptType: 'collection-draft',
@@ -919,7 +919,7 @@ describe('MetadataPreview', () => {
         token: null
       }, {})
 
-      expect(CollectionPreview).toHaveBeenNthCalledWith(1, {
+      expect(CollectionPreview).toHaveBeenNthCalledWith(2, {
         cmrHost: 'http://example.com',
         conceptId: 'C1000000-MMT',
         conceptType: 'collection',
@@ -960,24 +960,7 @@ describe('MetadataPreview', () => {
             variables: {
               params: {
                 limit: conceptsResultsLimitInt,
-                cursor: null,
-                conceptId: ['V100000_MMT', 'V100001_MMT', 'V100002_MMT', 'V100003_MMT', 'V100004_MMT', 'V100005_MMT', 'V100006_MMT', 'V100007_MMT', 'V100008_MMT', 'V100009_MMT', 'V100010_MMT', 'V100011_MMT', 'V100012_MMT', 'V100013_MMT', 'V100014_MMT', 'V100015_MMT', 'V100016_MMT', 'V100017_MMT', 'V100018_MMT', 'V100019_MMT', 'V100020_MMT']
-              }
-            }
-          },
-          result: {
-            data: {
-              variables: mockVariableList
-            }
-          }
-        }, {
-          request: {
-            query: conceptTypeQueries.Variables,
-            variables: {
-              params: {
-                limit: conceptsResultsLimitInt,
-                cursor: 'page-1-cursor',
-                conceptId: ['V100000_MMT', 'V100001_MMT', 'V100002_MMT', 'V100003_MMT', 'V100004_MMT', 'V100005_MMT', 'V100006_MMT', 'V100007_MMT', 'V100008_MMT', 'V100009_MMT', 'V100010_MMT', 'V100011_MMT', 'V100012_MMT', 'V100013_MMT', 'V100014_MMT', 'V100015_MMT', 'V100016_MMT', 'V100017_MMT', 'V100018_MMT', 'V100019_MMT', 'V100020_MMT']
+                conceptId: ['V100020_MMT']
               }
             }
           },
@@ -1071,8 +1054,7 @@ describe('MetadataPreview', () => {
             variables: {
               params: {
                 limit: conceptsResultsLimitInt,
-                cursor: null,
-                conceptId: ['V100000_MMT', 'V100001_MMT', 'V100002_MMT', 'V100003_MMT', 'V100004_MMT', 'V100005_MMT', 'V100006_MMT', 'V100007_MMT', 'V100008_MMT', 'V100009_MMT', 'V100010_MMT', 'V100011_MMT', 'V100012_MMT', 'V100013_MMT', 'V100014_MMT', 'V100015_MMT', 'V100016_MMT', 'V100017_MMT', 'V100018_MMT', 'V100019_MMT', 'V100020_MMT']
+                conceptId: ['V100020_MMT']
               }
             }
           },

--- a/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
+++ b/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
@@ -6,9 +6,14 @@ import {
   VariablePreview,
   VisualizationPreview
 } from '@edsc/metadata-preview'
-import { render, waitFor } from '@testing-library/react'
+import {
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React, { Suspense } from 'react'
+import { GraphQLError } from 'graphql'
 import { MockedProvider } from '@apollo/client/testing'
 import {
   MemoryRouter,
@@ -28,6 +33,8 @@ import {
   mockServiceDraft,
   mockToolDraft,
   mockVariableDraft,
+  mockVariableList,
+  mockVariableList2,
   mockVisualizationDraft
 } from './__mocks__/MatadataPreviewMocks'
 
@@ -36,7 +43,8 @@ vi.mock('@edsc/metadata-preview')
 vi.mock('@sharedUtils/getConfig', async () => ({
   ...await vi.importActual('@sharedUtils/getConfig'),
   getApplicationConfig: vi.fn(() => ({
-    cmrHost: 'http://example.com'
+    cmrHost: 'http://example.com',
+    conceptsResultLimit: '20'
   }))
 }))
 
@@ -104,7 +112,10 @@ describe('MetadataPreview', () => {
                 conceptId: 'TD000000-MMT',
                 conceptType: 'Tool'
               },
-              variableParams: null
+              citationParams: null,
+              serviceParams: null,
+              variableParams: null,
+              collectionsParams: null
             }
           },
           result: {
@@ -163,7 +174,7 @@ describe('MetadataPreview', () => {
         }, {})
       })
 
-      expect(ToolPreview).toHaveBeenCalledTimes(1)
+      expect(ToolPreview).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -182,7 +193,10 @@ describe('MetadataPreview', () => {
                 conceptId: 'SD000000-MMT',
                 conceptType: 'Service'
               },
-              variableParams: null
+              citationParams: null,
+              serviceParams: null,
+              variableParams: null,
+              collectionsParams: null
             }
           },
           result: {
@@ -236,7 +250,7 @@ describe('MetadataPreview', () => {
         }, {})
       })
 
-      expect(ServicePreview).toHaveBeenCalledTimes(1)
+      expect(ServicePreview).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -255,7 +269,10 @@ describe('MetadataPreview', () => {
                 conceptId: 'VISD000000-MMT',
                 conceptType: 'Visualization'
               },
-              variableParams: null
+              citationParams: null,
+              serviceParams: null,
+              variableParams: null,
+              collectionsParams: null
             }
           },
           result: {
@@ -303,7 +320,7 @@ describe('MetadataPreview', () => {
         }, {})
       })
 
-      expect(VisualizationPreview).toHaveBeenCalledTimes(1)
+      expect(VisualizationPreview).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -322,7 +339,10 @@ describe('MetadataPreview', () => {
                 conceptId: 'CITD0000000-MMT_1',
                 conceptType: 'Citation'
               },
-              variableParams: null
+              citationParams: null,
+              serviceParams: null,
+              variableParams: null,
+              collectionsParams: null
             }
           },
           result: {
@@ -368,7 +388,7 @@ describe('MetadataPreview', () => {
         }, {})
       })
 
-      expect(CitationPreview).toHaveBeenCalledTimes(1)
+      expect(CitationPreview).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -387,7 +407,10 @@ describe('MetadataPreview', () => {
                 conceptId: 'VD000000-MMT',
                 conceptType: 'Variable'
               },
-              variableParams: null
+              citationParams: null,
+              serviceParams: null,
+              variableParams: null,
+              collectionsParams: null
             }
           },
           result: {
@@ -442,7 +465,7 @@ describe('MetadataPreview', () => {
         }, {})
       })
 
-      expect(VariablePreview).toHaveBeenCalledTimes(1)
+      expect(VariablePreview).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -461,7 +484,10 @@ describe('MetadataPreview', () => {
                 conceptId: 'CD000000-MMT',
                 conceptType: 'Collection'
               },
-              variableParams: { limit: 1000 }
+              citationParams: { limit: 20 },
+              serviceParams: { limit: 20 },
+              variableParams: { limit: 20 },
+              collectionsParams: null
             }
           },
           result: {
@@ -564,7 +590,7 @@ describe('MetadataPreview', () => {
         }, {})
       })
 
-      expect(CollectionPreview).toHaveBeenCalledTimes(1)
+      expect(CollectionPreview).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -580,7 +606,10 @@ describe('MetadataPreview', () => {
             query: conceptTypeQueries.Collection,
             variables: {
               params: { conceptId: 'C1000000-MMT' },
-              variableParams: { limit: 1000 }
+              citationParams: { limit: 20 },
+              serviceParams: { limit: 20 },
+              variableParams: { limit: 20 },
+              collectionsParams: null
             }
           },
           result: {
@@ -606,7 +635,7 @@ describe('MetadataPreview', () => {
         }, {})
       })
 
-      expect(CollectionPreview).toHaveBeenCalledTimes(1)
+      expect(CollectionPreview).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -622,12 +651,47 @@ describe('MetadataPreview', () => {
             query: conceptTypeQueries.Collection,
             variables: {
               params: { conceptId: 'C1000000-MMT' },
-              variableParams: { limit: 1000 }
+              citationParams: { limit: 20 },
+              serviceParams: { limit: 20 },
+              variableParams: { limit: 20 },
+              collectionsParams: null
             }
           },
           result: {
             data: {
               collection: mockCollectionWithAssociatedVariables
+            }
+          }
+        }, {
+          request: {
+            query: conceptTypeQueries.Variables,
+            variables: {
+              params: {
+                limit: 20,
+                cursor: null,
+                conceptId: ['V100000_MMT']
+              }
+            }
+          },
+          result: {
+            data: {
+              variables: mockVariableList
+            }
+          }
+        }, {
+          request: {
+            query: conceptTypeQueries.Variables,
+            variables: {
+              params: {
+                limit: 20,
+                cursor: 'page-1-cursor',
+                conceptId: ['V100000_MMT']
+              }
+            }
+          },
+          result: {
+            data: {
+              variables: mockVariableList2
             }
           }
         }],
@@ -649,6 +713,86 @@ describe('MetadataPreview', () => {
       })
 
       expect(CollectionPreview).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when a network error is thrown', () => {
+    test('renders an error banner', async () => {
+      setup({
+        overrideProps: {
+          conceptId: 'C1000000-MMT',
+          conceptType: 'Collection'
+        },
+        mock: [{
+          request: {
+            query: conceptTypeQueries.Collection,
+            variables: {
+              params: { conceptId: 'C1000000-MMT' },
+              citationParams: { limit: 20 },
+              serviceParams: { limit: 20 },
+              variableParams: { limit: 20 },
+              collectionsParams: null
+            }
+          },
+          error: new Error('Error!')
+        }],
+        initialEntries: '/C1000000-MMT',
+        overrideRoute: '/:conceptId',
+        overridePath: '/'
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('error-banner__message')).toHaveTextContent('Error!')
+      })
+    })
+  })
+
+  describe('when a graphQL error is thrown', () => {
+    test('renders an error banner', async () => {
+      setup({
+        overrideProps: {
+          conceptId: 'C1000000-MMT',
+          conceptType: 'Collection'
+        },
+        mock: [{
+          request: {
+            query: conceptTypeQueries.Collection,
+            variables: {
+              params: { conceptId: 'C1000000-MMT' },
+              citationParams: { limit: 20 },
+              serviceParams: { limit: 20 },
+              variableParams: { limit: 20 },
+              collectionsParams: null
+            }
+          },
+          result: {
+            data: {
+              collection: mockCollectionWithAssociatedVariables
+            }
+          }
+        }, {
+          request: {
+            query: conceptTypeQueries.Variables,
+            variables: {
+              params: {
+                limit: 20,
+                cursor: null,
+                conceptId: ['V100000_MMT']
+              }
+            }
+          },
+          result: {
+            errors: [new GraphQLError('Error!')]
+          }
+        }],
+        initialEntries: '/C1000000-MMT',
+        overrideRoute: '/:conceptId',
+        overridePath: '/'
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('error-banner__message')).toHaveTextContent('Error!')
+      })
     })
   })
 })

--- a/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
+++ b/static/src/js/components/MetadataPreview/__tests__/MetadataPreview.test.jsx
@@ -35,6 +35,7 @@ import {
   mockVariableDraft,
   mockVariableList,
   mockVariableList2,
+  mockVariableList3,
   mockVisualizationDraft
 } from './__mocks__/MatadataPreviewMocks'
 
@@ -671,7 +672,7 @@ describe('MetadataPreview', () => {
               params: {
                 limit: conceptsResultsLimitInt,
                 cursor: null,
-                conceptId: ['V100000_MMT']
+                conceptId: ['V100000_MMT', 'V100001_MMT', 'V100002_MMT', 'V100003_MMT', 'V100004_MMT', 'V100005_MMT', 'V100006_MMT', 'V100007_MMT', 'V100008_MMT', 'V100009_MMT', 'V100010_MMT', 'V100011_MMT', 'V100012_MMT', 'V100013_MMT', 'V100014_MMT', 'V100015_MMT', 'V100016_MMT', 'V100017_MMT', 'V100018_MMT', 'V100019_MMT', 'V100020_MMT']
               }
             }
           },
@@ -687,7 +688,7 @@ describe('MetadataPreview', () => {
               params: {
                 limit: conceptsResultsLimitInt,
                 cursor: 'page-1-cursor',
-                conceptId: ['V100000_MMT']
+                conceptId: ['V100000_MMT', 'V100001_MMT', 'V100002_MMT', 'V100003_MMT', 'V100004_MMT', 'V100005_MMT', 'V100006_MMT', 'V100007_MMT', 'V100008_MMT', 'V100009_MMT', 'V100010_MMT', 'V100011_MMT', 'V100012_MMT', 'V100013_MMT', 'V100014_MMT', 'V100015_MMT', 'V100016_MMT', 'V100017_MMT', 'V100018_MMT', 'V100019_MMT', 'V100020_MMT']
               }
             }
           },
@@ -709,7 +710,10 @@ describe('MetadataPreview', () => {
           conceptType: 'collection',
           conceptUrlTemplate: '/{conceptType}/{conceptId}',
           isPlugin: true,
-          collection: mockCollectionWithAssociatedVariables,
+          collection: {
+            ...mockCollectionWithAssociatedVariables,
+            variables: mockVariableList3
+          },
           token: null
         }, {})
       })
@@ -779,7 +783,7 @@ describe('MetadataPreview', () => {
               params: {
                 limit: conceptsResultsLimitInt,
                 cursor: null,
-                conceptId: ['V100000_MMT']
+                conceptId: ['V100000_MMT', 'V100001_MMT', 'V100002_MMT', 'V100003_MMT', 'V100004_MMT', 'V100005_MMT', 'V100006_MMT', 'V100007_MMT', 'V100008_MMT', 'V100009_MMT', 'V100010_MMT', 'V100011_MMT', 'V100012_MMT', 'V100013_MMT', 'V100014_MMT', 'V100015_MMT', 'V100016_MMT', 'V100017_MMT', 'V100018_MMT', 'V100019_MMT', 'V100020_MMT']
               }
             }
           },

--- a/static/src/js/components/MetadataPreview/__tests__/__mocks__/MatadataPreviewMocks.js
+++ b/static/src/js/components/MetadataPreview/__tests__/__mocks__/MatadataPreviewMocks.js
@@ -1638,232 +1638,131 @@ export const mockCollection = {
 
 export const mockVariableList = {
   count: 21,
-  cursor: 'page-1-cursor',
+  cursor: '',
   items: [{
     __typename: 'Variable',
     conceptId: 'V100000_MMT',
     name: 'Variable_00',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100001_MMT',
     name: 'Variable_01',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100002_MMT',
     name: 'Variable_02',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100003_MMT',
     name: 'Variable_03',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100004_MMT',
     name: 'Variable_04',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100005_MMT',
     name: 'Variable_05',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100006_MMT',
     name: 'Variable_06',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100007_MMT',
     name: 'Variable_07',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100008_MMT',
     name: 'Variable_08',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100009_MMT',
     name: 'Variable_09',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100010_MMT',
     name: 'Variable_10',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100011_MMT',
     name: 'Variable_11',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100012_MMT',
     name: 'Variable_12',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100013_MMT',
     name: 'Variable_13',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100014_MMT',
     name: 'Variable_14',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100015_MMT',
     name: 'Variable_15',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100016_MMT',
     name: 'Variable_16',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100017_MMT',
     name: 'Variable_17',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100018_MMT',
     name: 'Variable_18',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   },
   {
     __typename: 'Variable',
     conceptId: 'V100019_MMT',
     name: 'Variable_19',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
+    type: 'SCIENCE_VARIABLE'
   }]
 }
 
 export const mockVariableList2 = {
   count: 21,
-  cursor: 'page-1-cursor',
   items: [{
     __typename: 'Variable',
     conceptId: 'V100020_MMT',

--- a/static/src/js/components/MetadataPreview/__tests__/__mocks__/MatadataPreviewMocks.js
+++ b/static/src/js/components/MetadataPreview/__tests__/__mocks__/MatadataPreviewMocks.js
@@ -26,6 +26,11 @@ export const mockCollection = {
     ]
   },
   associatedDois: null,
+  citations: {
+    count: 0,
+    items: null,
+    __typename: 'CitationList'
+  },
   collectionCitations: null,
   collectionProgress: 'COMPLETE',
   conceptId: 'C1200000104-MMT_2',
@@ -1658,7 +1663,14 @@ export const mockCollectionWithAssociatedVariables = {
     ]
   },
   associatedDois: null,
-  associationDetails: [],
+  associationDetails: {
+    variables: [{ conceptId: 'V100000_MMT' }]
+  },
+  citations: {
+    count: 0,
+    items: null,
+    __typename: 'CitationList'
+  },
   collectionCitations: null,
   collectionProgress: 'COMPLETE',
   conceptId: 'C1200000104-MMT_2',
@@ -3193,107 +3205,233 @@ export const mockCollectionWithAssociatedVariables = {
       {
         conceptId: 'V100000_MMT',
         name: 'Variable_00',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100001_MMT',
         name: 'Variable_01',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100002_MMT',
         name: 'Variable_02',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100003_MMT',
         name: 'Variable_03',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100004_MMT',
         name: 'Variable_04',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100005_MMT',
         name: 'Variable_05',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100006_MMT',
         name: 'Variable_06',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100007_MMT',
         name: 'Variable_07',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100008_MMT',
         name: 'Variable_08',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100009_MMT',
         name: 'Variable_09',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100010_MMT',
         name: 'Variable_10',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100011_MMT',
         name: 'Variable_11',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100012_MMT',
         name: 'Variable_12',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100013_MMT',
         name: 'Variable_13',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100014_MMT',
         name: 'Variable_14',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100015_MMT',
         name: 'Variable_15',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100016_MMT',
         name: 'Variable_16',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100017_MMT',
         name: 'Variable_17',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100018_MMT',
         name: 'Variable_18',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100019_MMT',
         name: 'Variable_19',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       },
       {
         conceptId: 'V100020_MMT',
         name: 'Variable_20',
-        __typename: 'Variable'
+        type: 'SCIENCE_VARIABLE',
+        __typename: 'Variable',
+        longName: 'long',
+        providerId: 'MMT',
+        revisionDate: null,
+        revisionId: 1,
+        userId: 1
       }
     ],
     __typename: 'VariableList'
@@ -3640,6 +3778,247 @@ export const mockVariableDraft = {
   },
   __typename: 'Draft'
 
+}
+
+export const mockVariableList = {
+  count: 21,
+  cursor: 'page-1-cursor',
+  items: [{
+    __typename: 'Variable',
+    conceptId: 'V100000_MMT',
+    name: 'Variable_00',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100001_MMT',
+    name: 'Variable_01',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100002_MMT',
+    name: 'Variable_02',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100003_MMT',
+    name: 'Variable_03',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100004_MMT',
+    name: 'Variable_04',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100005_MMT',
+    name: 'Variable_05',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100006_MMT',
+    name: 'Variable_06',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100007_MMT',
+    name: 'Variable_07',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100008_MMT',
+    name: 'Variable_08',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100009_MMT',
+    name: 'Variable_09',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100010_MMT',
+    name: 'Variable_10',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100011_MMT',
+    name: 'Variable_11',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100012_MMT',
+    name: 'Variable_12',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100013_MMT',
+    name: 'Variable_13',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100014_MMT',
+    name: 'Variable_14',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100015_MMT',
+    name: 'Variable_15',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100016_MMT',
+    name: 'Variable_16',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100017_MMT',
+    name: 'Variable_17',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100018_MMT',
+    name: 'Variable_18',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100019_MMT',
+    name: 'Variable_19',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  }]
+}
+
+export const mockVariableList2 = {
+  count: 21,
+  cursor: 'page-1-cursor',
+  items: [{
+    __typename: 'Variable',
+    conceptId: 'V100020_MMT',
+    name: 'Variable_20',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  }]
 }
 
 export const mockVisualizationDraft = {

--- a/static/src/js/components/MetadataPreview/__tests__/__mocks__/MatadataPreviewMocks.js
+++ b/static/src/js/components/MetadataPreview/__tests__/__mocks__/MatadataPreviewMocks.js
@@ -1636,6 +1636,264 @@ export const mockCollection = {
   __typename: 'Collection'
 }
 
+export const mockVariableList = {
+  count: 21,
+  cursor: 'page-1-cursor',
+  items: [{
+    __typename: 'Variable',
+    conceptId: 'V100000_MMT',
+    name: 'Variable_00',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100001_MMT',
+    name: 'Variable_01',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100002_MMT',
+    name: 'Variable_02',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100003_MMT',
+    name: 'Variable_03',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100004_MMT',
+    name: 'Variable_04',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100005_MMT',
+    name: 'Variable_05',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100006_MMT',
+    name: 'Variable_06',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100007_MMT',
+    name: 'Variable_07',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100008_MMT',
+    name: 'Variable_08',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100009_MMT',
+    name: 'Variable_09',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100010_MMT',
+    name: 'Variable_10',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100011_MMT',
+    name: 'Variable_11',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100012_MMT',
+    name: 'Variable_12',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100013_MMT',
+    name: 'Variable_13',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100014_MMT',
+    name: 'Variable_14',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100015_MMT',
+    name: 'Variable_15',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100016_MMT',
+    name: 'Variable_16',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100017_MMT',
+    name: 'Variable_17',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100018_MMT',
+    name: 'Variable_18',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  },
+  {
+    __typename: 'Variable',
+    conceptId: 'V100019_MMT',
+    name: 'Variable_19',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  }]
+}
+
+export const mockVariableList2 = {
+  count: 21,
+  cursor: 'page-1-cursor',
+  items: [{
+    __typename: 'Variable',
+    conceptId: 'V100020_MMT',
+    name: 'Variable_20',
+    type: 'SCIENCE_VARIABLE',
+    longName: 'long',
+    providerId: 'MMT',
+    revisionDate: null,
+    revisionId: 1,
+    userId: 1
+  }]
+}
+
+export const mockVariableList3 = {
+  ...mockVariableList,
+  items: [
+    ...mockVariableList.items,
+    {
+      __typename: 'Variable',
+      conceptId: 'V100020_MMT',
+      name: 'Variable_20',
+      type: 'SCIENCE_VARIABLE',
+      longName: 'long',
+      providerId: 'MMT',
+      revisionDate: null,
+      revisionId: 1,
+      userId: 1
+    }]
+}
+
 export const mockCollectionWithAssociatedVariables = {
   abstract: "The 2012 Environmental Performance Index (EPI) ranks 132 countries on 22 performance indicators in the following 10 policy categories:  environmental burden of disease, water (effects on human health), air pollution (effects on human health), air pollution (ecosystem effects), water resources (ecosystem effects), biodiversity and habitat, forestry, fisheries, agriculture and climate change. These categories track performance and progress on two broad policy objectives, environmental health and ecosystem vitality. Each indicator has an associated environmental public health or ecosystem sustainability target. The EPI's proximity-to-target methodology facilitates cross-country comparisons among economic and regional peer groups.\n\n\n\n\nThe Pilot Trend Environmental Performance Index (Trend EPI) ranks countries on the change in their environmental performance over the last decade. As a complement to the EPI, the Trend EPI shows who is improving and who is declining over time.\n\n\n\n\nThe 2012 EPI and Pilot Trend EPI were formally released in Davos, Switzerland, at the annual meeting of the World Economic Forum on January 27, 2012. These are the result of collaboration between the Yale Center for Environmental Law and Policy (YCELP) and the Columbia University Center for International Earth Science Information Network (CIESIN). The Interactive Website for the 2012 EPI is at http://epi.yale.edu/.",
   accessConstraints: {
@@ -1664,7 +1922,28 @@ export const mockCollectionWithAssociatedVariables = {
   },
   associatedDois: null,
   associationDetails: {
-    variables: [{ conceptId: 'V100000_MMT' }]
+    variables: [
+      { conceptId: 'V100000_MMT' },
+      { conceptId: 'V100001_MMT' },
+      { conceptId: 'V100002_MMT' },
+      { conceptId: 'V100003_MMT' },
+      { conceptId: 'V100004_MMT' },
+      { conceptId: 'V100005_MMT' },
+      { conceptId: 'V100006_MMT' },
+      { conceptId: 'V100007_MMT' },
+      { conceptId: 'V100008_MMT' },
+      { conceptId: 'V100009_MMT' },
+      { conceptId: 'V100010_MMT' },
+      { conceptId: 'V100011_MMT' },
+      { conceptId: 'V100012_MMT' },
+      { conceptId: 'V100013_MMT' },
+      { conceptId: 'V100014_MMT' },
+      { conceptId: 'V100015_MMT' },
+      { conceptId: 'V100016_MMT' },
+      { conceptId: 'V100017_MMT' },
+      { conceptId: 'V100018_MMT' },
+      { conceptId: 'V100019_MMT' },
+      { conceptId: 'V100020_MMT' }]
   },
   citations: {
     count: 0,
@@ -3198,244 +3477,7 @@ export const mockCollectionWithAssociatedVariables = {
     description: 'Users are free to use, copy, distribute, transmit, and adapt the work for commercial and non-commercial purposes, without restriction, as long as clear attribution of the source is provided.'
   },
   userId: 'admin',
-  variables: {
-    count: 21,
-    cursor: '',
-    items: [
-      {
-        conceptId: 'V100000_MMT',
-        name: 'Variable_00',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100001_MMT',
-        name: 'Variable_01',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100002_MMT',
-        name: 'Variable_02',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100003_MMT',
-        name: 'Variable_03',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100004_MMT',
-        name: 'Variable_04',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100005_MMT',
-        name: 'Variable_05',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100006_MMT',
-        name: 'Variable_06',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100007_MMT',
-        name: 'Variable_07',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100008_MMT',
-        name: 'Variable_08',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100009_MMT',
-        name: 'Variable_09',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100010_MMT',
-        name: 'Variable_10',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100011_MMT',
-        name: 'Variable_11',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100012_MMT',
-        name: 'Variable_12',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100013_MMT',
-        name: 'Variable_13',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100014_MMT',
-        name: 'Variable_14',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100015_MMT',
-        name: 'Variable_15',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100016_MMT',
-        name: 'Variable_16',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100017_MMT',
-        name: 'Variable_17',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100018_MMT',
-        name: 'Variable_18',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100019_MMT',
-        name: 'Variable_19',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      },
-      {
-        conceptId: 'V100020_MMT',
-        name: 'Variable_20',
-        type: 'SCIENCE_VARIABLE',
-        __typename: 'Variable',
-        longName: 'long',
-        providerId: 'MMT',
-        revisionDate: null,
-        revisionId: 1,
-        userId: 1
-      }
-    ],
-    __typename: 'VariableList'
-  },
+  variables: mockVariableList,
   versionDescription: null,
   versionId: '2012.00',
   visualizations: {
@@ -3777,248 +3819,6 @@ export const mockVariableDraft = {
     __typename: 'Variable'
   },
   __typename: 'Draft'
-
-}
-
-export const mockVariableList = {
-  count: 21,
-  cursor: 'page-1-cursor',
-  items: [{
-    __typename: 'Variable',
-    conceptId: 'V100000_MMT',
-    name: 'Variable_00',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100001_MMT',
-    name: 'Variable_01',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100002_MMT',
-    name: 'Variable_02',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100003_MMT',
-    name: 'Variable_03',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100004_MMT',
-    name: 'Variable_04',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100005_MMT',
-    name: 'Variable_05',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100006_MMT',
-    name: 'Variable_06',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100007_MMT',
-    name: 'Variable_07',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100008_MMT',
-    name: 'Variable_08',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100009_MMT',
-    name: 'Variable_09',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100010_MMT',
-    name: 'Variable_10',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100011_MMT',
-    name: 'Variable_11',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100012_MMT',
-    name: 'Variable_12',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100013_MMT',
-    name: 'Variable_13',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100014_MMT',
-    name: 'Variable_14',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100015_MMT',
-    name: 'Variable_15',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100016_MMT',
-    name: 'Variable_16',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100017_MMT',
-    name: 'Variable_17',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100018_MMT',
-    name: 'Variable_18',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  },
-  {
-    __typename: 'Variable',
-    conceptId: 'V100019_MMT',
-    name: 'Variable_19',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  }]
-}
-
-export const mockVariableList2 = {
-  count: 21,
-  cursor: 'page-1-cursor',
-  items: [{
-    __typename: 'Variable',
-    conceptId: 'V100020_MMT',
-    name: 'Variable_20',
-    type: 'SCIENCE_VARIABLE',
-    longName: 'long',
-    providerId: 'MMT',
-    revisionDate: null,
-    revisionId: 1,
-    userId: 1
-  }]
 }
 
 export const mockVisualizationDraft = {

--- a/static/src/js/components/PublishPreview/__tests__/__mocks__/publishPreview.js
+++ b/static/src/js/components/PublishPreview/__tests__/__mocks__/publishPreview.js
@@ -38,6 +38,9 @@ export const publishCollectionRecord = {
   associatedDois: [{
     doi: 'TestDOI'
   }],
+  associationDetails: {
+    variables: [{}]
+  },
   collectionCitations: [{
     releaseDate: '2024-01-23T00:00:00.000Z',
     title: 'Testing',
@@ -401,7 +404,11 @@ export const publishCollectionRecord = {
   userId: 'admin',
   variables: null,
   versionDescription: 'Mock Test',
-  versionId: '1'
+  versionId: '1',
+  visualizations: {
+    count: 0,
+    items: []
+  }
 }
 
 export const noTagsOrGranulesOrServicesOrCitationsCollection = {
@@ -444,6 +451,9 @@ export const noTagsOrGranulesOrServicesOrCitationsCollection = {
   associatedDois: [{
     doi: 'TestDOI'
   }],
+  associationDetails: {
+    variables: [{}]
+  },
   citations: {
     __typename: 'CitationList',
     count: 0,
@@ -799,7 +809,11 @@ export const noTagsOrGranulesOrServicesOrCitationsCollection = {
   userId: 'admin',
   variables: null,
   versionDescription: 'Mock Test',
-  versionId: '1'
+  versionId: '1',
+  visualizations: {
+    count: 0,
+    items: []
+  }
 }
 
 export const publishedVariableRecord = {

--- a/static/src/js/operations/queries/getCollection.js
+++ b/static/src/js/operations/queries/getCollection.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export const GET_COLLECTION = gql`
-  query GetCollection ($params: CollectionInput, , $variableParams: VariablesInput) {
+  query GetCollection ($params: CollectionInput, $citationParams: CitationsInput, $serviceParams: ServicesInput, $variableParams: VariablesInput) {
     collection (params: $params) {
       abstract
       accessConstraints
@@ -10,7 +10,7 @@ export const GET_COLLECTION = gql`
       archiveAndDistributionInformation
       associationDetails
       associatedDois
-      citations {
+      citations (params: $citationParams) {
         count
         items {
           conceptId
@@ -85,7 +85,7 @@ export const GET_COLLECTION = gql`
         }
       }
       scienceKeywords
-      services {
+      services (params: $serviceParams) {
         count
         items {
           conceptId
@@ -134,6 +134,7 @@ export const GET_COLLECTION = gql`
         items {
           conceptId
           name
+          type: variableType
         }
       }
       versionDescription

--- a/static/src/js/operations/queries/getVariables.js
+++ b/static/src/js/operations/queries/getVariables.js
@@ -4,7 +4,6 @@ export const GET_VARIABLES = gql`
   query GetVariables($params: VariablesInput) {
     variables(params: $params) {
       count
-      cursor
       items {
         conceptId
         name

--- a/static/src/js/operations/queries/getVariables.js
+++ b/static/src/js/operations/queries/getVariables.js
@@ -4,9 +4,11 @@ export const GET_VARIABLES = gql`
   query GetVariables($params: VariablesInput) {
     variables(params: $params) {
       count
+      cursor
       items {
         conceptId
         name
+        type: variableType
         longName
         providerId
         revisionDate


### PR DESCRIPTION
# Overview

### What is the feature?

For a Collection Preview, check if we need to get more variables from CMR. Also adjust the limit for collections, services, and citations.

### What is the Solution?

Added extra calls to get more variables and adjusted some limits.

### What areas of the application does this impact?

Metadata preview in MMT

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

View the metadata preview in MMT for C1200462006-CMR_ONLY. Make sure you can see all the associations and page through them. Also view the service preview for S1200296179-EDF_DEV06. Make sure you can view the collection associations and page through them.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.
<img width="1707" height="1027" alt="Screenshot 2026-05-21 at 10 39 07 PM" src="https://github.com/user-attachments/assets/d31e3eda-f1c3-416e-a12f-dc09ce9bceb1" />
<img width="1720" height="960" alt="Screenshot 2026-05-21 at 10 39 54 PM" src="https://github.com/user-attachments/assets/5b20bb93-2340-4473-a3ea-ad061914ff41" />


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
