### PR TITLE
MMT-4185: Lock down create and delete templates via MMT API

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -24,6 +24,10 @@ const commands = [
     name: 'api'
   },
   {
+    command: 'npm run s3:start',
+    name: 's3'
+  },
+  {
     command: 'npm run start:proxy',
     name: 'proxy',
     skipInFast: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,18 +114,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@apollo/client": {
       "version": "3.8.5",
       "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.5.tgz",
@@ -2660,12 +2648,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -2674,30 +2662,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
-      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.10",
-        "@babel/helper-compilation-targets": "^7.26.5",
-        "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.10",
-        "@babel/types": "^7.26.10",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -2741,13 +2729,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -2779,13 +2767,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
-      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.26.5",
-        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -2884,9 +2872,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2904,27 +2892,27 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3019,27 +3007,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3059,25 +3047,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
-      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.10"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -4383,31 +4371,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -4415,13 +4403,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4553,9 +4541,9 @@
       }
     },
     "node_modules/@edsc/metadata-preview": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@edsc/metadata-preview/-/metadata-preview-1.5.10.tgz",
-      "integrity": "sha512-wDCTBlf4eu+t+dEhRS6mPP0aP5yN1TcZa81aFIgZ48y32lFqo+itONxwQX8D8qjStopwRGebmBpz9mPA4wA/rw==",
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/@edsc/metadata-preview/-/metadata-preview-1.5.11.tgz",
+      "integrity": "sha512-fOsnphIBHWrm1GYSj7bFjknP9s2P27sdRLR73GPPxw/FEKwBjaUyxQ6WOoUF9Sq6EfqO1Xwqh8CVLqq8YOOnQQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5591,9 +5579,10 @@
       "integrity": "sha512-aKmlCO57XFZ26wso4rJsW4oTUnrgTFw2jh3io7CAtO9w4UltBNwRXvXIVzzyfkaaLRo3nluP/19msA8vDUUuKw=="
     },
     "node_modules/@hapi/wreck": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.1.tgz",
-      "integrity": "sha512-OLHER70+rZxvDl75xq3xXOfd3e8XIvz8fWY0dqg92UvhZ29zo24vQgfqgHSYhB5ZiuFpSLeriOisAlxAo/1jWg==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.2.tgz",
+      "integrity": "sha512-3dMnV2pfhQiyEqu8DL3VBmxkdLiRDiiUDuG79Dp+UK1gL9ZxAfDOUhB6k3D5MLqcgJJ1IARyGFhwoc1NITr/pg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@hapi/bourne": "^3.0.0",
@@ -5746,6 +5735,16 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -6058,9 +6057,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -6730,9 +6729,10 @@
       "license": "MIT"
     },
     "node_modules/@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -6740,7 +6740,8 @@
     "node_modules/@sideway/address/node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sideway/formula": {
       "version": "3.0.1",
@@ -10918,9 +10919,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10932,7 +10933,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -11146,12 +11147,12 @@
       }
     },
     "node_modules/browserify-sign": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
-      "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+      "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
       "license": "ISC",
       "dependencies": {
-        "bn.js": "^5.2.2",
+        "bn.js": "^5.2.3",
         "browserify-rsa": "^4.1.1",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
@@ -14341,15 +14342,15 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -14368,7 +14369,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -14886,16 +14887,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -15422,9 +15423,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -16721,13 +16723,14 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
-      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
@@ -16751,9 +16754,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -20416,12 +20429,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -20920,12 +20934,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -20935,13 +20949,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -22174,9 +22188,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -22187,14 +22201,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -22206,13 +22220,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -24167,9 +24181,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -26142,9 +26156,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "http-proxy": "^1.18.1",
         "jsdom": "^22.1.0",
         "react-select-event": "^5.5.1",
+        "s3rver": "^3.7.1",
         "start-server-and-test": "^2.0.2",
         "stylelint": "^15.10.3",
         "stylelint-config-idiomatic-order": "^9.0.0",
@@ -4426,6 +4427,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.2.tgz",
@@ -4510,6 +4521,18 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.13"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@edsc/eslint-config": {
@@ -5763,6 +5786,68 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
+    },
+    "node_modules/@koa/router": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-9.4.0.tgz",
+      "integrity": "sha512-dOOXgzqaDoHu5qqMEPLKEgLz5CeIA7q8+1W62mCvFVCOqeC71UoTGJ4u1xUSOpIl2J1x2pqrNULkFteUeZW3/A==",
+      "deprecated": "**IMPORTANT 10x+ PERFORMANCE UPGRADE**: Please upgrade to v12.0.1+ as we have fixed an issue with debuglog causing 10x slower router benchmark performance, see https://github.com/koajs/router/pull/173",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "http-errors": "^1.7.3",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@koa/router/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@koa/router/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@koa/router/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@koa/router/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -8553,6 +8638,17 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -9246,6 +9342,13 @@
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
       "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "dev": true,
       "license": "MIT"
     },
@@ -10073,6 +10176,19 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/anymatch": {
@@ -11159,6 +11275,18 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="
     },
+    "node_modules/busboy": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "dev": true,
+      "dependencies": {
+        "dicer": "0.3.0"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -11176,6 +11304,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cache-content-type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^2.1.18",
+        "ylru": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/call-bind": {
@@ -11359,6 +11501,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -11535,6 +11692,94 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/colord": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -11570,6 +11815,16 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/commafy/-/commafy-0.0.6.tgz",
       "integrity": "sha512-6EWybT00JPy+RxA5hDLt/7n64vZZ9SeBnlXcnUeIZh4IgHO3z8CoXLmfS/l8H9KDvzyWe37MGCANv2Ou+Ub1Tw=="
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
@@ -11816,6 +12071,20 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/core-js": {
       "version": "3.33.0",
@@ -12420,6 +12689,13 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -12478,6 +12754,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dicer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "0.1.2"
+      },
+      "engines": {
+        "node": ">=4.5.0"
       }
     },
     "node_modules/diff": {
@@ -12759,6 +13047,13 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -13401,6 +13696,16 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/eslint": {
       "version": "8.57.1",
@@ -14236,6 +14541,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -14504,6 +14816,13 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -15019,6 +15338,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -15385,6 +15714,64 @@
       "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g==",
       "dev": true
     },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -15456,6 +15843,12 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/humanize-number": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/humanize-number/-/humanize-number-0.0.2.tgz",
+      "integrity": "sha512-un3ZAcNQGI7RzaWGZzQDH47HETM4Wrj6z6E4TId8Yeq9w5ZKUVB1nrT2jwFheTUjEmqcgTjXDc959jum+ai1kQ==",
+      "dev": true
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -16589,6 +16982,19 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
@@ -16610,6 +17016,122 @@
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.28.0.tgz",
       "integrity": "sha512-9pSL5XB4J+ifHP0e0jmmC98OGC1nL8/JjS+fi6mnTlIf//yt/MfVLtKg7S6nCtj/8KTcWX7nRlY0XywoYY1ISQ==",
       "dev": true
+    },
+    "node_modules/koa": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz",
+      "integrity": "sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.9.0",
+        "debug": "^4.3.2",
+        "delegates": "^1.0.0",
+        "depd": "^2.0.0",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^2.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/koa-convert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "co": "^4.6.0",
+        "koa-compose": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/koa-logger": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa-logger/-/koa-logger-3.2.1.tgz",
+      "integrity": "sha512-MjlznhLLKy9+kG8nAXKJLM0/ClsQp/Or2vI3a5rbSQmgl8IJBQO0KI5FA70BvW+hqjtxjp49SpH2E7okS6NmHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.0",
+        "chalk": "^2.4.2",
+        "humanize-number": "0.0.2",
+        "passthrough-counter": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 7.6.0"
+      }
+    },
+    "node_modules/koa/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -16846,6 +17368,24 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -18623,6 +19163,16 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -18637,6 +19187,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
+      "dev": true
     },
     "node_modules/optimism": {
       "version": "0.17.5",
@@ -18874,6 +19430,13 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/passthrough-counter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passthrough-counter/-/passthrough-counter-1.0.0.tgz",
+      "integrity": "sha512-Wy8PXTLqPAN0oEgBrlnsXPMww3SYJ44tQ8aVrGAI4h4JZYCS0oYqsPqtPR8OhJpv6qFbpbB7XAn0liKV7EXubA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
@@ -21129,6 +21692,97 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/s3rver": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/s3rver/-/s3rver-3.7.1.tgz",
+      "integrity": "sha512-H9KIX6n8NqcfoE4ziFNbQASBQfjcNJgb+3wbT9L5iotEqfOncFO1c38cfJSFSo7xXTu1zM9HA6t2u9xKNlYRaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@koa/router": "^9.0.0",
+        "busboy": "^0.3.1",
+        "commander": "^5.0.0",
+        "fast-xml-parser": "^3.12.19",
+        "fs-extra": "^8.0.0",
+        "he": "^1.2.0",
+        "koa": "^2.7.0",
+        "koa-logger": "^3.2.0",
+        "lodash": "^4.17.5",
+        "statuses": "^2.0.0",
+        "winston": "^3.0.0"
+      },
+      "bin": {
+        "s3rver": "bin/s3rver.js"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/s3rver/node_modules/fast-xml-parser": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.4"
+      },
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
+    "node_modules/s3rver/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/s3rver/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/s3rver/node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/s3rver/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -21203,6 +21857,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -21811,6 +22475,16 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility"
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -21902,6 +22576,15 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
         "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/string_decoder": {
@@ -22388,6 +23071,19 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/supports-hyperlinks": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
@@ -22624,6 +23320,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -22826,6 +23529,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -22874,6 +23587,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -25278,6 +26001,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -25564,6 +26325,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ylru": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
+      "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cmr:start_and_setup": "start-server-and-test cmr:start http-get://localhost:3003/collections.json cmr:setup",
     "cmr:stop": "node setup/stopCmr.js",
     "cmr:reset": "node setup/resetCmr.js",
+    "s3:start": "node setup/startS3.js",
     "deploy-infrastructure": "cd cdk/mmt-infrastructure && npm ci --include=dev && npm run cdk deploy -- --progress events --require-approval never",
     "deploy-application": "cd cdk/mmt && npm ci --include=dev && npm run cdk deploy -- --progress events --require-approval never",
     "deploy-static": "cd cdk/mmt-static && npm ci --include=dev && npm run cdk deploy -- --progress events --require-approval never"
@@ -110,6 +111,7 @@
     "http-proxy": "^1.18.1",
     "jsdom": "^22.1.0",
     "react-select-event": "^5.5.1",
+    "s3rver": "^3.7.1",
     "start-server-and-test": "^2.0.2",
     "stylelint": "^15.10.3",
     "stylelint-config-idiomatic-order": "^9.0.0",

--- a/serverless/src/createTemplate/__tests__/handler.test.js
+++ b/serverless/src/createTemplate/__tests__/handler.test.js
@@ -42,37 +42,6 @@ describe('createTemplate', () => {
     expect(response.statusCode).toBe(200)
   })
 
-  test('it requires TemplateName to be provided', async () => {
-    s3ClientMock.on(PutObjectCommand).resolves({
-      $metadata: {
-        httpStatusCode: 200,
-        requestId: undefined,
-        extendedRequestId: undefined,
-        cfId: undefined,
-        attempts: 1,
-        totalRetryDelay: 0
-      },
-      ETag: '"1a7e08244b933e4fea1f920da4988500"'
-    })
-
-    const event = {
-      headers: {
-        Authorization: 'Bearer ABC-1'
-      },
-      body: JSON.stringify({
-        TemplateDescription: 'Test Template',
-        mock: 'Template Body'
-      }),
-      pathParameters: {
-        providerId: 'MMT_1'
-      }
-    }
-
-    const response = await createTemplate(event)
-
-    expect(response.statusCode).toBe(400)
-  })
-
   describe('when you do not have authorization to create', () => {
     test('returns a status code 401', async () => {
       const event = {

--- a/serverless/src/createTemplate/__tests__/handler.test.js
+++ b/serverless/src/createTemplate/__tests__/handler.test.js
@@ -62,4 +62,25 @@ describe('createTemplate', () => {
       expect(response.statusCode).toBe(401)
     })
   })
+
+  describe('when fetching providers throws an error', () => {
+    test('returns a status code 500', async () => {
+      const event = {
+        headers: {
+          Authorization: 'Bearer invalid_token'
+        },
+        body: JSON.stringify({
+          TemplateName: 'Test Template',
+          mock: 'Template Body'
+        }),
+        pathParameters: {
+          providerId: 'MMT_1'
+        }
+      }
+
+      const response = await createTemplate(event)
+
+      expect(response.statusCode).toBe(500)
+    })
+  })
 })

--- a/serverless/src/createTemplate/__tests__/handler.test.js
+++ b/serverless/src/createTemplate/__tests__/handler.test.js
@@ -25,17 +25,72 @@ describe('createTemplate', () => {
     })
 
     const event = {
+      headers: {
+        Authorization: 'Bearer ABC-1'
+      },
       body: JSON.stringify({
         TemplateName: 'Test Template',
         mock: 'Template Body'
       }),
       pathParameters: {
-        providerId: 'MMT-1'
+        providerId: 'MMT_1'
       }
     }
 
     const response = await createTemplate(event)
 
     expect(response.statusCode).toBe(200)
+  })
+
+  test('it requires TemplateName to be provided', async () => {
+    s3ClientMock.on(PutObjectCommand).resolves({
+      $metadata: {
+        httpStatusCode: 200,
+        requestId: undefined,
+        extendedRequestId: undefined,
+        cfId: undefined,
+        attempts: 1,
+        totalRetryDelay: 0
+      },
+      ETag: '"1a7e08244b933e4fea1f920da4988500"'
+    })
+
+    const event = {
+      headers: {
+        Authorization: 'Bearer ABC-1'
+      },
+      body: JSON.stringify({
+        TemplateDescription: 'Test Template',
+        mock: 'Template Body'
+      }),
+      pathParameters: {
+        providerId: 'MMT_1'
+      }
+    }
+
+    const response = await createTemplate(event)
+
+    expect(response.statusCode).toBe(400)
+  })
+
+  describe('when you do not have authorization to create', () => {
+    test('returns a status code 401', async () => {
+      const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
+        body: JSON.stringify({
+          TemplateName: 'Test Template',
+          mock: 'Template Body'
+        }),
+        pathParameters: {
+          providerId: 'MMT_3'
+        }
+      }
+
+      const response = await createTemplate(event)
+
+      expect(response.statusCode).toBe(401)
+    })
   })
 })

--- a/serverless/src/createTemplate/handler.js
+++ b/serverless/src/createTemplate/handler.js
@@ -34,17 +34,6 @@ const createTemplate = async (event) => {
   }
 
   const { TemplateName: templateName } = JSON.parse(body)
-
-  if (!templateName) {
-    console.error('Missing TemplateName in createTemplate request')
-
-    return {
-      statusCode: 400,
-      headers: defaultResponseHeaders,
-      body: JSON.stringify({ error: 'TemplateName is required' })
-    }
-  }
-
   const hashedName = Buffer.from(templateName).toString('base64')
   const guid = uuidv4()
 

--- a/serverless/src/createTemplate/handler.js
+++ b/serverless/src/createTemplate/handler.js
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { getApplicationConfig } from '../../../sharedUtils/getConfig'
 import { getS3Client } from '../utils/getS3Client'
+import fetchProviders from '../utils/fetchProviders'
 
 let s3Client
 
@@ -20,6 +21,15 @@ const createTemplate = async (event) => {
   const { body, pathParameters } = event
   const { providerId } = pathParameters
   const { TemplateName: templateName } = JSON.parse(body)
+
+  const providerIds = await fetchProviders(event)
+
+  if (!providerIds.includes(providerId)) {
+    return {
+      statusCode: 401,
+      headers: defaultResponseHeaders
+    }
+  }
 
   const hashedName = Buffer.from(templateName).toString('base64')
   const guid = uuidv4()

--- a/serverless/src/createTemplate/handler.js
+++ b/serverless/src/createTemplate/handler.js
@@ -22,13 +22,22 @@ const createTemplate = async (event) => {
   const { body, pathParameters } = event
   const { providerId } = pathParameters
 
-  const providerIds = await fetchProviders(event)
+  try {
+    const providerIds = await fetchProviders(event)
 
-  if (!providerIds.includes(providerId)) {
-    console.error(`Missing permissions for provider "${providerId}"`)
+    if (!providerIds.includes(providerId)) {
+      console.error(`Missing permissions for provider "${providerId}"`)
+
+      return {
+        statusCode: 401,
+        headers: defaultResponseHeaders
+      }
+    }
+  } catch (error) {
+    console.log('Error fetching providers:', error)
 
     return {
-      statusCode: 401,
+      statusCode: 500,
       headers: defaultResponseHeaders
     }
   }

--- a/serverless/src/createTemplate/handler.js
+++ b/serverless/src/createTemplate/handler.js
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { getApplicationConfig } from '../../../sharedUtils/getConfig'
 import { getS3Client } from '../utils/getS3Client'
+import { getCollectionTemplatesBucketName } from '../utils/getCollectionTemplatesBucketName'
 import fetchProviders from '../utils/fetchProviders'
 
 let s3Client
@@ -20,21 +21,34 @@ const createTemplate = async (event) => {
 
   const { body, pathParameters } = event
   const { providerId } = pathParameters
-  const { TemplateName: templateName } = JSON.parse(body)
 
   const providerIds = await fetchProviders(event)
 
   if (!providerIds.includes(providerId)) {
+    console.error(`Missing permissions for provider "${providerId}"`)
+
     return {
       statusCode: 401,
       headers: defaultResponseHeaders
     }
   }
 
+  const { TemplateName: templateName } = JSON.parse(body)
+
+  if (!templateName) {
+    console.error('Missing TemplateName in createTemplate request')
+
+    return {
+      statusCode: 400,
+      headers: defaultResponseHeaders,
+      body: JSON.stringify({ error: 'TemplateName is required' })
+    }
+  }
+
   const hashedName = Buffer.from(templateName).toString('base64')
   const guid = uuidv4()
 
-  const { COLLECTION_TEMPLATES_BUCKET_NAME: collectionTemplatesBucketName } = process.env
+  const collectionTemplatesBucketName = getCollectionTemplatesBucketName()
   const createCommand = new PutObjectCommand({
     Bucket: collectionTemplatesBucketName,
     Body: body,

--- a/serverless/src/deleteTemplate/__tests__/handler.test.js
+++ b/serverless/src/deleteTemplate/__tests__/handler.test.js
@@ -92,4 +92,25 @@ describe('deleteTemplate', () => {
       expect(listObjectsMock).toHaveBeenCalledTimes(0)
     })
   })
+
+  describe('when fetching providers throws an error', () => {
+    test('returns a status code 500', async () => {
+      const event = {
+        headers: {
+          Authorization: 'Bearer invalid_token'
+        },
+        body: JSON.stringify({
+          TemplateName: 'Test Template',
+          mock: 'Template Body'
+        }),
+        pathParameters: {
+          providerId: 'MMT_1'
+        }
+      }
+
+      const response = await deleteTemplate(event)
+
+      expect(response.statusCode).toBe(500)
+    })
+  })
 })

--- a/serverless/src/deleteTemplate/__tests__/handler.test.js
+++ b/serverless/src/deleteTemplate/__tests__/handler.test.js
@@ -30,9 +30,12 @@ describe('deleteTemplate', () => {
       })
 
       const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
         pathParameters: {
           id: 'mock-id',
-          providerId: 'MMT-1'
+          providerId: 'MMT_1'
         }
       }
 
@@ -41,7 +44,7 @@ describe('deleteTemplate', () => {
       expect(response.statusCode).toBe(200)
 
       expect(listObjectsMock).toHaveBeenCalledTimes(1)
-      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT-1/mock-id')
+      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT_1/mock-id')
     })
   })
 
@@ -50,9 +53,12 @@ describe('deleteTemplate', () => {
       const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects').mockResolvedValue([])
 
       const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
         pathParameters: {
           id: 'mock-id',
-          providerId: 'MMT-1'
+          providerId: 'MMT_1'
         }
       }
 
@@ -61,7 +67,29 @@ describe('deleteTemplate', () => {
       expect(response.statusCode).toBe(404)
 
       expect(listObjectsMock).toHaveBeenCalledTimes(1)
-      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT-1/mock-id')
+      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT_1/mock-id')
+    })
+  })
+
+  describe('when you do not have authorization to delete', () => {
+    test('returns a status code 401', async () => {
+      const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects').mockResolvedValue([])
+
+      const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
+        pathParameters: {
+          id: 'mock-id',
+          providerId: 'MMT_3'
+        }
+      }
+
+      const response = await deleteTemplate(event)
+
+      expect(response.statusCode).toBe(401)
+
+      expect(listObjectsMock).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/serverless/src/deleteTemplate/handler.js
+++ b/serverless/src/deleteTemplate/handler.js
@@ -41,8 +41,6 @@ const deleteTemplate = async (event) => {
   if (object) {
     const { Key: key } = object
 
-    console.log(`delete object key:${key}`)
-
     // Delete the file
     const deleteCommand = new DeleteObjectCommand({
       Bucket: collectionTemplatesBucketName,

--- a/serverless/src/deleteTemplate/handler.js
+++ b/serverless/src/deleteTemplate/handler.js
@@ -24,13 +24,22 @@ const deleteTemplate = async (event) => {
   const { pathParameters } = event
   const { id, providerId } = pathParameters
 
-  const providerIds = await fetchProviders(event)
+  try {
+    const providerIds = await fetchProviders(event)
 
-  if (!providerIds.includes(providerId)) {
-    console.error(`Missing permissions for provider "${providerId}"`)
+    if (!providerIds.includes(providerId)) {
+      console.error(`Missing permissions for provider "${providerId}"`)
+
+      return {
+        statusCode: 401,
+        headers: defaultResponseHeaders
+      }
+    }
+  } catch (error) {
+    console.log('Error fetching providers:', error)
 
     return {
-      statusCode: 401,
+      statusCode: 500,
       headers: defaultResponseHeaders
     }
   }

--- a/serverless/src/deleteTemplate/handler.js
+++ b/serverless/src/deleteTemplate/handler.js
@@ -2,6 +2,7 @@ import { DeleteObjectCommand } from '@aws-sdk/client-s3'
 
 import { getApplicationConfig } from '../../../sharedUtils/getConfig'
 import { getS3Client } from '../utils/getS3Client'
+import { getCollectionTemplatesBucketName } from '../utils/getCollectionTemplatesBucketName'
 import { s3ListObjects } from '../utils/s3ListObjects'
 import fetchProviders from '../utils/fetchProviders'
 
@@ -14,7 +15,7 @@ let s3Client
 const deleteTemplate = async (event) => {
   const { defaultResponseHeaders } = getApplicationConfig()
 
-  const { COLLECTION_TEMPLATES_BUCKET_NAME: collectionTemplatesBucketName } = process.env
+  const collectionTemplatesBucketName = getCollectionTemplatesBucketName()
 
   if (s3Client == null) {
     s3Client = getS3Client()
@@ -26,6 +27,8 @@ const deleteTemplate = async (event) => {
   const providerIds = await fetchProviders(event)
 
   if (!providerIds.includes(providerId)) {
+    console.error(`Missing permissions for provider "${providerId}"`)
+
     return {
       statusCode: 401,
       headers: defaultResponseHeaders

--- a/serverless/src/deleteTemplate/handler.js
+++ b/serverless/src/deleteTemplate/handler.js
@@ -3,6 +3,7 @@ import { DeleteObjectCommand } from '@aws-sdk/client-s3'
 import { getApplicationConfig } from '../../../sharedUtils/getConfig'
 import { getS3Client } from '../utils/getS3Client'
 import { s3ListObjects } from '../utils/s3ListObjects'
+import fetchProviders from '../utils/fetchProviders'
 
 let s3Client
 
@@ -12,6 +13,7 @@ let s3Client
  */
 const deleteTemplate = async (event) => {
   const { defaultResponseHeaders } = getApplicationConfig()
+
   const { COLLECTION_TEMPLATES_BUCKET_NAME: collectionTemplatesBucketName } = process.env
 
   if (s3Client == null) {
@@ -21,6 +23,15 @@ const deleteTemplate = async (event) => {
   const { pathParameters } = event
   const { id, providerId } = pathParameters
 
+  const providerIds = await fetchProviders(event)
+
+  if (!providerIds.includes(providerId)) {
+    return {
+      statusCode: 401,
+      headers: defaultResponseHeaders
+    }
+  }
+
   // Find an existing file with the same `id`
   const prefix = `${providerId}/${id}`
   const objectList = await s3ListObjects(s3Client, prefix)
@@ -29,6 +40,8 @@ const deleteTemplate = async (event) => {
   let statusCode = 404
   if (object) {
     const { Key: key } = object
+
+    console.log(`delete object key:${key}`)
 
     // Delete the file
     const deleteCommand = new DeleteObjectCommand({

--- a/serverless/src/getTemplate/__tests__/handler.test.js
+++ b/serverless/src/getTemplate/__tests__/handler.test.js
@@ -15,7 +15,7 @@ describe('getTemplate', () => {
   describe('when the object is found', () => {
     test('returns the template from s3', async () => {
       const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects').mockResolvedValue([{
-        Key: 'MMT-1/mock-id'
+        Key: 'MMT_1/mock-id'
       }])
 
       const mockBody = new Blob([JSON.stringify({ Mock: 'Template' })])
@@ -34,21 +34,26 @@ describe('getTemplate', () => {
       })
 
       const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
         pathParameters: {
-          id: 'mock-id'
+          id: 'mock-id',
+          providerId: 'MMT_1'
         }
       }
 
       const response = await getTemplate(event)
-      const result = JSON.parse(response.body)
 
       expect(response.statusCode).toBe(200)
+
+      const result = JSON.parse(response.body)
 
       expect(result.template).toEqual(expect.objectContaining({
         Mock: 'Template'
       }))
 
-      expect(result.providerId).toEqual('MMT-1')
+      expect(result.providerId).toEqual('MMT_1')
 
       expect(listObjectsMock).toHaveBeenCalledTimes(1)
       expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object))
@@ -75,6 +80,29 @@ describe('getTemplate', () => {
 
       expect(consoleMock).toHaveBeenCalledTimes(1)
       expect(consoleMock).toHaveBeenCalledWith('getTemplate Error:', expect.any(Object))
+    })
+  })
+
+  describe('when you do not have authorization to get', () => {
+    test('returns a status code 401', async () => {
+      const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects').mockResolvedValue([{
+        Key: 'MMT_3/mock-id'
+      }])
+
+      const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
+        pathParameters: {
+          id: 'mock-id'
+        }
+      }
+
+      const response = await getTemplate(event)
+
+      expect(response.statusCode).toBe(401)
+
+      expect(listObjectsMock).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/serverless/src/getTemplate/handler.js
+++ b/serverless/src/getTemplate/handler.js
@@ -3,6 +3,7 @@ import { GetObjectCommand } from '@aws-sdk/client-s3'
 import { getApplicationConfig } from '../../../sharedUtils/getConfig'
 import { s3ListObjects } from '../utils/s3ListObjects'
 import { getS3Client } from '../utils/getS3Client'
+import { getCollectionTemplatesBucketName } from '../utils/getCollectionTemplatesBucketName'
 import fetchProviders from '../utils/fetchProviders'
 
 let s3Client
@@ -42,19 +43,20 @@ const getTemplate = async (event) => {
     })
 
     const providerIds = await fetchProviders(event)
-    console.log(`providerIds: ${providerIds}`)
 
     if (!providerIds.includes(providerId)) {
+      console.error(`Missing permissions for provider "${providerId}"`)
+
       return {
         statusCode: 401,
         headers: defaultResponseHeaders
       }
     }
 
-    const { Key: key } = object
+    const key = object.Key
 
     // Retrieve the file from S3
-    const { COLLECTION_TEMPLATES_BUCKET_NAME: collectionTemplatesBucketName } = process.env
+    const collectionTemplatesBucketName = getCollectionTemplatesBucketName()
     const getCommand = new GetObjectCommand({
       Bucket: collectionTemplatesBucketName,
       Key: key

--- a/serverless/src/getTemplate/handler.js
+++ b/serverless/src/getTemplate/handler.js
@@ -3,6 +3,7 @@ import { GetObjectCommand } from '@aws-sdk/client-s3'
 import { getApplicationConfig } from '../../../sharedUtils/getConfig'
 import { s3ListObjects } from '../utils/s3ListObjects'
 import { getS3Client } from '../utils/getS3Client'
+import fetchProviders from '../utils/fetchProviders'
 
 let s3Client
 
@@ -39,6 +40,15 @@ const getTemplate = async (event) => {
 
       return false
     })
+
+    const providerIds = await fetchProviders(event)
+
+    if (!providerIds.includes(providerId)) {
+      return {
+        statusCode: 401,
+        headers: defaultResponseHeaders
+      }
+    }
 
     const { Key: key } = object
 

--- a/serverless/src/getTemplate/handler.js
+++ b/serverless/src/getTemplate/handler.js
@@ -12,6 +12,8 @@ let s3Client
  * @param {Object} event Details about the HTTP request that it received
  */
 const getTemplate = async (event) => {
+  console.log('Calling getTemplate')
+
   const { defaultResponseHeaders } = getApplicationConfig()
 
   if (s3Client == null) {
@@ -42,6 +44,7 @@ const getTemplate = async (event) => {
     })
 
     const providerIds = await fetchProviders(event)
+    console.log(`providerIds: ${providerIds}`)
 
     if (!providerIds.includes(providerId)) {
       return {

--- a/serverless/src/getTemplate/handler.js
+++ b/serverless/src/getTemplate/handler.js
@@ -12,8 +12,6 @@ let s3Client
  * @param {Object} event Details about the HTTP request that it received
  */
 const getTemplate = async (event) => {
-  console.log('Calling getTemplate')
-
   const { defaultResponseHeaders } = getApplicationConfig()
 
   if (s3Client == null) {

--- a/serverless/src/getTemplate/handler.js
+++ b/serverless/src/getTemplate/handler.js
@@ -42,6 +42,8 @@ const getTemplate = async (event) => {
       return false
     })
 
+    const key = object.Key
+
     const providerIds = await fetchProviders(event)
 
     if (!providerIds.includes(providerId)) {
@@ -52,8 +54,6 @@ const getTemplate = async (event) => {
         headers: defaultResponseHeaders
       }
     }
-
-    const key = object.Key
 
     // Retrieve the file from S3
     const collectionTemplatesBucketName = getCollectionTemplatesBucketName()

--- a/serverless/src/getTemplates/__tests__/handler.test.js
+++ b/serverless/src/getTemplates/__tests__/handler.test.js
@@ -15,10 +15,10 @@ describe('getTemplates', () => {
   describe('when the objects are found', () => {
     test('returns the template names from s3', async () => {
       const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects').mockResolvedValue([{
-        Key: 'MMT-1/34a25a4d-da4e-4ffd-b374-beae7978f689/VGVzdCBUZW1wbGF0ZSAy',
+        Key: 'MMT_1/34a25a4d-da4e-4ffd-b374-beae7978f689/VGVzdCBUZW1wbGF0ZSAy',
         LastModified: '2024-04-01T19:18:11.000Z'
       }, {
-        Key: 'MMT-1/460bfd33-cad3-46f8-9eee-47664f98038c/VGVzdCBUZW1wbGF0ZSAx',
+        Key: 'MMT_1/460bfd33-cad3-46f8-9eee-47664f98038c/VGVzdCBUZW1wbGF0ZSAx',
         LastModified: '2024-04-02T19:18:11.000Z'
       }])
 
@@ -38,9 +38,12 @@ describe('getTemplates', () => {
       })
 
       const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
         pathParameters: {
           id: 'mock-id',
-          providerId: 'MMT-1'
+          providerId: 'MMT_1'
         }
       }
 
@@ -52,14 +55,14 @@ describe('getTemplates', () => {
         id: '460bfd33-cad3-46f8-9eee-47664f98038c',
         name: 'Test Template 1',
         lastModified: '2024-04-02T19:18:11.000Z',
-        providerId: 'MMT-1'
+        providerId: 'MMT_1'
       }))
 
       expect(JSON.parse(response.body)[1]).toEqual(expect.objectContaining({
         id: '34a25a4d-da4e-4ffd-b374-beae7978f689',
         name: 'Test Template 2',
         lastModified: '2024-04-01T19:18:11.000Z',
-        providerId: 'MMT-1'
+        providerId: 'MMT_1'
       }))
 
       expect(listObjectsMock).toHaveBeenCalledTimes(1)
@@ -72,8 +75,11 @@ describe('getTemplates', () => {
       const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects').mockResolvedValue([])
 
       const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
         pathParameters: {
-          providerId: 'MMT-1'
+          providerId: 'MMT_1'
         }
       }
 
@@ -87,15 +93,37 @@ describe('getTemplates', () => {
     })
   })
 
-  describe('when running in offline mode', () => {
-    test('returns an empty array without making a fetch request to S3', async () => {
-      process.env.IS_OFFLINE = 'true'
+  describe('when you do not have authorization to get', () => {
+    test('returns an empty array', async () => {
+      const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects').mockResolvedValue([{
+        Key: 'MMT_3/34a25a4d-da4e-4ffd-b374-beae7978f689/VGVzdCBUZW1wbGF0ZSAy',
+        LastModified: '2024-04-01T19:18:11.000Z'
+      }, {
+        Key: 'MMT_3/460bfd33-cad3-46f8-9eee-47664f98038c/VGVzdCBUZW1wbGF0ZSAx',
+        LastModified: '2024-04-02T19:18:11.000Z'
+      }])
 
-      const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects')
+      const mockBody = new Blob([JSON.stringify({ Mock: 'Template' })])
+      const body = sdkStreamMixin(mockBody)
+
+      s3ClientMock.on(GetObjectCommand).resolves({
+        $metadata: {
+          httpStatusCode: 200,
+          requestId: undefined,
+          extendedRequestId: undefined,
+          cfId: undefined,
+          attempts: 1,
+          totalRetryDelay: 0
+        },
+        Body: body
+      })
 
       const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
         pathParameters: {
-          providerId: 'MMT-1'
+          id: 'mock-id'
         }
       }
 
@@ -104,7 +132,30 @@ describe('getTemplates', () => {
       expect(response.statusCode).toBe(200)
       expect(response.body).toBe(JSON.stringify([]))
 
-      expect(listObjectsMock).not.toHaveBeenCalled()
+      expect(listObjectsMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when there is an error', () => {
+    test('returns 404', async () => {
+      const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects').mockResolvedValue([{
+        Key: 'MMT_3/mock-id' // Incomplete mock
+      }])
+
+      const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
+        pathParameters: {
+          id: 'mock-id'
+        }
+      }
+
+      const response = await getTemplates(event)
+
+      expect(response.statusCode).toBe(404)
+
+      expect(listObjectsMock).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/serverless/src/getTemplates/handler.js
+++ b/serverless/src/getTemplates/handler.js
@@ -11,7 +11,6 @@ let s3Client
  */
 const getTemplates = async (event) => {
   const { defaultResponseHeaders } = getApplicationConfig()
-  console.log('🚀 ~ file: handler.js:14 ~ defaultResponseHeaders:', defaultResponseHeaders)
 
   if (s3Client == null) {
     s3Client = getS3Client()

--- a/serverless/src/getTemplates/handler.js
+++ b/serverless/src/getTemplates/handler.js
@@ -10,6 +10,8 @@ let s3Client
  * @param {Object} event Details about the HTTP request that it received
  */
 const getTemplates = async (event) => {
+  console.log('Calling getTemplates')
+
   const { defaultResponseHeaders } = getApplicationConfig()
 
   if (s3Client == null) {
@@ -29,6 +31,7 @@ const getTemplates = async (event) => {
     const objectList = await s3ListObjects(s3Client)
 
     const providerIds = await fetchProviders(event)
+    console.log(`providerIds: ${providerIds}`)
 
     const body = objectList.map((object) => {
       const [providerId, guid, hashedName] = object.Key.split('/')

--- a/serverless/src/getTemplates/handler.js
+++ b/serverless/src/getTemplates/handler.js
@@ -16,9 +16,8 @@ const getTemplates = async (event) => {
     s3Client = getS3Client()
   }
 
-  const providerIds = await fetchProviders(event)
-
   try {
+    const providerIds = await fetchProviders(event)
     const objectList = await s3ListObjects(s3Client)
 
     const body = objectList.map((object) => {

--- a/serverless/src/getTemplates/handler.js
+++ b/serverless/src/getTemplates/handler.js
@@ -10,8 +10,6 @@ let s3Client
  * @param {Object} event Details about the HTTP request that it received
  */
 const getTemplates = async (event) => {
-  console.log('Calling getTemplates')
-
   const { defaultResponseHeaders } = getApplicationConfig()
 
   if (s3Client == null) {

--- a/serverless/src/getTemplates/handler.js
+++ b/serverless/src/getTemplates/handler.js
@@ -1,6 +1,7 @@
 import { getApplicationConfig } from '../../../sharedUtils/getConfig'
 import { s3ListObjects } from '../utils/s3ListObjects'
 import { getS3Client } from '../utils/getS3Client'
+import fetchProviders from '../utils/fetchProviders'
 
 let s3Client
 
@@ -8,7 +9,7 @@ let s3Client
  * Retrieve a list of templates from S3
  * @param {Object} event Details about the HTTP request that it received
  */
-const getTemplates = async () => {
+const getTemplates = async (event) => {
   const { defaultResponseHeaders } = getApplicationConfig()
 
   if (s3Client == null) {
@@ -27,6 +28,8 @@ const getTemplates = async () => {
   try {
     const objectList = await s3ListObjects(s3Client)
 
+    const providerIds = await fetchProviders(event)
+
     const body = objectList.map((object) => {
       const [providerId, guid, hashedName] = object.Key.split('/')
 
@@ -38,7 +41,7 @@ const getTemplates = async () => {
         name,
         providerId
       }
-    })
+    }).filter((object) => providerIds.includes(object.providerId))
 
     const sortedBody = body.sort((a, b) => {
       const nameA = a.name.toUpperCase()

--- a/serverless/src/getTemplates/handler.js
+++ b/serverless/src/getTemplates/handler.js
@@ -11,25 +11,16 @@ let s3Client
  */
 const getTemplates = async (event) => {
   const { defaultResponseHeaders } = getApplicationConfig()
+  console.log('🚀 ~ file: handler.js:14 ~ defaultResponseHeaders:', defaultResponseHeaders)
 
   if (s3Client == null) {
     s3Client = getS3Client()
   }
 
-  // If we're running offline, return an empty array without making a fetch request to S3
-  if (process.env.IS_OFFLINE) {
-    return {
-      body: JSON.stringify([]),
-      statusCode: 200,
-      headers: defaultResponseHeaders
-    }
-  }
+  const providerIds = await fetchProviders(event)
 
   try {
     const objectList = await s3ListObjects(s3Client)
-
-    const providerIds = await fetchProviders(event)
-    console.log(`providerIds: ${providerIds}`)
 
     const body = objectList.map((object) => {
       const [providerId, guid, hashedName] = object.Key.split('/')

--- a/serverless/src/updateTemplate/__tests__/handler.test.js
+++ b/serverless/src/updateTemplate/__tests__/handler.test.js
@@ -159,4 +159,25 @@ describe('updateTemplate', () => {
       expect(response.statusCode).toBe(401)
     })
   })
+
+  describe('when fetching providers throws an error', () => {
+    test('returns a status code 500', async () => {
+      const event = {
+        headers: {
+          Authorization: 'Bearer test'
+        },
+        body: JSON.stringify({
+          TemplateName: 'Test Template',
+          mock: 'Template Body'
+        }),
+        pathParameters: {
+          providerId: 'MMT_1'
+        }
+      }
+
+      const response = await updateTemplate(event)
+
+      expect(response.statusCode).toBe(500)
+    })
+  })
 })

--- a/serverless/src/updateTemplate/__tests__/handler.test.js
+++ b/serverless/src/updateTemplate/__tests__/handler.test.js
@@ -19,7 +19,7 @@ describe('updateTemplate', () => {
   describe('when the object is found', () => {
     test('updates the template in s3', async () => {
       const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects').mockResolvedValue([{
-        Key: 'MMT-1/34a25a4d-da4e-4ffd-b374-beae7978f689/VGVzdCBUZW1wbGF0ZQ==',
+        Key: 'MMT_1/34a25a4d-da4e-4ffd-b374-beae7978f689/VGVzdCBUZW1wbGF0ZQ==',
         LastModified: '2024-04-01T19:18:11.000Z'
       }])
 
@@ -39,13 +39,16 @@ describe('updateTemplate', () => {
       })
 
       const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
         body: JSON.stringify({
           TemplateName: 'Test Template',
           mock: 'Template Body'
         }),
         pathParameters: {
           id: 'mock-id',
-          providerId: 'MMT-1'
+          providerId: 'MMT_1'
         }
       }
 
@@ -54,14 +57,14 @@ describe('updateTemplate', () => {
       expect(response.statusCode).toBe(200)
 
       expect(listObjectsMock).toHaveBeenCalledTimes(1)
-      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT-1/mock-id')
+      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT_1/mock-id')
     })
   })
 
   describe('when the template name is changed', () => {
     test('creates a new template and deletes the old template', async () => {
       const listObjectsMock = vi.spyOn(s3ListObjects, 's3ListObjects').mockResolvedValue([{
-        Key: 'MMT-1/34a25a4d-da4e-4ffd-b374-beae7978f689/VGVzdCBUZW1wbGF0ZQ==',
+        Key: 'MMT_1/34a25a4d-da4e-4ffd-b374-beae7978f689/VGVzdCBUZW1wbGF0ZQ==',
         LastModified: '2024-04-01T19:18:11.000Z'
       }])
 
@@ -83,13 +86,16 @@ describe('updateTemplate', () => {
       s3ClientMock.on(DeleteObjectCommand).resolves()
 
       const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
         body: JSON.stringify({
           TemplateName: 'Updated Test Template',
           mock: 'Template Body'
         }),
         pathParameters: {
           id: 'mock-id',
-          providerId: 'MMT-1'
+          providerId: 'MMT_1'
         }
       }
 
@@ -98,7 +104,7 @@ describe('updateTemplate', () => {
       expect(response.statusCode).toBe(200)
 
       expect(listObjectsMock).toHaveBeenCalledTimes(1)
-      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT-1/mock-id')
+      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT_1/mock-id')
     })
   })
 
@@ -108,13 +114,16 @@ describe('updateTemplate', () => {
       const consoleMock = vi.spyOn(console, 'log').mockImplementation(() => {})
 
       const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
         body: JSON.stringify({
           TemplateName: 'Test Template',
           mock: 'Template Body'
         }),
         pathParameters: {
           id: 'mock-id',
-          providerId: 'MMT-1'
+          providerId: 'MMT_1'
         }
       }
 
@@ -123,10 +132,31 @@ describe('updateTemplate', () => {
       expect(response.statusCode).toBe(404)
 
       expect(listObjectsMock).toHaveBeenCalledTimes(1)
-      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT-1/mock-id')
+      expect(listObjectsMock).toHaveBeenCalledWith(expect.any(Object), 'MMT_1/mock-id')
 
       expect(consoleMock).toHaveBeenCalledTimes(1)
       expect(consoleMock).toHaveBeenCalledWith('updateTemplate Error:', expect.any(Object))
+    })
+  })
+
+  describe('when you do not have authorization to update', () => {
+    test('returns a status code 401', async () => {
+      const event = {
+        headers: {
+          Authorization: 'Bearer ABC-1'
+        },
+        body: JSON.stringify({
+          TemplateName: 'Test Template',
+          mock: 'Template Body'
+        }),
+        pathParameters: {
+          providerId: 'MMT_3'
+        }
+      }
+
+      const response = await updateTemplate(event)
+
+      expect(response.statusCode).toBe(401)
     })
   })
 })

--- a/serverless/src/updateTemplate/handler.js
+++ b/serverless/src/updateTemplate/handler.js
@@ -3,6 +3,7 @@ import { DeleteObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3'
 import { getApplicationConfig } from '../../../sharedUtils/getConfig'
 import { getS3Client } from '../utils/getS3Client'
 import { s3ListObjects } from '../utils/s3ListObjects'
+import fetchProviders from '../utils/fetchProviders'
 
 let s3Client
 
@@ -20,6 +21,16 @@ const updateTemplate = async (event) => {
 
   const { body, pathParameters } = event
   const { id, providerId } = pathParameters
+
+  const providerIds = await fetchProviders(event)
+
+  if (!providerIds.includes(providerId)) {
+    return {
+      statusCode: 401,
+      headers: defaultResponseHeaders
+    }
+  }
+
   const { TemplateName: templateName } = JSON.parse(body)
   const hashedName = Buffer.from(templateName).toString('base64')
 

--- a/serverless/src/updateTemplate/handler.js
+++ b/serverless/src/updateTemplate/handler.js
@@ -2,6 +2,7 @@ import { DeleteObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3'
 
 import { getApplicationConfig } from '../../../sharedUtils/getConfig'
 import { getS3Client } from '../utils/getS3Client'
+import { getCollectionTemplatesBucketName } from '../utils/getCollectionTemplatesBucketName'
 import { s3ListObjects } from '../utils/s3ListObjects'
 import fetchProviders from '../utils/fetchProviders'
 
@@ -13,7 +14,7 @@ let s3Client
  */
 const updateTemplate = async (event) => {
   const { defaultResponseHeaders } = getApplicationConfig()
-  const { COLLECTION_TEMPLATES_BUCKET_NAME: collectionTemplatesBucketName } = process.env
+  const collectionTemplatesBucketName = getCollectionTemplatesBucketName()
 
   if (s3Client == null) {
     s3Client = getS3Client()
@@ -25,6 +26,8 @@ const updateTemplate = async (event) => {
   const providerIds = await fetchProviders(event)
 
   if (!providerIds.includes(providerId)) {
+    console.error(`Missing permissions for provider "${providerId}"`)
+
     return {
       statusCode: 401,
       headers: defaultResponseHeaders
@@ -32,6 +35,17 @@ const updateTemplate = async (event) => {
   }
 
   const { TemplateName: templateName } = JSON.parse(body)
+
+  if (!templateName) {
+    console.error('Missing TemplateName in updateTemplate request')
+
+    return {
+      statusCode: 400,
+      headers: defaultResponseHeaders,
+      body: JSON.stringify({ error: 'TemplateName is required' })
+    }
+  }
+
   const hashedName = Buffer.from(templateName).toString('base64')
 
   try {

--- a/serverless/src/updateTemplate/handler.js
+++ b/serverless/src/updateTemplate/handler.js
@@ -35,17 +35,6 @@ const updateTemplate = async (event) => {
   }
 
   const { TemplateName: templateName } = JSON.parse(body)
-
-  if (!templateName) {
-    console.error('Missing TemplateName in updateTemplate request')
-
-    return {
-      statusCode: 400,
-      headers: defaultResponseHeaders,
-      body: JSON.stringify({ error: 'TemplateName is required' })
-    }
-  }
-
   const hashedName = Buffer.from(templateName).toString('base64')
 
   try {

--- a/serverless/src/updateTemplate/handler.js
+++ b/serverless/src/updateTemplate/handler.js
@@ -23,13 +23,22 @@ const updateTemplate = async (event) => {
   const { body, pathParameters } = event
   const { id, providerId } = pathParameters
 
-  const providerIds = await fetchProviders(event)
+  try {
+    const providerIds = await fetchProviders(event)
 
-  if (!providerIds.includes(providerId)) {
-    console.error(`Missing permissions for provider "${providerId}"`)
+    if (!providerIds.includes(providerId)) {
+      console.error(`Missing permissions for provider "${providerId}"`)
+
+      return {
+        statusCode: 401,
+        headers: defaultResponseHeaders
+      }
+    }
+  } catch (error) {
+    console.log('Error fetching providers:', error)
 
     return {
-      statusCode: 401,
+      statusCode: 500,
       headers: defaultResponseHeaders
     }
   }

--- a/serverless/src/utils/__tests__/fetchProviders.test.js
+++ b/serverless/src/utils/__tests__/fetchProviders.test.js
@@ -1,0 +1,153 @@
+import fetchProviders from '../fetchProviders'
+import fetchEdlProfile from '../fetchEdlProfile'
+import createJwt from '../createJwt'
+import * as getConfig from '../../../../sharedUtils/getConfig'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mock('../../utils/fetchEdlProfile')
+  vi.spyOn(getConfig, 'getEdlConfig').mockImplementation(() => ({
+    host: 'https://localtest.urs.earthdata.nasa.gov'
+  }))
+
+  process.env.JWT_SECRET = 'test-secret'
+})
+
+global.fetch = vi.fn(() => Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve({
+    user_groups: [{ tag: 'MMT_3' }, { tag: 'MMT_4' }]
+  })
+}))
+
+afterEach(() => {
+  delete process.env.JWT_SECRET
+})
+
+describe('Retrieving Providers', () => {
+  fetchEdlProfile.mockImplementation(() => ({
+    email: 'test.user@localhost',
+    first_name: 'Test',
+    last_name: 'User',
+    uid: 'mock_user'
+  }))
+
+  const expiresAt = '2034-01-02T00:00:00Z'
+
+  test('returns the providers', async () => {
+    const token = createJwt(
+      'mock-access-token',
+      'mock-refresh-token',
+      expiresAt,
+      { uid: 'mock_user' }
+    )
+    const event = {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }
+    const providerIds = await fetchProviders(event)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith('https://localtest.urs.earthdata.nasa.gov/api/user_groups/groups_for_user/mock_user', {
+      headers: {
+        Authorization: 'Bearer mock-access-token',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+      },
+      method: 'GET'
+    })
+
+    expect(providerIds).toEqual(['MMT_3', 'MMT_4'])
+  })
+
+  test('returns the providers when offline', async () => {
+    process.env.IS_OFFLINE = true
+    const token = createJwt(
+      'mock-access-token',
+      'mock-refresh-token',
+      expiresAt,
+      { uid: 'mock_user' }
+    )
+    const event = {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }
+    const providerIds = await fetchProviders(event)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith('https://localtest.urs.earthdata.nasa.gov/api/user_groups/groups_for_user/mock_user', {
+      headers: {
+        Authorization: 'Bearer mock-access-token',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+      },
+      method: 'GET'
+    })
+
+    expect(providerIds).toEqual(['MMT_3', 'MMT_4'])
+  })
+
+  test('returns the correct providers when the test token is passed', async () => {
+    process.env.IS_OFFLINE = true
+    const event = {
+      headers: {
+        Authorization: 'Bearer ABC-1'
+      }
+    }
+    const providerIds = await fetchProviders(event)
+
+    expect(fetch).toHaveBeenCalledTimes(0)
+    expect(providerIds).toEqual(['MMT_1', 'MMT_2'])
+  })
+
+  test('returns undefined when the response from EDL is an error', async () => {
+    const token = createJwt(
+      'mock-access-token',
+      'mock-refresh-token',
+      expiresAt,
+      { uid: 'mock_user' }
+    )
+    const event = {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }
+    fetch.mockImplementationOnce(() => Promise.reject(new Error('Error calling EDL')))
+
+    const providerIds = await fetchProviders(event)
+      .catch((error) => {
+        expect(error.message).toEqual('Error calling EDL')
+      })
+
+    expect(providerIds).toEqual(undefined)
+  })
+
+  test('returns HTTP error when response is not ok', async () => {
+    const token = createJwt(
+      'mock-access-token',
+      'mock-refresh-token',
+      expiresAt,
+      { uid: 'mock_user' }
+    )
+    const event = {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }
+    fetch.mockImplementationOnce(() => Promise.resolve({
+      ok: false,
+      status: 401,
+
+      json: () => Promise.resolve({
+        message: 'Unauthorized'
+      })
+    }))
+
+    const providerIds = await fetchProviders(event)
+      .catch((error) => {
+        expect(error.message).toEqual('HTTP error! status: 401, body: {"message":"Unauthorized"}')
+      })
+
+    expect(providerIds).toEqual(undefined)
+  })
+})

--- a/serverless/src/utils/__tests__/fetchProviders.test.js
+++ b/serverless/src/utils/__tests__/fetchProviders.test.js
@@ -22,6 +22,7 @@ global.fetch = vi.fn(() => Promise.resolve({
 
 afterEach(() => {
   delete process.env.JWT_SECRET
+  delete process.env.IS_OFFLINE
 })
 
 describe('Retrieving Providers', () => {

--- a/serverless/src/utils/__tests__/fetchProviders.test.js
+++ b/serverless/src/utils/__tests__/fetchProviders.test.js
@@ -151,4 +151,16 @@ describe('Retrieving Providers', () => {
 
     expect(providerIds).toEqual(undefined)
   })
+
+  test('returns an error when no headers are passed in', async () => {
+    process.env.IS_OFFLINE = true
+    const event = {}
+    const providerIds = await fetchProviders(event)
+      .catch((error) => {
+        expect(error.message).toContain('Cannot destructure property \'edlToken\'')
+        expect(error.message).toContain('as it is null.')
+      })
+
+    expect(providerIds).toEqual(undefined)
+  })
 })

--- a/serverless/src/utils/__tests__/getCollectionTemplatesBucketName.test.js
+++ b/serverless/src/utils/__tests__/getCollectionTemplatesBucketName.test.js
@@ -1,0 +1,10 @@
+import { getCollectionTemplatesBucketName } from '../getCollectionTemplatesBucketName'
+
+describe('getCollectionTemplatesBucketName', () => {
+  test('returns the default when offline', () => {
+    process.env.IS_OFFLINE = true
+    const bucketName = getCollectionTemplatesBucketName()
+
+    expect(bucketName).toMatchObject('mmt-template-bucket-local')
+  })
+})

--- a/serverless/src/utils/__tests__/getCollectionTemplatesBucketName.test.js
+++ b/serverless/src/utils/__tests__/getCollectionTemplatesBucketName.test.js
@@ -5,6 +5,6 @@ describe('getCollectionTemplatesBucketName', () => {
     process.env.IS_OFFLINE = true
     const bucketName = getCollectionTemplatesBucketName()
 
-    expect(bucketName).toMatchObject('mmt-template-bucket-local')
+    expect(bucketName).toBe('mmt-template-bucket-local')
   })
 })

--- a/serverless/src/utils/fetchProviders.js
+++ b/serverless/src/utils/fetchProviders.js
@@ -1,0 +1,75 @@
+import jwt from 'jsonwebtoken'
+import { GET_AVAILABLE_PROVIDERS } from '@/js/operations/queries/getAvailableProviders'
+import {
+  ApolloClient,
+  InMemoryCache,
+  HttpLink
+} from '@apollo/client'
+import fetchEdlProfile from './fetchEdlProfile'
+import { getApplicationConfig } from '../../../sharedUtils/getConfig'
+import { downcaseKeys } from './downcaseKeys'
+
+/**
+ * Returns the user's EDL profile based on the event provided
+ * @param {Object} event Details about the HTTP request that it received
+ */
+const fetchProviders = async (event) => {
+  const { env } = process
+  const { JWT_SECRET } = env
+
+  const { headers = {} } = event
+  const { authorization: authorizationToken = '' } = downcaseKeys(headers)
+  const [, token] = authorizationToken.split('Bearer ')
+
+  // If we are working in development mode
+  if (token === 'ABC-1') {
+    return ['MMT_1', 'MMT_2']
+  }
+
+  const decodedJwt = jwt.verify(token, JWT_SECRET)
+  const { edlToken } = decodedJwt
+
+  const profile = await fetchEdlProfile(edlToken)
+  const { uid } = profile
+
+  const { graphQlHost } = getApplicationConfig()
+  const client = new ApolloClient({
+    link: new HttpLink({
+      uri: graphQlHost,
+      headers: {
+        Authorization: `Bearer ${edlToken}`
+      }
+    }),
+    cache: new InMemoryCache()
+  })
+
+  const variables = {
+    params: {
+      limit: 500,
+      permittedUser: uid,
+      target: 'PROVIDER_CONTEXT'
+    }
+  }
+
+  let providerIds = []
+
+  await client.query({
+    query: GET_AVAILABLE_PROVIDERS,
+    variables
+  })
+    .then((response) => {
+      const { acls = {} } = response.data
+      const { items = [] } = acls
+
+      providerIds = items.map(
+        (item) => item.providerIdentity.provider_id
+      )
+    })
+    .catch((error) => {
+      console.error('Error fetching GraphQL data:', error)
+    })
+
+  return providerIds
+}
+
+export default fetchProviders

--- a/serverless/src/utils/fetchProviders.js
+++ b/serverless/src/utils/fetchProviders.js
@@ -1,13 +1,7 @@
 import jwt from 'jsonwebtoken'
-import { GET_AVAILABLE_PROVIDERS } from '@/js/operations/queries/getAvailableProviders'
-import {
-  ApolloClient,
-  InMemoryCache,
-  HttpLink
-} from '@apollo/client'
 import fetchEdlProfile from './fetchEdlProfile'
-import { getApplicationConfig } from '../../../sharedUtils/getConfig'
 import { downcaseKeys } from './downcaseKeys'
+import { getEdlConfig } from '../../../sharedUtils/getConfig'
 
 /**
  * Returns the user's EDL profile based on the event provided
@@ -32,42 +26,28 @@ const fetchProviders = async (event) => {
   const profile = await fetchEdlProfile(edlToken)
   const { uid } = profile
 
-  const { graphQlHost } = getApplicationConfig()
-  const client = new ApolloClient({
-    link: new HttpLink({
-      uri: graphQlHost,
-      headers: {
-        Authorization: `Bearer ${edlToken}`
-      }
-    }),
-    cache: new InMemoryCache()
+  const { host } = getEdlConfig()
+
+  const response = await fetch(`${host}/api/user_groups/groups_for_user/${uid}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${edlToken}`,
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+    }
   })
 
-  const variables = {
-    params: {
-      limit: 500,
-      permittedUser: uid,
-      target: 'PROVIDER_CONTEXT'
-    }
+  const data = await response.json()
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}, body: ${JSON.stringify(data)}`)
   }
 
-  let providerIds = []
-
-  await client.query({
-    query: GET_AVAILABLE_PROVIDERS,
-    variables
-  })
-    .then((response) => {
-      const { acls = {} } = response.data
-      const { items = [] } = acls
-
-      providerIds = items.map(
-        (item) => item.providerIdentity.provider_id
-      )
-    })
-    .catch((error) => {
-      console.error('Error fetching GraphQL data:', error)
-    })
+  // eslint-disable-next-line camelcase
+  const { user_groups } = data
+  // eslint-disable-next-line camelcase
+  const providerIds = user_groups.map(
+    (group) => group.tag
+  )
 
   return providerIds
 }

--- a/serverless/src/utils/fetchProviders.js
+++ b/serverless/src/utils/fetchProviders.js
@@ -14,8 +14,6 @@ import { downcaseKeys } from './downcaseKeys'
  * @param {Object} event Details about the HTTP request that it received
  */
 const fetchProviders = async (event) => {
-  console.log('Calling fetchProviders')
-
   const { env } = process
   const { JWT_SECRET } = env
 
@@ -33,8 +31,6 @@ const fetchProviders = async (event) => {
 
   const profile = await fetchEdlProfile(edlToken)
   const { uid } = profile
-
-  console.log(`uid:${uid}`)
 
   const { graphQlHost } = getApplicationConfig()
   const client = new ApolloClient({

--- a/serverless/src/utils/fetchProviders.js
+++ b/serverless/src/utils/fetchProviders.js
@@ -15,6 +15,11 @@ const fetchProviders = async (event) => {
   const { authorization: authorizationToken = '' } = downcaseKeys(headers)
   const [, token] = authorizationToken.split('Bearer ')
 
+  // If we are in test mode
+  if (token === 'ABC-1') {
+    return ['MMT_1', 'MMT_2']
+  }
+
   // To run locally need to use decode instead of verify since we wont have the JWT_SECRET
   let decodedJwt
   if (env.IS_OFFLINE) {

--- a/serverless/src/utils/fetchProviders.js
+++ b/serverless/src/utils/fetchProviders.js
@@ -15,12 +15,14 @@ const fetchProviders = async (event) => {
   const { authorization: authorizationToken = '' } = downcaseKeys(headers)
   const [, token] = authorizationToken.split('Bearer ')
 
-  // If we are working in development mode
-  if (token === 'ABC-1') {
-    return ['MMT_1', 'MMT_2']
+  // To run locally need to use decode instead of verify since we wont have the JWT_SECRET
+  let decodedJwt
+  if (env.IS_OFFLINE) {
+    decodedJwt = jwt.decode(token)
+  } else {
+    decodedJwt = jwt.verify(token, JWT_SECRET)
   }
 
-  const decodedJwt = jwt.verify(token, JWT_SECRET)
   const { edlToken } = decodedJwt
 
   const profile = await fetchEdlProfile(edlToken)

--- a/serverless/src/utils/fetchProviders.js
+++ b/serverless/src/utils/fetchProviders.js
@@ -34,6 +34,8 @@ const fetchProviders = async (event) => {
   const profile = await fetchEdlProfile(edlToken)
   const { uid } = profile
 
+  console.log(`uid:${uid}`)
+
   const { graphQlHost } = getApplicationConfig()
   const client = new ApolloClient({
     link: new HttpLink({

--- a/serverless/src/utils/fetchProviders.js
+++ b/serverless/src/utils/fetchProviders.js
@@ -14,6 +14,8 @@ import { downcaseKeys } from './downcaseKeys'
  * @param {Object} event Details about the HTTP request that it received
  */
 const fetchProviders = async (event) => {
+  console.log('Calling fetchProviders')
+
   const { env } = process
   const { JWT_SECRET } = env
 

--- a/serverless/src/utils/fetchProviders.js
+++ b/serverless/src/utils/fetchProviders.js
@@ -46,13 +46,13 @@ const fetchProviders = async (event) => {
   const data = await response.json()
 
   if (!response.ok) {
+    console.error(`HTTP error! status: ${response.status}, body: ${JSON.stringify(data)}`)
+
     throw new Error(`HTTP error! status: ${response.status}, body: ${JSON.stringify(data)}`)
   }
 
-  // eslint-disable-next-line camelcase
-  const { user_groups } = data
-  // eslint-disable-next-line camelcase
-  const providerIds = user_groups.map(
+  const { user_groups: userGroups } = data
+  const providerIds = userGroups.map(
     (group) => group.tag
   )
 

--- a/serverless/src/utils/getCollectionTemplatesBucketName.js
+++ b/serverless/src/utils/getCollectionTemplatesBucketName.js
@@ -1,0 +1,10 @@
+/**
+ * Returns the collection templates bucket name
+ */
+export const getCollectionTemplatesBucketName = () => {
+  if (process.env.IS_OFFLINE) {
+    return 'mmt-template-bucket-local'
+  }
+
+  return process.env.COLLECTION_TEMPLATES_BUCKET_NAME
+}

--- a/serverless/src/utils/getS3Client.js
+++ b/serverless/src/utils/getS3Client.js
@@ -8,6 +8,7 @@ export const getS3Client = () => {
     forcePathStyle: true
   }
 
+  // Use S3rver to mock S3 in local mode
   if (process.env.IS_OFFLINE) {
     config.endpoint = 'http://localhost:4569'
     config.credentials = {

--- a/serverless/src/utils/s3ListObjects.js
+++ b/serverless/src/utils/s3ListObjects.js
@@ -1,13 +1,15 @@
 import { ListObjectsV2Command } from '@aws-sdk/client-s3'
 
+import { getCollectionTemplatesBucketName } from './getCollectionTemplatesBucketName'
+
 /**
  * Returns list of contents from an S3 ListObjectsV2Command
  * @param {Object} s3Client - S3 Client instance
  * @param {String} [prefix=''] - Prefix used to filter S3 objects
- * @param {String} [bucketName=process.env.COLLECTION_TEMPLATES_BUCKET_NAME] - Name of the S3 bucket
+ * @param {String} [bucketName=getCollectionTemplatesBucketName()] - Name of the S3 bucket
  * @returns {Promise<Array>} - List of S3 objects matching the prefix in the specified bucket
  */
-export const s3ListObjects = async (s3Client, prefix = '', bucketName = process.env.COLLECTION_TEMPLATES_BUCKET_NAME) => {
+export const s3ListObjects = async (s3Client, prefix = '', bucketName = getCollectionTemplatesBucketName()) => {
   const s3Command = new ListObjectsV2Command({
     Bucket: bucketName,
     Prefix: prefix

--- a/setup/startS3.js
+++ b/setup/startS3.js
@@ -1,0 +1,49 @@
+const S3rver = require('s3rver')
+const { S3Client, CreateBucketCommand, HeadBucketCommand } = require('@aws-sdk/client-s3')
+
+// Allow overriding this value but, this script is only need to be run in dev
+const bucketName = process.env.COLLECTION_TEMPLATES_BUCKET_NAME || 'mmt-template-bucket-local'
+const port = 4569
+
+const startS3 = async () => {
+  console.log(`Starting local S3 server on port ${port}...`)
+
+  const instance = new S3rver({
+    port,
+    address: 'localhost',
+    silent: false,
+    directory: './tmp/s3rver'
+  })
+
+  await instance.run()
+
+  console.log('Local S3 server started.')
+
+  const s3Client = new S3Client({
+    forcePathStyle: true,
+    endpoint: `http://localhost:${port}`,
+    credentials: {
+      accessKeyId: 'S3RVER',
+      secretAccessKey: 'S3RVER'
+    },
+    region: 'us-east-1'
+  })
+
+  try {
+    await s3Client.send(new HeadBucketCommand({ Bucket: bucketName }))
+    console.log(`Bucket "${bucketName}" already exists.`)
+  } catch (error) {
+    if (error.name === 'NotFound' || error.$metadata?.httpStatusCode === 404) {
+      console.log(`Creating bucket "${bucketName}"...`)
+      await s3Client.send(new CreateBucketCommand({ Bucket: bucketName }))
+      console.log(`Bucket "${bucketName}" created.`)
+    } else {
+      console.error('Error checking/creating bucket:', error)
+    }
+  }
+}
+
+startS3().catch((error) => {
+  console.error('Failed to start local S3 server:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
# Overview

### What is the feature?

prevent newly created EDL user from executing template operations

### What is the Solution?

Add check for user in edlgroups provider before executing template operations.

### What areas of the application does this impact?

MMT templates

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

See VDP-2954

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.
<img width="1431" height="828" alt="Screenshot 2026-07-14 at 10 20 39 PM" src="https://github.com/user-attachments/assets/7ad363f7-f2c3-4811-8c48-f1edf11c19d7" />

VDP-2954

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-based authorization for template create, get, list, update, and delete.
  * Added a local S3 start command to run an S3-compatible mock server.

* **Bug Fixes**
  * Template responses are now restricted to providers the requester is authorized to access (including returning `401`/`500` when appropriate).
  * Template listing no longer relies on an offline-only empty-list behavior; it’s filtered by authorization.
  * Standardized provider identifier formatting for S3 object matching and key prefixes.

* **Tests**
  * Expanded authorization and provider-fetch coverage, updated S3 key expectations, and added tests for bucket-name resolution and `fetchProviders` error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->