### PR TITLE
MMT-4076: Enable editing of the JSON text at bottom of the metadata form directly.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@apollo/client": "^3.8.5",
-        "@edsc/metadata-preview": "^1.5.12",
+        "@edsc/metadata-preview": "^1.5.13",
         "@node-saml/node-saml": "^5.1.0",
         "@rjsf/core": "^5.15.0",
         "@rjsf/utils": "^5.15.0",
@@ -17900,6 +17900,166 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.22.1.tgz",
+      "integrity": "sha512-5p2rnlVTv6Gpw4PlTLq925nTVh+HFh4MpegX8dPDYJae+NFVjQ67gY7O6iHIzQjLipDiYejFF0yHrhjU3XgLBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.22.1.tgz",
+      "integrity": "sha512-1FaBtcFrZqB2hkFbAxY//Pnp8koThvyB6AhjbdVqKD4/pu13Rl91fKt2N9qyeQPUt3xy7ORUvSO+dPk3J6EjXg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.22.1.tgz",
+      "integrity": "sha512-6rub98tYGfE5I5j0BP8t/2d4BZyu1S7Iz9vUkm0H26snAFHYxLfj3RbQn0xHHIePSetjLnhcg3QlfwUAkD/FYg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.22.1.tgz",
+      "integrity": "sha512-nYO5qGtb/1kkTZu3FeTiM+2B2TAb7m2DkLCTgQIs2bk2o9aEs7I96fwySKcoHWQAiQDGR9sMux9vkV4KQXqPaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.22.1.tgz",
+      "integrity": "sha512-MCV6RuRpzXbunvzwY644iz8cw4oQxvW7oer9xPkdadYqlEyiJJ6wl7FyJOH7Q6ZYH4yjGAUCvxDBxPbnDu9ZVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.22.1.tgz",
+      "integrity": "sha512-RjNgpdM20VUXgV7us/VmlO3Vn2ZRiDnc3/bUxCVvySZWPiVPprpqW/QDWuzkGa+NCUf6saAM5CLsZLSxncXJwg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.22.1.tgz",
+      "integrity": "sha512-ZgO4C7Rd6Hv/5MnyY2KxOYmIlzk4rplVolDt3NbkNR8DndnyX0Q5IR4acJWNTBICQ21j3zySzKbcJaiJpk/4YA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.22.1.tgz",
+      "integrity": "sha512-4pozV4eyD0MDET41ZLHAeBo+H04Nm2UEYIk5w/ts40231dRFV7E0cjwbnZvSoc1DXFgecAhiC0L16ruv/ZDCpg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -26891,23 +27051,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4541,9 +4541,9 @@
       }
     },
     "node_modules/@edsc/metadata-preview": {
-      "version": "1.5.12",
-      "resolved": "https://registry.npmjs.org/@edsc/metadata-preview/-/metadata-preview-1.5.12.tgz",
-      "integrity": "sha512-bvSP6XNYwgaCvPXFKlAD0KqnYnV3rj9eIBYw+0GiRu+ruKq7w+ePeEnwOwTDNaCoaf+5prE3NdIK3dc8UudGjA==",
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/@edsc/metadata-preview/-/metadata-preview-1.5.13.tgz",
+      "integrity": "sha512-CT1hwbSN+x114kl8jP7qJd/XZTcYg/FKAoetmmKK1rM1pk83qrLlXkMP1C5oIkcgnwchvmZr2vf+o9NLP1YU4Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4579,6 +4579,7 @@
         "classnames": "^2.2.6",
         "commafy-anything": "^1.1.3",
         "core-js": "^3.6.5",
+        "ejs": "^6.0.1",
         "events": "^3.3.0",
         "formik": "^2.2.1",
         "graphql": "^15.3.0",
@@ -4608,47 +4609,430 @@
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
         "sass": "^1.69.3",
-        "simple-oauth2": "^4.2.0",
+        "simple-oauth2": "^5.1.0",
         "tiny-cookie": "^2.3.2",
         "url-template": "^2.0.8",
-        "vite": "^6.4.1",
-        "vite-plugin-html": "^3.2.0",
+        "vite": "^7.3.6",
         "vite-plugin-svgr": "^4.5.0"
       },
       "engines": {
         "yarn": "Use npm instead."
       }
     },
-    "node_modules/@edsc/metadata-preview/node_modules/@hapi/boom": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
-      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "9.x.x"
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
-    "node_modules/@edsc/metadata-preview/node_modules/@hapi/bourne": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q==",
-      "license": "BSD-3-Clause"
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
-    "node_modules/@edsc/metadata-preview/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "license": "BSD-3-Clause"
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
-    "node_modules/@edsc/metadata-preview/node_modules/@hapi/wreck": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.2.0.tgz",
-      "integrity": "sha512-pJ5kjYoRPYDv+eIuiLQqhGon341fr2bNIYZjuotuPJG/3Ilzr/XtI+JAp0A86E2bYfsS3zBPABuS2ICkaXFT8g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@edsc/metadata-preview/node_modules/buffer": {
@@ -4680,6 +5064,59 @@
       "resolved": "https://registry.npmjs.org/commafy-anything/-/commafy-anything-1.1.3.tgz",
       "integrity": "sha512-bDSOvZwh7wQmeqQ/0kzXLeBou/9HKnzJZyEc6gGRBvUn4oLhCdmI3bQ4un82F9xr4lSI5VRjrx0bsLAVimh5xg=="
     },
+    "node_modules/@edsc/metadata-preview/node_modules/ejs": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-6.0.1.tgz",
+      "integrity": "sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.12.18"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/@edsc/metadata-preview/node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -4687,6 +5124,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/@edsc/metadata-preview/node_modules/graphql": {
@@ -4716,6 +5170,18 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@edsc/metadata-preview/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/@edsc/metadata-preview/node_modules/react-icons": {
       "version": "3.11.0",
@@ -4862,16 +5328,78 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/@edsc/metadata-preview/node_modules/simple-oauth2": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/simple-oauth2/-/simple-oauth2-4.3.0.tgz",
-      "integrity": "sha512-gjLIfy7M7WZSf3k5IZCQfEozbQwmW80zR9YMH4ph/WWG6S4U6sGhPujz8X6Hj6sZ8l7acSAxiyM4tF0vIN+E+A==",
-      "license": "Apache-2.0",
+    "node_modules/@edsc/metadata-preview/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "license": "MIT",
       "dependencies": {
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/wreck": "^17.0.0",
-        "debug": "^4.1.1",
-        "joi": "^17.3.0"
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -5760,6 +6288,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
       "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -5977,6 +6506,304 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.6.0",
+        "@parcel/watcher-darwin-arm64": "2.6.0",
+        "@parcel/watcher-darwin-x64": "2.6.0",
+        "@parcel/watcher-freebsd-x64": "2.6.0",
+        "@parcel/watcher-linux-arm-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm-musl": "2.6.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm64-musl": "2.6.0",
+        "@parcel/watcher-linux-x64-glibc": "2.6.0",
+        "@parcel/watcher-linux-x64-musl": "2.6.0",
+        "@parcel/watcher-win32-arm64": "2.6.0",
+        "@parcel/watcher-win32-x64": "2.6.0"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+      "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+      "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+      "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+      "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+      "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+      "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+      "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+      "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+      "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+      "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+      "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+      "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -6057,9 +6884,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
+      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -6231,9 +7058,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -9261,9 +10088,13 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.8.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.2.tgz",
-      "integrity": "sha512-Vvycsc9FQdwhxE3y3DzeIxuEJbWGDsnrxvMADzTDF/lcdR9/K+AQIeAghTQsHtotg/q0j3WEOYS/jQgSdWue3w=="
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.2",
@@ -10130,7 +10961,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -10190,18 +11020,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/argparse": {
@@ -10551,13 +11369,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -10898,14 +11717,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -11033,9 +11844,9 @@
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11377,15 +12188,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -11581,40 +12383,18 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 20.19.0"
       },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -11643,17 +12423,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
-    },
-    "node_modules/clean-css": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
-      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -11786,11 +12555,6 @@
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="
-    },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -12009,19 +12773,6 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
-    },
-    "node_modules/connect-history-api-fallback": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
-      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
@@ -12953,17 +13704,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/dunder-proto": {
@@ -14476,9 +15216,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -14596,15 +15336,15 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -14971,27 +15711,6 @@
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
       "dev": true
-    },
-    "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/fs-extra/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -15574,6 +16293,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
       "bin": {
         "he": "bin/he"
       }
@@ -15651,34 +16371,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "node_modules/html-minifier-terser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
-      "integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "clean-css": "^5.2.2",
-        "commander": "^8.3.0",
-        "he": "^1.2.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.10.0"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/html-minifier-terser/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/html-tags": {
       "version": "3.3.1",
@@ -15830,7 +16522,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -15896,9 +16587,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/import-cwd": {
@@ -16113,17 +16804,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -16756,9 +17436,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -16894,25 +17574,6 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
       "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
       "dev": true
-    },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
@@ -18714,9 +19375,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -18795,6 +19456,13 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -18812,15 +19480,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/node-html-parser": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-5.4.2.tgz",
-      "integrity": "sha512-RaBPP3+51hPne/OolXxcz89iYvQvKOydaqoePpOgXcrOKZhjVIzmpKZz+Hd/RBO2/zN2q6CNJhQzucVz+u3Jyw==",
-      "dependencies": {
-        "css-select": "^4.2.1",
-        "he": "1.2.0"
       }
     },
     "node_modules/node-releases": {
@@ -18978,6 +19637,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19339,15 +19999,6 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -19436,15 +20087,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/passthrough-counter": {
@@ -19556,11 +20198,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pathe": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-0.2.0.tgz",
-      "integrity": "sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw=="
-    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -19665,9 +20302,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -19684,7 +20321,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -20937,12 +21574,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
+      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "@remix-run/router": "1.23.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -20952,13 +21589,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
+      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "@remix-run/router": "1.23.4",
+        "react-router": "6.30.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -21121,14 +21758,16 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/redent": {
@@ -21269,14 +21908,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/remark-gfm": {
@@ -21893,19 +22524,23 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.69.5",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
-      "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
+      "version": "1.103.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.103.0.tgz",
+      "integrity": "sha512-+QpdXUDw19lVqRDlYIyje1Lq/0gHsnNHIl4x1CqeUg13zRhaQN11UvTvouwHWLXc9Q3rQVT6oBhFGRYJ5Z8gHw==",
+      "license": "MIT",
       "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.19.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/sax": {
@@ -23159,9 +23794,9 @@
       "dev": true
     },
     "node_modules/svgo": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
-      "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.3.tgz",
+      "integrity": "sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",
@@ -23262,6 +23897,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.33.0.tgz",
       "integrity": "sha512-JuPVaB7s1gdFKPKTelwUyRq5Sid2A3Gko2S0PncwdBq7kN9Ti9HPWDQ06MPsEDGsZeVESjKEnyGy68quBk1w6g==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -23312,12 +23948,14 @@
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
     },
     "node_modules/terser/node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -23808,6 +24446,12 @@
       "peerDependencies": {
         "react": ">=15.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -24455,48 +25099,6 @@
       "integrity": "sha512-23p1RS4PiA0veXY5/gHZ60pl3pPvd8NEqdBsDgxNK8nM1rjFFDcVb0paNmuipzCgNP/Y0f/Id22M7Il4kvZ2jA==",
       "dependencies": {
         "ejs": "^3.1.8"
-      }
-    },
-    "node_modules/vite-plugin-html": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-html/-/vite-plugin-html-3.2.0.tgz",
-      "integrity": "sha512-2VLCeDiHmV/BqqNn5h2V+4280KRgQzCFN47cst3WiNK848klESPQnzuC3okH5XHtgwHH/6s1Ho/YV6yIO0pgoQ==",
-      "dependencies": {
-        "@rollup/pluginutils": "^4.2.0",
-        "colorette": "^2.0.16",
-        "connect-history-api-fallback": "^1.6.0",
-        "consola": "^2.15.3",
-        "dotenv": "^16.0.0",
-        "dotenv-expand": "^8.0.2",
-        "ejs": "^3.1.6",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^10.0.1",
-        "html-minifier-terser": "^6.1.0",
-        "node-html-parser": "^5.3.3",
-        "pathe": "^0.2.0"
-      },
-      "peerDependencies": {
-        "vite": ">=2.0.0"
-      }
-    },
-    "node_modules/vite-plugin-html/node_modules/@rollup/pluginutils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/vite-plugin-html/node_modules/dotenv-expand": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-8.0.3.tgz",
-      "integrity": "sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/vite-plugin-node-polyfills": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.5",
-    "@edsc/metadata-preview": "^1.5.12",
+    "@edsc/metadata-preview": "^1.5.13",
     "@node-saml/node-saml": "^5.1.0",
     "@rjsf/core": "^5.15.0",
     "@rjsf/utils": "^5.15.0",

--- a/static/src/css/vendor/bootstrap/index.scss
+++ b/static/src/css/vendor/bootstrap/index.scss
@@ -52,7 +52,7 @@
 @import "bootstrap/scss/alert";
 // @import "bootstrap/scss/progress";
 @import "bootstrap/scss/list-group";
-@import "bootstrap/scss/close";
+// @import "bootstrap/scss/close";
 @import "bootstrap/scss/toasts";
 @import "bootstrap/scss/modal"; // Requires transitions
 @import "bootstrap/scss/tooltip";

--- a/static/src/css/vendor/bootstrap/index.scss
+++ b/static/src/css/vendor/bootstrap/index.scss
@@ -52,7 +52,7 @@
 @import "bootstrap/scss/alert";
 // @import "bootstrap/scss/progress";
 @import "bootstrap/scss/list-group";
-// @import "bootstrap/scss/close";
+@import "bootstrap/scss/close";
 @import "bootstrap/scss/toasts";
 @import "bootstrap/scss/modal"; // Requires transitions
 @import "bootstrap/scss/tooltip";

--- a/static/src/js/components/JsonPreview/JsonPreview.jsx
+++ b/static/src/js/components/JsonPreview/JsonPreview.jsx
@@ -66,7 +66,14 @@ const JsonPreview = ({ schema }) => {
       // value of the wrong type). Missing-required-field errors are ignored
       // here so saving through the JSON editor stays as permissive as saving
       // through the form fields, which never blocks on incomplete drafts.
-      const structuralErrors = schemaErrors.filter(({ name }) => name !== 'required')
+      // A missing required field inside a oneOf/anyOf branch (e.g. a
+      // discriminated union) doesn't just produce a 'required' error -- AJV
+      // also emits a wrapping 'oneOf'/'anyOf' error at the parent level
+      // ("must match a schema in oneOf/anyOf"), so those need to be ignored
+      // too or an otherwise-incomplete-but-valid draft would still be blocked.
+      const structuralErrors = schemaErrors.filter(
+        ({ name }) => !['required', 'oneOf', 'anyOf'].includes(name)
+      )
 
       if (structuralErrors.length > 0) {
         setErrors(structuralErrors.map(({

--- a/static/src/js/components/JsonPreview/JsonPreview.jsx
+++ b/static/src/js/components/JsonPreview/JsonPreview.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import Accordion from 'react-bootstrap/Accordion'
+import Modal from 'react-bootstrap/Modal'
 import JSONPretty from 'react-json-pretty'
 import { cloneDeep } from 'lodash-es'
 import PropTypes from 'prop-types'
@@ -21,83 +22,105 @@ const JsonPreview = ({ schema }) => {
 
   const [isEditing, setIsEditing] = useState(false)
   const [jsonText, setJsonText] = useState('')
-  const [errors, setErrors] = useState([])
-  // Snapshot of `data` (as a JSON string) taken the moment we entered edit
-  // mode. Used to detect if the draft changed out from under us while the
-  // textarea was open (e.g. the UI form was edited concurrently), so we
-  // know our buffer is stale relative to the source of truth.
-  const [editingSnapshot, setEditingSnapshot] = useState(null)
 
-  // Keep the buffer in sync with the draft whenever we're not actively
-  // editing (e.g. the form itself changed a field). If we ARE editing and
-  // the draft changes anyway (e.g. the UI form was edited/saved
-  // concurrently), our buffer is now stale relative to the source of
-  // truth -- bail out of edit mode rather than let a later Save overwrite
-  // the newer data with our stale copy.
-  useEffect(() => {
-    if (!isEditing) {
-      setJsonText(JSON.stringify(data, null, 2))
+  // Inline, blocking error -- only ever a JSON.parse failure. There's
+  // nothing to save yet, so this can't be resolved with a "save anyway"
+  // confirmation the way schema errors can.
+  const [parseError, setParseError] = useState(null)
 
-      return
-    }
-
-    if (editingSnapshot !== null && JSON.stringify(data) !== editingSnapshot) {
-      setIsEditing(false)
-      setErrors([])
-    }
-  }, [data, isEditing, editingSnapshot])
+  // Schema/structural errors surfaced on Save. These don't block saving --
+  // they open the confirmation modal below instead, and the user decides
+  // whether to save despite them.
+  const [pendingErrors, setPendingErrors] = useState([])
+  const [pendingParsed, setPendingParsed] = useState(null)
+  const [showConfirm, setShowConfirm] = useState(false)
 
   const handleEditClick = () => {
     setJsonText(JSON.stringify(data, null, 2))
-    // Compact form here, to match the compact JSON.stringify(data) used for
-    // comparison in the effect above -- the two need the same formatting or
-    // they'll never compare equal, even when the underlying data hasn't
-    // changed.
-    setEditingSnapshot(JSON.stringify(data))
-    setErrors([])
+    setParseError(null)
+    setPendingErrors([])
+    setPendingParsed(null)
     setIsEditing(true)
   }
 
   const handleCancel = () => {
     setJsonText(JSON.stringify(data, null, 2))
-    setErrors([])
+    setParseError(null)
+    setPendingErrors([])
+    setPendingParsed(null)
+    setShowConfirm(false)
     setIsEditing(false)
   }
 
   const handleTextChange = (event) => {
     setJsonText(event.target.value)
-    if (errors.length > 0) setErrors([])
+    if (parseError) setParseError(null)
   }
 
-  const handleSave = () => {
+  const commitSave = (parsed) => {
+    setDraft({
+      ...draft,
+      ummMetadata: parsed
+    })
+
+    setParseError(null)
+    setPendingErrors([])
+    setPendingParsed(null)
+    setShowConfirm(false)
+    setIsEditing(false)
+  }
+
+  const handleSaveClick = () => {
     let parsed
 
     try {
       parsed = JSON.parse(jsonText)
-    } catch (parseError) {
-      setErrors([`Invalid JSON: ${parseError.message}`])
+    } catch (parseErrorObj) {
+      setParseError(`Invalid JSON: ${parseErrorObj.message}`)
 
       return
     }
 
+    setParseError(null)
+
     if (schema) {
       const { errors: schemaErrors = [] } = validator.validateFormData(parsed, schema)
 
-      // Only block on structural problems (an unknown/typo'd field name, or a
+      // Only surface structural problems (an unknown/typo'd field name, or a
       // value of the wrong type). Missing-required-field errors are ignored
       // here so saving through the JSON editor stays as permissive as saving
       // through the form fields, which never blocks on incomplete drafts.
       // A missing required field inside a oneOf/anyOf branch (e.g. a
       // discriminated union) doesn't just produce a 'required' error -- AJV
-      // also emits a wrapping 'oneOf'/'anyOf' error at the parent level
-      // ("must match a schema in oneOf/anyOf"), so those need to be ignored
-      // too or an otherwise-incomplete-but-valid draft would still be blocked.
-      const structuralErrors = schemaErrors.filter(
-        ({ name }) => !['required', 'oneOf', 'anyOf'].includes(name)
+      // also emits a wrapping 'oneOf'/'anyOf' error at the same instancePath
+      // ("must match a schema in oneOf/anyOf"), so that wrapper needs to be
+      // ignored too or an otherwise-incomplete-but-valid draft would still
+      // trigger a confirmation.
+      //
+      // However, oneOf/anyOf errors aren't ONLY produced by missing-required
+      // noise -- some schemas express a controlled vocabulary (effectively
+      // an enum) as `oneOf: [{ const: 'A' }, { const: 'B' }, ...]` instead of
+      // a plain `enum`. An invalid value for one of those fields fails with
+      // a oneOf/anyOf error too, and a blanket filter would silently let it
+      // through. So only drop a oneOf/anyOf error when a 'required' error
+      // exists at that same instancePath (i.e. it's the wrapper noise) --
+      // keep it when it's the only error at that path, since that means it's
+      // a genuine invalid-value failure.
+      const requiredPaths = new Set(
+        schemaErrors
+          .filter(({ name }) => name === 'required')
+          .map(({ instancePath }) => instancePath)
       )
 
+      const structuralErrors = schemaErrors.filter(({ name, instancePath }) => {
+        if (name === 'required') return false
+        if ((name === 'oneOf' || name === 'anyOf') && requiredPaths.has(instancePath)) return false
+
+        return true
+      })
+
       if (structuralErrors.length > 0) {
-        setErrors(structuralErrors.map(({
+        const messages = structuralErrors.map(({
           name,
           property,
           message,
@@ -113,102 +136,149 @@ const JsonPreview = ({ schema }) => {
           }
 
           return property ? `${property} ${message}` : message
-        }))
+        })
+
+        setPendingErrors(messages)
+        setPendingParsed(parsed)
+        setShowConfirm(true)
 
         return
       }
     }
 
-    setDraft({
-      ...draft,
-      ummMetadata: parsed
-    })
+    commitSave(parsed)
+  }
 
-    setErrors([])
-    setIsEditing(false)
+  const handleConfirmSaveAnyway = () => {
+    commitSave(pendingParsed)
+  }
+
+  const handleConfirmBack = () => {
+    setShowConfirm(false)
+    setPendingErrors([])
+    setPendingParsed(null)
   }
 
   return (
-    <Accordion
-      defaultActiveKey="0"
-      className="mt-5"
-    >
-      <Accordion.Item eventKey="0">
-        <Accordion.Header>
-          JSON
-        </Accordion.Header>
-        <Accordion.Body>
-          <div className="d-flex justify-content-end mb-2">
-            {
-              isEditing
-                ? (
-                  <>
-                    <Button
-                      className="me-2"
-                      variant="secondary"
-                      size="sm"
-                      onClick={handleCancel}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      onClick={handleSave}
-                    >
-                      Save
-                    </Button>
-                  </>
-                )
-                : (
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={handleEditClick}
-                  >
-                    Edit JSON
-                  </Button>
-                )
-            }
-          </div>
+    <>
+      <Accordion
+        defaultActiveKey="0"
+        className="mt-5"
+      >
+        <Accordion.Item eventKey="0">
+          <Accordion.Header>
+            JSON
+          </Accordion.Header>
+          <Accordion.Body>
+            <div className="d-flex justify-content-end mb-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleEditClick}
+              >
+                Edit JSON
+              </Button>
+            </div>
 
+            <JSONPretty data={data} />
+          </Accordion.Body>
+        </Accordion.Item>
+      </Accordion>
+
+      <Modal
+        show={isEditing}
+        onHide={handleCancel}
+        size="lg"
+        animation={false}
+        aria-labelledby="json-preview-edit-modal-title"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="json-preview-edit-modal-title">
+            Edit JSON
+          </Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
           {
-            errors.length > 0 && (
+            parseError && (
               <div className="text-danger small mb-2" role="alert">
-                {
-                  errors.length === 1
-                    ? errors[0]
-                    : (
-                      <ul className="mb-0 ps-3">
-                        {
-                          errors.map((message) => (
-                            <li key={message}>{message}</li>
-                          ))
-                        }
-                      </ul>
-                    )
-                }
+                {parseError}
               </div>
             )
           }
 
-          {
-            isEditing
-              ? (
-                <textarea
-                  className={`form-control font-monospace ${errors.length > 0 ? 'is-invalid' : ''}`}
-                  rows={20}
-                  value={jsonText}
-                  onChange={handleTextChange}
-                  spellCheck={false}
-                  aria-label="Editable JSON metadata"
-                />
-              )
-              : <JSONPretty data={data} />
-          }
-        </Accordion.Body>
-      </Accordion.Item>
-    </Accordion>
+          <textarea
+            className={`form-control font-monospace ${parseError ? 'is-invalid' : ''}`}
+            rows={20}
+            value={jsonText}
+            onChange={handleTextChange}
+            spellCheck={false}
+            aria-label="Editable JSON metadata"
+          />
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleCancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleSaveClick}
+          >
+            Save
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      <Modal
+        show={showConfirm}
+        onHide={handleConfirmBack}
+        animation={false}
+        aria-labelledby="json-preview-confirm-modal-title"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="json-preview-confirm-modal-title">
+            Confirm Save
+          </Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          <p>Your record has following errors:</p>
+
+          <ul>
+            {
+              pendingErrors.map((message) => (
+                <li key={message}>{message}</li>
+              ))
+            }
+          </ul>
+
+          <p>Would you like to proceed?</p>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleConfirmBack}
+          >
+            Back
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleConfirmSaveAnyway}
+          >
+            Save & Continue
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
   )
 }
 

--- a/static/src/js/components/JsonPreview/JsonPreview.jsx
+++ b/static/src/js/components/JsonPreview/JsonPreview.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import Accordion from 'react-bootstrap/Accordion'
-import Modal from 'react-bootstrap/Modal'
 import JSONPretty from 'react-json-pretty'
 import { cloneDeep } from 'lodash-es'
 import PropTypes from 'prop-types'
@@ -9,6 +8,7 @@ import validator from '@rjsf/validator-ajv8'
 import useAppContext from '../../hooks/useAppContext'
 import removeEmpty from '../../utils/removeEmpty'
 import Button from '../Button/Button'
+import CustomModal from '../CustomModal/CustomModal'
 
 const JsonPreview = ({ schema }) => {
   const {
@@ -23,23 +23,19 @@ const JsonPreview = ({ schema }) => {
   const [isEditing, setIsEditing] = useState(false)
   const [jsonText, setJsonText] = useState('')
 
-  // Inline, blocking error -- only ever a JSON.parse failure. There's
-  // nothing to save yet, so this can't be resolved with a "save anyway"
-  // confirmation the way schema errors can.
+  // Inline, blocking error -- only ever a JSON.parse failure.
   const [parseError, setParseError] = useState(null)
 
-  // Schema/structural errors surfaced on Save. These don't block saving --
-  // they open the confirmation modal below instead, and the user decides
-  // whether to save despite them.
+  // Schema/structural errors surfaced on Apply. These block saving -- the
+  // errors modal below is a dead end that only lets the user go back and
+  // fix the JSON, it never commits the invalid draft.
   const [pendingErrors, setPendingErrors] = useState([])
-  const [pendingParsed, setPendingParsed] = useState(null)
-  const [showConfirm, setShowConfirm] = useState(false)
+  const [showErrors, setShowErrors] = useState(false)
 
   const handleEditClick = () => {
     setJsonText(JSON.stringify(data, null, 2))
     setParseError(null)
     setPendingErrors([])
-    setPendingParsed(null)
     setIsEditing(true)
   }
 
@@ -47,8 +43,7 @@ const JsonPreview = ({ schema }) => {
     setJsonText(JSON.stringify(data, null, 2))
     setParseError(null)
     setPendingErrors([])
-    setPendingParsed(null)
-    setShowConfirm(false)
+    setShowErrors(false)
     setIsEditing(false)
   }
 
@@ -57,20 +52,7 @@ const JsonPreview = ({ schema }) => {
     if (parseError) setParseError(null)
   }
 
-  const commitSave = (parsed) => {
-    setDraft({
-      ...draft,
-      ummMetadata: parsed
-    })
-
-    setParseError(null)
-    setPendingErrors([])
-    setPendingParsed(null)
-    setShowConfirm(false)
-    setIsEditing(false)
-  }
-
-  const handleSaveClick = () => {
+  const handleApplyClick = () => {
     let parsed
 
     try {
@@ -86,26 +68,12 @@ const JsonPreview = ({ schema }) => {
     if (schema) {
       const { errors: schemaErrors = [] } = validator.validateFormData(parsed, schema)
 
-      // Only surface structural problems (an unknown/typo'd field name, or a
-      // value of the wrong type). Missing-required-field errors are ignored
-      // here so saving through the JSON editor stays as permissive as saving
-      // through the form fields, which never blocks on incomplete drafts.
-      // A missing required field inside a oneOf/anyOf branch (e.g. a
-      // discriminated union) doesn't just produce a 'required' error -- AJV
-      // also emits a wrapping 'oneOf'/'anyOf' error at the same instancePath
-      // ("must match a schema in oneOf/anyOf"), so that wrapper needs to be
-      // ignored too or an otherwise-incomplete-but-valid draft would still
-      // trigger a confirmation.
-      //
-      // However, oneOf/anyOf errors aren't ONLY produced by missing-required
-      // noise -- some schemas express a controlled vocabulary (effectively
-      // an enum) as `oneOf: [{ const: 'A' }, { const: 'B' }, ...]` instead of
-      // a plain `enum`. An invalid value for one of those fields fails with
-      // a oneOf/anyOf error too, and a blanket filter would silently let it
-      // through. So only drop a oneOf/anyOf error when a 'required' error
-      // exists at that same instancePath (i.e. it's the wrapper noise) --
-      // keep it when it's the only error at that path, since that means it's
-      // a genuine invalid-value failure.
+      // Only surface structural errors (unknown field, wrong type). 'required'
+      // errors are ignored so the JSON editor stays as permissive as the form.
+      // A missing required field inside oneOf/anyOf also emits a wrapping
+      // oneOf/anyOf error at the same path -- drop that too, but only when a
+      // 'required' error exists at that path, since oneOf/anyOf is also how
+      // const-based enums fail on an invalid value (a real error to keep).
       const requiredPaths = new Set(
         schemaErrors
           .filter(({ name }) => name === 'required')
@@ -126,9 +94,7 @@ const JsonPreview = ({ schema }) => {
           message,
           params
         }) => {
-          // AJV puts the actual bad key in params.additionalProperty for this
-          // error type -- `property` here refers to the parent object, and
-          // `message` alone doesn't name the offending field at all.
+          // AJV reports the bad key in params.additionalProperty, not in `message`
           if (name === 'additionalProperties' && params?.additionalProperty) {
             const location = property ? `${property} ` : ''
 
@@ -139,24 +105,26 @@ const JsonPreview = ({ schema }) => {
         })
 
         setPendingErrors(messages)
-        setPendingParsed(parsed)
-        setShowConfirm(true)
+        setShowErrors(true)
 
         return
       }
     }
 
-    commitSave(parsed)
-  }
+    setDraft({
+      ...draft,
+      ummMetadata: parsed
+    })
 
-  const handleConfirmSaveAnyway = () => {
-    commitSave(pendingParsed)
-  }
-
-  const handleConfirmBack = () => {
-    setShowConfirm(false)
+    setParseError(null)
     setPendingErrors([])
-    setPendingParsed(null)
+    setShowErrors(false)
+    setIsEditing(false)
+  }
+
+  const handleErrorsBack = () => {
+    setShowErrors(false)
+    setPendingErrors([])
   }
 
   return (
@@ -185,99 +153,88 @@ const JsonPreview = ({ schema }) => {
         </Accordion.Item>
       </Accordion>
 
-      <Modal
+      <CustomModal
         show={isEditing}
-        onHide={handleCancel}
-        size="lg"
-        animation={false}
-        aria-labelledby="json-preview-edit-modal-title"
-      >
-        <Modal.Header closeButton>
-          <Modal.Title id="json-preview-edit-modal-title">
-            Edit JSON
-          </Modal.Title>
-        </Modal.Header>
-
-        <Modal.Body>
-          {
-            parseError && (
-              <div className="text-danger small mb-2" role="alert">
-                {parseError}
-              </div>
-            )
+        toggleModal={
+          (nextShow) => {
+            if (!nextShow) handleCancel()
           }
+        }
+        size="lg"
+        header="Editing JSON"
+        message={
+          (
+            <>
+              {
+                parseError && (
+                  <div className="text-danger small mb-2" role="alert">
+                    {parseError}
+                  </div>
+                )
+              }
 
-          <textarea
-            className={`form-control font-monospace ${parseError ? 'is-invalid' : ''}`}
-            rows={20}
-            value={jsonText}
-            onChange={handleTextChange}
-            spellCheck={false}
-            aria-label="Editable JSON metadata"
-          />
-        </Modal.Body>
-
-        <Modal.Footer>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={handleCancel}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={handleSaveClick}
-          >
-            Save
-          </Button>
-        </Modal.Footer>
-      </Modal>
-
-      <Modal
-        show={showConfirm}
-        onHide={handleConfirmBack}
-        animation={false}
-        aria-labelledby="json-preview-confirm-modal-title"
-      >
-        <Modal.Header closeButton>
-          <Modal.Title id="json-preview-confirm-modal-title">
-            Confirm Save
-          </Modal.Title>
-        </Modal.Header>
-
-        <Modal.Body>
-          <p>Your record has following errors:</p>
-
-          <ul>
+              <textarea
+                className={`form-control font-monospace ${parseError ? 'is-invalid' : ''}`}
+                rows={20}
+                value={jsonText}
+                onChange={handleTextChange}
+                spellCheck={false}
+                aria-label="Editable JSON metadata"
+              />
+            </>
+          )
+        }
+        actions={
+          [
             {
-              pendingErrors.map((message) => (
-                <li key={message}>{message}</li>
-              ))
+              label: 'Cancel',
+              variant: 'secondary',
+              onClick: handleCancel
+            },
+            {
+              label: 'Apply',
+              variant: 'primary',
+              onClick: handleApplyClick
             }
-          </ul>
+          ]
+        }
+      />
 
-          <p>Would you like to proceed?</p>
-        </Modal.Body>
+      <CustomModal
+        show={showErrors}
+        toggleModal={
+          (nextShow) => {
+            if (!nextShow) handleErrorsBack()
+          }
+        }
+        header="Invalid JSON"
+        message={
+          (
+            <>
+              <p>Your record has following errors:</p>
 
-        <Modal.Footer>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={handleConfirmBack}
-          >
-            Back
-          </Button>
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={handleConfirmSaveAnyway}
-          >
-            Save & Continue
-          </Button>
-        </Modal.Footer>
-      </Modal>
+              <ul>
+                {
+                  pendingErrors.map((message) => (
+                    <li key={message}>{message}</li>
+                  ))
+                }
+              </ul>
+
+              <p>You must fix these errors before proceeding to save.</p>
+            </>
+          )
+        }
+        actions={
+          [
+            {
+              label: 'Go Back',
+              variant: 'primary',
+              onClick: handleErrorsBack
+            }
+          ]
+        }
+      />
     </>
   )
 }

--- a/static/src/js/components/JsonPreview/JsonPreview.jsx
+++ b/static/src/js/components/JsonPreview/JsonPreview.jsx
@@ -68,24 +68,10 @@ const JsonPreview = ({ schema }) => {
     if (schema) {
       const { errors: schemaErrors = [] } = validator.validateFormData(parsed, schema)
 
-      // Only surface structural errors (unknown field, wrong type). 'required'
-      // errors are ignored so the JSON editor stays as permissive as the form.
-      // A missing required field inside oneOf/anyOf also emits a wrapping
-      // oneOf/anyOf error at the same path -- drop that too, but only when a
-      // 'required' error exists at that path, since oneOf/anyOf is also how
-      // const-based enums fail on an invalid value (a real error to keep).
-      const requiredPaths = new Set(
-        schemaErrors
-          .filter(({ name }) => name === 'required')
-          .map(({ instancePath }) => instancePath)
-      )
-
-      const structuralErrors = schemaErrors.filter(({ name, instancePath }) => {
-        if (name === 'required') return false
-        if ((name === 'oneOf' || name === 'anyOf') && requiredPaths.has(instancePath)) return false
-
-        return true
-      })
+      // Only surface structural errors (unknown field, wrong type, oneOf/anyOf
+      // mismatches). 'required' errors are ignored so the JSON editor stays as
+      // permissive as the form.
+      const structuralErrors = schemaErrors.filter(({ name }) => name !== 'required')
 
       if (structuralErrors.length > 0) {
         const messages = structuralErrors.map(({
@@ -160,7 +146,7 @@ const JsonPreview = ({ schema }) => {
             if (!nextShow) handleCancel()
           }
         }
-        size="lg"
+        size="xl"
         header="Editing JSON"
         message={
           (
@@ -175,7 +161,7 @@ const JsonPreview = ({ schema }) => {
 
               <textarea
                 className={`form-control font-monospace ${parseError ? 'is-invalid' : ''}`}
-                rows={20}
+                rows={32}
                 value={jsonText}
                 onChange={handleTextChange}
                 spellCheck={false}

--- a/static/src/js/components/JsonPreview/JsonPreview.jsx
+++ b/static/src/js/components/JsonPreview/JsonPreview.jsx
@@ -2,25 +2,26 @@ import React, { useState, useEffect } from 'react'
 import Accordion from 'react-bootstrap/Accordion'
 import JSONPretty from 'react-json-pretty'
 import { cloneDeep } from 'lodash-es'
+import PropTypes from 'prop-types'
+import validator from '@rjsf/validator-ajv8'
 
 import useAppContext from '../../hooks/useAppContext'
 import removeEmpty from '../../utils/removeEmpty'
 import Button from '../Button/Button'
 
-const JsonPreview = () => {
+const JsonPreview = ({ schema }) => {
   const {
     draft = {},
     setDraft
   } = useAppContext()
 
-  // Remove || {} in MMT-4070
   const { ummMetadata = {} } = draft || {}
 
   const data = cloneDeep(removeEmpty(ummMetadata))
 
   const [isEditing, setIsEditing] = useState(false)
   const [jsonText, setJsonText] = useState('')
-  const [error, setError] = useState(null)
+  const [errors, setErrors] = useState([])
 
   // Keep the buffer in sync with the draft whenever we're not actively editing
   // (e.g. the form itself changed a field).
@@ -32,19 +33,19 @@ const JsonPreview = () => {
 
   const handleEditClick = () => {
     setJsonText(JSON.stringify(data, null, 2))
-    setError(null)
+    setErrors([])
     setIsEditing(true)
   }
 
   const handleCancel = () => {
     setJsonText(JSON.stringify(data, null, 2))
-    setError(null)
+    setErrors([])
     setIsEditing(false)
   }
 
   const handleTextChange = (event) => {
     setJsonText(event.target.value)
-    if (error) setError(null)
+    if (errors.length > 0) setErrors([])
   }
 
   const handleSave = () => {
@@ -53,9 +54,41 @@ const JsonPreview = () => {
     try {
       parsed = JSON.parse(jsonText)
     } catch (parseError) {
-      setError(`Invalid JSON: ${parseError.message}`)
+      setErrors([`Invalid JSON: ${parseError.message}`])
 
       return
+    }
+
+    if (schema) {
+      const { errors: schemaErrors = [] } = validator.validateFormData(parsed, schema)
+
+      // Only block on structural problems (an unknown/typo'd field name, or a
+      // value of the wrong type). Missing-required-field errors are ignored
+      // here so saving through the JSON editor stays as permissive as saving
+      // through the form fields, which never blocks on incomplete drafts.
+      const structuralErrors = schemaErrors.filter(({ name }) => name !== 'required')
+
+      if (structuralErrors.length > 0) {
+        setErrors(structuralErrors.map(({
+          name,
+          property,
+          message,
+          params
+        }) => {
+          // AJV puts the actual bad key in params.additionalProperty for this
+          // error type -- `property` here refers to the parent object, and
+          // `message` alone doesn't name the offending field at all.
+          if (name === 'additionalProperties' && params?.additionalProperty) {
+            const location = property ? `${property} ` : ''
+
+            return `${location}must NOT have additional property '${params.additionalProperty}'`
+          }
+
+          return property ? `${property} ${message}` : message
+        }))
+
+        return
+      }
     }
 
     setDraft({
@@ -63,7 +96,7 @@ const JsonPreview = () => {
       ummMetadata: parsed
     })
 
-    setError(null)
+    setErrors([])
     setIsEditing(false)
   }
 
@@ -112,9 +145,21 @@ const JsonPreview = () => {
           </div>
 
           {
-            error && (
+            errors.length > 0 && (
               <div className="text-danger small mb-2" role="alert">
-                {error}
+                {
+                  errors.length === 1
+                    ? errors[0]
+                    : (
+                      <ul className="mb-0 ps-3">
+                        {
+                          errors.map((message) => (
+                            <li key={message}>{message}</li>
+                          ))
+                        }
+                      </ul>
+                    )
+                }
               </div>
             )
           }
@@ -123,7 +168,7 @@ const JsonPreview = () => {
             isEditing
               ? (
                 <textarea
-                  className={`form-control font-monospace ${error ? 'is-invalid' : ''}`}
+                  className={`form-control font-monospace ${errors.length > 0 ? 'is-invalid' : ''}`}
                   rows={20}
                   value={jsonText}
                   onChange={handleTextChange}
@@ -137,6 +182,18 @@ const JsonPreview = () => {
       </Accordion.Item>
     </Accordion>
   )
+}
+
+JsonPreview.defaultProps = {
+  schema: null
+}
+
+JsonPreview.propTypes = {
+  // The full UMM schema (not a section-limited schema) to validate the
+  // edited JSON against on save. If omitted, only JSON-syntax validation
+  // is performed.
+  // eslint-disable-next-line react/forbid-prop-types
+  schema: PropTypes.object
 }
 
 export default JsonPreview

--- a/static/src/js/components/JsonPreview/JsonPreview.jsx
+++ b/static/src/js/components/JsonPreview/JsonPreview.jsx
@@ -193,6 +193,7 @@ const JsonPreview = ({ schema }) => {
             if (!nextShow) handleErrorsBack()
           }
         }
+        size="lg"
         header="Invalid JSON"
         message={
           (

--- a/static/src/js/components/JsonPreview/JsonPreview.jsx
+++ b/static/src/js/components/JsonPreview/JsonPreview.jsx
@@ -22,17 +22,38 @@ const JsonPreview = ({ schema }) => {
   const [isEditing, setIsEditing] = useState(false)
   const [jsonText, setJsonText] = useState('')
   const [errors, setErrors] = useState([])
+  // Snapshot of `data` (as a JSON string) taken the moment we entered edit
+  // mode. Used to detect if the draft changed out from under us while the
+  // textarea was open (e.g. the UI form was edited concurrently), so we
+  // know our buffer is stale relative to the source of truth.
+  const [editingSnapshot, setEditingSnapshot] = useState(null)
 
-  // Keep the buffer in sync with the draft whenever we're not actively editing
-  // (e.g. the form itself changed a field).
+  // Keep the buffer in sync with the draft whenever we're not actively
+  // editing (e.g. the form itself changed a field). If we ARE editing and
+  // the draft changes anyway (e.g. the UI form was edited/saved
+  // concurrently), our buffer is now stale relative to the source of
+  // truth -- bail out of edit mode rather than let a later Save overwrite
+  // the newer data with our stale copy.
   useEffect(() => {
     if (!isEditing) {
       setJsonText(JSON.stringify(data, null, 2))
+
+      return
     }
-  }, [data, isEditing])
+
+    if (editingSnapshot !== null && JSON.stringify(data) !== editingSnapshot) {
+      setIsEditing(false)
+      setErrors([])
+    }
+  }, [data, isEditing, editingSnapshot])
 
   const handleEditClick = () => {
     setJsonText(JSON.stringify(data, null, 2))
+    // Compact form here, to match the compact JSON.stringify(data) used for
+    // comparison in the effect above -- the two need the same formatting or
+    // they'll never compare equal, even when the underlying data hasn't
+    // changed.
+    setEditingSnapshot(JSON.stringify(data))
     setErrors([])
     setIsEditing(true)
   }

--- a/static/src/js/components/JsonPreview/JsonPreview.jsx
+++ b/static/src/js/components/JsonPreview/JsonPreview.jsx
@@ -84,7 +84,7 @@ const JsonPreview = ({ schema }) => {
           if (name === 'additionalProperties' && params?.additionalProperty) {
             const location = property ? `${property} ` : ''
 
-            return `${location}must NOT have additional property '${params.additionalProperty}'`
+            return `${location} must NOT have additional property '${params.additionalProperty}'`
           }
 
           return property ? `${property} ${message}` : message
@@ -198,7 +198,7 @@ const JsonPreview = ({ schema }) => {
         message={
           (
             <>
-              <p>Your record has following errors:</p>
+              <p>Your record has the following errors:</p>
 
               <ul>
                 {

--- a/static/src/js/components/JsonPreview/JsonPreview.jsx
+++ b/static/src/js/components/JsonPreview/JsonPreview.jsx
@@ -215,8 +215,9 @@ const JsonPreview = ({ schema }) => {
 
               <ul>
                 {
-                  pendingErrors.map((message) => (
-                    <li key={message}>{message}</li>
+                  pendingErrors.map((message, index) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <li key={`${index}-${message}`}>{message}</li>
                   ))
                 }
               </ul>

--- a/static/src/js/components/JsonPreview/JsonPreview.jsx
+++ b/static/src/js/components/JsonPreview/JsonPreview.jsx
@@ -1,20 +1,71 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import Accordion from 'react-bootstrap/Accordion'
 import JSONPretty from 'react-json-pretty'
 import { cloneDeep } from 'lodash-es'
 
 import useAppContext from '../../hooks/useAppContext'
 import removeEmpty from '../../utils/removeEmpty'
+import Button from '../Button/Button'
 
 const JsonPreview = () => {
   const {
-    draft = {}
+    draft = {},
+    setDraft
   } = useAppContext()
 
   // Remove || {} in MMT-4070
   const { ummMetadata = {} } = draft || {}
 
   const data = cloneDeep(removeEmpty(ummMetadata))
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [jsonText, setJsonText] = useState('')
+  const [error, setError] = useState(null)
+
+  // Keep the buffer in sync with the draft whenever we're not actively editing
+  // (e.g. the form itself changed a field).
+  useEffect(() => {
+    if (!isEditing) {
+      setJsonText(JSON.stringify(data, null, 2))
+    }
+  }, [data, isEditing])
+
+  const handleEditClick = () => {
+    setJsonText(JSON.stringify(data, null, 2))
+    setError(null)
+    setIsEditing(true)
+  }
+
+  const handleCancel = () => {
+    setJsonText(JSON.stringify(data, null, 2))
+    setError(null)
+    setIsEditing(false)
+  }
+
+  const handleTextChange = (event) => {
+    setJsonText(event.target.value)
+    if (error) setError(null)
+  }
+
+  const handleSave = () => {
+    let parsed
+
+    try {
+      parsed = JSON.parse(jsonText)
+    } catch (parseError) {
+      setError(`Invalid JSON: ${parseError.message}`)
+
+      return
+    }
+
+    setDraft({
+      ...draft,
+      ummMetadata: parsed
+    })
+
+    setError(null)
+    setIsEditing(false)
+  }
 
   return (
     <Accordion
@@ -26,7 +77,62 @@ const JsonPreview = () => {
           JSON
         </Accordion.Header>
         <Accordion.Body>
-          <JSONPretty data={data} />
+          <div className="d-flex justify-content-end mb-2">
+            {
+              isEditing
+                ? (
+                  <>
+                    <Button
+                      className="me-2"
+                      variant="secondary"
+                      size="sm"
+                      onClick={handleCancel}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      onClick={handleSave}
+                    >
+                      Save
+                    </Button>
+                  </>
+                )
+                : (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleEditClick}
+                  >
+                    Edit JSON
+                  </Button>
+                )
+            }
+          </div>
+
+          {
+            error && (
+              <div className="text-danger small mb-2" role="alert">
+                {error}
+              </div>
+            )
+          }
+
+          {
+            isEditing
+              ? (
+                <textarea
+                  className={`form-control font-monospace ${error ? 'is-invalid' : ''}`}
+                  rows={20}
+                  value={jsonText}
+                  onChange={handleTextChange}
+                  spellCheck={false}
+                  aria-label="Editable JSON metadata"
+                />
+              )
+              : <JSONPretty data={data} />
+          }
         </Accordion.Body>
       </Accordion.Item>
     </Accordion>

--- a/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
+++ b/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
@@ -8,7 +8,17 @@ import AppContext from '../../../context/AppContext'
 
 vi.mock('react-json-pretty')
 
-const setup = (draft = undefined, overrides = {}) => {
+const mockSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['Name'],
+  properties: {
+    Name: { type: 'string' },
+    Age: { type: 'number' }
+  }
+}
+
+const setup = (draft = undefined, { schema = null } = {}) => {
   const setDraft = vi.fn()
 
   render(
@@ -16,12 +26,11 @@ const setup = (draft = undefined, overrides = {}) => {
       value={
         {
           draft,
-          setDraft,
-          ...overrides
+          setDraft
         }
       }
     >
-      <JsonPreview />
+      <JsonPreview schema={schema} />
     </AppContext.Provider>
   )
 
@@ -227,6 +236,161 @@ describe('JsonPreview Component', () => {
       await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
 
       expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' }).value).toContain('"Name": "Mock Name"')
+    })
+  })
+
+  describe('when a schema prop is provided', () => {
+    describe('when the edited JSON is only missing a required field', () => {
+      test('saves anyway, since missing-required-field errors are ignored', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Name: 'Mock Name'
+          }
+        }, { schema: mockSchema })
+
+        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+        // Removes the required `Name` field entirely
+        await user.clear(textarea)
+        await user.type(textarea, '{{}', { skipClick: true })
+
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(setDraft).toHaveBeenCalledTimes(1)
+        expect(setDraft).toHaveBeenCalledWith({
+          ummMetadata: {}
+        })
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
+      })
+    })
+
+    describe('when the edited JSON has an unknown/typo\'d field name', () => {
+      test('blocks the save, names the offending field, and stays in edit mode', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Name: 'Mock Name'
+          }
+        }, { schema: mockSchema })
+
+        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+        await user.clear(textarea)
+        await user.type(textarea, '{{"Name": "Mock Name", "Nmae": "typo"}', { skipClick: true })
+
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(setDraft).not.toHaveBeenCalled()
+
+        const alert = screen.getByRole('alert')
+
+        expect(alert).toHaveTextContent(/Nmae/)
+        expect(alert).toHaveTextContent(/must NOT have additional property/)
+
+        expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+      })
+    })
+
+    describe('when the edited JSON has a value of the wrong type', () => {
+      test('blocks the save and shows the type error', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Name: 'Mock Name'
+          }
+        }, { schema: mockSchema })
+
+        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+        await user.clear(textarea)
+        await user.type(textarea, '{{"Name": "Mock Name", "Age": "not a number"}', { skipClick: true })
+
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(setDraft).not.toHaveBeenCalled()
+
+        const alert = screen.getByRole('alert')
+
+        expect(alert).toHaveTextContent(/Age/)
+        expect(alert).toHaveTextContent(/must be number/)
+      })
+    })
+
+    describe('when the edited JSON has both a missing required field and a structural error', () => {
+      test('only the structural error is shown, the required error is omitted', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Name: 'Mock Name'
+          }
+        }, { schema: mockSchema })
+
+        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+        // Missing required `Name`, and has an unknown field `Nmae`
+        await user.clear(textarea)
+        await user.type(textarea, '{{"Nmae": "typo"}', { skipClick: true })
+
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(setDraft).not.toHaveBeenCalled()
+
+        const alert = screen.getByRole('alert')
+
+        expect(alert).toHaveTextContent(/Nmae/)
+        expect(alert).not.toHaveTextContent(/required/)
+
+        // A single error renders as plain text, not as a list
+        expect(screen.queryByRole('listitem')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('when the edited JSON has multiple structural errors', () => {
+      test('renders each error as a separate list item', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Name: 'Mock Name'
+          }
+        }, { schema: mockSchema })
+
+        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+        await user.clear(textarea)
+        await user.type(textarea, '{{"Name": "Mock Name", "Nmae": "typo", "Aeg": "typo2"}', { skipClick: true })
+
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(setDraft).not.toHaveBeenCalled()
+
+        const listItems = screen.getAllByRole('listitem')
+
+        expect(listItems).toHaveLength(2)
+
+        const combinedText = listItems.map((item) => item.textContent).join(' ')
+
+        expect(combinedText).toContain('Nmae')
+        expect(combinedText).toContain('Aeg')
+      })
     })
   })
 })

--- a/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
+++ b/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
@@ -1,5 +1,9 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen,
+  within
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import JSONPretty from 'react-json-pretty'
 
@@ -124,6 +128,10 @@ const openEditorAndType = async (user, jsonText) => {
   return textarea
 }
 
+// Joins the text content of the errors modal's list items, since that's
+// where the structural-error messages themselves are rendered.
+const errorListText = () => screen.getAllByRole('listitem').map((item) => item.textContent).join(' ')
+
 describe('JsonPreview Component', () => {
   describe('when draft is not present in the context', () => {
     test('renders JSONPretty', () => {
@@ -184,7 +192,8 @@ describe('JsonPreview Component', () => {
       })
 
       expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      expect(screen.queryByText('Editing JSON')).not.toBeInTheDocument()
+      expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument()
       expect(screen.queryByRole('textbox', { name: 'Editable JSON metadata' })).not.toBeInTheDocument()
     })
   })
@@ -201,19 +210,18 @@ describe('JsonPreview Component', () => {
 
       await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
 
-      const dialog = screen.getByRole('dialog', { name: 'Edit JSON' })
       const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
 
-      expect(dialog).toBeInTheDocument()
+      expect(screen.getByText('Editing JSON')).toBeInTheDocument()
       expect(textarea).toBeInTheDocument()
       expect(textarea.value).toContain('"Name": "Mock Name"')
 
-      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
     })
   })
 
-  describe('when the user edits the JSON and clicks Save', () => {
+  describe('when the user edits the JSON and clicks Apply', () => {
     test('calls setDraft with the parsed JSON merged into the draft and closes the modal', async () => {
       const user = userEvent.setup()
 
@@ -226,7 +234,7 @@ describe('JsonPreview Component', () => {
 
       await openEditorAndType(user, '{{"Name": "Updated Name"}')
 
-      await user.click(screen.getByRole('button', { name: 'Save' }))
+      await user.click(screen.getByRole('button', { name: 'Apply' }))
 
       expect(setDraft).toHaveBeenCalledTimes(1)
       expect(setDraft).toHaveBeenCalledWith({
@@ -236,13 +244,13 @@ describe('JsonPreview Component', () => {
         }
       })
 
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      expect(screen.queryByText('Editing JSON')).not.toBeInTheDocument()
       expect(screen.queryByRole('textbox', { name: 'Editable JSON metadata' })).not.toBeInTheDocument()
     })
   })
 
-  describe('when the user enters invalid JSON and clicks Save', () => {
-    test('shows an inline error, does not call setDraft, does not open a confirmation modal, and stays in edit mode', async () => {
+  describe('when the user enters invalid JSON and clicks Apply', () => {
+    test('shows an inline error, does not call setDraft, does not open the errors modal, and stays in edit mode', async () => {
       const user = userEvent.setup()
 
       const { setDraft } = setup({
@@ -253,19 +261,19 @@ describe('JsonPreview Component', () => {
 
       await openEditorAndType(user, '{{ this is not valid json')
 
-      await user.click(screen.getByRole('button', { name: 'Save' }))
+      await user.click(screen.getByRole('button', { name: 'Apply' }))
 
       expect(setDraft).not.toHaveBeenCalled()
       expect(screen.getByRole('alert')).toHaveTextContent(/Invalid JSON/)
 
-      // A parse failure isn't something a "save anyway" confirmation makes
-      // sense for -- there's no parsed data to save.
-      expect(screen.queryByRole('dialog', { name: 'Confirm Save' })).not.toBeInTheDocument()
+      // A parse failure isn't something the errors modal makes sense for --
+      // there's no parsed data to report structural errors about.
+      expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument()
 
-      // Should remain in the edit modal with Save/Cancel still present
-      expect(screen.getByRole('dialog', { name: 'Edit JSON' })).toBeInTheDocument()
+      // Should remain in the edit modal with Apply/Cancel still present
+      expect(screen.getByText('Editing JSON')).toBeInTheDocument()
       expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument()
     })
 
     test('clears the error once the user starts typing again', async () => {
@@ -279,7 +287,7 @@ describe('JsonPreview Component', () => {
 
       const textarea = await openEditorAndType(user, '{{ not valid')
 
-      await user.click(screen.getByRole('button', { name: 'Save' }))
+      await user.click(screen.getByRole('button', { name: 'Apply' }))
 
       expect(screen.getByRole('alert')).toBeInTheDocument()
 
@@ -304,7 +312,8 @@ describe('JsonPreview Component', () => {
       await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
       expect(setDraft).not.toHaveBeenCalled()
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      expect(screen.queryByText('Editing JSON')).not.toBeInTheDocument()
+      expect(screen.queryByRole('textbox', { name: 'Editable JSON metadata' })).not.toBeInTheDocument()
 
       // Re-opening edit mode should show the original (unsaved-change-free) JSON again
       await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
@@ -315,7 +324,7 @@ describe('JsonPreview Component', () => {
 
   describe('when a schema prop is provided', () => {
     describe('when the edited JSON is only missing a required field', () => {
-      test('saves immediately with no confirmation, since missing-required-field errors are ignored', async () => {
+      test('saves immediately with no errors modal, since missing-required-field errors are ignored', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -327,19 +336,20 @@ describe('JsonPreview Component', () => {
         // Removes the required `Name` field entirely
         await openEditorAndType(user, '{{}')
 
-        await user.click(screen.getByRole('button', { name: 'Save' }))
+        await user.click(screen.getByRole('button', { name: 'Apply' }))
 
         expect(setDraft).toHaveBeenCalledTimes(1)
         expect(setDraft).toHaveBeenCalledWith({
           ummMetadata: {}
         })
 
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        expect(screen.queryByText('Editing JSON')).not.toBeInTheDocument()
+        expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument()
       })
     })
 
     describe('when the edited JSON has an unknown/typo\'d field name', () => {
-      test('opens a confirmation modal naming the offending field, and does not save yet', async () => {
+      test('opens an errors modal naming the offending field, and does not save', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -350,22 +360,32 @@ describe('JsonPreview Component', () => {
 
         await openEditorAndType(user, '{{"Name": "Mock Name", "Nmae": "typo"}')
 
-        await user.click(screen.getByRole('button', { name: 'Save' }))
+        await user.click(screen.getByRole('button', { name: 'Apply' }))
 
         expect(setDraft).not.toHaveBeenCalled()
 
-        const confirmDialog = screen.getByRole('dialog', { name: 'Confirm Save' })
+        expect(screen.getByText('Invalid JSON')).toBeInTheDocument()
+        expect(errorListText()).toMatch(/Nmae/)
+        expect(errorListText()).toMatch(/must NOT have additional property/)
+        expect(screen.getByText(/must fix these errors before proceeding to save/i)).toBeInTheDocument()
 
-        expect(confirmDialog).toHaveTextContent(/Nmae/)
-        expect(confirmDialog).toHaveTextContent(/must NOT have additional property/)
-        expect(confirmDialog).toHaveTextContent(/would you like to proceed/i)
+        // There's no way to save from here -- only a way back to editing.
+        // The edit modal stays mounted underneath (with Apply still on it),
+        // so this has to be scoped to the errors modal itself.
+        const errorsModal = screen
+          .getAllByRole('dialog')
+          .find((dialog) => within(dialog).queryByText('Invalid JSON'))
+
+        expect(within(errorsModal).queryByRole('button', { name: 'Apply' })).not.toBeInTheDocument()
+        expect(within(errorsModal).queryByRole('button', { name: 'Save & Continue' })).not.toBeInTheDocument()
+        expect(within(errorsModal).getByRole('button', { name: 'Go Back' })).toBeInTheDocument()
 
         // The edit modal stays open underneath, with the unsaved text intact
-        expect(screen.getByRole('dialog', { name: 'Edit JSON' })).toBeInTheDocument()
+        expect(screen.getByText('Editing JSON')).toBeInTheDocument()
         expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' }).value).toContain('Nmae')
       })
 
-      test('clicking "Yes, save anyway" saves the structurally-invalid JSON and closes both modals', async () => {
+      test('clicking "Go Back" closes the errors modal without saving, keeping the edit modal open', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -375,47 +395,20 @@ describe('JsonPreview Component', () => {
         }, { schema: mockSchema })
 
         await openEditorAndType(user, '{{"Name": "Mock Name", "Nmae": "typo"}')
-        await user.click(screen.getByRole('button', { name: 'Save' }))
+        await user.click(screen.getByRole('button', { name: 'Apply' }))
 
-        await user.click(screen.getByRole('button', { name: 'Save & Continue' }))
-
-        expect(setDraft).toHaveBeenCalledTimes(1)
-        expect(setDraft).toHaveBeenCalledWith({
-          ummMetadata: {
-            Name: 'Mock Name',
-            Nmae: 'typo'
-          }
-        })
-
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-      })
-
-      test('clicking "No, go back" closes the confirmation modal without saving, keeping the edit modal open', async () => {
-        const user = userEvent.setup()
-
-        const { setDraft } = setup({
-          ummMetadata: {
-            Name: 'Mock Name'
-          }
-        }, { schema: mockSchema })
-
-        await openEditorAndType(user, '{{"Name": "Mock Name", "Nmae": "typo"}')
-        await user.click(screen.getByRole('button', { name: 'Save' }))
-
-        await user.click(screen.getByRole('button', { name: 'Back' }))
+        await user.click(screen.getByRole('button', { name: 'Go Back' }))
 
         expect(setDraft).not.toHaveBeenCalled()
-        expect(screen.queryByRole('dialog', { name: 'Confirm Save' })).not.toBeInTheDocument()
+        expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument()
 
-        const editDialog = screen.getByRole('dialog', { name: 'Edit JSON' })
-
-        expect(editDialog).toBeInTheDocument()
+        expect(screen.getByText('Editing JSON')).toBeInTheDocument()
         expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' }).value).toContain('Nmae')
       })
     })
 
     describe('when the edited JSON has a value of the wrong type', () => {
-      test('opens a confirmation modal with the type error', async () => {
+      test('opens an errors modal with the type error', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -426,19 +419,18 @@ describe('JsonPreview Component', () => {
 
         await openEditorAndType(user, '{{"Name": "Mock Name", "Age": "not a number"}')
 
-        await user.click(screen.getByRole('button', { name: 'Save' }))
+        await user.click(screen.getByRole('button', { name: 'Apply' }))
 
         expect(setDraft).not.toHaveBeenCalled()
 
-        const confirmDialog = screen.getByRole('dialog', { name: 'Confirm Save' })
-
-        expect(confirmDialog).toHaveTextContent(/Age/)
-        expect(confirmDialog).toHaveTextContent(/must be number/)
+        expect(screen.getByText('Invalid JSON')).toBeInTheDocument()
+        expect(errorListText()).toMatch(/Age/)
+        expect(errorListText()).toMatch(/must be number/)
       })
     })
 
     describe('when the edited JSON has an invalid value for a oneOf/const-style enum field', () => {
-      test('opens a confirmation modal instead of silently saving the invalid value', async () => {
+      test('opens an errors modal instead of silently saving the invalid value', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -451,38 +443,16 @@ describe('JsonPreview Component', () => {
         // required-field error at this path to (correctly) suppress it
         await openEditorAndType(user, '{{"Status": "Bogus"}')
 
-        await user.click(screen.getByRole('button', { name: 'Save' }))
+        await user.click(screen.getByRole('button', { name: 'Apply' }))
 
         expect(setDraft).not.toHaveBeenCalled()
 
-        const confirmDialog = screen.getByRole('dialog', { name: 'Confirm Save' })
-
-        expect(confirmDialog).toHaveTextContent(/Status/)
-        expect(confirmDialog).toHaveTextContent(/would you like to proceed/i)
+        expect(screen.getByText('Invalid JSON')).toBeInTheDocument()
+        expect(errorListText()).toMatch(/Status/)
+        expect(screen.getByText(/must fix these errors before proceeding to save/i)).toBeInTheDocument()
       })
 
-      test('clicking "Save & Continue" saves the invalid enum value', async () => {
-        const user = userEvent.setup()
-
-        const { setDraft } = setup({
-          ummMetadata: {
-            Status: 'Active'
-          }
-        }, { schema: mockEnumAsOneOfSchema })
-
-        await openEditorAndType(user, '{{"Status": "Bogus"}')
-        await user.click(screen.getByRole('button', { name: 'Save' }))
-        await user.click(screen.getByRole('button', { name: 'Save & Continue' }))
-
-        expect(setDraft).toHaveBeenCalledTimes(1)
-        expect(setDraft).toHaveBeenCalledWith({
-          ummMetadata: {
-            Status: 'Bogus'
-          }
-        })
-      })
-
-      test('a valid enum value saves immediately with no confirmation', async () => {
+      test('a valid enum value saves immediately with no errors modal', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -493,7 +463,7 @@ describe('JsonPreview Component', () => {
 
         await openEditorAndType(user, '{{"Status": "Inactive"}')
 
-        await user.click(screen.getByRole('button', { name: 'Save' }))
+        await user.click(screen.getByRole('button', { name: 'Apply' }))
 
         expect(setDraft).toHaveBeenCalledTimes(1)
         expect(setDraft).toHaveBeenCalledWith({
@@ -502,12 +472,13 @@ describe('JsonPreview Component', () => {
           }
         })
 
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        expect(screen.queryByText('Editing JSON')).not.toBeInTheDocument()
+        expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument()
       })
     })
 
     describe('when the edited JSON has both a missing required field and a structural error', () => {
-      test('the confirmation modal names only the structural error, the required error is omitted', async () => {
+      test('the errors modal names only the structural error, the required error is omitted', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -519,14 +490,12 @@ describe('JsonPreview Component', () => {
         // Missing required `Name`, and has an unknown field `Nmae`
         await openEditorAndType(user, '{{"Nmae": "typo"}')
 
-        await user.click(screen.getByRole('button', { name: 'Save' }))
+        await user.click(screen.getByRole('button', { name: 'Apply' }))
 
         expect(setDraft).not.toHaveBeenCalled()
 
-        const confirmDialog = screen.getByRole('dialog', { name: 'Confirm Save' })
-
-        expect(confirmDialog).toHaveTextContent(/Nmae/)
-        expect(confirmDialog).not.toHaveTextContent(/"required"/)
+        expect(errorListText()).toMatch(/Nmae/)
+        expect(errorListText()).not.toMatch(/"required"/)
 
         // A single structural error still renders as a one-item list
         expect(screen.getAllByRole('listitem')).toHaveLength(1)
@@ -534,7 +503,7 @@ describe('JsonPreview Component', () => {
     })
 
     describe('when the edited JSON is missing the required field in every oneOf branch', () => {
-      test('saves immediately with no confirmation, since the oneOf wrapper error is noise from the required errors', async () => {
+      test('saves immediately with no errors modal, since the oneOf wrapper error is noise from the required errors', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -546,7 +515,7 @@ describe('JsonPreview Component', () => {
         // Satisfies neither branch: no `Name` and no `Nickname`
         await openEditorAndType(user, '{{"Age": 5}')
 
-        await user.click(screen.getByRole('button', { name: 'Save' }))
+        await user.click(screen.getByRole('button', { name: 'Apply' }))
 
         expect(setDraft).toHaveBeenCalledTimes(1)
         expect(setDraft).toHaveBeenCalledWith({
@@ -555,12 +524,13 @@ describe('JsonPreview Component', () => {
           }
         })
 
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        expect(screen.queryByText('Editing JSON')).not.toBeInTheDocument()
+        expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument()
       })
     })
 
     describe('when the edited JSON has an unknown field under a oneOf schema', () => {
-      test('still opens a confirmation modal for the structural error, even though the oneOf wrapper error is ignored', async () => {
+      test('still opens an errors modal for the structural error, even though the oneOf wrapper error is ignored', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -572,19 +542,18 @@ describe('JsonPreview Component', () => {
         // Satisfies the `Name` branch, but also has a typo'd unknown field
         await openEditorAndType(user, '{{"Name": "Mock Name", "Nmae": "typo"}')
 
-        await user.click(screen.getByRole('button', { name: 'Save' }))
+        await user.click(screen.getByRole('button', { name: 'Apply' }))
 
         expect(setDraft).not.toHaveBeenCalled()
 
-        const confirmDialog = screen.getByRole('dialog', { name: 'Confirm Save' })
-
-        expect(confirmDialog).toHaveTextContent(/Nmae/)
-        expect(confirmDialog).toHaveTextContent(/must NOT have additional property/)
+        expect(screen.getByText('Invalid JSON')).toBeInTheDocument()
+        expect(errorListText()).toMatch(/Nmae/)
+        expect(errorListText()).toMatch(/must NOT have additional property/)
       })
     })
 
     describe('when the edited JSON has multiple structural errors', () => {
-      test('renders each error as a separate list item in the confirmation modal', async () => {
+      test('renders each error as a separate list item in the errors modal', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -595,7 +564,7 @@ describe('JsonPreview Component', () => {
 
         await openEditorAndType(user, '{{"Name": "Mock Name", "Nmae": "typo", "Aeg": "typo2"}')
 
-        await user.click(screen.getByRole('button', { name: 'Save' }))
+        await user.click(screen.getByRole('button', { name: 'Apply' }))
 
         expect(setDraft).not.toHaveBeenCalled()
 

--- a/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
+++ b/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
@@ -51,7 +51,7 @@ const mockOneOfSchema = {
 const setup = (draft = undefined, { schema = null } = {}) => {
   const setDraft = vi.fn()
 
-  render(
+  const { rerender } = render(
     <AppContext.Provider
       value={
         {
@@ -64,7 +64,28 @@ const setup = (draft = undefined, { schema = null } = {}) => {
     </AppContext.Provider>
   )
 
-  return { setDraft }
+  // Allows a test to simulate the draft changing out from under JsonPreview
+  // (e.g. the UI form calling its own setDraft) by re-rendering with a new
+  // draft, without going through JsonPreview's own setDraft mock.
+  const rerenderWithDraft = (nextDraft) => {
+    rerender(
+      <AppContext.Provider
+        value={
+          {
+            draft: nextDraft,
+            setDraft
+          }
+        }
+      >
+        <JsonPreview schema={schema} />
+      </AppContext.Provider>
+    )
+  }
+
+  return {
+    setDraft,
+    rerenderWithDraft
+  }
 }
 
 describe('JsonPreview Component', () => {
@@ -266,6 +287,89 @@ describe('JsonPreview Component', () => {
       await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
 
       expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' }).value).toContain('"Name": "Mock Name"')
+    })
+  })
+
+  describe('when the draft changes externally while editing (e.g. the UI form was saved)', () => {
+    test('exits edit mode, discards the stale buffer, and shows the new data', async () => {
+      const user = userEvent.setup()
+
+      const { setDraft, rerenderWithDraft } = setup({
+        ummMetadata: {
+          Name: 'Mock Name'
+        }
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+      // Make an unsaved edit in the JSON textarea
+      await user.clear(textarea)
+      await user.type(textarea, '{{"Name": "Unsaved JSON Edit"}', { skipClick: true })
+
+      expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' })).toBeInTheDocument()
+
+      // Simulate the UI form changing the draft concurrently (its own
+      // onChange -> setDraft), independent of anything JsonPreview did
+      rerenderWithDraft({
+        ummMetadata: {
+          Name: 'Changed From UI Form'
+        }
+      })
+
+      // JsonPreview should have bailed out of edit mode rather than let a
+      // later Save clobber the newer data with the stale JSON buffer
+      expect(screen.queryByRole('textbox', { name: 'Editable JSON metadata' })).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+      expect(JSONPretty).toHaveBeenLastCalledWith(expect.objectContaining({
+        data: {
+          Name: 'Changed From UI Form'
+        }
+      }), {})
+
+      // JsonPreview's own setDraft should never have been called -- the
+      // change came from elsewhere
+      expect(setDraft).not.toHaveBeenCalled()
+
+      // Re-entering edit mode should now start from the fresh data, not the
+      // discarded buffer
+      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+      expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' }).value)
+        .toContain('"Name": "Changed From UI Form"')
+    })
+
+    test('does not exit edit mode when the draft is re-rendered with the same data', async () => {
+      const user = userEvent.setup()
+
+      const { rerenderWithDraft } = setup({
+        ummMetadata: {
+          Name: 'Mock Name'
+        }
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+      await user.clear(textarea)
+      await user.type(textarea, '{{"Name": "Unsaved JSON Edit"}', { skipClick: true })
+
+      // Re-render with an equivalent (not just equal-by-reference) draft --
+      // this should NOT be treated as an external change
+      rerenderWithDraft({
+        ummMetadata: {
+          Name: 'Mock Name'
+        }
+      })
+
+      const stillTextarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+      expect(stillTextarea).toBeInTheDocument()
+      expect(stillTextarea.value).toContain('"Name": "Unsaved JSON Edit"')
     })
   })
 

--- a/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
+++ b/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import JSONPretty from 'react-json-pretty'
 
 import JsonPreview from '../JsonPreview'
@@ -7,12 +8,24 @@ import AppContext from '../../../context/AppContext'
 
 vi.mock('react-json-pretty')
 
-const setup = (draft = undefined) => {
+const setup = (draft = undefined, overrides = {}) => {
+  const setDraft = vi.fn()
+
   render(
-    <AppContext.Provider value={{ draft }}>
+    <AppContext.Provider
+      value={
+        {
+          draft,
+          setDraft,
+          ...overrides
+        }
+      }
+    >
       <JsonPreview />
     </AppContext.Provider>
   )
+
+  return { setDraft }
 }
 
 describe('JsonPreview Component', () => {
@@ -63,6 +76,157 @@ describe('JsonPreview Component', () => {
           Name: 'Mock Name'
         }
       }), {})
+    })
+  })
+
+  describe('when in view mode', () => {
+    test('renders an Edit JSON button and no textarea', () => {
+      setup({
+        ummMetadata: {
+          Name: 'Mock Name'
+        }
+      })
+
+      expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
+      expect(screen.queryByRole('textbox', { name: 'Editable JSON metadata' })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when the user clicks Edit JSON', () => {
+    test('shows a textarea pre-populated with the current JSON and hides JSONPretty', async () => {
+      const user = userEvent.setup()
+
+      setup({
+        ummMetadata: {
+          Name: 'Mock Name'
+        }
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+      expect(textarea).toBeInTheDocument()
+      expect(textarea.value).toContain('"Name": "Mock Name"')
+
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Edit JSON' })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when the user edits the JSON and clicks Save', () => {
+    test('calls setDraft with the parsed JSON merged into the draft and returns to view mode', async () => {
+      const user = userEvent.setup()
+
+      const { setDraft } = setup({
+        nativeId: 'MOCK-123',
+        ummMetadata: {
+          Name: 'Mock Name'
+        }
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+      await user.clear(textarea)
+      await user.type(textarea, '{{"Name": "Updated Name"}', { skipClick: true })
+
+      await user.click(screen.getByRole('button', { name: 'Save' }))
+
+      expect(setDraft).toHaveBeenCalledTimes(1)
+      expect(setDraft).toHaveBeenCalledWith({
+        nativeId: 'MOCK-123',
+        ummMetadata: {
+          Name: 'Updated Name'
+        }
+      })
+
+      expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
+      expect(screen.queryByRole('textbox', { name: 'Editable JSON metadata' })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when the user enters invalid JSON and clicks Save', () => {
+    test('shows an error message, does not call setDraft, and stays in edit mode', async () => {
+      const user = userEvent.setup()
+
+      const { setDraft } = setup({
+        ummMetadata: {
+          Name: 'Mock Name'
+        }
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+      await user.clear(textarea)
+      await user.type(textarea, '{{ this is not valid json', { skipClick: true })
+
+      await user.click(screen.getByRole('button', { name: 'Save' }))
+
+      expect(setDraft).not.toHaveBeenCalled()
+      expect(screen.getByRole('alert')).toHaveTextContent(/Invalid JSON/)
+
+      // Should remain in edit mode with the Save/Cancel buttons still present
+      expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    })
+
+    test('clears the error once the user starts typing again', async () => {
+      const user = userEvent.setup()
+
+      setup({
+        ummMetadata: {
+          Name: 'Mock Name'
+        }
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+      await user.clear(textarea)
+      await user.type(textarea, '{{ not valid', { skipClick: true })
+      await user.click(screen.getByRole('button', { name: 'Save' }))
+
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+
+      await user.type(textarea, 'a')
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when the user clicks Cancel after editing', () => {
+    test('discards changes, does not call setDraft, and returns to view mode', async () => {
+      const user = userEvent.setup()
+
+      const { setDraft } = setup({
+        ummMetadata: {
+          Name: 'Mock Name'
+        }
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+      await user.clear(textarea)
+      await user.type(textarea, '{{"Name": "Should Not Save"}', { skipClick: true })
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+      expect(setDraft).not.toHaveBeenCalled()
+      expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
+      expect(screen.queryByRole('textbox', { name: 'Editable JSON metadata' })).not.toBeInTheDocument()
+
+      // Re-opening edit mode should show the original (unsaved-change-free) JSON again
+      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+      expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' }).value).toContain('"Name": "Mock Name"')
     })
   })
 })

--- a/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
+++ b/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
@@ -18,6 +18,36 @@ const mockSchema = {
   }
 }
 
+// A discriminated-union-style schema: a valid document must satisfy exactly
+// one of the two branches below. Each branch has its own required field, so
+// AJV reports a missing branch field as both a `required` error *and* a
+// wrapping `oneOf` error ("must match a schema in oneOf") at the root.
+const mockOneOfSchema = {
+  type: 'object',
+  additionalProperties: false,
+  oneOf: [
+    {
+      required: ['Name'],
+      properties: {
+        Name: { type: 'string' },
+        Age: { type: 'number' }
+      }
+    },
+    {
+      required: ['Nickname'],
+      properties: {
+        Nickname: { type: 'string' },
+        Age: { type: 'number' }
+      }
+    }
+  ],
+  properties: {
+    Name: { type: 'string' },
+    Nickname: { type: 'string' },
+    Age: { type: 'number' }
+  }
+}
+
 const setup = (draft = undefined, { schema = null } = {}) => {
   const setDraft = vi.fn()
 
@@ -358,6 +388,67 @@ describe('JsonPreview Component', () => {
 
         // A single error renders as plain text, not as a list
         expect(screen.queryByRole('listitem')).not.toBeInTheDocument()
+      })
+    })
+
+    describe('when the edited JSON is missing the required field in every oneOf branch', () => {
+      test('saves anyway, since the resulting oneOf wrapper error is ignored along with the required errors', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Name: 'Mock Name'
+          }
+        }, { schema: mockOneOfSchema })
+
+        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+        // Satisfies neither branch: no `Name` and no `Nickname`
+        await user.clear(textarea)
+        await user.type(textarea, '{{"Age": 5}', { skipClick: true })
+
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(setDraft).toHaveBeenCalledTimes(1)
+        expect(setDraft).toHaveBeenCalledWith({
+          ummMetadata: {
+            Age: 5
+          }
+        })
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
+      })
+    })
+
+    describe('when the edited JSON has an unknown field under a oneOf schema', () => {
+      test('still blocks the save on the structural error, even though the oneOf wrapper error is ignored', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Name: 'Mock Name'
+          }
+        }, { schema: mockOneOfSchema })
+
+        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+        // Satisfies the `Name` branch, but also has a typo'd unknown field
+        await user.clear(textarea)
+        await user.type(textarea, '{{"Name": "Mock Name", "Nmae": "typo"}', { skipClick: true })
+
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(setDraft).not.toHaveBeenCalled()
+
+        const alert = screen.getByRole('alert')
+
+        expect(alert).toHaveTextContent(/Nmae/)
+        expect(alert).toHaveTextContent(/must NOT have additional property/)
       })
     })
 

--- a/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
+++ b/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
@@ -48,6 +48,30 @@ const mockOneOfSchema = {
   }
 }
 
+// A controlled-vocabulary field expressed as `oneOf: [{ const: ... }]`
+// rather than a plain `enum`. This is the pattern that was silently passing
+// validation before the fix: the blanket oneOf/anyOf filter was dropping
+// this error along with the legitimate required-field noise, even though
+// there's no missing-required-field involved here at all.
+const mockEnumAsOneOfSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    Status: {
+      oneOf: [
+        {
+          const: 'Active',
+          title: 'Active'
+        },
+        {
+          const: 'Inactive',
+          title: 'Inactive'
+        }
+      ]
+    }
+  }
+}
+
 const setup = (draft = undefined, { schema = null } = {}) => {
   const setDraft = vi.fn()
 
@@ -86,6 +110,18 @@ const setup = (draft = undefined, { schema = null } = {}) => {
     setDraft,
     rerenderWithDraft
   }
+}
+
+// Opens the edit modal and replaces its textarea contents with `jsonText`.
+const openEditorAndType = async (user, jsonText) => {
+  await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+
+  const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
+
+  await user.clear(textarea)
+  await user.type(textarea, jsonText, { skipClick: true })
+
+  return textarea
 }
 
 describe('JsonPreview Component', () => {
@@ -140,7 +176,7 @@ describe('JsonPreview Component', () => {
   })
 
   describe('when in view mode', () => {
-    test('renders an Edit JSON button and no textarea', () => {
+    test('renders an Edit JSON button and no modal', () => {
       setup({
         ummMetadata: {
           Name: 'Mock Name'
@@ -148,12 +184,13 @@ describe('JsonPreview Component', () => {
       })
 
       expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
       expect(screen.queryByRole('textbox', { name: 'Editable JSON metadata' })).not.toBeInTheDocument()
     })
   })
 
   describe('when the user clicks Edit JSON', () => {
-    test('shows a textarea pre-populated with the current JSON and hides JSONPretty', async () => {
+    test('opens a modal with a textarea pre-populated with the current JSON', async () => {
       const user = userEvent.setup()
 
       setup({
@@ -164,19 +201,20 @@ describe('JsonPreview Component', () => {
 
       await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
 
+      const dialog = screen.getByRole('dialog', { name: 'Edit JSON' })
       const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
 
+      expect(dialog).toBeInTheDocument()
       expect(textarea).toBeInTheDocument()
       expect(textarea.value).toContain('"Name": "Mock Name"')
 
       expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: 'Edit JSON' })).not.toBeInTheDocument()
     })
   })
 
   describe('when the user edits the JSON and clicks Save', () => {
-    test('calls setDraft with the parsed JSON merged into the draft and returns to view mode', async () => {
+    test('calls setDraft with the parsed JSON merged into the draft and closes the modal', async () => {
       const user = userEvent.setup()
 
       const { setDraft } = setup({
@@ -186,12 +224,7 @@ describe('JsonPreview Component', () => {
         }
       })
 
-      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
-      await user.clear(textarea)
-      await user.type(textarea, '{{"Name": "Updated Name"}', { skipClick: true })
+      await openEditorAndType(user, '{{"Name": "Updated Name"}')
 
       await user.click(screen.getByRole('button', { name: 'Save' }))
 
@@ -203,13 +236,13 @@ describe('JsonPreview Component', () => {
         }
       })
 
-      expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
       expect(screen.queryByRole('textbox', { name: 'Editable JSON metadata' })).not.toBeInTheDocument()
     })
   })
 
   describe('when the user enters invalid JSON and clicks Save', () => {
-    test('shows an error message, does not call setDraft, and stays in edit mode', async () => {
+    test('shows an inline error, does not call setDraft, does not open a confirmation modal, and stays in edit mode', async () => {
       const user = userEvent.setup()
 
       const { setDraft } = setup({
@@ -218,19 +251,19 @@ describe('JsonPreview Component', () => {
         }
       })
 
-      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
-      await user.clear(textarea)
-      await user.type(textarea, '{{ this is not valid json', { skipClick: true })
+      await openEditorAndType(user, '{{ this is not valid json')
 
       await user.click(screen.getByRole('button', { name: 'Save' }))
 
       expect(setDraft).not.toHaveBeenCalled()
       expect(screen.getByRole('alert')).toHaveTextContent(/Invalid JSON/)
 
-      // Should remain in edit mode with the Save/Cancel buttons still present
+      // A parse failure isn't something a "save anyway" confirmation makes
+      // sense for -- there's no parsed data to save.
+      expect(screen.queryByRole('dialog', { name: 'Confirm Save' })).not.toBeInTheDocument()
+
+      // Should remain in the edit modal with Save/Cancel still present
+      expect(screen.getByRole('dialog', { name: 'Edit JSON' })).toBeInTheDocument()
       expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
     })
@@ -244,12 +277,8 @@ describe('JsonPreview Component', () => {
         }
       })
 
-      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
+      const textarea = await openEditorAndType(user, '{{ not valid')
 
-      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
-      await user.clear(textarea)
-      await user.type(textarea, '{{ not valid', { skipClick: true })
       await user.click(screen.getByRole('button', { name: 'Save' }))
 
       expect(screen.getByRole('alert')).toBeInTheDocument()
@@ -261,7 +290,7 @@ describe('JsonPreview Component', () => {
   })
 
   describe('when the user clicks Cancel after editing', () => {
-    test('discards changes, does not call setDraft, and returns to view mode', async () => {
+    test('discards changes, does not call setDraft, and closes the modal', async () => {
       const user = userEvent.setup()
 
       const { setDraft } = setup({
@@ -270,18 +299,12 @@ describe('JsonPreview Component', () => {
         }
       })
 
-      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
-      await user.clear(textarea)
-      await user.type(textarea, '{{"Name": "Should Not Save"}', { skipClick: true })
+      await openEditorAndType(user, '{{"Name": "Should Not Save"}')
 
       await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
       expect(setDraft).not.toHaveBeenCalled()
-      expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
-      expect(screen.queryByRole('textbox', { name: 'Editable JSON metadata' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
       // Re-opening edit mode should show the original (unsaved-change-free) JSON again
       await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
@@ -290,92 +313,9 @@ describe('JsonPreview Component', () => {
     })
   })
 
-  describe('when the draft changes externally while editing (e.g. the UI form was saved)', () => {
-    test('exits edit mode, discards the stale buffer, and shows the new data', async () => {
-      const user = userEvent.setup()
-
-      const { setDraft, rerenderWithDraft } = setup({
-        ummMetadata: {
-          Name: 'Mock Name'
-        }
-      })
-
-      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
-      // Make an unsaved edit in the JSON textarea
-      await user.clear(textarea)
-      await user.type(textarea, '{{"Name": "Unsaved JSON Edit"}', { skipClick: true })
-
-      expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' })).toBeInTheDocument()
-
-      // Simulate the UI form changing the draft concurrently (its own
-      // onChange -> setDraft), independent of anything JsonPreview did
-      rerenderWithDraft({
-        ummMetadata: {
-          Name: 'Changed From UI Form'
-        }
-      })
-
-      // JsonPreview should have bailed out of edit mode rather than let a
-      // later Save clobber the newer data with the stale JSON buffer
-      expect(screen.queryByRole('textbox', { name: 'Editable JSON metadata' })).not.toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-      expect(JSONPretty).toHaveBeenLastCalledWith(expect.objectContaining({
-        data: {
-          Name: 'Changed From UI Form'
-        }
-      }), {})
-
-      // JsonPreview's own setDraft should never have been called -- the
-      // change came from elsewhere
-      expect(setDraft).not.toHaveBeenCalled()
-
-      // Re-entering edit mode should now start from the fresh data, not the
-      // discarded buffer
-      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-      expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' }).value)
-        .toContain('"Name": "Changed From UI Form"')
-    })
-
-    test('does not exit edit mode when the draft is re-rendered with the same data', async () => {
-      const user = userEvent.setup()
-
-      const { rerenderWithDraft } = setup({
-        ummMetadata: {
-          Name: 'Mock Name'
-        }
-      })
-
-      await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-      const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
-      await user.clear(textarea)
-      await user.type(textarea, '{{"Name": "Unsaved JSON Edit"}', { skipClick: true })
-
-      // Re-render with an equivalent (not just equal-by-reference) draft --
-      // this should NOT be treated as an external change
-      rerenderWithDraft({
-        ummMetadata: {
-          Name: 'Mock Name'
-        }
-      })
-
-      const stillTextarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
-      expect(stillTextarea).toBeInTheDocument()
-      expect(stillTextarea.value).toContain('"Name": "Unsaved JSON Edit"')
-    })
-  })
-
   describe('when a schema prop is provided', () => {
     describe('when the edited JSON is only missing a required field', () => {
-      test('saves anyway, since missing-required-field errors are ignored', async () => {
+      test('saves immediately with no confirmation, since missing-required-field errors are ignored', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -384,13 +324,8 @@ describe('JsonPreview Component', () => {
           }
         }, { schema: mockSchema })
 
-        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
         // Removes the required `Name` field entirely
-        await user.clear(textarea)
-        await user.type(textarea, '{{}', { skipClick: true })
+        await openEditorAndType(user, '{{}')
 
         await user.click(screen.getByRole('button', { name: 'Save' }))
 
@@ -399,13 +334,12 @@ describe('JsonPreview Component', () => {
           ummMetadata: {}
         })
 
-        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-        expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
       })
     })
 
     describe('when the edited JSON has an unknown/typo\'d field name', () => {
-      test('blocks the save, names the offending field, and stays in edit mode', async () => {
+      test('opens a confirmation modal naming the offending field, and does not save yet', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -414,29 +348,74 @@ describe('JsonPreview Component', () => {
           }
         }, { schema: mockSchema })
 
-        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
-        await user.clear(textarea)
-        await user.type(textarea, '{{"Name": "Mock Name", "Nmae": "typo"}', { skipClick: true })
+        await openEditorAndType(user, '{{"Name": "Mock Name", "Nmae": "typo"}')
 
         await user.click(screen.getByRole('button', { name: 'Save' }))
 
         expect(setDraft).not.toHaveBeenCalled()
 
-        const alert = screen.getByRole('alert')
+        const confirmDialog = screen.getByRole('dialog', { name: 'Confirm Save' })
 
-        expect(alert).toHaveTextContent(/Nmae/)
-        expect(alert).toHaveTextContent(/must NOT have additional property/)
+        expect(confirmDialog).toHaveTextContent(/Nmae/)
+        expect(confirmDialog).toHaveTextContent(/must NOT have additional property/)
+        expect(confirmDialog).toHaveTextContent(/would you like to proceed/i)
 
-        expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' })).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+        // The edit modal stays open underneath, with the unsaved text intact
+        expect(screen.getByRole('dialog', { name: 'Edit JSON' })).toBeInTheDocument()
+        expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' }).value).toContain('Nmae')
+      })
+
+      test('clicking "Yes, save anyway" saves the structurally-invalid JSON and closes both modals', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Name: 'Mock Name'
+          }
+        }, { schema: mockSchema })
+
+        await openEditorAndType(user, '{{"Name": "Mock Name", "Nmae": "typo"}')
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+
+        await user.click(screen.getByRole('button', { name: 'Save & Continue' }))
+
+        expect(setDraft).toHaveBeenCalledTimes(1)
+        expect(setDraft).toHaveBeenCalledWith({
+          ummMetadata: {
+            Name: 'Mock Name',
+            Nmae: 'typo'
+          }
+        })
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      })
+
+      test('clicking "No, go back" closes the confirmation modal without saving, keeping the edit modal open', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Name: 'Mock Name'
+          }
+        }, { schema: mockSchema })
+
+        await openEditorAndType(user, '{{"Name": "Mock Name", "Nmae": "typo"}')
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+
+        await user.click(screen.getByRole('button', { name: 'Back' }))
+
+        expect(setDraft).not.toHaveBeenCalled()
+        expect(screen.queryByRole('dialog', { name: 'Confirm Save' })).not.toBeInTheDocument()
+
+        const editDialog = screen.getByRole('dialog', { name: 'Edit JSON' })
+
+        expect(editDialog).toBeInTheDocument()
+        expect(screen.getByRole('textbox', { name: 'Editable JSON metadata' }).value).toContain('Nmae')
       })
     })
 
     describe('when the edited JSON has a value of the wrong type', () => {
-      test('blocks the save and shows the type error', async () => {
+      test('opens a confirmation modal with the type error', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -445,26 +424,90 @@ describe('JsonPreview Component', () => {
           }
         }, { schema: mockSchema })
 
-        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
-        await user.clear(textarea)
-        await user.type(textarea, '{{"Name": "Mock Name", "Age": "not a number"}', { skipClick: true })
+        await openEditorAndType(user, '{{"Name": "Mock Name", "Age": "not a number"}')
 
         await user.click(screen.getByRole('button', { name: 'Save' }))
 
         expect(setDraft).not.toHaveBeenCalled()
 
-        const alert = screen.getByRole('alert')
+        const confirmDialog = screen.getByRole('dialog', { name: 'Confirm Save' })
 
-        expect(alert).toHaveTextContent(/Age/)
-        expect(alert).toHaveTextContent(/must be number/)
+        expect(confirmDialog).toHaveTextContent(/Age/)
+        expect(confirmDialog).toHaveTextContent(/must be number/)
+      })
+    })
+
+    describe('when the edited JSON has an invalid value for a oneOf/const-style enum field', () => {
+      test('opens a confirmation modal instead of silently saving the invalid value', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Status: 'Active'
+          }
+        }, { schema: mockEnumAsOneOfSchema })
+
+        // "Bogus" doesn't match either const branch, and there's no
+        // required-field error at this path to (correctly) suppress it
+        await openEditorAndType(user, '{{"Status": "Bogus"}')
+
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(setDraft).not.toHaveBeenCalled()
+
+        const confirmDialog = screen.getByRole('dialog', { name: 'Confirm Save' })
+
+        expect(confirmDialog).toHaveTextContent(/Status/)
+        expect(confirmDialog).toHaveTextContent(/would you like to proceed/i)
+      })
+
+      test('clicking "Save & Continue" saves the invalid enum value', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Status: 'Active'
+          }
+        }, { schema: mockEnumAsOneOfSchema })
+
+        await openEditorAndType(user, '{{"Status": "Bogus"}')
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+        await user.click(screen.getByRole('button', { name: 'Save & Continue' }))
+
+        expect(setDraft).toHaveBeenCalledTimes(1)
+        expect(setDraft).toHaveBeenCalledWith({
+          ummMetadata: {
+            Status: 'Bogus'
+          }
+        })
+      })
+
+      test('a valid enum value saves immediately with no confirmation', async () => {
+        const user = userEvent.setup()
+
+        const { setDraft } = setup({
+          ummMetadata: {
+            Status: 'Active'
+          }
+        }, { schema: mockEnumAsOneOfSchema })
+
+        await openEditorAndType(user, '{{"Status": "Inactive"}')
+
+        await user.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(setDraft).toHaveBeenCalledTimes(1)
+        expect(setDraft).toHaveBeenCalledWith({
+          ummMetadata: {
+            Status: 'Inactive'
+          }
+        })
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
       })
     })
 
     describe('when the edited JSON has both a missing required field and a structural error', () => {
-      test('only the structural error is shown, the required error is omitted', async () => {
+      test('the confirmation modal names only the structural error, the required error is omitted', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -473,30 +516,25 @@ describe('JsonPreview Component', () => {
           }
         }, { schema: mockSchema })
 
-        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
         // Missing required `Name`, and has an unknown field `Nmae`
-        await user.clear(textarea)
-        await user.type(textarea, '{{"Nmae": "typo"}', { skipClick: true })
+        await openEditorAndType(user, '{{"Nmae": "typo"}')
 
         await user.click(screen.getByRole('button', { name: 'Save' }))
 
         expect(setDraft).not.toHaveBeenCalled()
 
-        const alert = screen.getByRole('alert')
+        const confirmDialog = screen.getByRole('dialog', { name: 'Confirm Save' })
 
-        expect(alert).toHaveTextContent(/Nmae/)
-        expect(alert).not.toHaveTextContent(/required/)
+        expect(confirmDialog).toHaveTextContent(/Nmae/)
+        expect(confirmDialog).not.toHaveTextContent(/"required"/)
 
-        // A single error renders as plain text, not as a list
-        expect(screen.queryByRole('listitem')).not.toBeInTheDocument()
+        // A single structural error still renders as a one-item list
+        expect(screen.getAllByRole('listitem')).toHaveLength(1)
       })
     })
 
     describe('when the edited JSON is missing the required field in every oneOf branch', () => {
-      test('saves anyway, since the resulting oneOf wrapper error is ignored along with the required errors', async () => {
+      test('saves immediately with no confirmation, since the oneOf wrapper error is noise from the required errors', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -505,13 +543,8 @@ describe('JsonPreview Component', () => {
           }
         }, { schema: mockOneOfSchema })
 
-        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
         // Satisfies neither branch: no `Name` and no `Nickname`
-        await user.clear(textarea)
-        await user.type(textarea, '{{"Age": 5}', { skipClick: true })
+        await openEditorAndType(user, '{{"Age": 5}')
 
         await user.click(screen.getByRole('button', { name: 'Save' }))
 
@@ -522,13 +555,12 @@ describe('JsonPreview Component', () => {
           }
         })
 
-        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-        expect(screen.getByRole('button', { name: 'Edit JSON' })).toBeInTheDocument()
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
       })
     })
 
     describe('when the edited JSON has an unknown field under a oneOf schema', () => {
-      test('still blocks the save on the structural error, even though the oneOf wrapper error is ignored', async () => {
+      test('still opens a confirmation modal for the structural error, even though the oneOf wrapper error is ignored', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -537,27 +569,22 @@ describe('JsonPreview Component', () => {
           }
         }, { schema: mockOneOfSchema })
 
-        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
         // Satisfies the `Name` branch, but also has a typo'd unknown field
-        await user.clear(textarea)
-        await user.type(textarea, '{{"Name": "Mock Name", "Nmae": "typo"}', { skipClick: true })
+        await openEditorAndType(user, '{{"Name": "Mock Name", "Nmae": "typo"}')
 
         await user.click(screen.getByRole('button', { name: 'Save' }))
 
         expect(setDraft).not.toHaveBeenCalled()
 
-        const alert = screen.getByRole('alert')
+        const confirmDialog = screen.getByRole('dialog', { name: 'Confirm Save' })
 
-        expect(alert).toHaveTextContent(/Nmae/)
-        expect(alert).toHaveTextContent(/must NOT have additional property/)
+        expect(confirmDialog).toHaveTextContent(/Nmae/)
+        expect(confirmDialog).toHaveTextContent(/must NOT have additional property/)
       })
     })
 
     describe('when the edited JSON has multiple structural errors', () => {
-      test('renders each error as a separate list item', async () => {
+      test('renders each error as a separate list item in the confirmation modal', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -566,12 +593,7 @@ describe('JsonPreview Component', () => {
           }
         }, { schema: mockSchema })
 
-        await user.click(screen.getByRole('button', { name: 'Edit JSON' }))
-
-        const textarea = screen.getByRole('textbox', { name: 'Editable JSON metadata' })
-
-        await user.clear(textarea)
-        await user.type(textarea, '{{"Name": "Mock Name", "Nmae": "typo", "Aeg": "typo2"}', { skipClick: true })
+        await openEditorAndType(user, '{{"Name": "Mock Name", "Nmae": "typo", "Aeg": "typo2"}')
 
         await user.click(screen.getByRole('button', { name: 'Save' }))
 

--- a/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
+++ b/static/src/js/components/JsonPreview/__tests__/JsonPreview.test.jsx
@@ -25,7 +25,8 @@ const mockSchema = {
 // A discriminated-union-style schema: a valid document must satisfy exactly
 // one of the two branches below. Each branch has its own required field, so
 // AJV reports a missing branch field as both a `required` error *and* a
-// wrapping `oneOf` error ("must match a schema in oneOf") at the root.
+// wrapping `oneOf` error ("must match a schema in oneOf") at the root. Only
+// the `required` error is filtered -- the `oneOf` error is now surfaced too.
 const mockOneOfSchema = {
   type: 'object',
   additionalProperties: false,
@@ -53,10 +54,8 @@ const mockOneOfSchema = {
 }
 
 // A controlled-vocabulary field expressed as `oneOf: [{ const: ... }]`
-// rather than a plain `enum`. This is the pattern that was silently passing
-// validation before the fix: the blanket oneOf/anyOf filter was dropping
-// this error along with the legitimate required-field noise, even though
-// there's no missing-required-field involved here at all.
+// rather than a plain `enum`. There's no missing-required-field involved
+// here, so this exercises the oneOf error path independent of `required`.
 const mockEnumAsOneOfSchema = {
   type: 'object',
   additionalProperties: false,
@@ -503,7 +502,7 @@ describe('JsonPreview Component', () => {
     })
 
     describe('when the edited JSON is missing the required field in every oneOf branch', () => {
-      test('saves immediately with no errors modal, since the oneOf wrapper error is noise from the required errors', async () => {
+      test('opens an errors modal for the oneOf wrapper error and does not save', async () => {
         const user = userEvent.setup()
 
         const { setDraft } = setup({
@@ -512,20 +511,20 @@ describe('JsonPreview Component', () => {
           }
         }, { schema: mockOneOfSchema })
 
-        // Satisfies neither branch: no `Name` and no `Nickname`
+        // Satisfies neither branch: no `Name` and no `Nickname`. The
+        // `required` errors for each branch are filtered, but the wrapping
+        // `oneOf` error at the root is not, so it should still be reported.
         await openEditorAndType(user, '{{"Age": 5}')
 
         await user.click(screen.getByRole('button', { name: 'Apply' }))
 
-        expect(setDraft).toHaveBeenCalledTimes(1)
-        expect(setDraft).toHaveBeenCalledWith({
-          ummMetadata: {
-            Age: 5
-          }
-        })
+        expect(setDraft).not.toHaveBeenCalled()
 
-        expect(screen.queryByText('Editing JSON')).not.toBeInTheDocument()
-        expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument()
+        expect(screen.getByText('Invalid JSON')).toBeInTheDocument()
+        expect(errorListText()).not.toMatch(/"required"/)
+        expect(screen.getByText(/must fix these errors before proceeding to save/i)).toBeInTheDocument()
+
+        expect(screen.getByText('Editing JSON')).toBeInTheDocument()
       })
     })
 

--- a/static/src/js/components/MetadataForm/MetadataForm.jsx
+++ b/static/src/js/components/MetadataForm/MetadataForm.jsx
@@ -406,7 +406,7 @@ const MetadataForm = () => {
 
       <Row className="json-view">
         <Col sm={8}>
-          <JsonPreview />
+          <JsonPreview schema={schema} />
         </Col>
       </Row>
     </Container>

--- a/static/src/js/components/TemplateForm/TemplateForm.jsx
+++ b/static/src/js/components/TemplateForm/TemplateForm.jsx
@@ -382,7 +382,7 @@ const TemplateForm = () => {
         </Row>
         <Row className="json-view">
           <Col sm={8}>
-            <JsonPreview />
+            <JsonPreview schema={ummCTemplateSchema} />
           </Col>
         </Row>
       </Container>

--- a/static/src/js/components/TemplateForm/__tests__/TemplateForm.test.jsx
+++ b/static/src/js/components/TemplateForm/__tests__/TemplateForm.test.jsx
@@ -38,6 +38,7 @@ import StreetAddressField from '@/js/components/StreetAddressField/StreetAddress
 import createTemplate from '@/js/utils/createTemplate'
 import errorLogger from '@/js/utils/errorLogger'
 import getTemplate from '@/js/utils/getTemplate'
+import getUmmVersion from '@/js/utils/getUmmVersion'
 import updateTemplate from '@/js/utils/updateTemplate'
 
 import { INGEST_DRAFT } from '@/js/operations/mutations/ingestDraft'
@@ -46,18 +47,21 @@ import useAvailableProviders from '@/js/hooks/useAvailableProviders'
 
 import TemplateForm from '../TemplateForm'
 
-import staticConfig from '../../../../../../static.config.json'
-
 vi.mock('@/js/utils/createTemplate')
 vi.mock('@/js/utils/errorLogger')
 vi.mock('@/js/utils/getTemplate')
+vi.mock('@/js/utils/getUmmVersion')
 vi.mock('@/js/utils/updateTemplate')
 vi.mock('@/js/components/ErrorBanner/ErrorBanner')
 vi.mock('@/js/components/FormNavigation/FormNavigation')
 
-const getConfig = () => staticConfig
+// The actual UMM-C version number is irrelevant to these tests - they only
+// care that whatever version getUmmVersion resolves to is threaded through
+// to the mutation correctly. Using a fixed, fake value keeps this test from
+// breaking every time the real UMM version is bumped in config.
+const mockUmmVersion = 'mock-umm-c-version'
 
-const ummCVersion = getConfig().ummVersions.ummC
+getUmmVersion.mockReturnValue(mockUmmVersion)
 
 vi.mock('@/js/hooks/useAvailableProviders')
 useAvailableProviders.mockReturnValue({
@@ -509,7 +513,7 @@ describe('TemplateForm', () => {
                   },
                   nativeId: 'MMT_mock-uuid',
                   providerId: 'MMT_2',
-                  ummVersion: `${ummCVersion}`
+                  ummVersion: mockUmmVersion
                 }
               },
               result: {
@@ -563,7 +567,7 @@ describe('TemplateForm', () => {
                   },
                   nativeId: 'MMT_mock-uuid',
                   providerId: 'MMT_2',
-                  ummVersion: `${ummCVersion}`
+                  ummVersion: mockUmmVersion
                 }
               },
               error: new Error('An error occurred')

--- a/static/src/js/components/TemplatePreview/__tests__/TemplatePreview.test.jsx
+++ b/static/src/js/components/TemplatePreview/__tests__/TemplatePreview.test.jsx
@@ -22,19 +22,23 @@ import ErrorBanner from '../../ErrorBanner/ErrorBanner'
 import deleteTemplate from '../../../utils/deleteTemplate'
 import errorLogger from '../../../utils/errorLogger'
 import getTemplate from '../../../utils/getTemplate'
+import getUmmVersion from '../../../utils/getUmmVersion'
 import { INGEST_DRAFT } from '../../../operations/mutations/ingestDraft'
-
-import staticConfig from '../../../../../../static.config.json'
 
 vi.mock('../../../utils/getTemplate')
 vi.mock('../../ErrorBanner/ErrorBanner')
 vi.mock('../../PreviewProgress/PreviewProgress')
 vi.mock('../../../utils/errorLogger')
 vi.mock('../../../utils/deleteTemplate')
+vi.mock('../../../utils/getUmmVersion')
 
-const getConfig = () => staticConfig
+// The actual UMM-C version number is irrelevant to these tests - they only
+// care that whatever version getUmmVersion resolves to is threaded through
+// to the mutation correctly. Using a fixed, fake value keeps this test from
+// breaking every time the real UMM version is bumped in config.
+const mockUmmVersion = 'mock-umm-c-version'
 
-const ummCVersion = getConfig().ummVersions.ummC
+getUmmVersion.mockReturnValue(mockUmmVersion)
 
 const setup = () => {
   const user = userEvent.setup()
@@ -371,7 +375,7 @@ describe('TemplatePreview', () => {
                 },
                 nativeId: 'MMT_mock-uuid',
                 providerId: 'MMT_2',
-                ummVersion: `${ummCVersion}`
+                ummVersion: mockUmmVersion
               }
             },
             result: {
@@ -413,7 +417,7 @@ describe('TemplatePreview', () => {
                 },
                 nativeId: 'MMT_mock-uuid',
                 providerId: 'MMT_2',
-                ummVersion: `${ummCVersion}`
+                ummVersion: mockUmmVersion
               }
             },
             error: new Error('An error occurred')


### PR DESCRIPTION
# Overview
### What is the feature?
The JSON preview panel (`JsonPreview`) on the Metadata Draft form and the Collection Template form was previously read-only — a collapsible accordion showing the current `ummMetadata` as pretty-printed JSON. This adds the ability to edit that JSON directly and save it back to the draft/template, instead of only being able to change fields through the generated form UI.

### What is the Solution?
JsonPreview now supports an Edit JSON mode: clicking **Edit JSON** opens an "Editing JSON" modal dialog with a textarea pre-filled with the current metadata, pretty-printed. The accordion behind it continues to show the read-only view.

- **Apply** parses the textarea contents as JSON, then optionally validates it against a `schema` prop (the full UMM schema, passed in by `MetadataForm` and `TemplateForm`).
  - **Invalid JSON syntax** blocks the save with an inline error in the modal (`Invalid JSON: ...`); the modal stays open so the text can be fixed.
  - **Structural schema errors** (an unknown/typo'd field name, or a value of the wrong type) block the save entirely. An "Invalid JSON" modal opens, listing the specific errors and stating that they must be fixed before saving. The only action is **Go Back**, which returns to the edit modal with the unsaved text intact — there's no way to save while structural errors are present.
  - **Missing required fields** never block or prompt — this matches existing form-save behavior, which already allows saving incomplete drafts.
  - On a successful save, the parsed metadata is written back to the draft via `setDraft`, and the modal closes.
- **Cancel** discards changes and closes the modal without altering the draft.

Modals are now built on the shared `CustomModal` component rather than `react-bootstrap`'s `Modal` directly, for consistency with the rest of the app. As part of that, `CustomModal` was fixed to wire its title to the dialog via `aria-labelledby`, so its modals get a proper accessible name (previously missing).

### What areas of the application does this impact?
- `JsonPreview` component (core change)
- `CustomModal` component — now used by `JsonPreview`; also received an `aria-labelledby` accessibility fix that benefits all of its existing consumers (e.g. `ChooseProviderModal`)
- `MetadataForm` — collection/service/tool/variable/etc. draft editing pages, which render `JsonPreview`
- `TemplateForm` — collection template editing page, which also renders `JsonPreview`
- `static/src/css/vendor/bootstrap/index.scss` — uncommented the `bootstrap/scss/close` import, which was previously excluded. It's needed for the modal's close ("×") button to render correctly; without it, the close button showed as an empty square.

# Testing
### Reproduction steps
- **Environment for testing:** `npm run start:fast`
1. Navigate to an existing draft (or create a new one) and open any form section.
2. Scroll down to the **JSON** accordion panel and expand it.
3. Click **Edit JSON**.
   - Verify a modal titled "Editing JSON" opens with a textarea pre-populated with the current metadata, pretty-printed, and **Cancel**/**Apply** buttons.
4. Edit a field value (e.g. change `ShortName`) and click **Apply**.
   - Verify the modal closes, and the change is reflected both in the JSON preview and in the corresponding form field above.
5. Click **Edit JSON** again, break the JSON syntax (e.g. delete a closing brace), and click **Apply**.
   - Verify an inline error appears in the modal (`Invalid JSON: ...`), the save is blocked, and the modal stays open.
6. Fix the syntax but rename a valid field to something invalid (e.g. `ShortName` → `ShrtName`) and click **Apply**.
   - Verify an "Invalid JSON" modal opens, naming the offending field (`must NOT have additional property 'ShrtName'`), and stating the errors must be fixed before saving.
   - Verify the only available action is **Go Back** — there is no option to save anyway.
   - Click **Go Back** — verify the "Invalid JSON" modal closes, the edit modal remains open with the unsaved text intact, and the draft is unchanged.
   - Fix the field name back to `ShortName` and click **Apply** — verify it now saves successfully and both modals close.
7. Change a field to the wrong type (e.g. set a string field to a number, or vice versa) and click **Apply**.
   - Verify the "Invalid JSON" modal opens with a type-mismatch error, and again offers only **Go Back**.
8. Delete a required field entirely (e.g. remove `EntryTitle`) but keep the JSON otherwise valid, and click **Apply**.
   - Verify the save **succeeds immediately with no errors modal** — missing required fields should not block or prompt, matching current form-field behavior.
9. Click **Edit JSON**, make an unsaved change, then click **Cancel**.
   - Verify the modal closes, the change is discarded, and the JSON preview reverts to the last saved state.
10. Repeat steps 1–10 on the **Collection Template** form (`/templates/collections/...`) to confirm the same behavior there.
### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON metadata editing with edit, cancel, and save controls.
  * Added JSON parsing and schema validation with clear validation messages.
  * Successfully saved metadata is now reflected in the draft.
  * Added protection against overwriting metadata after concurrent draft changes.

* **Bug Fixes**
  * Improved handling of optional fields and schema wrapper validation cases.

* **Tests**
  * Expanded coverage for editing, saving, canceling, invalid JSON, concurrent changes, and schema validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->